### PR TITLE
Setup clean and smudge filters

### DIFF
--- a/scripts/asmalign
+++ b/scripts/asmalign
@@ -1,0 +1,179 @@
+#! /usr/bin/env python3
+
+import io
+import argparse
+import sys
+
+# parameters
+
+opcodesWithoutOperands = [
+    'abx',
+    'asla', 'aslb', 'asld', 'aslq',
+    'asra', 'asrb', 'asrd', 'asrq',
+    'break',
+    'clra', 'clrb', 'clrd', 'comd', 'clre', 'clrf', 'clrw', 'clrq',
+    'coma', 'comb', 'comd', 'come', 'comf', 'comw', 'comq',
+    'daa',
+    'deca', 'decb', 'dece', 'decf', 'decw', 'sync',
+    'inca', 'incb', 'incd', 'ince', 'incf', 'incw',
+    'log',
+    'lsla', 'lslb', 'lsld', 'lsle', 'lslf', 'lslq',
+    'lsra', 'lsrb', 'lsrd', 'lsre', 'lsrf', 'lsrq',
+    'mul',
+    'nega', 'negb', 'negd', 'nege', 'negf', 'negw', 'negq',
+    'rti', 'rts',
+    'rola', 'rolb', 'rold', 'rolw',
+    'rora', 'rorb', 'rord', 'rorw',
+    'sex', 'sexw', 'swi', 'swi2', 'swi3',
+    'tsta', 'tstb', 'tstd', 'tste', 'tstf', 'tstw', 'tstq',
+    # psedu-ops
+    'ifp1', 'else', 'endc'
+]
+
+pseudoOpcodes = ['ifp1', 'ifgt', 'iflt', 'ifge', 'ifle', 'ifeq', 'ifne',
+    'ifdef', 'else', 'endc', 'macro', 'endm', 'struct', 'ends'
+]
+
+opcodesWithFullLines = [
+    'ttl'
+]
+
+opcodesWithStrings = [
+    'fcc', 'fcs', 'fcn', 'fcz'
+]
+
+def isEmptyLine(l):
+    l.strip()
+    if len(l) == 0:
+        return True
+    else:
+        return False
+
+def isComment(l):
+    if l[0] == '*' or l[0] == ';':
+        return True
+    else:
+        return False
+
+def hasLabel(l):
+    result = False
+    if len(l) > 0 and not l[0].isspace():
+        result = True
+    return result
+
+def buildStringOperand(l, op):
+    dchar = ''
+    sstr = ''
+    idx = l.index(op) # skip to the start of the operand
+#    sys.stderr.write('starting operand: "' + str(op) + "\"\n")
+
+# lwasm version
+    if idx < len(l) and not l[idx].isspace():
+        dchar = l[idx] # get first delimiting char
+        # we're assuming there's a matching delimiter
+        end = idx + l[idx+1:].index(dchar) + 2
+
+        # if there's a trailing comma, we add the comma to the operand and loop
+        if end < len(l) and l[end] == ',':
+            end += 1
+            while end < len(l) and not l[end].isspace():
+                end += 1
+
+        sstr = l[idx:end]
+
+    return sstr
+
+def showLine(label, opcode, operand, comment, opcodeCol, operandCol, commentCol):
+    if label == "" and opcode == "" and operand == "":
+        l = comment
+    else:
+        l = label
+        if opcode != "":
+            if opcodeCol > 1: l = l.ljust(opcodeCol-2)
+            l = " ".join([l,opcode]);
+        if operand != "":
+            if operandCol > 1: l = l.ljust(operandCol-2)
+            l = " ".join([l,operand]);
+        if comment != "":
+            if commentCol > 1: l = l.ljust(commentCol-2)
+            l = " ".join([l,comment]);
+    print(l)
+
+def processLine(args, l):
+    line = ""
+    label = ""
+    opcode = ""
+    operand = ""
+    comment = ""
+    dirs = args.dirs
+
+    opcodeCol = args.opcode
+    operandCol = args.operand
+    commentCol = args.comment
+
+    l = l.rstrip('\n')
+    if isEmptyLine(l) == True:
+        comment = ""
+    elif isComment(l) == True:
+        comment = l
+    else:
+        tokens = l.split()
+        startIndex = 0
+        if hasLabel(l) == True:
+            # the next token will be a label
+            label = tokens[startIndex]
+            startIndex = startIndex + 1
+        # the first token will be the opcode
+        if len(tokens) > startIndex:
+            opcode = tokens[startIndex]
+            # if the opcode is in the pseudo-op table, indent it less and make it uppercase
+            if opcode.lower() in pseudoOpcodes:
+#                opcode = opcode.upper()
+                if dirs:
+                    opcodeCol -= 2
+                    operandCol -= 2
+
+            # if there's a second token AND the first token takes an operand, the second token is an operand
+            if len(tokens) > startIndex + 1 and opcode.lower() not in opcodesWithoutOperands:
+                operand = tokens[startIndex + 1]
+                if len(tokens) > startIndex + 2:
+                    if opcode.lower() in opcodesWithStrings:
+                        operand = buildStringOperand(l, operand)
+
+                        comment = l[(l.index(operand)+len(operand)):].strip()
+                    elif opcode.lower() in opcodesWithFullLines:
+                        operand = l.split(None, startIndex + 1)[startIndex + 1]
+                    else:
+                        comment = l.split(None, startIndex + 2)[startIndex + 2]
+                else:
+                    comment = ""
+            else:
+                if len(tokens) > startIndex + 1:
+                    comment = l.split(None, startIndex + 1)[startIndex + 1]
+
+    showLine(label, opcode, operand, comment, opcodeCol, operandCol, commentCol)
+
+parser = argparse.ArgumentParser(description='Reformat 6x09 assembly language by inserting space between fields. Indenting is controlled by specifying field positions. The label, opcode, operand, and comment are kept in order and separated by at least one space. Columns are numbered started with one.')
+
+parser.add_argument('-d', "--directive", help="unindent directives two spaces", dest='dirs', default=False, action='store_true')
+
+parser.add_argument('-o', "--opcode", metavar='N', help="opcode starting column", dest='opcode', type=int, default=21)
+
+parser.add_argument('-p', "--operand", metavar='N', help="operand starting column", dest='operand', type=int, default=31)
+
+parser.add_argument('-c', "--comment", metavar='N', help="comment starting column", dest='comment', type=int, default=51)
+
+parser.add_argument('filename', nargs='?', metavar='FILE', help="file to process (stdin used if not given or '-')") # positional argument
+
+args = parser.parse_args()
+
+sys.stdin.reconfigure(encoding='cp850')
+sys.stdout.reconfigure(encoding='cp850')
+
+if args.filename == '-' or args.filename == None:
+    for line in sys.stdin:
+        processLine(args, line)
+else: # Using the 'with' statement ensures that the file is properly closed after its suite finishes.
+    with open(args.filename, 'r', encoding='cp850') as file:
+        for line in file:
+            processLine(args, line)

--- a/scripts/asmclean
+++ b/scripts/asmclean
@@ -1,0 +1,147 @@
+#! /usr/bin/env python3
+
+import io
+import re
+import sys
+
+opcodesWithoutOperands = [
+    'abx',
+    'asla', 'aslb', 'asld', 'aslq',
+    'asra', 'asrb', 'asrd', 'asrq',
+    'break',
+    'clra', 'clrb', 'clrd', 'comd', 'clre', 'clrf', 'clrw', 'clrq',
+    'coma', 'comb', 'comd', 'come', 'comf', 'comw', 'comq',
+    'daa',
+    'deca', 'decb', 'dece', 'decf', 'decw', 'sync',
+    'inca', 'incb', 'incd', 'ince', 'incf', 'incw',
+    'log',
+    'lsla', 'lslb', 'lsld', 'lsle', 'lslf', 'lslq',
+    'lsra', 'lsrb', 'lsrd', 'lsre', 'lsrf', 'lsrq',
+    'mul',
+    'nega', 'negb', 'negd', 'nege', 'negf', 'negw', 'negq',
+    'rti', 'rts',
+    'rola', 'rolb', 'rold', 'rolw',
+    'rora', 'rorb', 'rord', 'rorw',
+    'sex', 'sexw', 'swi', 'swi2', 'swi3',
+    'tsta', 'tstb', 'tstd', 'tste', 'tstf', 'tstw', 'tstq',
+    # psedu-ops
+    'ifp1', 'else', 'endc', 'ends', 'endm', 'endsect'
+]
+
+pseudoOpcodes = ['ifp1', 'ifgt', 'iflt', 'ifge', 'ifle', 'ifeq', 'ifne',
+    'ifdef', 'else', 'endc', 'macro', 'endm', 'struct', 'ends'
+]
+
+opcodesWithFullLines = [
+    'ttl'
+]
+
+opcodesWithStrings = [
+    'fcc', 'fcs', 'fcn', 'fcz'
+]
+
+alphanumericCharset = '$0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+
+def isEmptyLine(l):
+    l.strip()
+    if len(l) == 0:
+        return True
+    return False
+
+def isComment(l):
+    l.strip()
+    if len(l) and (l[0] == '*' or l[0] == ';'):
+        return True
+    return False
+
+def hasLabel(l):
+    if len(l) > 0 and not l[0].isspace():
+        return True
+    return False
+
+def buildStringOperand(l, op):
+    dchar = ''
+    sstr = ''
+    idx = l.index(op) # skip to the start of the operand
+#    sys.stderr.write('starting operand: "' + str(op) + "\"\n")
+
+# lwasm version
+    if idx < len(l) and not l[idx].isspace():
+        dchar = l[idx] # get first delimiting char
+        # we're assuming there's a matching delimiter
+        end = idx + l[idx+1:].index(dchar) + 2
+
+        # if there's a trailing comma, we add the comma to the operand and loop
+        if end < len(l) and l[end] == ',':
+            end += 1
+            while end < len(l) and not l[end].isspace():
+                end += 1
+
+        sstr = l[idx:end]
+
+    return sstr
+
+def showLine(label, opcode, operand, comment, debug):
+    if debug == True:
+        line = [label, opcode, operand, comment]
+        sys.stderr.write(str(line) + "\n")
+#        print (line)
+#        return
+
+    if label == "" and opcode == "" and operand == "":
+        line = comment
+    else:
+        if opcode.lower() in opcodesWithoutOperands:
+            instr = opcode
+        else:
+            instr = opcode + ' ' + operand
+        line = label + ' ' + instr + ' ' + comment
+
+    line = line.rstrip()
+    print(line)
+
+def processLine(l):
+    label = ""
+    opcode = ""
+    operand = ""
+    comment = ""
+
+    l = l.rstrip('\n')
+    if isComment(l) == True:
+        comment = l
+    else:
+        tokens = l.split()
+        startIndex = 0
+        if hasLabel(l) == True:
+            # the next token will be a label
+            label = tokens[startIndex]
+            startIndex = startIndex + 1
+        # the first token will be the opcode
+        if len(tokens) > startIndex:
+            opcode = tokens[startIndex]
+
+            # if there's a second token AND the first token takes an operand, the second token is an operand
+            if len(tokens) > startIndex + 1 and opcode.lower() not in opcodesWithoutOperands:
+                operand = tokens[startIndex + 1]
+                if len(tokens) > startIndex + 2:
+                    if opcode.lower() in opcodesWithStrings:
+                        operand = buildStringOperand(l, operand)
+
+                        comment = l[(l.index(operand)+len(operand)):].strip()
+                    elif opcode.lower() in opcodesWithFullLines:
+                        operand = l.split(None, startIndex + 1)[startIndex + 1]
+                    else:
+                        comment = l.split(None, startIndex + 2)[startIndex + 2]
+                else:
+                    comment = ""
+            else:
+                if len(tokens) > startIndex + 1:
+                    comment = l.split(None, startIndex + 1)[startIndex + 1]
+
+    showLine(label, opcode, operand, comment, False)
+
+sys.stdin.reconfigure(encoding='cp850')
+sys.stdout.reconfigure(encoding='cp850')
+
+for line in sys.stdin:
+    processLine(line)

--- a/scripts/asmpp
+++ b/scripts/asmpp
@@ -1,0 +1,193 @@
+#! /usr/bin/env python3
+
+import io
+import argparse
+import sys
+
+# parameters
+stripWhiteSpaceAtEnd = True
+
+opcodesWithoutOperands = [
+    'abx',
+    'asla', 'aslb', 'asld', 'aslq',
+    'asra', 'asrb', 'asrd', 'asrq',
+    'break',
+    'clra', 'clrb', 'clrd', 'comd', 'clre', 'clrf', 'clrw', 'clrq',
+    'coma', 'comb', 'comd', 'come', 'comf', 'comw', 'comq',
+    'daa',
+    'deca', 'decb', 'dece', 'decf', 'decw', 'sync',
+    'inca', 'incb', 'incd', 'ince', 'incf', 'incw',
+    'log',
+    'lsla', 'lslb', 'lsld', 'lsle', 'lslf', 'lslq',
+    'lsra', 'lsrb', 'lsrd', 'lsre', 'lsrf', 'lsrq',
+    'mul',
+    'nega', 'negb', 'negd', 'nege', 'negf', 'negw', 'negq',
+    'rti', 'rts',
+    'rola', 'rolb', 'rold', 'rolw',
+    'rora', 'rorb', 'rord', 'rorw',
+    'sex', 'sexw', 'swi', 'swi2', 'swi3',
+    'tsta', 'tstb', 'tstd', 'tste', 'tstf', 'tstw', 'tstq',
+    # psedu-ops
+    'ifp1', 'else', 'endc'
+]
+
+pseudoOpcodes = ['ifp1', 'ifgt', 'iflt', 'ifge', 'ifle', 'ifeq', 'ifne',
+    'ifdef', 'else', 'endc', 'macro', 'endm', 'struct', 'ends'
+]
+
+opcodesWithFullLines = [
+    'ttl'
+]
+
+opcodesWithStrings = [
+    'fcc', 'fcs', 'fcn', 'fcz'
+]
+
+def isEmptyLine(l):
+    l.strip()
+    if len(l) == 0:
+        return True
+    else:
+        return False
+
+def isComment(l):
+    if l[0] == '*' or l[0] == ';':
+        return True
+    else:
+        return False
+
+def hasLabel(l):
+    result = False
+    if len(l) > 0 and not l[0].isspace():
+        result = True
+    return result
+
+def buildStringOperand(l, op):
+    dchar = ''
+    sstr = ''
+    idx = l.index(op) # skip to the start of the operand
+#    sys.stderr.write('starting operand: "' + str(op) + "\"\n")
+
+# lwasm version
+    if idx < len(l) and not l[idx].isspace():
+        dchar = l[idx] # get first delimiting char
+        # we're assuming there's a matching delimiter
+        end = idx + l[idx+1:].index(dchar) + 2
+
+        # if there's a trailing comma, we add the comma to the operand and loop
+        if end < len(l) and l[end] == ',':
+            end += 1
+            while end < len(l) and not l[end].isspace():
+                end += 1
+
+        sstr = l[idx:end]
+
+    return sstr
+
+def showLine(label, opcode, operand, comment, labelWidth, opcodeWidth, operandWidth, instrWidth, debug):
+    if debug == True:
+        line = [label, opcode, operand, comment]
+    else:
+        if label == "" and opcode == "" and operand == "":
+            line = comment
+        elif instrWidth:
+            if opcode.lower() in opcodesWithoutOperands:
+                instr = opcode
+            else:
+                instr = opcode + " " + operand
+            formatString = f"{label:<{labelWidth}} {instr:<{instrWidth}} {comment:<{0}}"
+            line = formatString
+        else:
+            formatString = f"{label:<{labelWidth}} {opcode:<{opcodeWidth}} {operand:<{operandWidth}} {comment:<{0}}"
+            line = formatString
+    if stripWhiteSpaceAtEnd == True:
+        line = line.rstrip()
+    print(line)
+
+def processLine(args, l):
+    line = ""
+    label = ""
+    opcode = ""
+    operand = ""
+    comment = ""
+    instrWidth = args.instr
+    nodirs = args.nodirs
+    labelWidth = args.label - 1
+    opcodeWidth = args.opcode - 1
+    operandWidth = args.operand - 1
+
+    if instrWidth != None and instrWidth > 2: instrWidth -= 1
+
+    l = l.rstrip('\n')
+    if isEmptyLine(l) == True:
+        comment = ""
+    elif isComment(l) == True:
+        comment = l
+    else:
+        tokens = l.split()
+        startIndex = 0
+        if hasLabel(l) == True:
+            # the next token will be a label
+            label = tokens[startIndex]
+            startIndex = startIndex + 1
+        # the first token will be the opcode
+        if len(tokens) > startIndex:
+            opcode = tokens[startIndex]
+            # if the opcode is in the pseudo-op table, indent it less and make it uppercase
+            if opcode.lower() in pseudoOpcodes:
+#                opcode = opcode.upper()
+                if not nodirs:
+                    labelWidth -= 2
+                    opcodeWidth -=2
+                    operandWidth -= 2
+
+                    if labelWidth < 1: labelWidth = 1
+                    if opcodeWidth < 1: opcodeWidth = 1
+                    if operandWidth < 1: operandWidth = 1;
+
+            # if there's a second token AND the first token takes an operand, the second token is an operand
+            if len(tokens) > startIndex + 1 and opcode.lower() not in opcodesWithoutOperands:
+                operand = tokens[startIndex + 1]
+                if len(tokens) > startIndex + 2:
+                    if opcode.lower() in opcodesWithStrings:
+                        operand = buildStringOperand(l, operand)
+
+                        comment = l[(l.index(operand)+len(operand)):].strip()
+                    elif opcode.lower() in opcodesWithFullLines:
+                        operand = l.split(None, startIndex + 1)[startIndex + 1]
+                    else:
+                        comment = l.split(None, startIndex + 2)[startIndex + 2]
+                else:
+                    comment = ""
+            else:
+                if len(tokens) > startIndex + 1:
+                    comment = l.split(None, startIndex + 1)[startIndex + 1]
+
+    showLine(label, opcode, operand, comment, labelWidth, opcodeWidth, operandWidth, instrWidth, False)
+
+parser = argparse.ArgumentParser(description='Reformat 6x09 assembly language input')
+
+parser.add_argument('-l', "--label-width", metavar='N', help="Minimum width of label", dest='label', type=int, default=20)
+
+parser.add_argument('-i', "--instruction-width", metavar='N', help="Width of instruction (overrides opcode, operand)", dest='instr', type=int, default=None)
+
+parser.add_argument('-n', "--no-pseudo", help="Disable unindenting directives", dest='nodirs', default=False, action='store_true')
+
+parser.add_argument('-o', "--opcode-width", metavar='N', help="Width of the opcode", dest='opcode', type=int, default=10)
+
+parser.add_argument('-p', "--operand-width", metavar='N', help="Width of the operand", dest='operand', type=int, default=10)
+
+parser.add_argument('filename', nargs='?', metavar='FILE', help="File to process (stdin used if not given or '-')") # positional argument
+
+args = parser.parse_args()
+
+sys.stdin.reconfigure(encoding='cp850')
+sys.stdout.reconfigure(encoding='cp850')
+
+if args.filename == '-' or args.filename == None:
+    for line in sys.stdin:
+        processLine(args, line)
+else: # Using the 'with' statement ensures that the file is properly closed after its suite finishes.
+    with open(args.filename, 'r', encoding='cp850') as file:
+        for line in file:
+            processLine(args, line)

--- a/scripts/setup-filters
+++ b/scripts/setup-filters
@@ -1,0 +1,229 @@
+#!/bin/sh
+
+REPODIR=$(pwd)
+
+# Until the github repo is converted to condensed format we use 
+# asmalign with defaults as the clean filter.  The asmalign filter
+# accepts Opcode, Operand, and Comment start positions as arguments.
+# These default to columns 21, 31, and 51 respectively. Additionally
+# an optional argument can be used to turn on direcive indenting.
+# The defaults match the "spread out" github repo formatting that is
+# being depreciated.
+
+ASMCLEAN=$REPODIR/scripts/asmalign
+
+# After the github repo is converted to the new "condensed" formatting
+# we should to use asmclean as the filter and the following line should
+# be uncommented:
+
+#ASMCLEAN=$REPODIR/scripts/asmclean
+
+# The asmclean filter accepts no arguments and produces the most compact
+# assembly source possible.
+
+# Asmpp is another filter that could be used. The difference between it and
+# asmalign is with the arguments used to control formatting. They use the
+# same logic to find fields in the source and can be used to produce
+# identical formatting in most cases. The differences in result occur when
+# fields overflow, asmalign is more capable of maintaining alignment of
+# fields in those cases. Another difference is asmalign by default does
+# not indent directives two spaces while asmpp will. This allows is to
+# work as a clean filter to match "spread out" formatting. Because of these
+# advantages asmalign is used here but asmpp could be used instead by
+# editing the .git/config file.
+
+ASMINDENT=$REPODIR/scripts/asmalign
+
+# Verify the filters can be found
+if [ ! -x $ASMCLEAN -o ! -x $ASMINDENT ]; then
+  echo
+  echo Setup must run from the root of the nitros9 repository.
+  echo Change to that directory then run 'scripts/setup-filters'.
+  echo If you already did that and you still get this message
+  echo the filters are missing from the scripts subdirectory.
+  echo
+  return
+fi
+
+echo
+echo This script will set up clean and smudge filters for nitros9
+echo assembler sources. This will allow the sources in your working 
+echo directory to have the format of your choice. If the files in
+echo the git index are not in a clean state adding the clean filter
+echo can have the undesired effect of causing git to assume files
+echo have been changed. You should check that you have a clean
+echo repository before proceeding.  If for some reason you move your
+echo working directory you must run this script again.
+echo
+echo Git attributes for assembler source files must be setup to use
+echo the filters.  This only needs to be done once. If you want this
+echo script to write a new .git/info/attributes file with settings 
+echo for Nitros9 assembler source files just press enter.
+echo
+while true; do
+  read -p "Create new attributes file for assembler source? [y] " ans
+  case $ans in
+    [Qq]* ) return;;
+    [Nn]* ) 
+      break;;
+    * ) 
+      cat << EOS > .git/info/attributes
+*.a      filter=assembly
+*.asm    filter=assembly
+*.as     filter=assembly
+*.d      filter=assembly
+defsfile filter=assembly
+EOS
+      echo Created new attributes file
+      break;;
+  esac
+done
+
+# Verify clean filter will run
+if echo -n | $ASMCLEAN; then
+  echo 
+else
+  echo
+  echo Clean filter does not seem to work. Is Python3 in your
+  echo environment?
+  echo
+  return
+fi
+
+read -p "Install the clean filter? [y] " ans
+case $ans in
+  [Nn]* )
+      read -p "Are you sure? [n] " ans;; 
+  [Yy]* | '' ) ans='true';;
+esac
+case $ans in
+  [Qq]* ) return;;
+  [Nn]* ) return;;
+  [Yy]* ) break;;
+  * )
+    git config filter.assembly.clean "$ASMCLEAN"
+    if [ $? -ne 0 ] ; then
+      echo Clean filter config failed. Something is wrong with your
+      echo git configuration.
+      return
+    fi
+    echo Clean filter installed;;
+esac
+
+echo
+echo Field spacing is controlled by specifying field columns. The label, 
+echo opcode, operand, and comment are kept in order and separated by at
+echo least one space. Columns are numbered starting with one. A field 
+echo column specified as zero has the effect of separating it from the
+echo previous field by just one space.
+echo
+
+read -p "Proceed with re-alignment (smudge) filter? [y] " ans
+case $ans in
+  [Nn]* ) return;;
+  [Qq]* ) return;;
+esac
+
+echo
+echo Some nice settings are suggested. Use or change them to suit. If you
+echo want to match the original spread out formatting use 21, 31, and 51.
+echo
+
+opcode="12"
+operand="0"
+comment="32"
+
+while true; do
+  while true; do
+    read -p "Opcode column? [$opcode] " ans
+    case $ans in
+      *[!0-9]*) echo enter a column number;;
+      * | '') break;;
+    esac
+  done
+  [ -n "$ans" ] && opcode=$ans;
+
+  while true; do
+    read -p "Operand column? [$operand] " ans
+    case $ans in
+      *[!0-9]*) echo enter a column number;;
+      * | '') break;;
+    esac
+  done
+  [ -n "$ans" ] && operand=$ans;
+
+  while true; do
+    read -p "Comment column? [$comment] " ans
+    case $ans in
+      *[!0-9]*) echo enter a column number;;
+      * | '') break;;
+    esac
+  done
+  [ -n "$ans" ] && comment=$ans;
+
+  echo
+  read -p "Is $opcode, $operand, $comment okay? [y] " ans
+  case $ans in
+    [Nn]*) ;;
+    * ) break;;
+  esac
+done
+
+echo
+read -p "Two space indenting of directives? [n] " ans
+case $ans in
+  [Yy]* ) dirs="-d"; break;;
+  * ) dirs=""; break;;
+esac
+
+# set up smudge filter
+ARGS="$dirs -o$opcode -p$operand -c$comment"
+git config filter.assembly.smudge "$ASMINDENT $ARGS"
+if [ $? -ne 0 ] ; then
+  echo "Realignment filter configure failed"
+  return
+fi
+
+echo
+echo Filters are setup but assembler source in your working directory
+echo might not reflect the updated alignment. To fix the formatting for
+echo a source file you can delete it and use git checkout to replace
+echo it with the new formatting.  Instead the entire working directory
+echo can be updated now by allowing this script to do that for all
+echo assembler source files.
+echo  
+
+while true; do
+  read -p "Update your entire working directory to new format? [n] " ans
+  case $ans in
+    [Yy]* ) break;;
+    * ) return;;
+  esac
+done
+
+# Check if there are any uncommitted changes
+if [ -n "$(git status -s)" ]; then
+  echo
+  echo There are uncommitted changes in your working directory. If they
+  echo are assembler source they might be lost. If you know this is not
+  echo a problem you can continue.
+  echo
+  read -p "Are you sure you want to continue? [n] " ans
+  case $ans in
+    [Yy]* ) break;;
+    * ) return;;
+  esac
+fi
+
+# Test checkout
+git checkout -q main
+if [ $? -ne 0 ] ; then
+  echo The script could not checkout the main branch.
+  echo Sorry. You have to investigate why and try again
+  return
+fi
+
+echo Updating the working directory. This might take a while.
+git ls-files **.a **.asm **.as **.d **defsfile | xargs rm
+git checkout main -- .
+


### PR DESCRIPTION
Commit clean and smudge filters into the repo and the setup-filters script is added.  The script can be used to setup the filters and must be run from a shell command line in the nitros9 repo base directory.  To run the setup type "scripts/setup-filters"

Filters require python3 and the script requires /bin/sh

On initial commit the script clean filter defaults to the "spread out" source formatting currently in github.

After the github repository is converted to "condensed" formatting the local repo must also be converted and the setup-filters line "#ASMCLEAN=$REPODIR/scripts/asmclean" should be uncommented.