### PR TITLE
change test for bsd vs gnu stat in level2/bootfiles/padup256

### DIFF
--- a/level2/f256/bootfiles/padup256
+++ b/level2/f256/bootfiles/padup256
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [[ $OSTYPE == 'darwin'* ]]; then
+if stat -f "%z" $1 > /dev/null 2>&1 ; then
      export padding=`stat -f "(%z + 255) / 256 * 256" $1 | bc`
 else
      export padding=`stat -c "(%s + 255) / 256 * 256" $1 | bc`


### PR DESCRIPTION
Linux uses dash for sh and doesn't recognize the [[ ]] syntax.  This change eliminates the [[ ]] syntax and replaces it with a test to detect bsd vs gnu stat.  This should be OS agnostic and work across multiple OS without having to test individually for each one.