### PR TITLE
Fix build of libfnxsnd.a and paths that reference it.

### DIFF
--- a/level1/f256/cmds/makefile
+++ b/level1/f256/cmds/makefile
@@ -6,7 +6,7 @@ vpath %.asm $(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09:$(3RDPARTY)/packages/bra
 DEPENDS		= ./makefile $(NOSLIB)/net.o
 
 AFLAGS         += --includedir=$(3RDPARTY)/packages/basic09 --includedir=$(3RDPARTY)/packages/brainfuck
-LFLAGS         += -L $(NITROS9DIR)/lib -lnet -lf256 -lalib -lf256snd
+LFLAGS         += -L $(NITROS9DIR)/lib -L $(LEVEL1)/$(PORT)/libs -lnet -lf256 -lalib -lfnxsnd
 
 BASIC09		= basic09 runb inkey syscall
 BF  		= bf

--- a/level1/f256/libs/fnxsnd/makefile
+++ b/level1/f256/libs/fnxsnd/makefile
@@ -4,10 +4,10 @@ include $(NITROS9DIR)/rules.mak
 
 MODS = psg.o
 
-all:	libfnxsnd.a
+all:	../libfnxsnd.a
 
-libfnxsnd.a: $(MODS)
+../libfnxsnd.a: $(MODS)
 	$(LWAR) $@ $?
 
 clean:
-	$(RM) *.o libfnxsnd.a *.list *.map
+	$(RM) *.o ../libfnxsnd.a *.list *.map

--- a/level2/f256/cmds/makefile
+++ b/level2/f256/cmds/makefile
@@ -10,8 +10,8 @@ AFLAGS      += -I$(3RDPARTY)/packages/basic09
 AFLAGS      += -I$(3RDPARTY)/packages/brainfuck
 AFLAGS      += -I$(3RDPARTY)/packages/cpm
 AFLAGS      += -I../defs
-LFLAGS		+= -L$(NITROS9DIR)/lib
-LFLAGS		+= -lf256 -lf256snd
+LFLAGS		+= -L$(NITROS9DIR)/lib -L$(LEVEL2)/$(PORT)/libs
+LFLAGS		+= -lf256 -lfnxsnd
 LFLAGS		+= -lnet -lalib -lnos96809l2
 
 BASIC09	= basic09 runb inkey syscall foenix

--- a/level2/f256/libs/fnxsnd/makefile
+++ b/level2/f256/libs/fnxsnd/makefile
@@ -5,10 +5,10 @@ vpath %.as $(LEVEL1)/f256/libs/fnxsnd
 
 MODS = psg.o
 
-all:	libfnxsnd.a
+all:	../libfnxsnd.a
 
-libfnxsnd.a: $(MODS)
+../libfnxsnd.a: $(MODS)
 	$(LWAR) $@ $?
 
 clean:
-	$(RM) *.o libfnxsnd.a *.list *.map
+	$(RM) *.o ../libfnxsnd.a *.list *.map


### PR DESCRIPTION
I moved libfnxsnd.a from the root folder's lib folder into level1/f256/libs since it's an F256-specific library.