### PR TITLE
Fix d64/cmds/makefile to use same path as other ports' cmds/makefile

### DIFF
--- a/level1/d64/cmds/makefile
+++ b/level1/d64/cmds/makefile
@@ -1,7 +1,4 @@
-ifeq ($(PORT),)
-        PORT=d64
-endif
-include $(NITROS9DIR)/rules.mak
+include ../port.mak
 
 vpath %.as $(LEVEL1)/cmds
 vpath %.asm $(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09


### PR DESCRIPTION
This is a minor fix, but it lines up this makefile with other ports. The `include ../port.mak` includes the file above it which sets `PORT` and pulls in the `rules.mak`