### PR TITLE
Allow compile-time param definitions for boot-emu.

### DIFF
--- a/level1/coco1/modules/boot_emu.asm
+++ b/level1/coco1/modules/boot_emu.asm
@@ -15,11 +15,22 @@
 *   0      2024/02/15  E J Jaquay
 * Created.
 
-* Defines for boot device
+* Defines for boot device can be overridden with `-D` flags.
+ ifndef DEVADDR
 DEVADDR             equ       $FF80
+ endif
+
+ ifndef DISKNUM
 DISKNUM             equ       0
+ endif
+
+ ifndef LSN24BIT
 LSN24BIT            equ       1
+ endif
+
+ ifndef FLOPPY
 FLOPPY              equ       0
+ endif
 
                     nam       Boot
                     ttl       CoCo Emulator Virtual Hard Disk Boot


### PR DESCRIPTION
I need to change which drive number the boot_emu module will use, 
for TFR9 to be able to boot Level 1, Level 2, and more, from a common emulated setup.
There are three other parameters that could also reasonably be changed. 

lwasm doesn't let you override with -D like the C preprocessor does,
so I insert "ifndef" statements around the definitions. 

