### PR TITLE
clock_50hz was running at 60Hz causing 1 minute to be lost every 6.

### DIFF
--- a/defs/atari.d
+++ b/defs/atari.d
@@ -62,8 +62,8 @@ ATARI.D             set       1
 **********************************
 * Power Line Frequency Definitions
 *
-Hz50                equ       1                   Assemble clock for 50 hz power
-Hz60                equ       2                   Assemble clock for 60 hz power
+Hz50                equ       50                  Assemble clock for 50 hz power
+Hz60                equ       60                  Assemble clock for 60 hz power
                     IFNDEF    PwrLnFrq
 PwrLnFrq            set       Hz60                Set to Appropriate freq
                     ENDC

--- a/defs/coco.d
+++ b/defs/coco.d
@@ -73,8 +73,8 @@ CPUSpeed            SET       TwoMHz
 **********************************
 * Power Line Frequency Definitions
 *
-Hz50                EQU       1                   Assemble clock for 50 hz power
-Hz60                EQU       2                   Assemble clock for 60 hz power
+Hz50                EQU       50                  Assemble clock for 50 hz power
+Hz60                EQU       60                  Assemble clock for 60 hz power
                     IFNDEF    PwrLnFrq
 PwrLnFrq            SET       Hz60                Set to Appropriate freq
                     ENDC

--- a/defs/dragon.d
+++ b/defs/dragon.d
@@ -32,8 +32,8 @@ HW.Page             SET       $FF                 Device descriptor hardware pag
 **********************************
 * Power Line Frequency Definitions
 *
-Hz50                EQU       1                   Assemble clock for 50 hz power
-Hz60                EQU       2                   Assemble clock for 60 hz power
+Hz50                EQU       50                  Assemble clock for 50 hz power
+Hz60                EQU       60                  Assemble clock for 60 hz power
                     IFNDEF    PwrLnFrq
 PwrLnFrq            SET       Hz60                Set to Appropriate freq
                     ENDC


### PR DESCRIPTION
This also brings atari.d, coco.d, and dragon.d in line with mc09.d