### PR TITLE
F256/wizfi updates

### DIFF
--- a/defs/f256.d
+++ b/defs/f256.d
@@ -858,6 +858,8 @@ DMA_STATUS_TRF_IP   equ       $80       transfer in progress
 * Wifi_Control_Register:
 * Bit[0] = 0 = 115,200K Mode, 1 = 921,600K Mode
 * Bit[1] = 0 Default, 1 = Reset FIFO (you need to bring it back to 0) This is directly connected to reset line of the FIFO
+* Bit[2] = RX FIFO Empty ( 1 = Empty, 0 = Data Available)
+* Bit[3] = TX FIFO Empty ( 1 = Empty, 0 = Data Available)
                     org       $0
 WizFi_CtrlReg       rmb       1
 WizFi_DataReg       rmb       1

--- a/defs/os9.d
+++ b/defs/os9.d
@@ -495,7 +495,6 @@ D.DWSubAddr         RMB       2                   DriveWire subroutine module po
 D.DWStat            RMB       2                   DriveWire statics page
 D.DWSrvID           RMB       1                   DriveWire server ID
 D.IRQTmp            RMB       2                   1 or 2 byte DP scratch var (for when IRQ's are off)
-D.WizFi             rmb       2
 
                     ORG       $20
 

--- a/level1/f256/modules/n0.asm
+++ b/level1/f256/modules/n0.asm
@@ -1,14 +1,12 @@
+                    nam       n0
+                    ttl       WizFi360 device descriptor
+
 ********************************************************************
-* WZ - WizFi360 device descriptor
-*
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
 *   1/1    2025/03/31  Roger Taylor
 
-
-                    nam       n0
-                    ttl       WizFi360 device descriptor
 
                     ifp1
                     use       defsfile
@@ -16,7 +14,7 @@
 
 Base                set       $FF20
 Connection          set       $0
-DeviceMode          set       $00
+DeviceMode          set       $08
 tylg                set       Devic+Objct
 atrv                set       ReEnt+rev
 rev                 set       $00
@@ -48,7 +46,7 @@ rev                 set       $00
                     fcb       C$BSP               backspace echo character
                     fcb       C$BELL              line overflow character (bell)
                     fcb       PARNONE             parity
-                    fcb       STOP1+WORD8+1   stop bits/word size/baud rate
+                    fcb       STOP1+WORD8+1       stop bits/word size/baud rate
                     fdb       name                copy of descriptor name address
                     fcb       $00		C$XON               acia xon char
                     fcb       $00		C$XOFF              acia xoff char

--- a/level1/f256/modules/n1.asm
+++ b/level1/f256/modules/n1.asm
@@ -1,14 +1,12 @@
+                    nam       n1
+                    ttl       WizFi360 device descriptor
+
 ********************************************************************
-* WZ - WizFi360 device descriptor
-*
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
 *   1/1    2025/03/31  Roger Taylor
 
-
-                    nam       n1
-                    ttl       WizFi360 device descriptor
 
                     ifp1
                     use       defsfile
@@ -48,7 +46,7 @@ rev                 set       $00
                     fcb       C$BSP               backspace echo character
                     fcb       C$BELL              line overflow character (bell)
                     fcb       PARNONE             parity
-                    fcb       STOP1+WORD8+B9600   stop bits/word size/baud rate
+                    fcb       STOP1+WORD8+1       stop bits/word size/baud rate
                     fdb       name                copy of descriptor name address
                     fcb       $00		C$XON               acia xon char
                     fcb       $00		C$XOFF              acia xoff char

--- a/level1/f256/modules/n2.asm
+++ b/level1/f256/modules/n2.asm
@@ -1,14 +1,12 @@
+                    nam       n2
+                    ttl       WizFi360 device descriptor
+
 ********************************************************************
-* WZ - WizFi360 device descriptor
-*
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
 *   1/1    2025/03/31  Roger Taylor
 
-
-                    nam       n2
-                    ttl       WizFi360 device descriptor
 
                     ifp1
                     use       defsfile
@@ -48,7 +46,7 @@ rev                 set       $00
                     fcb       C$BSP               backspace echo character
                     fcb       C$BELL              line overflow character (bell)
                     fcb       PARNONE             parity
-                    fcb       STOP1+WORD8+B9600   stop bits/word size/baud rate
+                    fcb       STOP1+WORD8+1       stop bits/word size/baud rate
                     fdb       name                copy of descriptor name address
                     fcb       $00		C$XON               acia xon char
                     fcb       $00		C$XOFF              acia xoff char

--- a/level1/f256/modules/n3.asm
+++ b/level1/f256/modules/n3.asm
@@ -1,14 +1,12 @@
+                    nam       n3
+                    ttl       WizFi360 device descriptor
+
 ********************************************************************
-* WZ - WizFi360 device descriptor
-*
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
 *   1/1    2025/03/31  Roger Taylor
 
-
-                    nam       n3
-                    ttl       WizFi360 device descriptor
 
                     ifp1
                     use       defsfile
@@ -48,7 +46,7 @@ rev                 set       $00
                     fcb       C$BSP               backspace echo character
                     fcb       C$BELL              line overflow character (bell)
                     fcb       PARNONE             parity
-                    fcb       STOP1+WORD8+B9600   stop bits/word size/baud rate
+                    fcb       STOP1+WORD8+1       stop bits/word size/baud rate
                     fdb       name                copy of descriptor name address
                     fcb       $00		C$XON               acia xon char
                     fcb       $00		C$XOFF              acia xoff char

--- a/level1/f256/modules/wz.asm
+++ b/level1/f256/modules/wz.asm
@@ -1,14 +1,12 @@
+                    nam       wz
+                    ttl       WizFi360 device descriptor
+
 ********************************************************************
-* WZ - WizFi360 device descriptor
-*
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
 *   1/1    2025/03/31  Roger Taylor
 
-
-                    nam       WZ
-                    ttl       WizFi360 device descriptor
 
                     ifp1
                     use       defsfile

--- a/level1/f256/scripts/wizfast
+++ b/level1/f256/scripts/wizfast
@@ -1,2 +1,5 @@
 echo AT+UART_CUR=921600,8,1,0,0>/wz
 modem /wz /wz /wz
+xmode /wz bau=1
+echo AT>/wz
+modem /wz /wz

--- a/level1/f256/scripts/wizlog1
+++ b/level1/f256/scripts/wizlog1
@@ -1,0 +1,10 @@
+echo * WizFi360 Helper - Remote passthrough connection
+echo * From the remote client connect to port 23 of
+echo * the WizFi's IP address now...
+modem /wz
+sleep 30
+echo AT+CIPSEND>/wz
+modem /wz
+sleep 30
+xmode /wz eko=1
+tsmon /wz&

--- a/level1/f256/scripts/wizlog4
+++ b/level1/f256/scripts/wizlog4
@@ -1,0 +1,7 @@
+echo * WizFi360 Helper - Remote packet connection
+echo * From the remote client connect to port 23 of
+echo * the WizFi's IP address now...
+modem /wz
+iniz /n0
+xmode /n0 eko=1
+tsmon /n0&

--- a/level1/f256/scripts/wizslow
+++ b/level1/f256/scripts/wizslow
@@ -1,2 +1,5 @@
-echo AT+UART_CUR=115200,8,1,0,0>/n0
-modem /n0 /n0 /n0
+echo AT+UART_CUR=115200,8,1,0,0>/wz
+modem /wz /wz /wz
+xmode /wz bau=0
+echo AT>/wz
+modem /wz /wz

--- a/level1/f256/scripts/wizsv1
+++ b/level1/f256/scripts/wizsv1
@@ -1,0 +1,13 @@
+echo * WizFi360 Helper - Start passthrough server
+xmode /wz eko=0
+echo ATE0>/wz
+modem /wz /wz
+echo AT+CIPSERVERMAXCONN=1>/wz
+modem /wz /wz
+echo AT+CIPMUX=1>/wz
+modem /wz /wz
+echo AT+CIPMODE=1>/wz
+modem /wz /wz
+echo AT+CIPSERVER=1,23>/wz
+modem /wz /wz /wz
+echo * Done

--- a/level1/f256/scripts/wizsv4
+++ b/level1/f256/scripts/wizsv4
@@ -1,0 +1,16 @@
+echo * WizFi360 Helper - Start packet server
+xmode /wz eko=0
+echo ATE0>/wz
+modem /wz /wz
+echo AT+CIPMODE=0>/wz
+modem /wz /wz
+echo AT+CIPMUX=1>/wz
+modem /wz /wz
+echo AT+CIPSERVERMAXCONN=4>/wz
+modem /wz /wz
+echo AT+CIPSERVER=1,23>/wz
+modem /wz /wz
+echo AT+CIPSTO=0>/wz
+modem /wz /wz
+modem /wz
+echo * Done

--- a/level2/f256/startup
+++ b/level2/f256/startup
@@ -1,2 +1,4 @@
 load utilpak1
 link shell
+iniz wz
+modem /wz /wz /wz /wz /wz /wz


### PR DESCRIPTION
Synchronizes everything back up to use the new modem command, high-speed /n# connections, updates the convenience scripts, and moves the WizFi driver a little closer to the attempt to handle multiple connections at once.
