### PR TITLE
boot_emu.asm make sure floppy controller is inactive

### DIFF
--- a/level1/coco1/modules/boot_emu.asm
+++ b/level1/coco1/modules/boot_emu.asm
@@ -53,6 +53,8 @@ HWInit              ldb       #13                 Forced interrupt command
                     clrb
 delay@              decb                          Delay for NMI
                     bne       delay@              loop 256 times
+                    lda       $FF48               clear controller
+                    clr       $FF40               Motor off and clear drive select
 
 * HWTerm - nothing to do
 HWTerm              clrb


### PR DESCRIPTION
When using boottrack from floppy on VCC the floppy controller was interfering with the load of os9boot from the vhd.  Instructions added to ensure floppy controller is deactivated.

Tested by added a boottrack containing boot_emu to an otherwise empty floppy and using it to boot nitros9.