### PR TITLE
Update rbmem.asm

### DIFF
--- a/level1/f256/modules/rbmem.asm
+++ b/level1/f256/modules/rbmem.asm
@@ -235,7 +235,7 @@ TfrFSect            lda       FlashBlock,u        copy from Flash block to Cache
                     lbsr      TfrSect             Write the 256-byte sector into the 8K Cache
                     puls      x,y
                     tst       EmptySector,u
-*                    beq       c@                  old OS-9 sector is empty, so we just need to write over Only It
+                    beq       c@                  old OS-9 sector is empty, so we just need to write over Only It
                     tfr       y,d                 Y = address of OS-9 256-byte sector within the 8K Cache
                     anda      #$10                compute which half of the 8K Flash block it's in (A12 of address)
                     tfr       d,x               


### PR DESCRIPTION
Enable the Flash write efficiency.  This may need to become a dmode option for long-term testing.  In my tests it never fails, and provides much faster writes after the Flash chip has been erased or soft-formatted to $FF sectors.