### PR TITLE
Correct floppy interrupt command in boot_emu

### DIFF
--- a/level1/coco1/modules/boot_emu.asm
+++ b/level1/coco1/modules/boot_emu.asm
@@ -48,7 +48,7 @@ name                fcs       /Boot/
 
 * HWInit - Stop any floppy activity.
 * Force floppy interrupt per R Gault
-HWInit              ldb       #13                 Forced interrupt command
+HWInit              ldb       #$d0                Force interrupt
                     stb       $FF48               put to floppy command address
                     clrb
 delay@              decb                          Delay for NMI


### PR DESCRIPTION
The boot_emu init section has code to interrupt the floppy drive and kill floppy operations in prepration for a nitros9 boot from an emulated hard disk. The command used to interrupt the floppy controller was found to be in error by inspection.