### PR TITLE
Level2 krn must be 3840 bytes; it got 3 bytes too big.

### DIFF
--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -54,9 +54,9 @@ MName          fcs       /Krn/
                ifne      H6309
                fcc       /www.nitros9.org /
                fcc       /www.nitros9.org /
-               fcc       /www.nit/
+               fcc       /www./
                else      
-               fcc       /www.nit/
+               fcc       /www./
                endc      
 
 * Might as well have this here as just past the end of Kernel...


### PR DESCRIPTION
After trimming 3 junk bytes:

$ find nitros9 -name krn -ls
  8582431      4 -rw-r--r--   1 strick   primarygroup     2047 Oct 21 20:55 nitros9/level1/coco1/modules/krn
  8582430      4 -rw-r--r--   1 strick   primarygroup     2047 Oct 21 20:55 nitros9/level1/coco1/modules/kernel/krn
  8583203      4 -rw-r--r--   1 strick   primarygroup     3840 Oct 21 20:56 nitros9/level2/coco3_6309/modules/krn
  8583202      4 -rw-r--r--   1 strick   primarygroup     3840 Oct 21 20:56 nitros9/level2/coco3_6309/modules/kernel/krn
  8582807      4 -rw-r--r--   1 strick   primarygroup     3840 Oct 21 20:56 nitros9/level2/coco3/modules/krn
  8582806      4 -rw-r--r--   1 strick   primarygroup     3840 Oct 21 20:56 nitros9/level2/coco3/modules/kernel/krn
$ 