### PR TITLE
OS-9 in ROM booting fix

### DIFF
--- a/level2/coco3/bootroms/makefile
+++ b/level2/coco3/bootroms/makefile
@@ -43,3 +43,6 @@ kernel_rom: $(KERNEL_ROM) $(DEPENDS)
 clean:
 	$(RM) $(ALLROMS) $(KERNELS)
 
+# Load Ostrich Emulator
+loadromemu: nos96809l2.rom
+	ostrich2.py --device $(ROMEMUDEV) write --address 0x8000 $^

--- a/level2/coco3/bootroms/makefile
+++ b/level2/coco3/bootroms/makefile
@@ -46,3 +46,4 @@ clean:
 # Load Ostrich Emulator
 loadromemu: nos96809l2.rom
 	ostrich2.py --device $(ROMEMUDEV) write --address 0x8000 $^
+	

--- a/level2/coco3/modules/boot_rom.asm
+++ b/level2/coco3/modules/boot_rom.asm
@@ -11,6 +11,10 @@
 *
 *   1r1    2003/09/07  Boisy G. Pitre
 * Added 6309 optimizations
+*
+*   2      2024/09/05  Boisy G. Pitre
+* Fixed some assumptions in the code about which blocks were mapped into which
+* MMU slots. Attempted to make the code a bit more general.
 
                     nam       Boot
                     ttl       NitrOS-9 Level 2 ROM Boot Module
@@ -22,7 +26,7 @@
 tylg                set       Systm+Objct
 atrv                set       ReEnt+rev
 rev                 set       $01
-edition             set       1
+edition             set       2
 
                     mod       eom,name,tylg,atrv,start,size
 
@@ -96,14 +100,14 @@ RelCode             equ       *
                     sta       $FFDE               ROM/RAM mode
 
 * Map ROM Blocks in
-                    ldd       $FFA6
-                    pshs      d
-                    ldd       $FFA4
-                    pshs      d
-                    ldd       #$3C3D
-                    std       $FFA4
-                    lda       #$3E
-                    sta       $FFA6
+                    ldd       $FFA6               get the two bytes at $FFA6-$FFA7
+                    pshs      d                   save on the stack
+                    ldd       $FFA4               get the two bytes at $FFA4-$FFA5
+                    pshs      d                   save on the stack
+                    ldd       #$3C3D              we're mapping the first 16K of ROM...
+                    std       $FFA4               ... into $8000-$BFFF
+                    lda       #$3E                and the next 8K of ROM...
+                    sta       $FFA6               ... into $C000-$DFFF
 
 * Map block 1 at $6000
                     lda       $FFA3

--- a/level2/coco3_6309/bootroms/makefile
+++ b/level2/coco3_6309/bootroms/makefile
@@ -1,7 +1,9 @@
-include $(NITROS9DIR)/rules.mak
+include ../port.mak
 
 # Module directory
 MD		= ../modules
+# Commands directory
+CMDSDIR		= ../cmds
 
 DEPENDS		= ./makefile
 
@@ -13,9 +15,11 @@ BOOTFILE_ROM	= $(MD)/rominfo $(MD)/krnp2 $(MD)/ioman $(MD)/init \
 		$(MD)/covdg.io \
 		$(MD)/term_vdg.dt \
 		$(MD)/clock_60hz $(MD)/clock2_soft \
-		$(MD)/sysgo_rom
+		$(MD)/sysgo_rom \
+		$(CMDSDIR)/shell_21 \
+		$(CMDSDIR)/mdir
 
-BOOTROMS	= nos96809l2.rom
+BOOTROMS	= nos96309l2.rom
 KERNELS		= kernel_rom
 
 ALLROMS		= $(BOOTROMS)
@@ -23,7 +27,7 @@ ALLROMS		= $(BOOTROMS)
 all:	$(ALLROMS)
 
 # Bootfiles
-nos96809l2.rom: $(BOOTFILE_ROM) $(KERNEL_ROM) $(DEPENDS)
+nos96309l2.rom: $(BOOTFILE_ROM) $(KERNEL_ROM) $(DEPENDS)
 	$(MERGE) $(BOOTFILE_ROM)>$@.tmp
 	$(PADROM) 27648 $@.tmp
 	$(MERGE) $@.tmp $(KERNEL_ROM)>$@.tmp2
@@ -39,3 +43,6 @@ kernel_rom: $(KERNEL_ROM) $(DEPENDS)
 clean:
 	$(RM) $(ALLROMS) $(KERNELS)
 
+# Load Ostrich Emulator
+loadromemu: nos96309l2.rom
+	ostrich2.py --device $(ROMEMUDEV) write --address 0x8000 $^

--- a/level2/modules/kernel/krnp2.asm
+++ b/level2/modules/kernel/krnp2.asm
@@ -88,7 +88,7 @@ TC9                 set       false               "true" use TC-9 6309 trap vect
 Edition             equ       20
 Revision            equ       0
 
-                    mod       eom,MName,Systm,ReEnt+Revision,krnp2,$0100
+                    mod       eom,MName,Systm+Objct,ReEnt+Revision,krnp2,$0100
 
 MName               fcs       /KrnP2/
                     fcb       Edition


### PR DESCRIPTION
I added more robust code to `boot_rom.asm` for OS-9 Level 2 on the CoCo 3 that fixed the boot issue.