### PR TITLE
Document RBF ChgDir, and unify PEXEC mode handling in ChgDir.

### DIFF
--- a/defs/rbf.d
+++ b/defs/rbf.d
@@ -200,8 +200,8 @@ PD.TFM              RMB       1                   DMA Transfer Mode
 PD.Exten            RMB       2                   Path Extension (PE) for record locking
 PD.SToff            RMB       1                   Sector/Track offsets (for "foreign" disk formats)
 PD.ATT              RMB       1                   File attributes
-PD.FD               RMB       3                   File descriptor psn
-PD.DFD              RMB       3                   Directory file descriptor psn
+PD.FD               RMB       3                   File descriptor psn (i.e. 3-byte inode number)
+PD.DFD              RMB       3                   Directory file descriptor psn (i.e. 3-byte inode number)
 PD.DCP              RMB       4                   File directory entry ptr
 PD.DVT              RMB       2                   User readable dev tbl ptr
 
@@ -219,7 +219,8 @@ BufBusy             EQU       $40                 Buffer is currently busy
 * Random Block Path Extension Format
 *
 * RBF paths under Level Two have additional information that
-* is referenced by the path extension area.
+* is referenced by the path extension area.  These are 64-byte
+* allocs from the same table (D.PthDBT) as the Path Descriptors.
 *
                     ORG       0
 PE.PE               RMB       1                   PE path number

--- a/level1/modules/rbf.asm
+++ b/level1/modules/rbf.asm
@@ -493,15 +493,89 @@ SetMTime            lbsr      RdFlDscr            read in file descriptor sector
 
 *
 * I$ChgDir Entry Point
+*    The user's requested mode is in PD.MOD,y.
+*    It should have at least one bit of READ. or WRITE. or EXEC.
+*    CWD is changed if READ. ($1) or WRITE. ($2) is set.
+*    CXD is changed if EXEC. ($4) is set.
+*    Both may be changed.
+*    If no bits were set, it does nothing but returns OK.
+*
+*    (Level 1 used to allow PEXEC. ($20) as well as EXEC. ($4),
+*    but Level 2 did not.  To unify the levels, now both will
+*    accept PEXEC., but this was probably never documented.)
+*
+*    IOMan creates a temporary 64-byte Path Descriptor,
+*    and closes the descriptor before IOMan returns.
+*    That is the path descriptor passed to ChgDir in the Y register.
+*
+*    Using that path descriptor, IOMan calls I$Attach on the device before
+*    calling the ChgDir entry here, and calls I$Detach on the device after
+*    we return.  I$Attach links the Device Descriptor module, its Driver
+*    module, and its File Mananger module.  I$Detach unlinks all three.
+*
+*    Here's how this seems to work.  In the process descriptor,
+*    there are 12 bytes, starting with the label P$DIO.  The headers
+*    do not describe the internal structure.
+*
+*    IOMan imposes this much structure:
+*    The Device Table Entry Pointer for the CWD device
+*    is two bytes stored at offset 0.
+*    The Device Table Entry Pointer for the CXD device
+*    is two bytes stored at offset 6.
+*    That implies that the File Manager of a device with directories
+*    can use four bytes, offsets 2 through 5, to remember which directory
+*    is the CWD; and can use four bytes, offsets 8 through 11,
+*    to remember which directory is the CXD.
+*
+*    RBF saves the 3-byte PSN Sector Number of the inode of the CWD
+*    in offsets 3 through 5.  It appears offset 2 is unused.
+*
+*    RBF saves the 3-byte PSN Sector Number of the inode of the CXD
+*    in offsets 9 through 11.  It appears offset 8 is unused.
+*
+*    Is there any Link Count on the Device (in the Device Table Entry)
+*    to mark the fact that a process is using it for its CWD or CXD?
+*    It seems to me (strick) that there should be, but I cannot find
+*    where a link count is being maintained.  This should involve
+*    three things:  1. A new process inherits CWD and CXD from its
+*    parent process, so it should add a link to each device;
+*    2.  When a process changes a current directory, it should unlink
+*    the old one, and link the new one;  and 3.  A process unlinks them
+*    when the process dies.
+*
+*    However I think in Nitros9 actually 1. A new process gets a copy
+*    of its parent's 12 byte P$DIO structure, but no links are done;
+*    2. When one changes directories, the old values are ignored
+*    and the new values are not linked; and 3. When a process dies,
+*    its P$DIO structure is ignored, and just vanishes.
+*
+*    (In most unices, the CWD and CRD (working and root) directories
+*    are ordinary open paths to the directory, which would link the
+*    usage of the device.  Why didn't OS9 do the same thing?)
+*
+*    Fact: The name `P$DIO` does not occur in any of the Level2
+*    kernel module sources.   In Level1, it only appears in `ffork.asm`
+*    where it is used to copy the 12 bytes from parent to child.
+*
+*    Bug?  If you unlink a device (with no open paths) while some
+*    process uses it for CWD or CXD, are not the Device Table
+*    Entry Pointers now pointing to garbage?
 *
 * Entry:
+*    Y -> a temporary path descriptor, created just for this operation.
+*
+* How this block exits:
+*    The entry Y value should have been pushed onto the stack.
+*    Notice all exits are branches to Clos2A0.
 *
 * Exit:
+*    The only result is a side effect in the P$DIO structure in the
+*    process descriptor.
 *
 * Error: CC Carry set
 *        B = errcode
 *
-ChgDir              pshs      y                   preserve path descriptor pointer
+ChgDir              pshs      y                   preserve path descriptor pointer (to be pulled at Clos2A0)
                     ifne      UNTESTED_H6309
                     oim       #DIR.,PD.MOD,y      ensure the directory bit is set
                     else
@@ -509,26 +583,26 @@ ChgDir              pshs      y                   preserve path descriptor point
                     ora       #DIR.               add the directory bit,
                     sta       PD.MOD,y            and save back to pd.
                     endc
-                    lbsr      Open                go open the directory
+                    lbsr      Open                go open the directory in the path descriptor at Y.
                     bcs       Clos2A0             exit on error
                     ldx       <D.Proc             get current process pointer
-                    ldu       PD.FD+1,y           get LSW of file descriptor sector #
+                    ldu       PD.FD+1,y           get LSW of file descriptor sector # (i.e. inode)
                     ldb       PD.MOD,y            get current file mode
                     bitb      #UPDAT.             read or write mode?
                     beq       CD30D               no, skip ahead
 * Change current data dir
-                    ldb       PD.FD,y
-                    stb       P$DIO+3,x
-                    stu       P$DIO+4,x
+                    ldb       PD.FD,y             get MSB of file descriptor sector # (i.e. inode)
+                    stb       P$DIO+3,x           save MSB in Proc descriptor (changes the CWD of the proc)
+                    stu       P$DIO+4,x           save LSW in Proc descriptor (changes the CWD of the proc)
 CD30D               ldb       PD.MOD,y            get current file mode
-                    bitb      #EXEC.              is it execution dir?
-                    beq       CD31C               no, skip ahead
+                    bitb      #PEXEC.+EXEC.       is it execution dir?
+                    beq       CD31C               no, skip ahead (do nothing but return OK, if no R, W, or E mode bits)
 * Change current execution directory
-                    ldb       PD.FD,y
-                    stb       P$DIO+9,x
-                    stu       P$DIO+10,x
+                    ldb       PD.FD,y             get MSB of file descriptor sector # (i.e. inode)
+                    stb       P$DIO+9,x           save MSB in Proc descriptor (changes the CXD of the proc)
+                    stu       P$DIO+10,x          save LSW in Proc descriptor (changes the CXD of the proc)
 CD31C               clrb                          clear errors
-                    bra       Clos2A0             return to system
+                    bra       Clos2A0             Close the path that was Opened above, and return to system.
 
 
 *
@@ -1192,13 +1266,13 @@ Sst7FB              anda      #$7F                strip high bit
                     leax      -$01,x              bump path pointer back 1
                     lda       PD.MOD,y            get file mode
                     ldu       <D.Proc             get pointer to current process
-                    leau      P$DIO,u             point to default data directory FD sector #
-                    bita      #$24
+                    leau      P$DIO,u             point to default data directory FD sector # (i.e. CWD inode # is at offset 3)
+                    bita      #EXEC.              do they want execution dir?
                     beq       Sst814              no, skip ahead
-                    leau      $06,u               point to execution dir
-Sst814              ldb       $03,u               get LSB of logical sector # of FD to dir
+                    leau      $06,u               point to execution dir (i.e. CXD inode # is at offset 3)
+Sst814              ldb       $03,u               get MSB of logical sector # of FD to dir
                     stb       PD.FD,y             put it in path descriptor
-                    ldd       $04,u               get MSW of logical sector # of FD to dir
+                    ldd       $04,u               get LSW of logical sector # of FD to dir
                     std       PD.FD+1,y
 Sst81E              ldu       PD.DEV,y            get pointer to device table
                     stu       PD.DVT,y            copy it for user


### PR DESCRIPTION
Mostly this is to add more documentation about how ChgDir works on RBF devices, in preparation for writing other File Managers, especially FUSE or remote file managers, that do not use the RBF disk format.

I made one small change to Level2:
In Level1, you can change the current execution directory (CXD) by setting either the EXEC or PEXEC mode on the
I$ChgDir system call.  In Level2, it was only
accepting EXEC.  This commit changes Level2 so that it also accepts PEXEC.

I think this is really minor, and that PEXEC was probably never documented or used in the I$ChgDir API.
But unifying Levels 1 and 2 is a goal,
and I don't want to break any existing code.