### PR TITLE
Remove pipe-related modules to keep the FEU bootfile under the necess…

### DIFF
--- a/level1/f256/feu/makefile
+++ b/level1/f256/feu/makefile
@@ -72,7 +72,6 @@ BOOTFILE_F256K = $(KERNEL) \
 		$(SCF) $(SCVT_F256K) $(FONT) $(PALETTE) \
 		$(RBF) $(RBFDW) $(DWIO) \
 		$(RBSUPER) $(RBFNXSD) $(RBMEM) \
-		$(PIPE) \
 		$(CLOCK) \
 		sysgo $(CMDSDIR)/shell_21 \
 		$(CMDSDIR)/display \
@@ -88,7 +87,6 @@ BOOTFILE_F256JR = $(KERNEL) \
 		$(SCF) $(SCVT_F256JR) $(FONT) $(PALETTE) \
 		$(RBF) $(RBFDW) $(DWIO) \
 		$(RBSUPER) $(RBFNXSD) $(RBMEM) \
-		$(PIPE) \
 		$(CLOCK) \
 		sysgo $(CMDSDIR)/shell_21 \
 		$(CMDSDIR)/display \


### PR DESCRIPTION
…ary size.

- Since FEU is really just a minimal OS-9 Level 1 environment for booting, running the debugger, and basic file manipulation, it doesn't need all the features of a full OS-9 Level 1 system, which can still be made on an SD card.