### PR TITLE
level1/d64: update makefile

### DIFF
--- a/level1/d64/cmds/makefile
+++ b/level1/d64/cmds/makefile
@@ -3,9 +3,14 @@ ifeq ($(PORT),)
 endif
 include $(NITROS9DIR)/rules.mak
 
+vpath %.as $(LEVEL1)/cmds
 vpath %.asm $(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09
 
 DEPENDS		= ./makefile
+
+AFLAGS		+= -I$(LEVEL1)/$(PORT)
+AFLAGS		+= -I$(3RDPARTY)/packages/basic09
+LFLAGS		+= -L $(NITROS9DIR)/lib -lnet -ldragon -lalib
 
 CMDS		= asm attr backup bawk binex build cmp cobbler cobbler_dragon copy cputype \
 		date dcheck debug ded deiniz del deldir devs dir dirsort disasm \


### PR DESCRIPTION
vpath and flag variables adapted from level1/coco1 changes.

Seems to fix the build for d64 and related ports.