### PR TITLE
F256/feu makefile

### DIFF
--- a/level1/f256/feu/makefile
+++ b/level1/f256/feu/makefile
@@ -173,7 +173,6 @@ f256k.zip: booter_flash_f256k
 	-rm -rf mapfiles
 	mkdir mapfiles
 	os9 ident -s $^ > mapfiles/bootlist
-	cp ../modules/kernel/*.map ../modules/kernel/*.list ../modules/*.map ../modules/*.list mapfiles
 	zip $@ bulk.csv booter_0 booter_1 booter_2 mapfiles/*
 
 flash_f256k: f256k.zip
@@ -190,7 +189,6 @@ f256jr.zip: booter_flash_f256jr
 	-rm -rf mapfiles
 	mkdir mapfiles
 	os9 ident -s $^ > mapfiles/bootlist
-	cp ../modules/kernel/*.map ../modules/kernel/*.list ../modules/*.map ../modules/*.list mapfiles
 	zip $@ bulk.csv booter_0 booter_1 booter_2 mapfiles/*
 
 flash_f256jr: f256jr.zip


### PR DESCRIPTION
Remove cp map and list files from feu makefile because the map and list files don't exist and cp throws an error.  Tested on f256jr.jr.