### PR TITLE
Update rules.mak

### DIFF
--- a/rules.mak
+++ b/rules.mak
@@ -25,6 +25,10 @@ OS9		= os9
 
 NITROS9VER	= v0$(NOS9VER)0$(NOS9MAJ)0$(NOS9MIN)
 
+ifeq ($(OS),Windows_NT)
+    OS := W
+endif
+
 DEFSDIR		= $(NITROS9DIR)/defs
 DSKDIR		= $(NITROS9DIR)/dsks
 
@@ -90,7 +94,11 @@ UMOUNT		= sudo umount
 LOREMOVE	= sudo losetup -d
 LOSETUP		= sudo losetup
 LINK		= ln
+ifeq ($(OS),W)
+SOFTLINK	= $(LINK)	# Special case for Windows
+else
 SOFTLINK	= $(LINK) -s
+endif
 ARCHIVE		= zip -D -9 -j
 MKDSKINDEX	= perl $(NITROS9DIR)/scripts/mkdskindex
 DROP_EXTRA_SPACES = fn() { mv "$$1" "$$1.tmp" && sed 's/  */ /g' "$$1.tmp" > "$$1" && rm "$$1.tmp"; }; fn


### PR DESCRIPTION
Fix symlink issue on Windows systems.  Master conditional shortens the environment variable from "WINDOWS_NT" to "W" to be reused across the repo if needed.