### PR TITLE
Minor kernel enhancements

### DIFF
--- a/level1/modules/kernel/ffork.asm
+++ b/level1/modules/kernel/ffork.asm
@@ -5,7 +5,7 @@
 ;;; Entry:  A = The type/language byte.
 ;;;         B = Size of the optional data area (in pages).
 ;;;         X = Address of the module name or filename.
-;;;         Y = Size of the parameter area (in pages). The default is 0.
+;;;         Y = Size of the parameter area (in bytes). The default is 0.
 ;;;         U = Starting address of the parameter area. This must be at least one page.
 ;;;
 ;;; Exit:   A = New process I/O number.

--- a/level1/modules/kernel/krn.asm
+++ b/level1/modules/kernel/krn.asm
@@ -284,6 +284,8 @@ copy@               ldd       ,y++                get vector bytes
                     leax      >SysSvc,pcr         get the system state service routine
                     stx       <D.SysSvc           store it in system globals
                     stx       <D.SWI2             and in the SWI2 vector
+                    leax      DUMMY,pcr           get the DUMMY routine
+                    stx       <D.NMI              store it in the NMI vector
                     leax      >Poll,pcr           get the default polling routine
                     stx       <D.Poll             store it in system globals
                     leax      >Clock,pcr          get the default tick generator routine


### PR DESCRIPTION
- Fix comment in ffork.asm regarding pages vs bytes
- Level 1 kernel now places the `DUMMY` pointer in the  `D.NMI` vector .This addresses an issue that caused a crash on the F256. It's a good idea for all ports to do this.