### PR TITLE
The scdwv driver now supports the SS.BlkWr setstat call

### DIFF
--- a/level1/modules/scdwv.asm
+++ b/level1/modules/scdwv.asm
@@ -247,7 +247,7 @@ Write               equ       *
                     pshs      a
                     leax      ,s
                     ldy       #$0002              ; 3 bytes to send.. ugh.  need WRITEM (data mode)
-Blast               ifgt      Level-1
+                    ifgt      Level-1
                     ldu       <D.DWSubAddr
                     else
                     ldu       >D.DWSubAddr
@@ -488,8 +488,8 @@ SendStat
 SetStat
                     cmpa      #SS.Open
                     bne       isitblkwr
-                    lbsr       open
-                    lbcs       ssbye
+                    lbsr      open
+                    lbcs      ssbye
                     ldd       #SS.Open*256+OP_SERSETSTAT
                     bra       SendStat
 isitblkwr           cmpa      #SS.BlkWr

--- a/level1/modules/scdwvdesc.asm
+++ b/level1/modules/scdwvdesc.asm
@@ -100,7 +100,11 @@ initsize            equ       *
 
 name                equ       *
                     ifeq      Addr-0
+                    ifne      FUJIDEV
+                    fcs       /fuji/
+                    else
                     fcs       /Term/
+                    endc
                     else
                     ifeq      Addr-14
                     fcs       /MIDI/

--- a/level2/coco3/bootfiles/makefile
+++ b/level2/coco3/bootfiles/makefile
@@ -72,7 +72,7 @@ RBCOCO3FPGA = $(MD)/rbsuper.dr $(MD)/llcoco3fpga.dr \
 		$(MD)/sd1_coco3fpga.dd $(MD)/ramd_coco3fpga.dr \
 		$(MD)/r0_ramd_coco3fpga.dd
 
-SCDWV_NET  = $(MD)/n_scdwv.dd $(MD)/n1_scdwv.dd $(MD)/n2_scdwv.dd \
+SCDWV_NET  = $(MD)/fuji_scdwv.dd $(MD)/n_scdwv.dd $(MD)/n1_scdwv.dd $(MD)/n2_scdwv.dd \
 		$(MD)/n3_scdwv.dd $(MD)/n4_scdwv.dd $(MD)/midi_scdwv.dd
 SCDWV_WIN  = $(MD)/z1_scdwv.dd $(MD)/z2_scdwv.dd
 SCDWP     = $(MD)/scdwp.dr $(MD)/p_scdwp.dd
@@ -283,12 +283,6 @@ BOOTFILE_DW	= $(MD)/krnp2 $(MD)/ioman $(MD)/init \
 		$(SCDWP) \
 		$(PIPE) \
 		$(CLOCK60HZDW)
-#		$(MD)/scdwv.dr \
-#		$(MD)/n_scdwv.dd $(MD)/n1_scdwv.dd $(MD)/n2_scdwv.dd \
-#		$(MD)/n3_scdwv.dd $(MD)/n4_scdwv.dd $(MD)/n5_scdwv.dd \
-#		$(MD)/n6_scdwv.dd $(MD)/n7_scdwv.dd $(MD)/n8_scdwv.dd \
-#		$(MD)/n9_scdwv.dd $(MD)/n10_scdwv.dd $(MD)/n11_scdwv.dd \
-#		$(MD)/n12_scdwv.dd $(MD)/n13_scdwv.dd $(MD)/midi_scdwv.dd \
 
 # NitrOS-9 disk bootfile to allow booting from DriveWire 3 server
 # Headless mode

--- a/level2/coco3/modules/makefile
+++ b/level2/coco3/modules/makefile
@@ -72,7 +72,7 @@ SCF		= scf.mn \
 		v1.dw v2.dw v3.dw v4.dw v5.dw \
 		v6.dw v7.dw \
 		scdwv.dr term_scdwv.dt n_scdwv.dd \
-		n1_scdwv.dd n2_scdwv.dd n3_scdwv.dd \
+		fuji_scdwv.dd n1_scdwv.dd n2_scdwv.dd n3_scdwv.dd \
 		n4_scdwv.dd n5_scdwv.dd n6_scdwv.dd n7_scdwv.dd \
 		n8_scdwv.dd n9_scdwv.dd n10_scdwv.dd n11_scdwv.dd \
 		n12_scdwv.dd n13_scdwv.dd midi_scdwv.dd \
@@ -323,6 +323,9 @@ h1_emudsk.dd: emudskdesc.asm
 # DriveWire SCF descriptors
 term_scdwv.dt: scdwvdesc.asm
 	$(AS) $< $(ASOUT)$@ $(AFLAGS) -DAddr=0
+
+fuji_scdwv.dd: scdwvdesc.asm
+	$(AS) $< $(ASOUT)$@ $(AFLAGS) -DAddr=0 -DFUJIDEV
 
 n_scdwv.dd: scdwvdesc.asm
 	$(AS) $< $(ASOUT)$@ $(AFLAGS) -DAddr=255


### PR DESCRIPTION
This change allows a program to open up a /n device and use this SetStat to blast bytes to the dwio subroutine module.