### PR TITLE
L1/modem cmd

### DIFF
--- a/level1/cmds/modem.asm
+++ b/level1/cmds/modem.asm
@@ -1,17 +1,14 @@
+                    nam       Modem
+                    ttl       Modem Command/Response Utility
+
 ********************************************************************
-* MergeLn - Experimental, Merge text files into one file
+* Modem - Similar to the MERGE command at this time,
+* but aimed at Telnet/WIFI Modem devices.
+* Will evolve into a full AT command issuer and response parser.
 *
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
-*   4      ????/??/??
-* From Tandy OS-9 Level One VR 02.00.00.
-*
-*   5      2003/09/06
-* Added -z option to read files from stdin
-
-                    nam       MergeLn
-                    ttl       Merge text files into one file
 
                     ifp1
                     use       defsfile
@@ -42,7 +39,7 @@ d.buffer            rmb       2496                should reserve 7k, leaving som
                     rmb       STACKSZ+PARMSZ
 size                equ       .
 
-name                fcs       /MergeLn/
+name                fcs       /Modem/
                     fcb       edition             change to 6, as merge 5 has problems?
 
 * Here's how registers are set when this process is forked:

--- a/level1/f256/cmds/makefile
+++ b/level1/f256/cmds/makefile
@@ -14,11 +14,11 @@ CMDS		= asm attr backup bawk binex build cmp copy \
 		date dcheck debug ded deiniz del deldir devs dir dirsort disasm \
 		display dmode dsave dump echo edit error exbin format \
 		free grep help ident iniz irqs link list load login makdir \
-		megaread mdir merge mergeln mfree more padrom park printerr procs prompt pwd pxd \
+		megaread mdir merge modem mfree more padrom park printerr procs prompt pwd pxd \
 		rename save setime shellplus shell_21 sleep \
 		tee tmode touch tsmon unlink verify xmode \
 		inetd telnet dw httpd $(BASIC09) $(BF) \
-		bootos9 fnxinfo fnxreset pick play mergeln
+		bootos9 fnxinfo fnxreset pick play modem
 
 ALLOBJS		= $(CMDS)
 

--- a/level1/f256/scripts/wizfast
+++ b/level1/f256/scripts/wizfast
@@ -1,2 +1,2 @@
 echo AT+UART_CUR=921600,8,1,0,0>/wz
-mergeln /wz /wz /wz
+modem /wz /wz /wz

--- a/level1/f256/scripts/wizi
+++ b/level1/f256/scripts/wizi
@@ -1,2 +1,2 @@
 iniz /wz
-mergeln /wz /wz /wz /wz /wz /wz
+modem /wz /wz /wz /wz /wz /wz

--- a/level1/f256/scripts/wizmon
+++ b/level1/f256/scripts/wizmon
@@ -1,9 +1,9 @@
 echo * WizFi360 Helper - Remote passthrough connection over /wz
 echo * From the remote client connect to port 23 of
 echo * the WizFi's IP address now...
-mergeln /wz
+modem /wz
 sleep 30
 echo AT+CIPSEND>/wz
-mergeln /wz
+modem /wz
 sleep 30
 xmode /wz eko=1

--- a/level1/f256/scripts/wizmonfast
+++ b/level1/f256/scripts/wizmonfast
@@ -1,9 +1,9 @@
 echo * WizFi360 Helper - Remote passthrough connection over /n0
 echo * From the remote client connect to port 23 of
 echo * the WizFi's IP address now...
-mergeln /n0
+modem /n0
 sleep 30
 echo AT+CIPSEND>/n0
-mergeln /n0
+modem /n0
 sleep 30
 xmode /n0 eko=1

--- a/level1/f256/scripts/wizserver
+++ b/level1/f256/scripts/wizserver
@@ -1,13 +1,13 @@
 echo * WizFi360 Helper - Start passthrough server on /wz
 xmode /wz eko=0
 echo ATE0>/wz
-mergeln /wz /wz
+modem /wz /wz
 echo AT+CIPSERVERMAXCONN=1>/wz
-mergeln /wz /wz
+modem /wz /wz
 echo AT+CIPMUX=1>/wz
-mergeln /wz /wz
+modem /wz /wz
 echo AT+CIPMODE=1>/wz
-mergeln /wz /wz
+modem /wz /wz
 echo AT+CIPSERVER=1,23>/wz
-mergeln /wz /wz /wz
+modem /wz /wz /wz
 echo * Done

--- a/level1/f256/scripts/wizserverfast
+++ b/level1/f256/scripts/wizserverfast
@@ -2,13 +2,13 @@ echo * WizFi360 Helper - Start 921600 bps passthrough server on /n0
 iniz /n0
 xmode /n0 eko=0
 echo ATE0>/n0
-mergeln /n0 /n0
+modem /n0 /n0
 echo AT+CIPSERVERMAXCONN=1>/n0
-mergeln /n0 /n0
+modem /n0 /n0
 echo AT+CIPMUX=1>/n0
-mergeln /n0 /n0
+modem /n0 /n0
 echo AT+CIPMODE=1>/n0
-mergeln /n0 /n0
+modem /n0 /n0
 echo AT+CIPSERVER=1,23>/n0
-mergeln /n0 /n0 /n0
+modem /n0 /n0 /n0
 echo * Done

--- a/level1/f256/scripts/wizslow
+++ b/level1/f256/scripts/wizslow
@@ -1,2 +1,2 @@
 echo AT+UART_CUR=115200,8,1,0,0>/n0
-mergeln /n0 /n0 /n0
+modem /n0 /n0 /n0

--- a/level2/f256/cmds/makefile
+++ b/level2/f256/cmds/makefile
@@ -22,7 +22,7 @@ CMDS    = asm attr backup bawk binex build cmp copy \
 		date dcheck debug ded deiniz del deldir devs dir dirsort disasm \
 		display dmem dmode dsave dump echo edit error exbin \
 		format free grep help ident iniz irqs link list load login \
-		makdir mdir megaread merge mergeln mfree minted mmap modpatch more padrom park \
+		makdir mdir megaread merge modem mfree minted mmap modpatch more padrom park \
 		pmap proc procs prompt pwd pxd rename save setime shellplus \
 		shell_21 sleep smap tee tmode touch tsmon unlink verify xmode \
 		bootos9 fnxinfo fnxreset rogue fstatus fcfg xtclut drawtest play foenix shellbg shellbgoff \
@@ -32,7 +32,7 @@ CMDS_CART      = asm attr backup bawk binex build cmp copy \
 		date dcheck debug ded deiniz del deldir devs dir dirsort disasm \
 		display dmem dmode dsave dump echo edit error exbin \
 		format free grep help ident iniz irqs link list load login \
-		makdir mdir merge mergeln mfree minted mmap more padrom park \
+		makdir mdir merge modem mfree minted mmap more padrom park \
 		pmap proc procs prompt pwd pxd rename save setime \
 		sleep smap tee tmode touch tsmon unlink verify xmode \
 		bootos9 fnxinfo fnxreset rogue fstatus fcfg xtclut play foenix


### PR DESCRIPTION
Renamed confusing command title from "mergeln" to "modem".

Modem is evolving and currently works for the purpose requested by existing users of a WIFI-Modem device, and the goal is to progress into something that benefits all users of Telnet/WIFI/real modems on all versions of OS-9 on all platforms.

                    nam       Modem
                    ttl       Modem Command/Response Utility

********************************************************************
* Modem - Similar to the MERGE command at this time,
* aimed at Telnet/WIFI Modem devices.
* Will evolve into a full AT command issuer and response parser.
