### PR TITLE
Update rbmem.asm

### DIFF
--- a/level1/f256/modules/rbmemdesc.asm
+++ b/level1/f256/modules/rbmemdesc.asm
@@ -21,7 +21,7 @@ DRVTYP              equ       $80
 TRACKS              equ       64       number of tracks
 BLOCKSTART          equ       $80       starting block number
 SECTRK              equ       16
-SAS                 equ       4
+SAS                 equ       1
 modes               equ       DIR.+SHARE.+PREAD.+PWRIT.+PEXEC.+READ.+WRITE.+EXEC.
                   ELSE
 * Geometry values equals the size of the flash area: 5 8K blocks (40,960 bytes)


### PR DESCRIPTION
Moved ORCC instruction in Write routine.
Added Flash write error checking, return with CRC error if 256 attempts with wrong readback. Need to assess whether interrupts need to be masked at all except for during the Flash command sequences and programming cycle.