### PR TITLE
WizFi experience

### DIFF
--- a/level1/f256/modules/wizfi.asm
+++ b/level1/f256/modules/wizfi.asm
@@ -278,10 +278,10 @@ Init                clrb                          default to no error...
 * 0 = 115200 bps (aka Slow mode)
 * 1 = 921600 bps (aka Fast mode) doesn't appear to work at this time
                 sta	>WIZFI_UART_CtrlReg
-                ldy	#2048
-p@      	ldb	>WIZFI_UART_DataReg
-                leay	-1,y
-                bne	p@
+*                ldy	#2048
+*p@      	ldb	>WIZFI_UART_DataReg
+*                leay	-1,y
+*                bne	p@
                 stx	>WORK_SLOT
                 puls	x
 

--- a/level1/f256/scripts/wizcon
+++ b/level1/f256/scripts/wizcon
@@ -12,6 +12,3 @@ sleep 90
 echo AT+CWDHCP_CUR=1,1>/wz
 sleep 90
 echo AT+CWJAP_CUR="SSID","PASSWORD">/wz
-sleep 90
-echo AT+CIPSTA_CUR?>/wz
-sleep 90


### PR DESCRIPTION
After running the wizcon script containing your router's SSID and password,
power off...   power back up.

If the connection was made, at this time you should have the following 6 lines in the FIFO buffer:

ready<cr><lf>
WIFI CONNECTED<cr><lf>
WIFI GOT IP<cr><lf>
<cr><lf>
OK<cr><lf>
<cr><lf>

After these 6 lines are purged or however many lines you expect to exist in the FIFO before any interaction has been made, you can then run the wizmon script if you want to start a remote shell session.

To purge the above 6 lines, I use  mergeln /wz /wz /wz /wz /wz /wz
You can place the mergeln command in your startup file, but it needs to run before starting the wizmon script.