### PR TITLE
F256 Optimizations

### DIFF
--- a/defs/f256.d
+++ b/defs/f256.d
@@ -42,7 +42,7 @@ F256.D              set       1
 * Modified to address new memory map that Stefany created.
 
 ********************************************************************
-* Ticks per second
+* Ticks per second.
 *
 TkPerSec            set       60
 
@@ -217,7 +217,7 @@ INT_POLARITY_3      equ       $FE27               not used
 INT_EDGE_3          equ       $FE2B               not used
 INT_MASK_3          equ       $FE2F               not used
 
-* Interrupt Group 0 Flags
+* Interrupt group 0 flags
 INT_VKY_SOF         equ       %00000001           TinyVicky start of frame interrupt
 INT_VKY_SOL         equ       %00000010           TinyVicky start of line interrupt
 INT_PS2_KBD         equ       %00000100           PS/2 keyboard event
@@ -226,14 +226,14 @@ INT_TIMER_0         equ       %00010000           TIMER0 has reached its target 
 INT_TIMER_1         equ       %00010000           TIMER1 has reached its target value
 INT_CARTRIDGE       equ       %10000000           Interrupt asserted by the cartridge
 
-* Interrupt Group 1 Flags
+* Interrupt group 1 flags
 INT_UART            equ       %00000001           UART is ready to receive or send data
 INT_RTC             equ       %00010000           event from the real time clock chip
 INT_VIA0            equ       %00100000           event from the 65C22 VIA chip
 INT_VIA1            equ       %01000000           F256K Only: local keyboard
 INT_SDC_INS         equ       %01000000           yser has inserted an SD card
 
-* Interrupt Group 2 Flags
+* Interrupt group 2 flags
 IEC_DATA_i          equ       %00000001           IEC data in
 IEC_CLK_i           equ       %00000010           IEC clock in
 IEC_ATN_i           equ       %00000100           IEC ATN in
@@ -276,25 +276,27 @@ T1_CMP_CTR          equ       $FE3C               timer 1 compare counter (read/
 T1_CMP              equ       $FE3D               timer 1 compare value (read/write)
 
 ********************************************************************
-* F256 VIA definitions
+* F256 VIA (W65C22S) definitions
 *
 * VIA addresses
-IORB                equ       $FFB0               port b data
-IORA                equ       $FFB1               port a data
-DDRB                equ       $FFB2               port b data direction register
-DDRA                equ       $FFB3               port a data direction register
-T1C_L               equ       $FFB4               timer 1 counter low
-T1C_H               equ       $FFB5               timer 1 counter high
-T1L_L               equ       $FFB6               timer 1 latch low
-T1L_H               equ       $FFB7               timer 1 latch high
-T2C_L               equ       $FFB8               timer 2 counter low
-T2C_H               equ       $FFB9               timer 2 counter high
-SDR                 equ       $FFBA               serial data register
-ACR                 equ       $FFBB               auxiliary control register
-PCR                 equ       $FFBC               peripheral control register
-IFR                 equ       $FFBD               interrupt flag register
-IER                 equ       $FFBE               interrupt enable register
-IORA2               equ       $FFBF               port a data (no handshake)
+VIA.Base            equ       $FFB0
+                    org       0
+VIA_ORB_IRB         rmb       1                   port b data
+VIA_ORA_IRA         rmb       1                   port a data
+VIA_DDRB            rmb       1                   port b data direction register
+VIA_DDRA            rmb       1                   port a data direction register
+VIA_T1CL            rmb       1                   timer 1 counter low
+VIA_T1CH            rmb       1                   timer 1 counter high
+VIA_T1LL            rmb       1                   timer 1 latch low
+VIA_T1LH            rmb       1                   timer 1 latch high
+VIA_T2CL            rmb       1                   timer 2 counter low
+VIA_T2CH            rmb       1                   timer 2 counter high
+VIA_SR              rmb       1                   serial data register
+VIA_ACR             rmb       1                   auxiliary control register
+VIA_PCR             rmb       1                   peripheral control register
+VIA_IFR             rmb       1                   interrupt flag register
+VIA_IER             rmb       1                   interrupt enable register
+VIA_ORA_IRA_AUX     rmb       1                   port a data (no handshake)
 
 * ACR control register values
 T1_CTRL             equ       %11000000
@@ -333,46 +335,32 @@ CA2E                equ       %00000001
 * F256 real-time clock definitions
 *
 RTC.Base            equ       0xFE40
-RTC_SEC             equ       0x00                seconds register
-RTC_SEC_ALARM       equ       0x01                seconds alarm register
-RTC_MIN             equ       0x02                minutes register
-RTC_MIN_ALARM       equ       0x03                minutes alarm register
-RTC_HRS             equ       0x04                hours register
-RTC_HRS_ALARM       equ       0x05                hours alarm register
-RTC_DAY             equ       0x06                day register
-RTC_DAY_ALARM       equ       0x07                day alarm register
-RTC_DOW             equ       0x08                day of week register
-RTC_MONTH           equ       0x09                month register
-RTC_YEAR            equ       0x0A                year register
-RTC_RATES           equ       0x0B                rates register
-RTC_ENABLE          equ       0x0C                enables register
-RTC_FLAGS           equ       0x0D                flags register
-RTC_CTRL            equ       0x0E                control register
-RTC_CENTURY         equ       0x0F                century register
+                    org       0
+RTC_SEC             rmb       1                   seconds register
+RTC_SEC_ALARM       rmb       1                   seconds alarm register
+RTC_MIN             rmb       1                   minutes register
+RTC_MIN_ALARM       rmb       1                   minutes alarm register
+RTC_HRS             rmb       1                   hours register
+RTC_HRS_ALARM       rmb       1                   hours alarm register
+RTC_DAY             rmb       1                   day register
+RTC_DAY_ALARM       rmb       1                   day alarm register
+RTC_DOW             rmb       1                   day of week register
+RTC_MONTH           rmb       1                   month register
+RTC_YEAR            rmb       1                   year register
+RTC_RATES           rmb       1                   rates register
+RTC_ENABLE          rmb       1                   enables register
+RTC_FLAGS           rmb       1                   flags register
+RTC_CTRL            rmb       1                   control register
+RTC_CENTURY         rmb       1                   century register
 
 RTC_24HR            equ       $02                 12/24 hour flag (1 = 24 Hr, 0 = 12 Hr)
 RTC_STOP            equ       $04                 0 = STOP when power off, 1 = run from battery when power off
 RTC_UTI             equ       $08                 update transfer inhibit
+
 ********************************************************************
-* F256 W65C22S definitions
+* F256 joystick port definitions
 *
-VIA_ORB_IRB         equ       0xFFB0              output/input register port B
-VIA_ORA_IRA         equ       0xFFB1              output/input register port B
-VIA_DDRB            equ       0xFFB2              data direction port B
-VIA_DDRA            equ       0xFFB3              data direction port A
-VIA_T1CL            equ       0xFFB4              T1C-L
-VIA_T1CH            equ       0xFFB5              T1C-H
-VIA_T1LL            equ       0xFFB6              T1L-L
-VIA_T1LH            equ       0xFFB7              T1L-H
-VIA_T2CL            equ       0xFFB8              T2C-L
-VIA_T2CH            equ       0xFFB9              T2C-H
-VIA_SR              equ       0xFFBA              SR
-VIA_ACR             equ       0xFFBB              ACR
-VIA_PCR             equ       0xFFBC              PCR
-VIA_IFR             equ       0xFFBD              IFR
-VIA_IER             equ       0xFFBE              IER
-VIA_ORA_IRA_AUX     equ       0xFFBF              ORA/IRA
-* Definition for where the Joystick Ports are
+
 * Port A (Joystick Port 1)
 JOYA_UP             equ       0x01
 JOYA_DWN            equ       0x02
@@ -381,6 +369,7 @@ JOTA_RGT            equ       0x08
 JOTA_BUT0           equ       0x10
 JOYA_BUT1           equ       0x20
 JOYA_BUT2           equ       0x40
+
 * Port B (Joystick Port 0)
 JOYB_UP             equ       0x01
 JOYB_DWN            equ       0x02
@@ -393,17 +382,19 @@ JOYB_BUT2           equ       0x40
 ********************************************************************
 * F256 UART definitions
 *
-UART_TRHB           equ       0xFE60              transmit/receive hold buffer
-UART_DLL            equ       0xFE60              divisor latch low byte
-UART_DLH            equ       0xFE61              divisor latch high byte
-UART_IER            equ       0xFE61              interrupt enable register
-UART_FCR            equ       0xFE62              FIFO control register
-UART_IIR            equ       0xFE62              interrupt identification register
-UART_LCR            equ       0xFE63              line control register
-UART_MCR            equ       0xFE64              modem control register
-UART_LSR            equ       0xFE65              line status register
-UART_MSR            equ       0xFE66              modem status register
-UART_SR             equ       0xFE67              scratch register
+UART.Base           equ       0xFE60
+                    org       0
+UART_TRHB           rmb       1                   transmit/receive hold buffer
+UART_DLL            equ       UART_TRHB           divisor latch low byte
+UART_DLH            rmb       1                   divisor latch high byte
+UART_IER            equ       UART_DLH            interrupt enable register
+UART_FCR            rmb       1                   FIFO control register
+UART_IIR            equ       UART_FCR            interrupt identification register
+UART_LCR            rmb       1                   line control register
+UART_MCR            rmb       1                   modem control register
+UART_LSR            rmb       1                   line status register
+UART_MSR            rmb       1                   modem status register
+UART_SR             rmb       1                   scratch register
 
 * FCR register definitions
 FCR_RXT_5           equ       0x00
@@ -415,7 +406,7 @@ FCR_TXR             equ       0x04
 FCR_RXR             equ       0x02
 FCR_FIFOE           equ       0x01
 
-* Interrupt Enable Flags
+* Interrupt enable flags
 UINT_LOW_POWER      equ       0x20                enable low power mode (16750)
 UINT_SLEEP_MODE     equ       0x10                enable sleep mode (16750)
 UINT_MODEM_STATUS   equ       0x08                enable modem status interrupt
@@ -423,7 +414,7 @@ UINT_LINE_STATUS    equ       0x04                enable receiver line status in
 UINT_THR_EMPTY      equ       0x02                enable transmit holding register empty interrupt
 UINT_DATA_AVAIL     equ       0x01                enable receive data available interrupt
 
-; Interrupt Identification Register Codes
+* Interrupt identification register codes
 IIR_FIFO_ENABLED    equ       0x80                FIFO is enabled
 IIR_FIFO_NONFUNC    equ       0x40                FIFO is not functioning
 IIR_FIFO_64BYTE     equ       0x20                64 byte FIFO enabled (16750)
@@ -432,9 +423,9 @@ IIR_THR_EMPTY       equ       0x02                transmit holding register empt
 IIR_DATA_AVAIL      equ       0x04                data available interrupt
 IIR_LINE_STATUS     equ       0x06                line status interrupt
 IIR_TIMEOUT         equ       0x0C                time-out interrupt (16550 and later)
-IIR_INTERRUPT_PENDING equ       0x01              interrupt pending flag
+IIR_INTERRUPT_PENDING equ       0x01                interrupt pending flag
 
-; Line Control Register Codes
+* Line control register codes
 LCR_DLB             equ       0x80                divisor latch access bit
 LCR_SBE             equ       0x60                set break enable
 
@@ -470,18 +461,59 @@ TEXT_LUT_BG         equ       $FF40
 ********************************************************************
 * F256 SD card interface definitions
 *
-SDC_BASE_ADDR       equ       $FE90
-SDC_STAT            equ       0
-SDC_DATA            equ       1
+SDC.Base            equ       $FE90
+                    org       0
+SDC_STAT            rmb       1
+SDC_DATA            rmb       1
 
 * SDC status bits
 SPI_BUSY            equ       %10000000
 SPI_CLK             equ       %00000010
 CS_EN               equ       %00000001
 
-MASTER_CTRL_REG_L   equ       $FFC0
-;Control Bits Fields
-Mstr_Ctrl_Text_Mode_En equ       $01                  enable the text mode
+********************************************************************
+* F256 text screen definitions
+*
+TXT.Base            equ       $FFC0
+                    org       0
+MASTER_CTRL_REG_L   rmb       1
+MASTER_CTRL_REG_H   rmb       1
+VKY_RESERVED_00     rmb       1
+VKY_RESERVED_01     rmb       1
+BORDER_CTRL_REG     rmb       1                   bit[0] - enable (1 by default)  bit[4..6]: X scroll offset (will scroll left) (acceptable values: 0..7)
+BORDER_COLOR_B      rmb       1
+BORDER_COLOR_G      rmb       1
+BORDER_COLOR_R      rmb       1
+BORDER_X_SIZE       rmb       1                   X values: 0 - 32 (default: 32)
+BORDER_Y_SIZE       rmb       1                   Y values: 0 - 32 (default: 32)
+VKY_RESERVED_02     rmb       1
+VKY_RESERVED_03     rmb       1
+VKY_RESERVED_04     rmb       1
+* Valid in graphics mode only
+BACKGROUND_COLOR_B  rmb       1                   when in graphic mode, if a pixel is "0" then the background pixel is chosen
+BACKGROUND_COLOR_G  rmb       1
+BACKGROUND_COLOR_R  rmb       1
+* Cursor registers
+VKY_TXT_CURSOR_CTRL_REG rmb       1                   [0] Enable Text Mode
+VKY_TXT_START_ADD_PTR rmb       1                   this is an offset to change the starting address of the text mode Buffer (in X)
+VKY_TXT_CURSOR_CHAR_REG rmb       1
+VKY_TXT_CURSOR_COLR_REG rmb       1
+VKY_TXT_CURSOR_X_REG_L rmb       1
+VKY_TXT_CURSOR_X_REG_H rmb       1
+VKY_TXT_CURSOR_Y_REG_L rmb       1
+VKY_TXT_CURSOR_Y_REG_H rmb       1
+; Line interrupt
+VKY_LINE_IRQ_CTRL_REG rmb       1                   [0] - enable line 0 - write only
+VKY_LINE_CMP_VALUE_LO rmb       1                   write only [7:0]
+VKY_LINE_CMP_VALUE_HI rmb       1                   write only [3:0]
+
+VKY_PIXEL_X_POS_LO  equ       VKY_LINE_IRQ_CTRL_REG this is where on the video line is the pixel
+VKY_PIXEL_X_POS_HI  equ       VKY_LINE_CMP_VALUE_LO or what pixel is being displayed when the register is read
+VKY_LINE_Y_POS_LO   equ       VKY_LINE_CMP_VALUE_HI this is the line value of the raster
+VKY_LINE_Y_POS_HI   rmb       1
+
+* Text control bit definitions
+Mstr_Ctrl_Text_Mode_En equ       $01                 enable the text mode
 Mstr_Ctrl_Text_Overlay equ       $02                 enable the overlay of the text mode on top of graphic mode (the background color is ignored)
 Mstr_Ctrl_Graph_Mode_En equ       $04                 enable the graphic mode
 Mstr_Ctrl_Bitmap_En equ       $08                 enable the bitmap module in Vicky
@@ -489,7 +521,13 @@ Mstr_Ctrl_TileMap_En equ       $10                 enable the tile module in Vic
 Mstr_Ctrl_Sprite_En equ       $20                 enable the sprite module in Vicky
 Mstr_Ctrl_GAMMA_En  equ       $40                 this enables the gamma correction - the analog and DVI have different color values; the gamma is great to correct the difference
 Mstr_Ctrl_Disable_Vid equ       $80                 this will disable the scanning of the video hence giving 100% bandwidth to the CPU
-MASTER_CTRL_REG_H   equ       $FFC1
+
+* Cursor control bit definitions
+Vky_Cursor_Enable   equ       $01
+Vky_Cursor_Flash_Rate0 equ       $02
+Vky_Cursor_Flash_Rate1 equ       $04
+Vky_Cursor_Flash_Disable equ       $08
+
 FON_SET             equ       %0010000
 FON_OVLY            equ       %00010000
 MON_SLP             equ       %00001000
@@ -497,47 +535,8 @@ DBL_Y               equ       %00000100
 DBL_X               equ       %00000010
 CLK_70              equ       %00000001
 
-; Reserved - TBD
-VKY_RESERVED_00     equ       $FFC2
-VKY_RESERVED_01     equ       $FFC3
-;
-BORDER_CTRL_REG     equ       $FFC4               bit[0] - enable (1 by default)  bit[4..6]: X scroll offset (will scroll left) (acceptable values: 0..7)
+* Border control bit definitions
 Border_Ctrl_Enable  equ       $01
-BORDER_COLOR_B      equ       $FFC5
-BORDER_COLOR_G      equ       $FFC6
-BORDER_COLOR_R      equ       $FFC7
-BORDER_X_SIZE       equ       $FFC8               X values: 0 - 32 (default: 32)
-BORDER_Y_SIZE       equ       $FFC9               Y values: 0 - 32 (default: 32)
-; Reserved - TBD
-VKY_RESERVED_02     equ       $FFCA
-VKY_RESERVED_03     equ       $FFCB
-VKY_RESERVED_04     equ       $FFCC
-; Valid in Graphics Mode Only
-BACKGROUND_COLOR_B  equ       $FFCD               when in graphic mode, if a pixel is "0" then the background pixel is chosen
-BACKGROUND_COLOR_G  equ       $FFCE
-BACKGROUND_COLOR_R  equ       $FFCF               
-; Cursor Registers
-VKY_TXT_CURSOR_CTRL_REG equ       $FFD0               [0] Enable Text Mode
-Vky_Cursor_Enable   equ       $01
-Vky_Cursor_Flash_Rate0 equ       $02
-Vky_Cursor_Flash_Rate1 equ       $04
-Vky_Cursor_Flash_Disable equ       $08
-VKY_TXT_START_ADD_PTR equ       $FFD1               this is an offset to change the starting address of the text mode Buffer (in X)
-VKY_TXT_CURSOR_CHAR_REG equ       $FFD2
-VKY_TXT_CURSOR_COLR_REG equ       $FFD3
-VKY_TXT_CURSOR_X_REG_L equ       $FFD4
-VKY_TXT_CURSOR_X_REG_H equ       $FFD5
-VKY_TXT_CURSOR_Y_REG_L equ       $FFD6
-VKY_TXT_CURSOR_Y_REG_H equ       $FFD7
-; Line interrupt
-VKY_LINE_IRQ_CTRL_REG equ       $FFD8               [0] - enable line 0 - write only
-VKY_LINE_CMP_VALUE_LO equ       $FFD9               write only [7:0]
-VKY_LINE_CMP_VALUE_HI equ       $FFDA               write only [3:0]
-
-VKY_PIXEL_X_POS_LO  equ       $FFD8               this is where on the video line is the pixel
-VKY_PIXEL_X_POS_HI  equ       $FFD9               or what pixel is being displayed when the register is read
-VKY_LINE_Y_POS_LO   equ       $FFDA               this is the line value of the raster
-VKY_LINE_Y_POS_HI   equ       $FFDB               
 
 ; Bitmap
 ;BM0
@@ -711,8 +710,48 @@ TyVKY_LUT2          equ       $F000               -$d800 - $dbff
 TyVKY_LUT3          equ       $F400               -$dc00 - $dfff
 
 
-;DMA
-DMA_CTRL_REG        equ       $FEE0
+********************************************************************
+* F256 Direct Memory Access (DMA) definitions
+*
+DMA.Base            equ       $FEE0
+
+                    org       0
+DMA_CTRL_REG        rmb       1
+DMA_STATUS_REG      rmb       1                   read only
+DMA_DATA_2_WRITE    equ       DMA_STATUS_REG      write only
+DMA_RESERVED_0      rmb       1
+DMA_RESERVED_1      rmb       1
+* Source address.
+DMA_SOURCE_ADDR_L   rmb       1
+DMA_SOURCE_ADDR_M   rmb       1
+DMA_SOURCE_ADDR_H   rmb       1
+DMA_RESERVED_2      rmb       1
+* Destination address.
+DMA_DEST_ADDR_L     rmb       1
+DMA_DEST_ADDR_M     rmb       1
+DMA_DEST_ADDR_H     rmb       1
+DMA_RESERVED_3      rmb       1
+* Size in 1D mode.
+DMA_SIZE_1D_L       rmb       1
+DMA_SIZE_1D_M       rmb       1
+DMA_SIZE_1D_H       rmb       1
+DMA_RESERVED_4      rmb       1
+* Size in 1D mode.
+DMA_SIZE_X_L        equ       DMA_SIZE_1D_L
+DMA_SIZE_X_M        equ       DMA_SIZE_1D_M
+DMA_SIZE_Y_L        equ       DMA_SIZE_1D_H
+DMA_SIZE_Y_H        equ       DMA_RESERVED_4
+* Stride in 2D mode.
+DMA_SRC_STRIDE_X_L  rmb       1
+DMA_SRC_STRIDE_X_H  rmb       1
+DMA_DST_STRIDE_Y_L  rmb       1
+DMA_DST_STRIDE_Y_H  rmb       1
+DMA_RESERVED_5      rmb       1
+DMA_RESERVED_6      rmb       1
+DMA_RESERVED_7      rmb       1
+DMA_RESERVED_8      rmb       1
+
+* DMA_CTRL_REG bit definitions
 DMA_CTRL_Enable     equ       $01
 DMA_CTRL_1D_2D      equ       $02
 DMA_CTRL_Fill       equ       $04
@@ -722,40 +761,7 @@ DMA_CTRL_NotUsed1   equ       $20
 DMA_CTRL_NotUsed2   equ       $40
 DMA_CTRL_Start_Trf  equ       $80
 
-DMA_DATA_2_WRITE    equ       $FEE1               write only
-DMA_STATUS_REG      equ       $FEE1               read only
+* DMA_STATUS_REG bit definitions
 DMA_STATUS_TRF_IP   equ       $80                 transfer in progress
-DMA_RESERVED_0      equ       $FEE2
-DMA_RESERVED_1      equ       $FEE3
 
-; Source addy
-DMA_SOURCE_ADDY_L   equ       $FEE4
-DMA_SOURCE_ADDY_M   equ       $FEE5
-DMA_SOURCE_ADDY_H   equ       $FEE6
-DMA_RESERVED_2      equ       $FEE7
-; Destination Addy
-DMA_DEST_ADDY_L     equ       $FEE8
-DMA_DEST_ADDY_M     equ       $FEE9
-DMA_DEST_ADDY_H     equ       $FEEA
-DMA_RESERVED_3      equ       $FEEB
-; Size in 1D Mode
-DMA_SIZE_1D_L       equ       $FEEC
-DMA_SIZE_1D_M       equ       $FEED
-DMA_SIZE_1D_H       equ       $FEEE
-DMA_RESERVED_4      equ       $FEEF
-; Size in 2D Mode
-DMA_SIZE_X_L        equ       $FEEC
-DMA_SIZE_X_H        equ       $FEED
-DMA_SIZE_Y_L        equ       $FEEE
-DMA_SIZE_Y_H        equ       $FEEF
-; Stride in 2D Mode
-DMA_SRC_STRIDE_X_L  equ       $FEF0
-DMA_SRC_STRIDE_X_H  equ       $FEF1
-DMA_DST_STRIDE_Y_L  equ       $FEF2
-DMA_DST_STRIDE_Y_H  equ       $FEF3
-
-DMA_RESERVED_5      equ       $FEF4
-DMA_RESERVED_6      equ       $FEF5
-DMA_RESERVED_7      equ       $FEF6
-DMA_RESERVED_8      equ       $FEF7
                     endc

--- a/defs/f256.d
+++ b/defs/f256.d
@@ -576,7 +576,7 @@ TILE_LUT2           equ       $08
 TILE_SIZE           equ       $10                 0 -> 16x16, 0 -> 8x8
 
 ;
-;Tile mao layer 0 registers
+;Tile map layer 0 registers
 TL0_CONTROL_REG     equ       $F100               bit[0] - enable, bit[3:1] - LUT select
 TL0_START_ADDY_L    equ       $F101               not used right now - starting address to where is the map
 TL0_START_ADDY_M    equ       $F102

--- a/level1/f256/modules/dwinit_f256.asm
+++ b/level1/f256/modules/dwinit_f256.asm
@@ -1,29 +1,30 @@
 DWInit
 * Initialize the baud rate.
-               lda       UART_LCR
-               ora       #LCR_DLB
-               sta       UART_LCR
-               lda       UART_LCR
+                    ldx       #UART.Base
+                    lda       UART_LCR,x
+                    ora       #LCR_DLB
+                    sta       UART_LCR,x
+                    lda       UART_LCR,x
 
-               lda       #0
-               sta       UART_DLH
+                    lda       #0
+                    sta       UART_DLH,x
 *               lda       #13                 (25.125Mhz / (16 * 115200)) = 13.65 (internal speed of Devices inside FPGA is 25.175Mhz (not 6Mhz))
-               lda       #6                  (25.125Mhz / (16 * 230400)) = 6.82 (internal speed of Devices inside FPGA is 25.175Mhz (not 6Mhz))
-               sta       UART_DLL
+                    lda       #6                  (25.125Mhz / (16 * 230400)) = 6.82 (internal speed of Devices inside FPGA is 25.175Mhz (not 6Mhz))
+                    sta       UART_DLL,x
 
-               lda       UART_LCR
-               eora      #LCR_DLB
-               sta       UART_LCR
+                    lda       UART_LCR,x
+                    eora      #LCR_DLB
+                    sta       UART_LCR,x
 * Initialize serial parameters.
-               lda       #LCR_PARITY_NONE|LCR_STOPBIT_1|LCR_DATABITS_8
-               anda      #0x7F
-               sta       UART_LCR
+                    lda       #LCR_PARITY_NONE|LCR_STOPBIT_1|LCR_DATABITS_8
+                    anda      #0x7F
+                    sta       UART_LCR,x
 
-               lda       #%11000000          ; FIFO Mode is always On and it has only 14Bytes
-               sta       UART_FCR
+                    lda       #%11000000          FIFO mode is always on and it has only 14 Bytes
+                    sta       UART_FCR,x
 * Read until no more data left.
-loop2@         lda       UART_TRHB           read byte from TX/RX holding register
-               lda       UART_LSR            get the LSR register value
-               bita      #LSR_DATA_AVAIL     test for data available
-               bne       loop2@              if available, get byte
-               rts
+loop2@              lda       UART_TRHB,x         read byte from TX/RX holding register
+                    lda       UART_LSR,x          get the LSR register value
+                    bita      #LSR_DATA_AVAIL     test for data available
+                    bne       loop2@              if available, get byte
+                    rts

--- a/level1/f256/modules/dwread_f256.asm
+++ b/level1/f256/modules/dwread_f256.asm
@@ -16,31 +16,31 @@
 *    U is preserved.  All accumulators are clobbered
 *
 
-DWRead         clra                          clear carry (no framing error)
-               clrb
-               pshs      u,x,d,cc            preserve registers
-               orcc      #IntMasks           mask interrupts
-               leau      ,x
-               ldx       #$0000
-loop@          ldd       #$0000              store counter
-               std       1,s
-loop2@         lda       UART_LSR            get the LSR register value
-               bita      #LSR_DATA_AVAIL     test for data available
-               bne       getbyte@            if available, get byte
-               ldd       1,s
-               addb      #$01
-               adca      #$00
-               std       1,s
-               cmpd      #$0000
-               bne       loop2@
-               lda       ,s                  get CC off stack
-               anda      #^$04               clear the Z flag to indicate not all bytes received.
-               sta       ,s
-               bra       bye@
-getbyte@       ldb       UART_TRHB           get the data byte
-               stb       ,u+                 save off acquired byte
-               abx                           update checksum
-               leay      ,-y                 decrement Y
-               bne       loop@               branch if more to obtain
-               leay      ,x                  return checksum in Y
-bye@           puls      cc,d,x,u,pc         restore registers and return
+DWRead              clra                          clear carry (no framing error)
+                    clrb
+                    pshs      u,x,d,cc            preserve registers
+                    orcc      #IntMasks           mask interrupts
+                    leau      ,x
+                    ldx       #$0000
+loop@               ldd       #$0000              store counter
+                    std       1,s
+loop2@              lda       UART.Base+UART_LSR  get the LSR register value
+                    bita      #LSR_DATA_AVAIL     test for data available
+                    bne       getbyte@            if available, get byte
+                    ldd       1,s
+                    addb      #$01
+                    adca      #$00
+                    std       1,s
+                    cmpd      #$0000
+                    bne       loop2@
+                    lda       ,s                  get CC off stack
+                    anda      #^$04               clear the Z flag to indicate not all bytes received.
+                    sta       ,s
+                    bra       bye@
+getbyte@            ldb       UART.Base+UART_TRHB get the data byte
+                    stb       ,u+                 save off acquired byte
+                    abx                           update checksum
+                    leay      ,-y                 decrement Y
+                    bne       loop@               branch if more to obtain
+                    leay      ,x                  return checksum in Y
+bye@                puls      cc,d,x,u,pc         restore registers and return

--- a/level1/f256/modules/dwwrite_f256.asm
+++ b/level1/f256/modules/dwwrite_f256.asm
@@ -1,4 +1,4 @@
-               *******************************************************
+                    *******************************************************
 *
 * DWWrite
 *    Send a packet to the DriveWire server.
@@ -14,13 +14,13 @@
 *    All others preserved
 *
 
-DWWrite        pshs      u,a,cc              preserve registers
-               orcc      #IntMasks           mask interupts
-loop@          lda       UART_LSR            get status register
-               anda      #LSR_XMIT_DONE      is transmit FIFO empty?
-               beq       loop@               branch if not
-               lda       ,x+                 get byte from buffer
-               sta       UART_TRHB           put it to PIA
-               leay      -1,y                decrement byte counter
-               bne       loop@               loop if more to send
-               puls      cc,a,u,pc           restore registers and return
+DWWrite             pshs      u,a,cc              preserve registers
+                    orcc      #IntMasks           mask interupts
+loop@               lda       UART.Base+UART_LSR  get status register
+                    anda      #LSR_XMIT_DONE      is transmit FIFO empty?
+                    beq       loop@               branch if not
+                    lda       ,x+                 get byte from buffer
+                    sta       UART.Base+UART_TRHB put it to PIA
+                    leay      -1,y                decrement byte counter
+                    bne       loop@               loop if more to send
+                    puls      cc,a,u,pc           restore registers and return

--- a/level1/f256/modules/rbfnxsddesc.asm
+++ b/level1/f256/modules/rbfnxsddesc.asm
@@ -77,7 +77,7 @@ SAS                 set       $08
                     use       rbsuper.d
                     use       f256.d
 
-SDAddr              set       SDC_BASE_ADDR
+SDAddr              set       SDC.Base
 
 tylg                set       Devic+Objct
 atrv                set       ReEnt+rev

--- a/level2/modules/kernel/ccbkrn.asm
+++ b/level2/modules/kernel/ccbkrn.asm
@@ -22,26 +22,26 @@
 * F$SRqMem now properly scans the DAT images of the system to update
 * the D.SysMem map.
 
-               nam       krn
-               ttl       NitrOS-9 Level 2 Kernel
+                    nam       krn
+                    ttl       NitrOS-9 Level 2 Kernel
 
-               use       defsfile
+                    use       defsfile
 
 * defines for customizations
-Revision       set       9                   module revision
-Edition        set       19                  module Edition
-Where          equ       $F000               absolute address of where Kernel starts in memory
+Revision            set       9                   module revision
+Edition             set       19                  module Edition
+Where               equ       $F000               absolute address of where Kernel starts in memory
 
-               mod       eom,MName,Systm,ReEnt+Revision,entry,0
+                    mod       eom,MName,Systm,ReEnt+Revision,entry,0
 
-        * CCB Change: module name changes to CCBKrn
-MName          fcs       /CCBKrn/
-               fcb       Edition
+                    *         CCB                 Change: module name changes to CCBKrn
+MName               fcs       /CCBKrn/
+                    fcb       Edition
 
-        * CCB Change: added a automagic "fill" directive
-        * between the end of the kernel module, proper, and the fe page code
-        * see way down. Manually refilling the empty space after each
-        * code change was a pain and error prone.  BG
+                    *         CCB                 Change: added a automagic "fill" directive
+                    *         between             the end of the kernel module, proper, and the fe page code
+                    *         see                 way down. Manually refilling the empty space after each
+                    *         code                change was a pain and error prone.  BG
 
 * FILL - all unused bytes are now here
 *       fcc     /www.nitros9.org /
@@ -60,295 +60,295 @@ MName          fcs       /CCBKrn/
 
 * Might as well have this here as just past the end of Kernel...
 DisTable
-               fdb       L0CD2+Where         D.Clock absolute address at the start
-               fdb       XSWI3+Where         D.XSWI3
-               fdb       XSWI2+Where         D.XSWI2
-               fdb       D.Crash             D.XFIRQ crash on an FIRQ
-               fdb       XIRQ+Where          D.XIRQ
-               fdb       XSWI+Where          D.XSWI
-               fdb       D.Crash             D.XNMI crash on an NMI
-               fdb       $0055               D.ErrRst ??? Not used as far as I can tell
-               fdb       Sys.Vec+Where       Initial Kernel system call vector
-DisSize        equ       *-DisTable
+                    fdb       L0CD2+Where         D.Clock absolute address at the start
+                    fdb       XSWI3+Where         D.XSWI3
+                    fdb       XSWI2+Where         D.XSWI2
+                    fdb       D.Crash             D.XFIRQ crash on an FIRQ
+                    fdb       XIRQ+Where          D.XIRQ
+                    fdb       XSWI+Where          D.XSWI
+                    fdb       D.Crash             D.XNMI crash on an NMI
+                    fdb       $0055               D.ErrRst ??? Not used as far as I can tell
+                    fdb       Sys.Vec+Where       Initial Kernel system call vector
+DisSize             equ       *-DisTable
 * DO NOT ADD ANYTHING BETWEEN THESE 2 TABLES: see code using 'SubSiz', below
-LowSub         equ       $0160               start of low memory subroutines
-SubStrt        equ       *
+LowSub              equ       $0160               start of low memory subroutines
+SubStrt             equ       *
 * D.Flip0 - switch to system task 0
-R.Flip0        equ       *
-               ifne      H6309
-               aim       #$FE,<D.TINIT       map type 0
-               lde       <D.TINIT            another 2 bytes saved if GRFDRV does: tfr cc,e
-               ste       >DAT.Task           and we can use A here, instead of E
-               else
-               pshs      a
-               lda       <D.TINIT
-               anda      #$FE                force TR=0
-               sta       <D.TINIT
-               sta       >DAT.Task
-               puls      a
-               endc
-               clr       <D.SSTskN
-               tfr       x,s
-               tfr       a,cc
-               rts
-SubSiz         equ       *-SubStrt
+R.Flip0             equ       *
+                    ifne      H6309
+                    aim       #$FE,<D.TINIT       map type 0
+                    lde       <D.TINIT            another 2 bytes saved if GRFDRV does: tfr cc,e
+                    ste       >DAT.Task           and we can use A here, instead of E
+                    else
+                    pshs      a
+                    lda       <D.TINIT
+                    anda      #$FE                force TR=0
+                    sta       <D.TINIT
+                    sta       >DAT.Task
+                    puls      a
+                    endc
+                    clr       <D.SSTskN
+                    tfr       x,s
+                    tfr       a,cc
+                    rts
+SubSiz              equ       *-SubStrt
 * Don't add any code here: See L0065, below.
 * Interrupt service routine
-Vectors        jmp       [<-(D.SWI3-D.XSWI3),x] (-$10) (Jmp to 2ndary vector)
+Vectors             jmp       [<-(D.SWI3-D.XSWI3),x] (-$10) (Jmp to 2ndary vector)
 
 * Let's start by initializing system page
-entry          equ       *
-        * CCB Addition - save stacked OS9Boot size and make a dummy kernel printer
-               pulu      d                   pull boot file size from CoCoBoot and
-               std       <D.BtSz             save to direct page for later use
-               inc       <D.Boot             mark boot attempted flag
-               inc       <D.Speed            mark high speed
-               lds       #$1fff              reset system stack (s/b 0x2000 ?!?!)
-               lda       #$7e                put code in DP so rest of kernel can
-               sta       <D.BtBug            call kernel printing routine
-               leax      BtDebug,pc
-               stx       <D.BtBug+1
-               sta       <D.Crash            and do the same with the kernel crash
-               leax      Crash,pc            code
-               stx       <D.Crash+1
-               bra       CCBEND              jump over new kprint & crash routines
+entry               equ       *
+                    *         CCB                 Addition - save stacked OS9Boot size and make a dummy kernel printer
+                    pulu      d                   pull boot file size from CoCoBoot and
+                    std       <D.BtSz             save to direct page for later use
+                    inc       <D.Boot             mark boot attempted flag
+                    inc       <D.Speed            mark high speed
+                    lds       #$1fff              reset system stack (s/b 0x2000 ?!?!)
+                    lda       #$7e                put code in DP so rest of kernel can
+                    sta       <D.BtBug            call kernel printing routine
+                    leax      BtDebug,pc
+                    stx       <D.BtBug+1
+                    sta       <D.Crash            and do the same with the kernel crash
+                    leax      Crash,pc            code
+                    stx       <D.Crash+1
+                    bra       CCBEND              jump over new kprint & crash routines
 
-        * This is a kernel print routine
-        *   This is added to replace the same routine found in "rel.asm"
-        *   so we get debug output.
-        *   Takes A - charactor to print
-        *   modifies - nothing
-BtDebug        pshs      cc,d,x              save the register
-               orcc      #IntMasks           turn IRQ's off
-               ldb       #$3b                block to map in
-               stb       >DAT.Regs           map the boot screen into block 0
-               ldx       >$0002              where to put the bytes
-               sta       ,x+                 put the character on-screen
-               stx       >$0002              save updated address
-               clr       >DAT.Regs           map block 0 in again
-               puls      cc,d,x,pc           restore and return
-        * This routine just prints "!" and loops forever
-Crash          lda       #'!                 print a "!"
-               jsr       <D.BtBug
-e              bra       e                   loop forever
+                    *         This                is a kernel print routine
+                    *         This                is added to replace the same routine found in "rel.asm"
+                    *         so                  we get debug output.
+                    *         Takes               A - charactor to print
+                    *         modifies            - nothing
+BtDebug             pshs      cc,d,x              save the register
+                    orcc      #IntMasks           turn IRQ's off
+                    ldb       #$3b                block to map in
+                    stb       >DAT.Regs           map the boot screen into block 0
+                    ldx       >$0002              where to put the bytes
+                    sta       ,x+                 put the character on-screen
+                    stx       >$0002              save updated address
+                    clr       >DAT.Regs           map block 0 in again
+                    puls      cc,d,x,pc           restore and return
+                    *         This                routine just prints "!" and loops forever
+Crash               lda       #'!                 print a "!"
+                    jsr       <D.BtBug
+e                   bra       e                   loop forever
 CCBEND
-        * end of CCB Addition
+                    *         end                 of CCB Addition
 
-        * This code clears the rest of the low block
-        * rel.asm/cocoboot has cleared the DP already.
-               ifne      H6309
-               ldq       #$01001f00          start address to clear & # bytes to clear
-               leay      <entry+2,pc         point to a 0
-               tfm       y,d+
-               std       <D.CCStk            set pointer to top of global memory to $2000
-               lda       #$01                set task user table to $0100
-               else
-               ldx       #$100
-               ldy       #$2000-$100
-               clra
-               clrb
-L001C          std       ,x++
-               leay      -2,y
-               bne       L001C
-               stx       <D.CCStk            Set pointer to top of global memory to $2000
-               inca                          D = $0100
-               endc
+                    *         This                code clears the rest of the low block
+                    *         rel.asm/cocoboot    has cleared the DP already.
+                    ifne      H6309
+                    ldq       #$01001f00          start address to clear & # bytes to clear
+                    leay      <entry+2,pc         point to a 0
+                    tfm       y,d+
+                    std       <D.CCStk            set pointer to top of global memory to $2000
+                    lda       #$01                set task user table to $0100
+                    else
+                    ldx       #$100
+                    ldy       #$2000-$100
+                    clra
+                    clrb
+L001C               std       ,x++
+                    leay      -2,y
+                    bne       L001C
+                    stx       <D.CCStk            Set pointer to top of global memory to $2000
+                    inca                          D = $0100
+                    endc
 
 * Setup system direct page variables
-               std       <D.Tasks            set Task Structure pointer to 0x100
-               addb      #$20                set Task image table pointer to $0120
-               std       <D.TskIPt
-               clrb                          set memory block map pointer to $0200
-               inca
-               std       <D.BlkMap
-               addb      #$40                set second block map pointer to $0240
-               std       <D.BlkMap+2
-               clrb                          set system service dispatch table
-               inca                          pointer to 0x300
-               std       <D.SysDis
-               inca                          set user dispatch table pointer to $0400
-               std       <D.UsrDis
-               inca                          set process descriptor block pointer to $0500
-               std       <D.PrcDBT
-               inca                          set system process descriptor pointer to $0600
-               std       <D.SysPrc
-               std       <D.Proc             set user process descriptor pointer to $0600
-               adda      #$02                set stack pointer to $0800
-               tfr       d,s
-               inca                          set system stack base pointer to $0900
-               std       <D.SysStk
-               std       <D.SysMem           set system memory map ptr $0900
-               inca                          set module directory start ptr to $0a00
-               std       <D.ModDir
-               std       <D.ModEnd           set module directory end ptr to $0a00
-               adda      #$06                set secondary module directory start to $1000
-               std       <D.ModDir+2
-               std       <D.ModDAT           set module directory DAT pointer to $1000
-               std       <D.CCMem            set pointer to beginning of global memory to $1000
+                    std       <D.Tasks            set Task Structure pointer to 0x100
+                    addb      #$20                set Task image table pointer to $0120
+                    std       <D.TskIPt
+                    clrb                          set memory block map pointer to $0200
+                    inca
+                    std       <D.BlkMap
+                    addb      #$40                set second block map pointer to $0240
+                    std       <D.BlkMap+2
+                    clrb                          set system service dispatch table
+                    inca                          pointer to 0x300
+                    std       <D.SysDis
+                    inca                          set user dispatch table pointer to $0400
+                    std       <D.UsrDis
+                    inca                          set process descriptor block pointer to $0500
+                    std       <D.PrcDBT
+                    inca                          set system process descriptor pointer to $0600
+                    std       <D.SysPrc
+                    std       <D.Proc             set user process descriptor pointer to $0600
+                    adda      #$02                set stack pointer to $0800
+                    tfr       d,s
+                    inca                          set system stack base pointer to $0900
+                    std       <D.SysStk
+                    std       <D.SysMem           set system memory map ptr $0900
+                    inca                          set module directory start ptr to $0a00
+                    std       <D.ModDir
+                    std       <D.ModEnd           set module directory end ptr to $0a00
+                    adda      #$06                set secondary module directory start to $1000
+                    std       <D.ModDir+2
+                    std       <D.ModDAT           set module directory DAT pointer to $1000
+                    std       <D.CCMem            set pointer to beginning of global memory to $1000
 * In following line, CRC=ON if it is STA <D.CRC, CRC=OFF if it is a STB <D.CRC
-               stb       <D.CRC              set CRC checking flag to off
+                    stb       <D.CRC              set CRC checking flag to off
 
 * Initialize interrupt vector tables, move pointer data down to DP
 * CCB Change:
 * this line was an error?
 *       leay    <DisTable,pcr
-               leay      DisTable,pcr        point to table of absolute vector addresses
+                    leay      DisTable,pcr        point to table of absolute vector addresses
 *
 *
-               ldx       #D.Clock            where to put it in memory
-               ifne      H6309
-               ldf       #DisSize            size of the table - E=0 from TFM, above
-               tfm       y+,x+               move it over
-               else
-               ldb       #DisSize
+                    ldx       #D.Clock            where to put it in memory
+                    ifne      H6309
+                    ldf       #DisSize            size of the table - E=0 from TFM, above
+                    tfm       y+,x+               move it over
+                    else
+                    ldb       #DisSize
 l@
-               lda       ,y+                 load a byte from source
-               sta       ,x+                 store a byte to dest
-               decb                          bump counter
-               bne       l@                  loop if we're not done
-               endc
+                    lda       ,y+                 load a byte from source
+                    sta       ,x+                 store a byte to dest
+                    decb                          bump counter
+                    bne       l@                  loop if we're not done
+                    endc
 
 * initialize D.Flip0 routine in low memory, move function down to low
 * memory.
 * Y=ptr to R.Flip0 already
 *         leay  >R.Flip0,pc
-               ldu       #LowSub             move to 0x160
-               stu       <D.Flip0            store fuction pointer to DP area
-               ifne      H6309
-               ldf       #SubSiz             size of it
-               tfm       y+,u+               copy it over
-               else
-               ldb       #SubSiz
-Loop2          lda       ,y+                 load a byte from source
-               sta       ,u+                 and save to destination
-               decb                          bump counter
-               bne       Loop2               loop if not done
-               endc
+                    ldu       #LowSub             move to 0x160
+                    stu       <D.Flip0            store fuction pointer to DP area
+                    ifne      H6309
+                    ldf       #SubSiz             size of it
+                    tfm       y+,u+               copy it over
+                    else
+                    ldb       #SubSiz
+Loop2               lda       ,y+                 load a byte from source
+                    sta       ,u+                 and save to destination
+                    decb                          bump counter
+                    bne       Loop2               loop if not done
+                    endc
 
 *         leau   <Vectors,pc   point to vector
 * fill in the secondard interrupt vectors to all point to
-               tfr       y,u                 move the pointer to a faster register
-L0065          stu       ,x++                Set all IRQ vectors to go to Vectors for now
-               cmpx      #D.NMI
-               bls       L0065
+                    tfr       y,u                 move the pointer to a faster register
+L0065               stu       ,x++                Set all IRQ vectors to go to Vectors for now
+                    cmpx      #D.NMI
+                    bls       L0065
 
 * Initialize user interupt vectors
-               ldx       <D.XSWI2            Get SWI2 (os9 command) service routine pointer
-               stx       <D.UsrSvc           Save it as user service routine pointer
-               ldx       <D.XIRQ             Get IRQ service routine pointer
-               stx       <D.UsrIRQ           Save it as user IRQ routine pointer
+                    ldx       <D.XSWI2            Get SWI2 (os9 command) service routine pointer
+                    stx       <D.UsrSvc           Save it as user service routine pointer
+                    ldx       <D.XIRQ             Get IRQ service routine pointer
+                    stx       <D.UsrIRQ           Save it as user IRQ routine pointer
 
-               leax      >SysCall,pc         Setup System service routine entry vector
-               stx       <D.SysSvc
-               stx       <D.XSWI2
+                    leax      >SysCall,pc         Setup System service routine entry vector
+                    stx       <D.SysSvc
+                    stx       <D.XSWI2
 
-               leax      >S.SysIRQ,pc        Setup system IRQ service vector
-               stx       <D.SysIRQ
-               stx       <D.XIRQ
+                    leax      >S.SysIRQ,pc        Setup system IRQ service vector
+                    stx       <D.SysIRQ
+                    stx       <D.XIRQ
 
-               leax      >S.SvcIRQ,pc        Setup in system IRQ service vector
-               stx       <D.SvcIRQ
-               leax      >S.Poll,pc          Setup interrupt polling vector
-               stx       <D.Poll             ORCC #$01;RTS
-               leax      >S.AltIRQ,pc        Setup alternate IRQ vector: pts to an RTS
-               stx       <D.AltIRQ
+                    leax      >S.SvcIRQ,pc        Setup in system IRQ service vector
+                    stx       <D.SvcIRQ
+                    leax      >S.Poll,pc          Setup interrupt polling vector
+                    stx       <D.Poll             ORCC #$01;RTS
+                    leax      >S.AltIRQ,pc        Setup alternate IRQ vector: pts to an RTS
+                    stx       <D.AltIRQ
 
-               lda       #'K                 --- in Kernel
-               jsr       <D.BtBug            ---
+                    lda       #'K                 --- in Kernel
+                    jsr       <D.BtBug            ---
 
-               leax      >S.Flip1,pc         Setup change to task 1 vector
-               stx       <D.Flip1
+                    leax      >S.Flip1,pc         Setup change to task 1 vector
+                    stx       <D.Flip1
 
 * Setup System calls
-               leay      >SysCalls,pc        load y with address of table, below
-               lbsr      InstallSvc          copy table below into dispatch table
+                    leay      >SysCalls,pc        load y with address of table, below
+                    lbsr      InstallSvc          copy table below into dispatch table
 
 * Initialize system process descriptor
-               ldu       <D.PrcDBT           get process table pointer
-               ldx       <D.SysPrc           get system process pointer
+                    ldu       <D.PrcDBT           get process table pointer
+                    ldx       <D.SysPrc           get system process pointer
 
 * These overlap because it is quicker than trying to strip hi byte from X
-               stx       ,u                  save it as first process in table
-               stx       1,u                 save it as the second as well
-               ifne      H6309
-               oim       #$01,P$ID,x         Set process ID to 1 (inited to 0)
-               oim       #SysState,P$State,x Set to system state (inited to 0)
-               else
-               ldd       #$01*256+SysState
-               sta       P$ID,x              set PID to 1
-               stb       P$State,x           set state to system (*NOT* zero )
-               endc
-               clra                          set System task as task #0
-               sta       <D.SysTsk
-               sta       P$Task,x
-               coma                          Setup its priority & age ($FF)
-               sta       P$Prior,x
-               sta       P$Age,x
-               leax      <P$DATImg,x         point to DAT image
-               stx       <D.SysDAT           save it as a pointer in DP
+                    stx       ,u                  save it as first process in table
+                    stx       1,u                 save it as the second as well
+                    ifne      H6309
+                    oim       #$01,P$ID,x         Set process ID to 1 (inited to 0)
+                    oim       #SysState,P$State,x Set to system state (inited to 0)
+                    else
+                    ldd       #$01*256+SysState
+                    sta       P$ID,x              set PID to 1
+                    stb       P$State,x           set state to system (*NOT* zero )
+                    endc
+                    clra                          set System task as task #0
+                    sta       <D.SysTsk
+                    sta       P$Task,x
+                    coma                          Setup its priority & age ($FF)
+                    sta       P$Prior,x
+                    sta       P$Age,x
+                    leax      <P$DATImg,x         point to DAT image
+                    stx       <D.SysDAT           save it as a pointer in DP
 * actually, since block 0 is tfm'd to be zero, we can skip the next 2 lines
-               ifne      H6309
-               clrd
-               else
-               clra
-               clrb
-               endc
-               std       ,x++                initialize 1st block to 0 (for this DP)
+                    ifne      H6309
+                    clrd
+                    else
+                    clra
+                    clrb
+                    endc
+                    std       ,x++                initialize 1st block to 0 (for this DP)
 
 * Dat.BlCt-ROMCount-RAMCount
-               lda       #$06                initialize the rest of the blocks to be free
-               ldu       #DAT.Free
-L00EF          stu       ,x++                store free "flag"
-               deca                          bump counter
-               bne       L00EF               loop if not done
+                    lda       #$06                initialize the rest of the blocks to be free
+                    ldu       #DAT.Free
+L00EF               stu       ,x++                store free "flag"
+                    deca                          bump counter
+                    bne       L00EF               loop if not done
 
-               ldu       #KrnBlk             Block where the kernel will live
-               stu       ,x
+                    ldu       #KrnBlk             Block where the kernel will live
+                    stu       ,x
 
-               ldx       <D.Tasks            Point to task user table
-               inc       ,x                  mark first 2 in use (system & GrfDrv)
-               inc       1,x
+                    ldx       <D.Tasks            Point to task user table
+                    inc       ,x                  mark first 2 in use (system & GrfDrv)
+                    inc       1,x
 
 * Setup system memory map
-               ldx       <D.SysMem           Get system memory map pointer
-               ldb       <D.CCStk            Get MSB of top of CC memory
-L0104          inc       ,x+                 Mark it as used
-               decb                          Done?
-               bne       L0104               No, go back till done
+                    ldx       <D.SysMem           Get system memory map pointer
+                    ldb       <D.CCStk            Get MSB of top of CC memory
+L0104               inc       ,x+                 Mark it as used
+                    decb                          Done?
+                    bne       L0104               No, go back till done
 
 * Calculate memory size
-        * CCB Comment:
-        * This code only modifies 2 bytes in the x0 blocks (x=doesn't cares)
-        * which at worst will be our DP. Should not effect CCB's prior load of
-        * OS9Boot it can only be loaded into block x1 through x6 and 3f so
-        * we should be safe.
-               ldx       <D.BlkMap           get ptr to 8k block map
-               inc       <KrnBlk,x           mark block holding kernel as used
-               ifne      H6309
-               ldq       #$00080100          e=Marker, D=Block # to check
-L0111          asld                          get next block #
-               stb       >DAT.Regs+5         Map block into block 6 of my task
-               ste       >-$6000,x           save marker to that block
-               cmpe      ,x                  did it ghost to block 0?
-               bne       L0111               No, keep going till ghost is found
-               stb       <D.MemSz            Save # 8k mem blocks that exist
-               addr      x,d                 add number of blocks to block map start
-               else
-               ldd       #$0008
-L0111          aslb
-               rola
-               stb       >DAT.Regs+5
-               pshs      a
-               lda       #$01
-               sta       >-$6000,x
-               cmpa      ,x
-               puls      a
-               bne       L0111
-               stb       <D.MemSz
-               pshs      x
-               addd      ,s++
-               endc
-               std       <D.BlkMap+2         save block map end pointer
+                    *         CCB                 Comment:
+                    *         This                code only modifies 2 bytes in the x0 blocks (x=doesn't cares)
+                    *         which               at worst will be our DP. Should not effect CCB's prior load of
+                    *         OS9Boot             it can only be loaded into block x1 through x6 and 3f so
+                    *         we                  should be safe.
+                    ldx       <D.BlkMap           get ptr to 8k block map
+                    inc       <KrnBlk,x           mark block holding kernel as used
+                    ifne      H6309
+                    ldq       #$00080100          e=Marker, D=Block # to check
+L0111               asld                          get next block #
+                    stb       >DAT.Regs+5         Map block into block 6 of my task
+                    ste       >-$6000,x           save marker to that block
+                    cmpe      ,x                  did it ghost to block 0?
+                    bne       L0111               No, keep going till ghost is found
+                    stb       <D.MemSz            Save # 8k mem blocks that exist
+                    addr      x,d                 add number of blocks to block map start
+                    else
+                    ldd       #$0008
+L0111               aslb
+                    rola
+                    stb       >DAT.Regs+5
+                    pshs      a
+                    lda       #$01
+                    sta       >-$6000,x
+                    cmpa      ,x
+                    puls      a
+                    bne       L0111
+                    stb       <D.MemSz
+                    pshs      x
+                    addd      ,s++
+                    endc
+                    std       <D.BlkMap+2         save block map end pointer
 
 * [D] at this point will contain 1 of the following:
 * $0210 - 128k
@@ -356,18 +356,18 @@ L0111          aslb
 * $0240 - 512k
 * $0280 - 1024k
 * $0300 - 2048k
-               bitb      #%00110000          block above 128K-256K?
-               beq       L0170               yes, no need to mark block map
-               tstb                          2 meg?
-               beq       L0170               yes, skip this
+                    bitb      #%00110000          block above 128K-256K?
+                    beq       L0170               yes, no need to mark block map
+                    tstb                          2 meg?
+                    beq       L0170               yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
-               abx                           add maximum block number to block map start
-               leax      -1,x                Skip good blocks that are RAM
-               lda       #NotRAM             Not RAM flag
-               subb      #$3F                Calculate # blocks to mark as not RAM
-L0127          sta       ,x+                 Mark them all
-               decb
-               bne       L0127
+                    abx                           add maximum block number to block map start
+                    leax      -1,x                Skip good blocks that are RAM
+                    lda       #NotRAM             Not RAM flag
+                    subb      #$3F                Calculate # blocks to mark as not RAM
+L0127               sta       ,x+                 Mark them all
+                    decb
+                    bne       L0127
 
 L0170
 * CCB - Commented out next two line. we don't have REL or BOOT, so the verify will be only
@@ -381,63 +381,63 @@ L0170
 *       lbsr    I.VBlock        go verify it
 *       bsr     L01D2           go mark system map
 * CCB Change - I'm commenting out this whole section, and replacing it
-               ifeq      1
+                    ifeq      1
 * See if init module is in memory already
-L01B0          leax      <init,pc            point to 'Init' module name
-               bsr       link                try & link it
-               bcc       L01BF               no error, go on
-L01B8          os9       F$Boot              error linking init, try & load boot file
-               bcc       L01B0               got it, try init again
-               bra       L01CE               error, re-booting do D.Crash
-L01BF          stu       <D.Init             Save init module pointer
-               lda       Feature1,u          Get feature byte #1 from init module
-               bita      #CRCOn              CRC feature on?
-               beq       ShowI               if not, continue
-               inc       <D.CRC              else inc. CRC flag
-ShowI          lda       #'i                 found init module
-               jsr       <D.BtBug
+L01B0               leax      <init,pc            point to 'Init' module name
+                    bsr       link                try & link it
+                    bcc       L01BF               no error, go on
+L01B8               os9       F$Boot              error linking init, try & load boot file
+                    bcc       L01B0               got it, try init again
+                    bra       L01CE               error, re-booting do D.Crash
+L01BF               stu       <D.Init             Save init module pointer
+                    lda       Feature1,u          Get feature byte #1 from init module
+                    bita      #CRCOn              CRC feature on?
+                    beq       ShowI               if not, continue
+                    inc       <D.CRC              else inc. CRC flag
+ShowI               lda       #'i                 found init module
+                    jsr       <D.BtBug
 
-L01C1          leax      <krnp2,pc           Point to it's name
-               bsr       link                Try to link it
-               bcc       L01D0               It worked, execute it
-               os9       F$Boot              It doesn't exist try re-booting
-               bcc       L01C1               No error's, let's try to link it again
-L01CE          jmp       <D.Crash            obviously can't do it, crash machine
-L01D0          jmp       ,y                  execute krnp2
-               endc
+L01C1               leax      <krnp2,pc           Point to it's name
+                    bsr       link                Try to link it
+                    bcc       L01D0               It worked, execute it
+                    os9       F$Boot              It doesn't exist try re-booting
+                    bcc       L01C1               No error's, let's try to link it again
+L01CE               jmp       <D.Crash            obviously can't do it, crash machine
+L01D0               jmp       ,y                  execute krnp2
+                    endc
 
 * CCB we'll replace above with this:
-               ldd       <D.BtSz             get the size of OS9Boot file
-               addd      #$fff               add size of krn and round to higher size
-               clrb
-               pshs      d                   save on stack
-               os9       F$SRqMem            get memory - U is our starting address
-               stu       <D.BtPtr            save this just incase something uses it
-               tfr       u,x                 setup x for vblock
-               puls      d                   setup d for vblock with stacked size
-               lbsr      I.VBlock            verify OS9Boot
-        * this was copied from f$boot
-        * I dont know why we need to do this.  Wouldn't
-        * f$srqmem do this for us?!?!  But the system won't boot without.
-               ldx       <D.SysDAT           get system DAT pointer
-               ldb       $0D,x               get highest allocated block number
-               incb                          allocate block 0, too
-               ldx       <D.BlkMap           point to the memory block map
-               bsr       L01DF               and go mark the blocks as used
-        * end of copy from f$boot
-               leax      <init,pc            point to 'Init' module name
-               bsr       link                try & link it
-L01BF          stu       <D.Init             Save init module pointer
-               lda       Feature1,u          Get feature byte #1 from init module
-               bita      #CRCOn              CRC feature on?
+                    ldd       <D.BtSz             get the size of OS9Boot file
+                    addd      #$fff               add size of krn and round to higher size
+                    clrb
+                    pshs      d                   save on stack
+                    os9       F$SRqMem            get memory - U is our starting address
+                    stu       <D.BtPtr            save this just incase something uses it
+                    tfr       u,x                 setup x for vblock
+                    puls      d                   setup d for vblock with stacked size
+                    lbsr      I.VBlock            verify OS9Boot
+                    *         this                was copied from f$boot
+                    *         I                   dont know why we need to do this.  Wouldn't
+                    *         f$srqmem            do this for us?!?!  But the system won't boot without.
+                    ldx       <D.SysDAT           get system DAT pointer
+                    ldb       $0D,x               get highest allocated block number
+                    incb                          allocate block 0, too
+                    ldx       <D.BlkMap           point to the memory block map
+                    bsr       L01DF               and go mark the blocks as used
+                    *         end                 of copy from f$boot
+                    leax      <init,pc            point to 'Init' module name
+                    bsr       link                try & link it
+L01BF               stu       <D.Init             Save init module pointer
+                    lda       Feature1,u          Get feature byte #1 from init module
+                    bita      #CRCOn              CRC feature on?
 *       beq     ShowI           if not, continue
-               inc       <D.CRC              else inc. CRC flag
-ShowI          lda       #'i                 found init module
-               jsr       <D.BtBug
-L01C1          leax      <krnp2,pc           Point to it's name
-               bsr       link                Try to link it
+                    inc       <D.CRC              else inc. CRC flag
+ShowI               lda       #'i                 found init module
+                    jsr       <D.BtBug
+L01C1               leax      <krnp2,pc           Point to it's name
+                    bsr       link                Try to link it
 *e      bra     e
-L01D0          jmp       ,y                  execute krnp2
+L01D0               jmp       ,y                  execute krnp2
 
 
 * CCB - End of change
@@ -448,7 +448,7 @@ L01D0          jmp       ,y                  execute krnp2
 *       * CCB Change - only mark KRN as used (BOOT and REL don't exist)
 *       ldd     #NotRAM*256+(Bt.Start/256)      B = MSB of start of the boot
 *       ldd     #NotRam*256+(Where/256)         B = MSB of start of REL
-        * CCB Change end
+                    *         CCB                 Change end
 *       abx                     point to Bt.Start - start of boot track
 *       comb                    we have $FF-$ED pages to mark as used
 *       sta     b,x             Mark I/O as not RAM
@@ -456,398 +456,398 @@ L01D0          jmp       ,y                  execute krnp2
 * Mark kernel and boot file in system memory as used - there is no
 * reason this is a routine anymore - only one place calls it, but
 * some speghetti is here... one of the IRQ routines "borrows" this rts.
-L01DF          lda       #RAMinUse           get in use flag
-L01E1          sta       ,x+                 save it
-               decb                          done?
-               bne       L01E1               no, keep going
-               ldx       <D.BlkMap           get pointer to start of block map
-               sta       <KrnBlk,x           mark kernel block as RAMinUse, instead of ModInBlk
-S.AltIRQ       rts                           return
+L01DF               lda       #RAMinUse           get in use flag
+L01E1               sta       ,x+                 save it
+                    decb                          done?
+                    bne       L01E1               no, keep going
+                    ldx       <D.BlkMap           get pointer to start of block map
+                    sta       <KrnBlk,x           mark kernel block as RAMinUse, instead of ModInBlk
+S.AltIRQ            rts                           return
 
 * Link module pointed to by X
-link           lda       #Systm              Attempt to link system module
-               os9       F$Link
-               rts
+link                lda       #Systm              Attempt to link system module
+                    os9       F$Link
+                    rts
 
-init           fcs       'Init'
-krnp2          fcs       'krnp2'
+init                fcs       'Init'
+krnp2               fcs       'krnp2'
 
 * Service vector call pointers
-SysCalls       fcb       F$Link
-               fdb       FLink-*-2
-               fcb       F$PrsNam
-               fdb       FPrsNam-*-2
-               fcb       F$CmpNam
-               fdb       FCmpNam-*-2
-               fcb       F$CmpNam+SysState
-               fdb       FSCmpNam-*-2
-               fcb       F$CRC
-               fdb       FCRC-*-2
-               fcb       F$SRqMem+SysState
-               fdb       FSRqMem-*-2
-               fcb       F$SRtMem+SysState
-               fdb       FSRtMem-*-2
-               fcb       F$AProc+SysState
-               fdb       FAProc-*-2
-               fcb       F$NProc+SysState
-               fdb       FNProc-*-2
-               fcb       F$VModul+SysState
-               fdb       FVModul-*-2
-               fcb       F$SSvc+SysState
-               fdb       FSSvc-*-2
-               fcb       F$SLink+SysState
-               fdb       FSLink-*-2
-               fcb       F$Boot+SysState
-               fdb       FBoot-*-2
-               fcb       F$BtMem+SysState
-               fdb       FSRqMem-*-2
-               ifne      H6309
-               fcb       F$CpyMem
-               fdb       FCpyMem-*-2
-               endc
-               fcb       F$Move+SysState
-               fdb       FMove-*-2
-               fcb       F$AllImg+SysState
-               fdb       FAllImg-*-2
-               fcb       F$SetImg+SysState
-               fdb       FFreeLB-*-2
-               fcb       F$FreeLB+SysState
-               fdb       FSFreeLB-*-2
-               fcb       F$FreeHB+SysState
-               fdb       FFreeHB-*-2
-               fcb       F$AllTsk+SysState
-               fdb       FAllTsk-*-2
-               fcb       F$DelTsk+SysState
-               fdb       FDelTsk-*-2
-               fcb       F$SetTsk+SysState
-               fdb       FSetTsk-*-2
-               fcb       F$ResTsk+SysState
-               fdb       FResTsk-*-2
-               fcb       F$RelTsk+SysState
-               fdb       FRelTsk-*-2
-               fcb       F$DATLog+SysState
-               fdb       FDATLog-*-2
-               fcb       F$LDAXY+SysState
-               fdb       FLDAXY-*-2
-               fcb       F$LDDDXY+SysState
-               fdb       FLDDDXY-*-2
-               fcb       F$LDABX+SysState
-               fdb       FLDABX-*-2
-               fcb       F$STABX+SysState
-               fdb       FSTABX-*-2
-               fcb       F$ELink+SysState
-               fdb       FELink-*-2
-               fcb       F$FModul+SysState
-               fdb       FFModul-*-2
-               fcb       F$VBlock+SysState
-               fdb       FVBlock-*-2
-               ifne      H6309
-               fcb       F$DelRAM
-               fdb       FDelRAM-*-2
-               endc
-               fcb       $80
+SysCalls            fcb       F$Link
+                    fdb       FLink-*-2
+                    fcb       F$PrsNam
+                    fdb       FPrsNam-*-2
+                    fcb       F$CmpNam
+                    fdb       FCmpNam-*-2
+                    fcb       F$CmpNam+SysState
+                    fdb       FSCmpNam-*-2
+                    fcb       F$CRC
+                    fdb       FCRC-*-2
+                    fcb       F$SRqMem+SysState
+                    fdb       FSRqMem-*-2
+                    fcb       F$SRtMem+SysState
+                    fdb       FSRtMem-*-2
+                    fcb       F$AProc+SysState
+                    fdb       FAProc-*-2
+                    fcb       F$NProc+SysState
+                    fdb       FNProc-*-2
+                    fcb       F$VModul+SysState
+                    fdb       FVModul-*-2
+                    fcb       F$SSvc+SysState
+                    fdb       FSSvc-*-2
+                    fcb       F$SLink+SysState
+                    fdb       FSLink-*-2
+                    fcb       F$Boot+SysState
+                    fdb       FBoot-*-2
+                    fcb       F$BtMem+SysState
+                    fdb       FSRqMem-*-2
+                    ifne      H6309
+                    fcb       F$CpyMem
+                    fdb       FCpyMem-*-2
+                    endc
+                    fcb       F$Move+SysState
+                    fdb       FMove-*-2
+                    fcb       F$AllImg+SysState
+                    fdb       FAllImg-*-2
+                    fcb       F$SetImg+SysState
+                    fdb       FSetImg-*-2
+                    fcb       F$FreeLB+SysState
+                    fdb       FSFreeLB-*-2
+                    fcb       F$FreeHB+SysState
+                    fdb       FFreeHB-*-2
+                    fcb       F$AllTsk+SysState
+                    fdb       FAllTsk-*-2
+                    fcb       F$DelTsk+SysState
+                    fdb       FDelTsk-*-2
+                    fcb       F$SetTsk+SysState
+                    fdb       FSetTsk-*-2
+                    fcb       F$ResTsk+SysState
+                    fdb       FResTsk-*-2
+                    fcb       F$RelTsk+SysState
+                    fdb       FRelTsk-*-2
+                    fcb       F$DATLog+SysState
+                    fdb       FDATLog-*-2
+                    fcb       F$LDAXY+SysState
+                    fdb       FLDAXY-*-2
+                    fcb       F$LDDDXY+SysState
+                    fdb       FLDDDXY-*-2
+                    fcb       F$LDABX+SysState
+                    fdb       FLDABX-*-2
+                    fcb       F$STABX+SysState
+                    fdb       FSTABX-*-2
+                    fcb       F$ELink+SysState
+                    fdb       FELink-*-2
+                    fcb       F$FModul+SysState
+                    fdb       FFModul-*-2
+                    fcb       F$VBlock+SysState
+                    fdb       FVBlock-*-2
+                    ifne      H6309
+                    fcb       F$DelRAM
+                    fdb       FDelRAM-*-2
+                    endc
+                    fcb       $80
 
 * SWI3 vector entry
-XSWI3          lda       #P$SWI3             point to SWI3 vector
-               fcb       $8C                 skip 2 bytes
+XSWI3               lda       #P$SWI3             point to SWI3 vector
+                    fcb       $8C                 skip 2 bytes
 
 * SWI vector entry
-XSWI           lda       #P$SWI              point to SWI vector
-               ldx       <D.Proc             get process pointer
-               ldu       a,x                 user defined SWI[x]?
-               beq       L028E               no, go get option byte
-GoUser         lbra      L0E5E               Yes, go call users's routine
+XSWI                lda       #P$SWI              point to SWI vector
+                    ldx       <D.Proc             get process pointer
+                    ldu       a,x                 user defined SWI[x]?
+                    beq       L028E               no, go get option byte
+GoUser              lbra      L0E5E               Yes, go call users's routine
 
 * SWI2 vector entry
-XSWI2          ldx       <D.Proc             get current process descriptor
-               ldu       P$SWI2,x            any SWI vector?
-               bne       GoUser              yes, go execute it
+XSWI2               ldx       <D.Proc             get current process descriptor
+                    ldu       P$SWI2,x            any SWI vector?
+                    bne       GoUser              yes, go execute it
 
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-L028E          ldu       <D.SysSvc           set system call processor to system side
-               stu       <D.XSWI2
-               ldu       <D.SysIRQ           do the same thing for IRQ's
-               stu       <D.XIRQ
-               ifne      H6309
-               oim       #SysState,P$State,x mark process as in system state
-               else
-               lda       P$State,x
-               ora       #SysState
-               sta       P$State,x
-               endc
+L028E               ldu       <D.SysSvc           set system call processor to system side
+                    stu       <D.XSWI2
+                    ldu       <D.SysIRQ           do the same thing for IRQ's
+                    stu       <D.XIRQ
+                    ifne      H6309
+                    oim       #SysState,P$State,x mark process as in system state
+                    else
+                    lda       P$State,x
+                    ora       #SysState
+                    sta       P$State,x
+                    endc
 * copy register stack to process descriptor
-               sts       P$SP,x              save stack pointer
-               leas      (P$Stack-R$Size),x  point S to register stack destination
+                    sts       P$SP,x              save stack pointer
+                    leas      (P$Stack-R$Size),x  point S to register stack destination
 
-               ifne      H6309
-               leau      R$Size-1,s          point to last byte of destination register stack
-               leay      -1,y                point to caller's register stack in $FEE1
-               ldw       #R$Size             size of the register stack
-               tfm       y-,u-
-               leau      ,s                  needed because the TFM is u-, not -u (post, not pre)
-               else
+                    ifne      H6309
+                    leau      R$Size-1,s          point to last byte of destination register stack
+                    leay      -1,y                point to caller's register stack in $FEE1
+                    ldw       #R$Size             size of the register stack
+                    tfm       y-,u-
+                    leau      ,s                  needed because the TFM is u-, not -u (post, not pre)
+                    else
 * Note!  R$Size MUST BE an EVEN number of bytes for this to work!
-               leau      R$Size,s            point to last byte of destination register stack
-               lda       #R$Size/2
-Loop3          ldx       ,--y
-               stx       ,--u
-               deca
-               bne       Loop3
-               endc
-               andcc     #^IntMasks
+                    leau      R$Size,s            point to last byte of destination register stack
+                    lda       #R$Size/2
+Loop3               ldx       ,--y
+                    stx       ,--u
+                    deca
+                    bne       Loop3
+                    endc
+                    andcc     #^IntMasks
 * B=function code already from calling process: DON'T USE IT!
-               ldx       R$PC,u              get where PC was from process
-               leax      1,x                 move PC past option
-               stx       R$PC,u              save updated PC to process
+                    ldx       R$PC,u              get where PC was from process
+                    leax      1,x                 move PC past option
+                    stx       R$PC,u              save updated PC to process
 * execute function call
-               ldy       <D.UsrDis           get user dispatch table pointer
-               lbsr      L033B               go execute option
-               ifne      H6309
-               aim       #^IntMasks,R$CC,u   Clear interrupt flags in caller's CC
-               else
-               lda       R$CC,u
-               anda      #^IntMasks
-               sta       R$CC,u
-               endc
-               ldx       <D.Proc             get current process ptr
-               ifne      H6309
-               aim       #^(SysState+TimOut),P$State,x Clear system & timeout flags
-               else
-               lda       P$State,x
-               anda      #^(SysState+TimOut)
-               sta       P$State,x
-               endc
+                    ldy       <D.UsrDis           get user dispatch table pointer
+                    lbsr      L033B               go execute option
+                    ifne      H6309
+                    aim       #^IntMasks,R$CC,u   Clear interrupt flags in caller's CC
+                    else
+                    lda       R$CC,u
+                    anda      #^IntMasks
+                    sta       R$CC,u
+                    endc
+                    ldx       <D.Proc             get current process ptr
+                    ifne      H6309
+                    aim       #^(SysState+TimOut),P$State,x Clear system & timeout flags
+                    else
+                    lda       P$State,x
+                    anda      #^(SysState+TimOut)
+                    sta       P$State,x
+                    endc
 
 * Check for image change now, which lets stuff like F$MapBlk and F$ClrBlk
 * do the short-circuit thing, too.  Adds about 20 cycles to each system call.
-               lbsr      TstImg              it doesn't hurt to call this twice
-               lda       P$State,x           get current state of the process
-               ora       <P$Signal,x         is there a pending signal?
-               sta       <D.Quick            save quick return flag
-               beq       AllClr              if nothing's have changed, do full checks
+                    lbsr      TstImg              it doesn't hurt to call this twice
+                    lda       P$State,x           get current state of the process
+                    ora       <P$Signal,x         is there a pending signal?
+                    sta       <D.Quick            save quick return flag
+                    beq       AllClr              if nothing's have changed, do full checks
 
-DoFull         bsr       L02DA               move the stack frame back to user state
-               lbra      L0D80               go back to the process
+DoFull              bsr       L02DA               move the stack frame back to user state
+                    lbra      L0D80               go back to the process
 
 * add ldu P$SP,x, etc...
-AllClr         equ       *
-               ifne      H6309
-               inc       <D.QCnt
-               aim       #$1F,<D.QCnt
-               beq       DoFull              every 32 system calls, do the full check
-               ldw       #R$Size             --- size of the register stack
-               ldy       #Where+SWIStack     --- to stack at top of memory
-               orcc      #IntMasks
-               tfm       u+,y+               --- move the stack to the top of memory
-               else
-               lda       <D.QCnt
-               inca
-               anda      #$1F
-               sta       <D.QCnt
-               beq       DoFull
-               ldb       #R$Size
-               ldy       #Where+SWIStack
-               orcc      #IntMasks
-Loop4          lda       ,u+
-               sta       ,y+
-               decb
-               bne       Loop4
-               endc
-               lbra      BackTo1             otherwise simply return to the user
+AllClr              equ       *
+                    ifne      H6309
+                    inc       <D.QCnt
+                    aim       #$1F,<D.QCnt
+                    beq       DoFull              every 32 system calls, do the full check
+                    ldw       #R$Size             --- size of the register stack
+                    ldy       #Where+SWIStack     --- to stack at top of memory
+                    orcc      #IntMasks
+                    tfm       u+,y+               --- move the stack to the top of memory
+                    else
+                    lda       <D.QCnt
+                    inca
+                    anda      #$1F
+                    sta       <D.QCnt
+                    beq       DoFull
+                    ldb       #R$Size
+                    ldy       #Where+SWIStack
+                    orcc      #IntMasks
+Loop4               lda       ,u+
+                    sta       ,y+
+                    decb
+                    bne       Loop4
+                    endc
+                    lbra      BackTo1             otherwise simply return to the user
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-L02CB          pshs      cc,x,y,u            preserve registers
-               ldb       P$Task,x            get task #
-               ldx       P$SP,x              get stack pointer
-               lbsr      L0BF3               calculate block offset (only affects A&X)
-               leax      -$6000,x            adjust pointer to where memory map will be
-               bra       L02E9               go copy it
+L02CB               pshs      cc,x,y,u            preserve registers
+                    ldb       P$Task,x            get task #
+                    ldx       P$SP,x              get stack pointer
+                    lbsr      L0BF3               calculate block offset (only affects A&X)
+                    leax      -$6000,x            adjust pointer to where memory map will be
+                    bra       L02E9               go copy it
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-L02DA          pshs      cc,x,y,u            preserve registers
-               ldb       P$Task,x            get task # of destination
-               ldx       P$SP,x              get stack pointer
-               lbsr      L0BF3               calculate block offset (only affects A&X)
-               leax      -$6000,x            adjust pointer to where memory map will be
-               exg       x,y                 swap pointers & copy
+L02DA               pshs      cc,x,y,u            preserve registers
+                    ldb       P$Task,x            get task # of destination
+                    ldx       P$SP,x              get stack pointer
+                    lbsr      L0BF3               calculate block offset (only affects A&X)
+                    leax      -$6000,x            adjust pointer to where memory map will be
+                    exg       x,y                 swap pointers & copy
 * Copy a register stack
 * Entry: X=Source
 *        Y=Destination
 *        A=Offset into DAT image of stack
 *        B=Task #
-L02E9          leau      a,u                 point to block # of where stack is
-               lda       1,u                 get first block
-               ldb       3,u                 get a second just in case of overlap
-               orcc      #IntMasks           shutdown interupts while we do this
-               std       >DAT.Regs+5         map blocks in
-               ifne      H6309
-               ldw       #R$Size             get size of register stack
-               tfm       x+,y+               copy it
-               else
-               ldb       #R$Size
-Loop5          lda       ,x+
-               sta       ,y+
-               decb
-               bne       Loop5
-               endc
-               ldx       <D.SysDAT           remap the blocks we took out
-               lda       $0B,x
-               ldb       $0D,x
-               std       >DAT.Regs+5
-               puls      cc,x,y,u,pc         restore & return
+L02E9               leau      a,u                 point to block # of where stack is
+                    lda       1,u                 get first block
+                    ldb       3,u                 get a second just in case of overlap
+                    orcc      #IntMasks           shutdown interupts while we do this
+                    std       >DAT.Regs+5         map blocks in
+                    ifne      H6309
+                    ldw       #R$Size             get size of register stack
+                    tfm       x+,y+               copy it
+                    else
+                    ldb       #R$Size
+Loop5               lda       ,x+
+                    sta       ,y+
+                    decb
+                    bne       Loop5
+                    endc
+                    ldx       <D.SysDAT           remap the blocks we took out
+                    lda       $0B,x
+                    ldb       $0D,x
+                    std       >DAT.Regs+5
+                    puls      cc,x,y,u,pc         restore & return
 
 * Process software interupts from system state
 * Entry: U=Register stack pointer
-SysCall        leau      ,s                  get pointer to register stack
-               lda       <D.SSTskN           Get system task # (0=SYSTEM, 1=GRFDRV)
-               clr       <D.SSTskN           Force to System Process
-               pshs      a                   Save the system task number
-               lda       ,u                  Restore callers CC register (R$CC=$00)
-               tfr       a,cc                make it current
-               ldx       R$PC,u              Get my caller's PC register
-               leax      1,x                 move PC to next position
-               stx       R$PC,u              Save my caller's updated PC register
-               ldy       <D.SysDis           get system dispatch table pointer
-               bsr       L033B               execute system call
-               puls      a                   restore system state task number
-               lbra      L0E2B               return to process
+SysCall             leau      ,s                  get pointer to register stack
+                    lda       <D.SSTskN           Get system task # (0=SYSTEM, 1=GRFDRV)
+                    clr       <D.SSTskN           Force to System Process
+                    pshs      a                   Save the system task number
+                    lda       ,u                  Restore callers CC register (R$CC=$00)
+                    tfr       a,cc                make it current
+                    ldx       R$PC,u              Get my caller's PC register
+                    leax      1,x                 move PC to next position
+                    stx       R$PC,u              Save my caller's updated PC register
+                    ldy       <D.SysDis           get system dispatch table pointer
+                    bsr       L033B               execute system call
+                    puls      a                   restore system state task number
+                    lbra      L0E2B               return to process
 
 * Entry: X = system call vector to jump to
-Sys.Vec        jmp       ,x                  execute service call
+Sys.Vec             jmp       ,x                  execute service call
 
 * Execute system call
 * Entry: B=Function call #
 *        Y=Function dispatch table pointer (D.SysDis or D.UsrDis)
 L033B
-               lslb                          is it a I/O call? (Also multiplys by 2 for offset)
-               bcc       L0345               no, go get normal vector
+                    lslb                          is it a I/O call? (Also multiplys by 2 for offset)
+                    bcc       L0345               no, go get normal vector
 * Execute I/O system calls
-               ldx       IOEntry,y           get IOMan vector
+                    ldx       IOEntry,y           get IOMan vector
 * Execute the system call
-L034F          pshs      u                   preserve register stack pointer
-               jsr       [D.SysVec]          perform a vectored system call
-               puls      u                   restore pointer
-L0355          tfr       cc,a                move CC to A for stack update
-               bcc       L035B               go update it if no error from call
-               stb       R$B,u               save error code to caller's B
-L035B          ldb       R$CC,u              get callers CC, R$CC=$00
-               ifne      H6309
-               andd      #$2FD0              [A]=H,N,Z,V,C [B]=E,F,I
-               orr       b,a                 merge them together
-               else
-               anda      #$2F                [A]=H,N,Z,V,C
-               andb      #$D0                [B]=E,F,I
-               pshs      b
-               ora       ,s+
-               endc
-               sta       R$CC,u              return it to caller, R$CC=$00
-               rts
+L034F               pshs      u                   preserve register stack pointer
+                    jsr       [D.SysVec]          perform a vectored system call
+                    puls      u                   restore pointer
+L0355               tfr       cc,a                move CC to A for stack update
+                    bcc       L035B               go update it if no error from call
+                    stb       R$B,u               save error code to caller's B
+L035B               ldb       R$CC,u              get callers CC, R$CC=$00
+                    ifne      H6309
+                    andd      #$2FD0              [A]=H,N,Z,V,C [B]=E,F,I
+                    orr       b,a                 merge them together
+                    else
+                    anda      #$2F                [A]=H,N,Z,V,C
+                    andb      #$D0                [B]=E,F,I
+                    pshs      b
+                    ora       ,s+
+                    endc
+                    sta       R$CC,u              return it to caller, R$CC=$00
+                    rts
 
 * Execute regular system calls
 L0345
-               clra                          clear MSB of offset
-               ldx       d,y                 get vector to call
-               bne       L034F               it's initialized, go execute it
-               comb                          set carry for error
-               ldb       #E$UnkSvc           get error code
-               bra       L0355               return with it
+                    clra                          clear MSB of offset
+                    ldx       d,y                 get vector to call
+                    bne       L034F               it's initialized, go execute it
+                    comb                          set carry for error
+                    ldb       #E$UnkSvc           get error code
+                    bra       L0355               return with it
 
-               use       fssvc.asm
+                    use       fssvc.asm
 
-               use       flink.asm
+                    use       flink.asm
 
-               use       fvmodul.asm
+                    use       fvmodul.asm
 
-               use       ffmodul.asm
+                    use       ffmodul.asm
 
-               use       fprsnam.asm
+                    use       fprsnam.asm
 
-               use       fcmpnam.asm
+                    use       fcmpnam.asm
 
-               use       ccbfsrqmem.asm
+                    use       ccbfsrqmem.asm
 
 *         use   fallram.asm
 
 
-               ifne      H6309
-               use       fdelram.asm
-               endc
+                    ifne      H6309
+                    use       fdelram.asm
+                    endc
 
-               use       fallimg.asm
+                    use       fallimg.asm
 
-               use       ffreehb.asm
+                    use       ffreehb.asm
 
-               use       fdatlog.asm
+                    use       fdatlog.asm
 
-               use       fld.asm
+                    use       fld.asm
 
-               ifne      H6309
-               use       fcpymem.asm
-               endc
+                    ifne      H6309
+                    use       fcpymem.asm
+                    endc
 
-               use       fmove.asm
+                    use       fmove.asm
 
-               use       fldabx.asm
+                    use       fldabx.asm
 
-               use       falltsk.asm
+                    use       falltsk.asm
 
-               use       faproc.asm
+                    use       faproc.asm
 
 * System IRQ service routine
-XIRQ           ldx       <D.Proc             get current process pointer
-               sts       P$SP,x              save the stack pointer
-               lds       <D.SysStk           get system stack pointer
-               ldd       <D.SysSvc           set system service routine to current
-               std       <D.XSWI2
-               ldd       <D.SysIRQ           set system IRQ routine to current
-               std       <D.XIRQ
-               jsr       [>D.SvcIRQ]         execute irq service
-               bcc       L0D5B
+XIRQ                ldx       <D.Proc             get current process pointer
+                    sts       P$SP,x              save the stack pointer
+                    lds       <D.SysStk           get system stack pointer
+                    ldd       <D.SysSvc           set system service routine to current
+                    std       <D.XSWI2
+                    ldd       <D.SysIRQ           set system IRQ routine to current
+                    std       <D.XIRQ
+                    jsr       [>D.SvcIRQ]         execute irq service
+                    bcc       L0D5B
 
-               ldx       <D.Proc             get current process pointer
-               ldb       P$Task,x
-               ldx       P$SP,x              get it's stack pointer
+                    ldx       <D.Proc             get current process pointer
+                    ldb       P$Task,x
+                    ldx       P$SP,x              get it's stack pointer
 
-               pshs      u,d,cc              save some registers
-               leau      ,s                  point to a 'caller register stack'
-               lbsr      L0C40               do a LDB 0,X in task B
-               puls      u,d,cc              and now A ( R$A,U ) = the CC we want
+                    pshs      u,d,cc              save some registers
+                    leau      ,s                  point to a 'caller register stack'
+                    lbsr      L0C40               do a LDB 0,X in task B
+                    puls      u,d,cc              and now A ( R$A,U ) = the CC we want
 
-               ora       #IntMasks           disable it's IRQ's
-               lbsr      L0C28               save it back
-L0D5B          orcc      #IntMasks           shut down IRQ's
-               ldx       <D.Proc             get current process pointer
-               tst       <D.QIRQ             was it a clock IRQ?
-               lbne      L0DF7               if not, do a quick return
+                    ora       #IntMasks           disable it's IRQ's
+                    lbsr      L0C28               save it back
+L0D5B               orcc      #IntMasks           shut down IRQ's
+                    ldx       <D.Proc             get current process pointer
+                    tst       <D.QIRQ             was it a clock IRQ?
+                    lbne      L0DF7               if not, do a quick return
 
-               lda       P$State,x           Get it's state
-               bita      #TimOut             Is it timed out?
-               bne       L0D7C               yes, wake it up
+                    lda       P$State,x           Get it's state
+                    bita      #TimOut             Is it timed out?
+                    bne       L0D7C               yes, wake it up
 * Update active process queue
-               ldu       #(D.AProcQ-P$Queue) point to active process queue
-               ldb       #Suspend            get suspend flag
-L0D6A          ldu       P$Queue,u           get a active process pointer
-               beq       L0D78
-               bitb      P$State,u           is it suspended?
-               bne       L0D6A               yes, go to next one in chain
-               ldb       P$Prior,x           get current process priority
-               cmpb      P$Prior,u           do we bump this one?
-               blo       L0D7C
+                    ldu       #(D.AProcQ-P$Queue) point to active process queue
+                    ldb       #Suspend            get suspend flag
+L0D6A               ldu       P$Queue,u           get a active process pointer
+                    beq       L0D78
+                    bitb      P$State,u           is it suspended?
+                    bne       L0D6A               yes, go to next one in chain
+                    ldb       P$Prior,x           get current process priority
+                    cmpb      P$Prior,u           do we bump this one?
+                    blo       L0D7C
 
-L0D78          ldu       P$SP,x
-               bra       L0DB9
+L0D78               ldu       P$SP,x
+                    bra       L0DB9
 
-L0D7C          anda      #^TimOut
-               sta       P$State,x
+L0D7C               anda      #^TimOut
+                    sta       P$State,x
 
-L0D80          equ       *
-L0D83          bsr       L0D11               activate next process
+L0D80               equ       *
+L0D83               bsr       L0D11               activate next process
 
-               use       ccbfnproc.asm
+                    use       ccbfnproc.asm
 
 * The following routines must appear no earlier than $E00 when assembled, as
 * they have to always be in the vector RAM page ($FE00-$FEFF)
@@ -855,185 +855,185 @@ L0D83          bsr       L0D11               activate next process
 * CCB: this code (after pad) start assembling *before* 0xfe00, it's too big to
 * fit into the memory as stated above!!!!
 
-PAD            fill      $00,($0df1-*)       fill memory to ensure the above happens
+PAD                 fill      $00,($0df1-*)       fill memory to ensure the above happens
 * Default routine for D.SysIRQ
 S.SysIRQ
-               lda       <D.SSTskN           Get current task's GIME task # (0 or 1)
-               beq       FastIRQ             Use super-fast version for system state
-               clr       <D.SSTskN           Clear out memory copy (task 0)
-               jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
-               inc       <D.SSTskN           Save task # for system state
-               lda       #1                  Task 1
-               ora       <D.TINIT            Merge task bit's into Shadow version
-               sta       <D.TINIT            Update shadow
-               sta       >DAT.Task           Save to GIME as well & return
-               bra       DoneIRQ             Check for error and exit
+                    lda       <D.SSTskN           Get current task's GIME task # (0 or 1)
+                    beq       FastIRQ             Use super-fast version for system state
+                    clr       <D.SSTskN           Clear out memory copy (task 0)
+                    jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
+                    inc       <D.SSTskN           Save task # for system state
+                    lda       #1                  Task 1
+                    ora       <D.TINIT            Merge task bit's into Shadow version
+                    sta       <D.TINIT            Update shadow
+                    sta       >DAT.Task           Save to GIME as well & return
+                    bra       DoneIRQ             Check for error and exit
 
-FastIRQ        jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
-DoneIRQ        bcc       L0E28               No error on IRQ, exit
-               ifne      H6309
-               oim       #IntMasks,0,s       Setup RTI to shut interrupts off again
-               else
-               lda       ,s
-               ora       #IntMasks
-               sta       ,s
-               endc
-L0E28          rti
+FastIRQ             jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
+DoneIRQ             bcc       L0E28               No error on IRQ, exit
+                    ifne      H6309
+                    oim       #IntMasks,0,s       Setup RTI to shut interrupts off again
+                    else
+                    lda       ,s
+                    ora       #IntMasks
+                    sta       ,s
+                    endc
+L0E28               rti
 
 * return from a system call
-L0E29          clra                          Force System task # to 0 (non-GRDRV)
-L0E2B          ldx       <D.SysPrc           Get system process dsc. ptr
-               lbsr      TstImg              check image, and F$SetTsk (PRESERVES A)
-               orcc      #IntMasks           Shut interrupts off
-               sta       <D.SSTskN           Save task # for system state
-               beq       Fst2                If task 0, skip subroutine
-               ora       <D.TINIT            Merge task bit's into Shadow version
-               sta       <D.TINIT            Update shadow
-               sta       >DAT.Task           Save to GIME as well & return
-Fst2           leas      ,u                  Stack ptr=U & return
-               rti
+L0E29               clra                          Force System task # to 0 (non-GRDRV)
+L0E2B               ldx       <D.SysPrc           Get system process dsc. ptr
+                    lbsr      TstImg              check image, and F$SetTsk (PRESERVES A)
+                    orcc      #IntMasks           Shut interrupts off
+                    sta       <D.SSTskN           Save task # for system state
+                    beq       Fst2                If task 0, skip subroutine
+                    ora       <D.TINIT            Merge task bit's into Shadow version
+                    sta       <D.TINIT            Update shadow
+                    sta       >DAT.Task           Save to GIME as well & return
+Fst2                leas      ,u                  Stack ptr=U & return
+                    rti
 
 * Switch to new process, X=Process descriptor pointer, U=Stack pointer
-L0E4C          equ       *
-               ifne      H6309
-               oim       #$01,<D.TINIT       switch GIME shadow to user state
-               lda       <D.TINIT
-               else
-               lda       <D.TINIT
-               ora       #$01
-               sta       <D.TINIT
-               endc
-               sta       >DAT.Task           save it to GIME
-               leas      ,y                  point to new stack
-               tstb                          is the stack at SWISTACK?
-               bne       MyRTI               no, we're doing a system-state rti
+L0E4C               equ       *
+                    ifne      H6309
+                    oim       #$01,<D.TINIT       switch GIME shadow to user state
+                    lda       <D.TINIT
+                    else
+                    lda       <D.TINIT
+                    ora       #$01
+                    sta       <D.TINIT
+                    endc
+                    sta       >DAT.Task           save it to GIME
+                    leas      ,y                  point to new stack
+                    tstb                          is the stack at SWISTACK?
+                    bne       MyRTI               no, we're doing a system-state rti
 
-               ifne      H6309
-               ldf       #R$Size             E=0 from call to L0E8D before
-               ldu       #Where+SWIStack     point to the stack
-               tfm       u+,y+               move the stack from top of memory to user memory
-               else
-               ldb       #R$Size
-               ldu       #Where+SWIStack     point to the stack
-RtiLoop        lda       ,u+
-               sta       ,y+
-               decb
-               bne       RtiLoop
-               endc
-MyRTI          rti                           return from IRQ
+                    ifne      H6309
+                    ldf       #R$Size             E=0 from call to L0E8D before
+                    ldu       #Where+SWIStack     point to the stack
+                    tfm       u+,y+               move the stack from top of memory to user memory
+                    else
+                    ldb       #R$Size
+                    ldu       #Where+SWIStack     point to the stack
+RtiLoop             lda       ,u+
+                    sta       ,y+
+                    decb
+                    bne       RtiLoop
+                    endc
+MyRTI               rti                           return from IRQ
 
 
 * Execute routine in task 1 pointed to by U
 * comes from user requested SWI vectors
-L0E5E          equ       *
-               ifne      H6309
-               oim       #$01,<D.TINIT       switch GIME shadow to user state
-               ldb       <D.TINIT
-               else
-               ldb       <D.TINIT
-               orb       #$01
-               stb       <D.TINIT
-               endc
-               stb       >DAT.Task
-               jmp       ,u
+L0E5E               equ       *
+                    ifne      H6309
+                    oim       #$01,<D.TINIT       switch GIME shadow to user state
+                    ldb       <D.TINIT
+                    else
+                    ldb       <D.TINIT
+                    orb       #$01
+                    stb       <D.TINIT
+                    endc
+                    stb       >DAT.Task
+                    jmp       ,u
 
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
-S.Flip1        ldb       #2                  get Task image entry numberx2 for Grfdrv (task 1)
-               bsr       L0E8D               copy over the DAT image
-               ifne      H6309
-               oim       #$01,<D.TINIT
-               lda       <D.TINIT            get copy of GIME Task side
-               else
-               lda       <D.TINIT
-               ora       #$01
-               sta       <D.TINIT
-               endc
-               sta       >DAT.Task           save it to GIME register
-               inc       <D.SSTskN           increment system state task number
-               rti                           return
+S.Flip1             ldb       #2                  get Task image entry numberx2 for Grfdrv (task 1)
+                    bsr       L0E8D               copy over the DAT image
+                    ifne      H6309
+                    oim       #$01,<D.TINIT
+                    lda       <D.TINIT            get copy of GIME Task side
+                    else
+                    lda       <D.TINIT
+                    ora       #$01
+                    sta       <D.TINIT
+                    endc
+                    sta       >DAT.Task           save it to GIME register
+                    inc       <D.SSTskN           increment system state task number
+                    rti                           return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-L0E8D          cmpb      <D.Task1N           are we going back to the same task
-               beq       L0EA3               without the DAT image changing?
-               stb       <D.Task1N           nope, save current task in map type 1
-               ldx       #DAT.Regs+8         get MMU start register for process's
-               ldu       <D.TskIPt           get task image pointer table
-               ldu       b,u                 get address of DAT image
-L0E93          leau      1,u                 point to actual MMU block
-               ifne      H6309
-               lde       #4                  get # banks/2 for task
-               else
-               lda       #4
-               pshs      a
-               endc
-L0E9B          lda       ,u++                get a bank
-               ldb       ,u++                and next one
-               std       ,x++                Save it to MMU
-               ifne      H6309
-               dece                          done?
-               else
-               dec       ,s
-               endc
-               bne       L0E9B               no, keep going
-               ifeq      H6309
-               leas      1,s
-               endc
-L0EA3          rts                           return
+L0E8D               cmpb      <D.Task1N           are we going back to the same task
+                    beq       L0EA3               without the DAT image changing?
+                    stb       <D.Task1N           nope, save current task in map type 1
+                    ldx       #DAT.Regs+8         get MMU start register for process's
+                    ldu       <D.TskIPt           get task image pointer table
+                    ldu       b,u                 get address of DAT image
+L0E93               leau      1,u                 point to actual MMU block
+                    ifne      H6309
+                    lde       #4                  get # banks/2 for task
+                    else
+                    lda       #4
+                    pshs      a
+                    endc
+L0E9B               lda       ,u++                get a bank
+                    ldb       ,u++                and next one
+                    std       ,x++                Save it to MMU
+                    ifne      H6309
+                    dece                          done?
+                    else
+                    dec       ,s
+                    endc
+                    bne       L0E9B               no, keep going
+                    ifeq      H6309
+                    leas      1,s
+                    endc
+L0EA3               rts                           return
 
 * Execute FIRQ vector (called from $FEF4)
-FIRQVCT        ldx       #D.FIRQ             get DP offset of vector
-               bra       L0EB8               go execute it
+FIRQVCT             ldx       #D.FIRQ             get DP offset of vector
+                    bra       L0EB8               go execute it
 
 * Execute IRQ vector (called from $FEF7)
-IRQVCT         orcc      #IntMasks           disasble IRQ's
-               ldx       #D.IRQ              get DP offset of vector
+IRQVCT              orcc      #IntMasks           disasble IRQ's
+                    ldx       #D.IRQ              get DP offset of vector
 
 * Execute interrupt vector, B=DP Vector offset
-L0EB8          clra                          (faster than CLR >$xxxx)
-               sta       >DAT.Task           Force to Task 0 (system state)
-               ifne      H6309
-               tfr       0,dp                setup DP
-               else
-               tfr       a,dp
-               endc
-MapGrf         equ       *
-               ifne      H6309
-               aim       #$FE,<D.TINIT       switch GIME shadow to system state
-               lda       <D.TINIT            set GIME again just in case timer is used
-               else
-               lda       <D.TINIT
-               anda      #$FE
-               sta       <D.TINIT
-               endc
-MapT0          sta       >DAT.Task
-               jmp       [,x]                execute it
+L0EB8               clra                          (faster than CLR >$xxxx)
+                    sta       >DAT.Task           Force to Task 0 (system state)
+                    ifne      H6309
+                    tfr       0,dp                setup DP
+                    else
+                    tfr       a,dp
+                    endc
+MapGrf              equ       *
+                    ifne      H6309
+                    aim       #$FE,<D.TINIT       switch GIME shadow to system state
+                    lda       <D.TINIT            set GIME again just in case timer is used
+                    else
+                    lda       <D.TINIT
+                    anda      #$FE
+                    sta       <D.TINIT
+                    endc
+MapT0               sta       >DAT.Task
+                    jmp       [,x]                execute it
 
 * Execute SWI3 vector (called from $FEEE)
-SWI3VCT        orcc      #IntMasks           disable IRQ's
-               ldx       #D.SWI3             get DP offset of vector
-               bra       SWICall             go execute it
+SWI3VCT             orcc      #IntMasks           disable IRQ's
+                    ldx       #D.SWI3             get DP offset of vector
+                    bra       SWICall             go execute it
 
 * Execute SWI2 vector (called from $FEF1)
-SWI2VCT        orcc      #IntMasks           disasble IRQ's
-               ldx       #D.SWI2             get DP offset of vector
+SWI2VCT             orcc      #IntMasks           disasble IRQ's
+                    ldx       #D.SWI2             get DP offset of vector
 
 * This routine is called from an SWI, SWI2, or SWI3
 * saves 1 cycle on system-system calls
 * saves about 200 cycles (calls to I.LDABX and L029E) on grfdrv-system,
 *  or user-system calls.
-SWICall        ldb       [R$PC,s]            get callcode of the system call
+SWICall             ldb       [R$PC,s]            get callcode of the system call
 * NOTE: Alan DeKok claims that this is BAD.  It crashed Colin McKay's
 * CoCo 3.  Instead, we should do a clra/sta >DAT.Task.
 *         clr   >DAT.Task       go to map type 1
-               clra
-               sta       >DAT.Task
+                    clra
+                    sta       >DAT.Task
 * set DP to zero
-               ifne      H6309
-               tfr       0,dp
-               else
-               tfr       a,dp
-               endc
+                    ifne      H6309
+                    tfr       0,dp
+                    else
+                    tfr       a,dp
+                    endc
 
 * These lines add a total of 81 addition cycles to each SWI(2,3) call,
 * and 36 bytes+12 for R$Size in the constant page at $FExx
@@ -1042,47 +1042,47 @@ SWICall        ldb       [R$PC,s]            get callcode of the system call
 * For processes that re-vector SWI, SWI3, it adds 81 cycles.  BUT SWI(3)
 * CANNOT be vectored to L0EBF cause the user SWI service routine has been
 * changed
-               lda       <D.TINIT            get map type flag
-               bita      #$01                check it without changing it
+                    lda       <D.TINIT            get map type flag
+                    bita      #$01                check it without changing it
 
 * Change to LBEQ R.SysSvc to avoid JMP [,X]
 * and add R.SysSvc STA >DAT.Task ???
-               beq       MapT0               in map 0: restore hardware and do system service
-               tst       <D.SSTskN           get system state 0,1
-               bne       MapGrf              if in grfdrv, go to map 0 and do system service
+                    beq       MapT0               in map 0: restore hardware and do system service
+                    tst       <D.SSTskN           get system state 0,1
+                    bne       MapGrf              if in grfdrv, go to map 0 and do system service
 
 * the preceding few lines are necessary, as all SWI's still pass thru
 * here before being vectored to the system service routine... which
 * doesn't copy the stack from user state.
-               sta       >DAT.Task           go to map type X again to get user's stack
+                    sta       >DAT.Task           go to map type X again to get user's stack
 * a byte less, a cycle more than ldy #$FEED-R$Size, or ldy #$F000+SWIStack
-               leay      <SWIStack,pc        where to put the register stack: to $FEDF
-               tfr       s,u                 get a copy of where the stack is
-               ifne      H6309
-               ldw       #R$Size             get the size of the stack
-               tfm       u+,y+               move the stack to the top of memory
-               else
-               pshs      b
-               ldb       #R$Size
-Looper         lda       ,u+
-               sta       ,y+
-               decb
-               bne       Looper
-               puls      b
-               endc
-               bra       L0EB8               and go from map type 1 to map type 0
+                    leay      <SWIStack,pc        where to put the register stack: to $FEDF
+                    tfr       s,u                 get a copy of where the stack is
+                    ifne      H6309
+                    ldw       #R$Size             get the size of the stack
+                    tfm       u+,y+               move the stack to the top of memory
+                    else
+                    pshs      b
+                    ldb       #R$Size
+Looper              lda       ,u+
+                    sta       ,y+
+                    decb
+                    bne       Looper
+                    puls      b
+                    endc
+                    bra       L0EB8               and go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
-SWIVCT         ldx       #D.SWI              get DP offset of vector
-               bra       SWICall             go execute it
+SWIVCT              ldx       #D.SWI              get DP offset of vector
+                    bra       SWICall             go execute it
 
 * Execute NMI vector (called from $FEFD)
-NMIVCT         ldx       #D.NMI              get DP offset of vector
-               bra       L0EB8               go execute it
+NMIVCT              ldx       #D.NMI              get DP offset of vector
+                    bra       L0EB8               go execute it
 
 * The end of the kernel module is here
-               emod
-eom            equ       *
+                    emod
+eom                 equ       *
 
 * What follows after the kernel module is the register stack, starting
 * at $FEDD (6309) or $FEDF (6809).  This register stack area is used by
@@ -1090,28 +1090,28 @@ eom            equ       *
 * because it doesn't* get "switched out" no matter the contents of the
 * MMU registers.
 SWIStack
-               fcc       /REGISTER STACK/    same # bytes as R$Size for 6809
-               ifne      H6309
-               fcc       /63/                if 6309, add two more spaces
-               endc
+                    fcc       /REGISTER STACK/    same # bytes as R$Size for 6809
+                    ifne      H6309
+                    fcc       /63/                if 6309, add two more spaces
+                    endc
 
-               fcb       $55                 D.ErrRst
+                    fcb       $55                 D.ErrRst
 
 * This list of addresses ends up at $FEEE after the kernel track is loaded
 * into memory.  All interrupts come through the 6809 vectors at $FFF0-$FFFE
 * and get directed to here.  From here, the BRA takes CPU control to the
 * various handlers in the kernel.
-               bra       SWI3VCT             SWI3 vector comes here
-               nop
-               bra       SWI2VCT             SWI2 vector comes here
-               nop
-               bra       FIRQVCT             FIRQ vector comes here
-               nop
-               bra       IRQVCT              IRQ vector comes here
-               nop
-               bra       SWIVCT              SWI vector comes here
-               nop
-               bra       NMIVCT              NMI vector comes here
-               nop
+                    bra       SWI3VCT             SWI3 vector comes here
+                    nop
+                    bra       SWI2VCT             SWI2 vector comes here
+                    nop
+                    bra       FIRQVCT             FIRQ vector comes here
+                    nop
+                    bra       IRQVCT              IRQ vector comes here
+                    nop
+                    bra       SWIVCT              SWI vector comes here
+                    nop
+                    bra       NMIVCT              NMI vector comes here
+                    nop
 
-               end
+                    end

--- a/level2/modules/kernel/fallram.asm
+++ b/level2/modules/kernel/fallram.asm
@@ -9,35 +9,35 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FAllRAM        ldb       R$B,u               Get # blocks requested
-               pshs      b,x,y               Save regs
-               ldx       <D.BlkMap           Get ptr to start of block map
-L0974          leay      ,x                  Point Y to current block
-               ldb       ,s                  Get # blocks requested
-srchblk        cmpx      <D.BlkMap+2         Hit end of map yet?
-               bhs       L0995               Yes, exit with No RAM error
-               lda       ,x+                 Get block marker
-               bne       L0974               Already used, start over with next block up
-               decb                          Dec # blocks still needed
-               bne       srchblk             Still more, keep checking
-* Entry: Y=ptr to start of memory found
+FAllRAM             ldb       R$B,u               get the number blocks requested
+                    pshs      b,x,y               save registers
+                    ldx       <D.BlkMap           get pointer to the start of the block map
+L0974               leay      ,x                  point Y to the current block
+                    ldb       ,s                  get the number of blocks requested
+srchblk             cmpx      <D.BlkMap+2         hit end of map yet?
+                    bhs       L0995               yes, exit with No RAM error
+                    lda       ,x+                 get the block marker
+                    bne       L0974               already used, start over with the next block up
+                    decb                          decrement the number blocks still needed
+                    bne       srchblk             still more, keep checking
+* Entry: Y=pointer to start of memory found
 * Note: Due to fact that block map always starts @ $200 (up to $2FF), we
-*       don't need to calc A
-L0983          tfr       y,d                 Copy start of requested block mem ptr to D (B)
-               lda       ,s                  Get # blocks requested
-               stb       ,s                  Save start block #
-L098D          inc       ,y+                 Flag blocks as used
-               deca                          (for all blocks allocated)
-               bne       L098D               Do until done
-               puls      b                   Get start block #
-               clra                          (allow for D as per original calls)
-               std       R$D,u               Save for caller
-               puls      x,y,pc              Restore regs & return
+*       don't need to calculate A
+L0983               tfr       y,d                 copy the start of the requested block memory pointer to D (B)
+                    lda       ,s                  get the number blocks requested
+                    stb       ,s                  save the starting block number
+L098D               inc       ,y+                 flag the blocks as used
+                    deca                          (for all blocks allocated)
+                    bne       L098D               do this until done
+                    puls      b                   get the starting block number
+                    clra                          (allow for D as per original calls)
+                    std       R$D,u               save for the caller
+                    puls      x,y,pc              restore the registers and return
 
-L0995          comb                          Exit with No RAM error
-               ldb       #E$NoRAM
-               stb       ,s
-               puls      b,x,y,pc
+L0995               comb                          set the carry
+                    ldb       #E$NoRAM            exit with No RAM error
+                    stb       ,s                  save B on the stack for the caller
+                    puls      b,x,y,pc            restore the registers and return
 
 
 **************************************************
@@ -51,15 +51,15 @@ L0995          comb                          Exit with No RAM error
 *
 * Error:  CC = C bit set; B = error code
 *
-FAlHRAM        ldb       R$B,u               Get # blocks to allocate
-               pshs      b,x,y               Preserve regs
-               ldx       <D.BlkMap+2         Get ptr to end of block map
-L09A9          ldb       ,s                  Get # blocks requested
-L09AB          cmpx      <D.BlkMap           Are we at beginning of RAM yet?
-               bls       L0995               Yes, exit with No RAM error
-               lda       ,-x                 Get RAM block marker
-               bne       L09A9               If not free, start checking next one down
-               decb                          Free block, dec # blocks left to find count
-               bne       L09AB               Still more needed, keep checking
-               tfr       x,y                 Found enough contigous blocks, move ptr to Y
-               bra       L0983               Go mark blocks as used, & return info to caller
+FAlHRAM             ldb       R$B,u               get the number blocks to allocate
+                    pshs      b,x,y               preserve registers
+                    ldx       <D.BlkMap+2         get the pointer to the end of block map
+L09A9               ldb       ,s                  get the number blocks requested
+L09AB               cmpx      <D.BlkMap           are we at the beginning of RAM yet?
+                    bls       L0995               yes, exit with No RAM error
+                    lda       ,-x                 get the RAM block marker
+                    bne       L09A9               if not free, start checking the next one down
+                    decb                          free block; decrement the number blocks left to find the count
+                    bne       L09AB               still more needed, so keep checking
+                    tfr       x,y                 found enough contiguous blocks, so move the pointer to Y
+                    bra       L0983               go mark then blocks as used and return the information to caller

--- a/level2/modules/kernel/fclrblk.asm
+++ b/level2/modules/kernel/fclrblk.asm
@@ -10,44 +10,44 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FClrBlk        ldb       R$B,u
-               beq       L0BE9
-               ldd       R$U,u
-               tstb      
-               bne       L0BAA
-               bita      #$1F
-               bne       L0BAA
-               ldx       <D.Proc
-               lda       P$SP,x
-               anda      #$E0
-               suba      R$U,u
-               bcs       L0BCE
-               lsra      
-               lsra      
-               lsra      
-               lsra      
-               lsra      
-               cmpa      R$B,u
-               bcs       L0BAA
-L0BCE                    
-               ifne      H6309
-               oim       #ImgChg,P$State,x
-               else      
-               lda       P$State,x
-               ora       #ImgChg
-               sta       P$State,x
-               endc      
-               lda       R$U,u
-               lsra      
-               lsra      
-               lsra      
-               lsra      
-               leay      P$DATImg,x
-               leay      a,y
-               ldb       R$B,u
-               ldx       #DAT.Free
-L0BE4          stx       ,y++
-               decb      
-               bne       L0BE4
-L0BE9          clrb      
-               rts       
+FClrBlk             ldb       R$B,u
+                    beq       L0BE9
+                    ldd       R$U,u
+                    tstb
+                    bne       IllBlkErr
+                    bita      #$1F
+                    bne       IllBlkErr
+                    ldx       <D.Proc
+                    lda       P$SP,x
+                    anda      #$E0
+                    suba      R$U,u
+                    bcs       L0BCE
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    cmpa      R$B,u
+                    bcs       IllBlkErr
+L0BCE
+                    ifne      H6309
+                    oim       #ImgChg,P$State,x
+                    else
+                    lda       P$State,x
+                    ora       #ImgChg
+                    sta       P$State,x
+                    endc
+                    lda       R$U,u
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    leay      P$DATImg,x
+                    leay      a,y
+                    ldb       R$B,u
+                    ldx       #DAT.Free
+L0BE4               stx       ,y++
+                    decb
+                    bne       L0BE4
+L0BE9               clrb
+                    rts

--- a/level2/modules/kernel/ffreehb.asm
+++ b/level2/modules/kernel/ffreehb.asm
@@ -1,111 +1,122 @@
-**************************************************
-* System Call: F$FreeHB
-*
-* Function: Get free high block
-*
-* Called from F$MapBlk and from SS.MpGPB)
-*
-* Input:  B = Block count
-*         Y = DAT image pointer
-*
-* Output: A = High block number
-*
-* Error:  CC = C bit set; B = error code
-*
-FFreeHB        ldb       R$B,u               Get # blocks requested
-               ldy       R$Y,u               Get DAT Img ptr
-               bsr       L0A31               Go find free blocks in high part of DAT
-L0A2C          bcs       L0A30               Couldn't find any, exit with error
-               sta       R$A,u               Save starting block #
-L0A30          rts                           Return
+;;; F$FreeHB
+;;;
+;;; Get the highest free block in a process' address space.
+;;;
+;;; Entry:  B = The block count.
+;;;         Y = The DAT image pointer.
+;;;
+;;; Exit:   A = The highest free block number.
+;;;
+;;; Error:  B = A non-zero error code.
+;;;        CC = Carry flag set to indicate error.
 
-L0A31          tfr       b,a                 Copy # blocks requested to A
+FFreeHB             ldb       R$B,u               get the number blocks requested
+                    ldy       R$Y,u               get the DAT image pointer
+                    bsr       L0A31               go find free blocks in high part of DAT
+L0A2C               bcs       L0A30               couldn't find any, exit with error
+                    sta       R$A,u               save the starting block number
+L0A30               rts                           return
+
+L0A31               tfr       b,a                 copy the number blocks requested to A
 * This gets called directly from within F$Link
-L0A33          suba      #$09                Invert within 8
-               nega      
-               pshs      x,d                 Save X, block # & block count
-               ldd       #$FFFF              -1'
-L0A56          pshs      d
+L0A33               suba      #$09                invert within 8
+                    nega                          negate
+                    pshs      x,d                 save X, the block number and the block count
+                    ldd       #$FFFF              -1
+L0A56               pshs      d                   save the value on the stack
 
 * Move to next block - SHOULD OPTIMIZE WITH W
-L0A58          clra                          # free blocks found so far=0
-               ldb       2,s                 Get block #
-               addb      ,s                  Add block increment (point to next block)
-               stb       2,s                 Save new block # to check
-               cmpb      1,s                 Same as block count?
-               bne       L0A75               No, skip ahead
-               ldb       #E$MemFul           Preset error for 207 (Process mem full)
-               cmpy      <D.SysDAT           Is it the system process?
-               bne       L0A6C               No, exit with error 207
-               ldb       #E$NoRAM            System Mem full (237)
-L0A6C          stb       3,s                 Save error code
-               comb                          set carry
-               bra       L0A82               Exit with error
+L0A58               clra                          number free blocks found so far=0
+                    ldb       2,s                 get the block number
+                    addb      ,s                  add the block increment (point to next block)
+                    stb       2,s                 save the new block number to check
+                    cmpb      1,s                 same as block count?
+                    bne       L0A75               no, skip ahead
+                    ldb       #E$MemFul           preset error for 207 (process memory full)
+                    cmpy      <D.SysDAT           is it the system process?
+                    bne       L0A6C               no, exit with error 207
+                    ldb       #E$NoRAM            system memory full (237)
+L0A6C               stb       3,s                 save the error code
+                    comb                          set the carry
+                    bra       L0A82               exit with error
 
-L0A71          tfr       a,b                 Copy # blocks to B
-               addb      2,s                 Add to current start block #
-L0A75          lslb                          Multiply block # by 2
-               ldx       b,y                 Get DAT marker for that block
-               cmpx      #DAT.Free           Empty block?
-               bne       L0A58               No, move to next block
-               inca                          Bump up # blocks free counter
-               cmpa      3,s                 Have we got enough?
-               bne       L0A71               No, keep looking
-L0A82          leas      2,s                 Eat temporary stack
-               puls      d,x,pc              Restore reg, error code & return
+L0A71               tfr       a,b                 copy the number of blocks to B
+                    addb      2,s                 add the current start block number
+L0A75               lslb                          multiply the block number by 2
+                    ldx       b,y                 get the DAT marker for that block
+                    cmpx      #DAT.Free           is it an empty block?
+                    bne       L0A58               no, move to the next block
+                    inca                          bump up the number blocks free counter
+                    cmpa      3,s                 have we got enough?
+                    bne       L0A71               no, keep looking
+L0A82               leas      2,s                 eat the temporary stack
+                    puls      d,x,pc              restore registers, error code, and return
 
+
+;;; F$FreeLB
+;;;
+;;; Get the lowest free block in a process' address space.
+;;;
+;;; Entry:  B = The block count.
+;;;         Y = The DAT image pointer.
+;;;
+;;; Exit:   A = The lowest free block number.
+;;;
+;;; Error:  B = A non-zero error code.
+;;;        CC = Carry flag set to indicate error.
 
 * WHERE DOES THIS EVER GET CALLED FROM???
 * Rodney says: "It's called via os9p1 syscall vector in line 393"
-FSFreeLB       ldb       R$B,u               Get block count
-               ldy       R$Y,u               Get ptr to DAT Image
-               bsr       L0A4B               Go find block #'s
-               bra       L0A2C               Do error checking & exit (since never called,
-* not worried about speed)
+FSFreeLB            ldb       R$B,u               get the block count
+                    ldy       R$Y,u               get the pointer to DAT Image
+                    bsr       L0A4B               go find the block numbers
+                    bra       L0A2C               do error checking and exit
 
-L0A4B          lda       #$FF                Value to start loop at block 0
-               pshs      x,d                 Preserve X,flag & block count
-*         lda   #$01           # to add to go to next block (positive here)
-               nega                          -(-1)=+1
-               subb      #9                  Drop block count to -8 to -1 (invert within 8)
-               negb                          Negate so it is a positive # again
-               bra       L0A56               Go into main find loop
+L0A4B               lda       #$FF                the value to start the loop at block 0
+                    pshs      x,d                 preserve X, flag, and block count
+*         lda   #$01           number to add to go to the next block (positive here)
+                    nega                          -(-1)=+1
+                    subb      #9                  drop the block count to -8 to -1 (invert within 8)
+                    negb                          negate so it is a positive number again
+                    bra       L0A56               go into the main find loop
 
 
-**************************************************
-* System Call: F$FreeLB
-*
-* Function: Get free low block
-*
-* Input:  B = Block count
-*         Y = DAT image pointer
-*
-* Output: A = Low block number
-*
-* Error:  CC = C bit set; B = error code
-*
-FFreeLB        ldd       R$D,u
-               ldx       R$X,u
-               ldu       R$U,u
-L0A8C          pshs      d,x,y,u
-               leay      <P$DATImg,x
-               lsla      
-               leay      a,y
-               ifne      H6309
-               clra      
-               lslb      
-               tfr       d,w
-               tfm       u+,y+
-               oim       #ImgChg,P$State,x
-               else      
-               lslb      
-L0ALoop        lda       ,u+
-               sta       ,y+
-               decb      
-               bne       L0ALoop
-               lda       P$State,x
-               ora       #ImgChg
-               sta       P$State,x
-               endc      
-               clrb      
-               puls      d,x,y,u,pc
+;;; F$SetImg
+;;;
+;;; Copy all or part of the DAT image into a process descriptor.
+;;;
+;;; Entry:  A = The starting image block number.
+;;;         B = The block count.
+;;;         X = The process descriptor pointer.
+;;;         U = The new image pointer.
+;;;
+;;; Exit:   None
+;;;
+;;; Error:  B = A non-zero error code.
+;;;        CC = Carry flag set to indicate error.
+
+FSetImg             ldd       R$D,u               get the starting image block number and blcok count
+                    ldx       R$X,u               get the process descriptor pointer
+                    ldu       R$U,u               get the new image pointer
+L0A8C               pshs      d,x,y,u             save these onto the stack
+                    leay      <P$DATImg,x         point to the DAT image within the process descriptor
+                    lsla                          multiply the starting image block number by 2
+                    leay      a,y                 point Y into the starting point of the DAT image area of the process descriptor
+                    ifne      H6309
+                    clra                          clear the upper 8 bits
+                    lslb                          and multiply the lower 8 bits by 2
+                    tfr       d,w                 transfer the count to W
+                    tfm       u+,y+               perform the transfer
+                    oim       #ImgChg,P$State,x   set the "image changed" flag
+                    else
+                    lslb                          multiply the block count by 2
+loop@               lda       ,u+                 get the new image value
+                    sta       ,y+                 and store it in the process descriptor image area
+                    decb                          decrement the counter
+                    bne       loop@               branch if not done
+                    lda       P$State,x           get the process' state
+                    ora       #ImgChg             set the "image changed" flag
+                    sta       P$State,x           and store it back
+                    endc
+                    clrb                          clear the carry
+                    puls      d,x,y,u,pc          restore the registers and return to the caller

--- a/level2/modules/kernel/fmapblk.asm
+++ b/level2/modules/kernel/fmapblk.asm
@@ -1,60 +1,62 @@
-**************************************************
-* System Call: F$MapBlk
-*
-* Function: Map specific block
-*
-* Input:  B = Number of blocks
-*         X = Beginning block number
-*
-* Output: U = Address of first block
-*
-* Error:  CC = C bit set; B = error code
-*
-FMapBlk        lda       R$B,u               get # blocks
-               beq       L0BAA               can't map 0 blocks, return error
-               cmpa      #DAT.BlCt           within range of DAT image?
-               bhi       L0BAA               no, return error
-               leas      -$10,s              make a buffer to hold DAT image
-               ldx       R$X,u               get start block #
-               ldb       #1                  block increment value
-               ifne      H6309
-* Change to W 05/19/93 - used W since one cycle faster per block
-               tfr       s,w                 point to buffer
-FMapBlk2       stx       ,w++                save block # to buffer
-               else      
-               tfr       s,y                 point to buffer
-FMapBlk2       stx       ,y++                save block # to buffer
-               endc      
-               abx                           Next block
-               deca                          done?
-               bne       FMapBlk2            no, keep going
-               ldb       R$B,u               get block count again
-               ldx       <D.Proc             get process pointer
-               leay      <P$DATImg,x         point to DAT image
-               os9       F$FreeHB            find the highest free block offset
-               bcs       L0BA6               no room, return error
-               ifne      H6309
-               tfr       d,w                 Preserve start block # & # of blocks
-               else      
-               pshs      d
-               endc      
-               lsla                          Multiply start block # by 32
-               lsla      
-               lsla      
-               lsla      
-               lsla      
-               clrb      
-               std       R$U,u               save address of first block
-               ifne      H6309
-               tfr       w,d                 Restore offset
-               else      
-               puls      d
-               endc      
-               leau      ,s                  move DAT image into process descriptor
-               os9       F$SetImg            Change process dsc to reflect new blocks
-L0BA6          leas      <$10,s              Eat DAT image copy & return
-               rts       
+;;; F$MapBlk
+;;;
+;;; Map one or more blocks into the calling process' address space.
+;;;
+;;; Entry:  B = The number of blocks to map in.
+;;;         X = The starting block number.
+;;;
+;;; Exit:   U = The address of the first block in the caller's address space.
+;;;
+;;; Error:  B = A non-zero error code.
+;;;        CC = Carry flag set to indicate error.
 
-L0BAA          comb                          Illegal Block address error
-               ldb       #E$IBA
-               rts       
+stackbuff           set       DAT.BlCt*2
+
+FMapBlk             lda       R$B,u               get the number blocks from the caller's B
+                    beq       IllBlkErr           if zero, we can't map 0 blocks, so return an error
+                    cmpa      #DAT.BlCt           is the blck count within range of DAT image?
+                    bhi       IllBlkErr           no, return an error
+                    leas      -stackbuff,s        make a buffer on the stack to hold the DAT image
+                    ldx       R$X,u               get the start block number from the caller's X
+                    ldb       #1                  load the block increment value
+                    ifne      H6309
+* Change to W 05/19/93 - used W since one cycle faster per block
+                    tfr       s,w                 point to the buffer
+loop@               stx       ,w++                save the block number to the buffer
+                    else
+                    tfr       s,y                 point to the buffer
+loop@               stx       ,y++                save the block number to the buffer
+                    endc
+                    abx                           go to next block
+                    deca                          done?
+                    bne       loop@               no, keep going
+                    ldb       R$B,u               get the block count again
+                    ldx       <D.Proc             get the current process pointer
+                    leay      <P$DATImg,x         point to the DAT image
+                    os9       F$FreeHB            find the highest free block offset
+                    bcs       L0BA6               return with error if carry is set (no room)
+                    ifne      H6309
+                    tfr       d,w                 preserve the starting block number and the number of blocks
+                    else
+                    pshs      d                   preserve the starting block number and the number of blocks
+                    endc
+                    lsla                          multiply the start block number by 2
+                    lsla                          and by 2 again (total is 4)
+                    lsla                          and by 2 again (total is 8)
+                    lsla                          and by 2 again (total is 16)
+                    lsla                          and by 2 again (total is 32)
+                    clrb                          clear the lower 8 bits
+                    std       R$U,u               save the address of the first block
+                    ifne      H6309
+                    tfr       w,d                 restore the offset
+                    else
+                    puls      d                   restore the offset
+                    endc
+                    leau      ,s                  move the DAT image into the process descriptor
+                    os9       F$SetImg            change the process descriptor to reflect new blocks
+L0BA6               leas      <stackbuff,s        eat the DAT image copy on the stack
+                    rts                           return to the caller
+
+IllBlkErr           comb                          set the carry
+                    ldb       #E$IBA              illegal block address error
+                    rts                           return to the caller

--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -676,7 +676,7 @@ SysCalls            fcb       F$Link
                     fcb       F$AllImg+SysState
                     fdb       FAllImg-*-2
                     fcb       F$SetImg+SysState
-                    fdb       FFreeLB-*-2
+                    fdb       FSetImg-*-2
                     fcb       F$FreeLB+SysState
                     fdb       FSFreeLB-*-2
                     fcb       F$FreeHB+SysState


### PR DESCRIPTION
f256.d offsets have changed for certain hardware features.
Drivers using these offsets have changed, emitting smaller code.
F$MapBlk commented.
FFreeLB label has been changed to FSetImg, fixing a long-standing "text only" source bug.
Added a SS.DMAFill SetStat to the F256 vito driver.