### PR TITLE
Commented out FONT and PALETTE in makefile for OS9Boot.

### DIFF
--- a/level2/f256/bootfiles/makefile
+++ b/level2/f256/bootfiles/makefile
@@ -42,8 +42,8 @@ SCVT_F256K	 = $(MD)/vtio.dr $(MD)/keydrv_f256k.sb $(MD)/mousedrv_ps2.sb $(MD)/te
 SCVT_F256JR  = $(MD)/vtio.dr $(MD)/keydrv_ps2.sb $(MD)/mousedrv_ps2.sb $(MD)/term.dt
 
 # Font & palette
-FONT		 = $(FNT)/bannerfont.sb
-PALETTE	 = $(MD)/palette.sb
+#FONT		 = $(FNT)/bannerfont.sb
+#PALETTE	 = $(MD)/palette.sb
 
 # SCF DriveWire virtual networking/window driver
 SCDWV = 	$(MD)/scdwv.dr $(SCDWV_NET) $(SCDWV_WIN)


### PR DESCRIPTION
Boot up will be ugly until we can load font and palette in FEU. This saves 2048 Bytes in font data and 128 Bytes of palette data in OS9Boot file.