### PR TITLE
Update clock2_f256.asm

### DIFF
--- a/level1/f256/modules/clock2_f256.asm
+++ b/level1/f256/modules/clock2_f256.asm
@@ -42,6 +42,7 @@ GetTime             ldx       M$Mem,pcr           get RTC base address
                     bsr       bcd2bin             convert from BCD to binary
                     stb       <D.Min              save in globals
                     lda       RTC_HRS,x           get the RTC value
+                    anda      $7F                 remove AM/PM bit
                     bsr       bcd2bin             convert from BCD to binary
                     stb       <D.Hour             save in globals
                     lda       RTC_DAY,x           get the RTC value


### PR DESCRIPTION
HOUR and HOUR_ALARM parameters of RTC need to consider that bit 7 denotes AM/PM.