### PR TITLE
Fix Dragon 64 CMDS makefile to build grep and other .as files.

### DIFF
--- a/level1/d64/cmds/makefile
+++ b/level1/d64/cmds/makefile
@@ -1,11 +1,16 @@
 ifeq ($(PORT),)
         PORT=d64
 endif
-include $(NITROS9DIR)/rules.mak
+include ../port.mak
 
+vpath %.as $(LEVEL1)/cmds
 vpath %.asm $(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09
 
 DEPENDS		= ./makefile
+
+AFLAGS		+= -I$(LEVEL1)/$(PORT)
+AFLAGS		+= -I$(3RDPARTY)/packages/basic09
+LFLAGS		+= -L $(NITROS9DIR)/lib -lnet -lcoco -lalib
 
 CMDS		= asm attr backup bawk binex build cmp cobbler cobbler_dragon copy cputype \
 		date dcheck debug ded deiniz del deldir devs dir dirsort disasm \


### PR DESCRIPTION
The Dragon 64 (and by extension, Tano) `makefile` for CMDS now mirrors the `level1/coco1/makefile` more closely, fixing some build errors.