### PR TITLE
MaxVhd parameter for emudsk

### DIFF
--- a/level1/coco1/modules/boot_emu.asm
+++ b/level1/coco1/modules/boot_emu.asm
@@ -15,11 +15,22 @@
 *   0      2024/02/15  E J Jaquay
 * Created.
 
-* Defines for boot device
+* Defines for boot device can be overridden with `-D` flags.
+ ifndef DEVADDR
 DEVADDR             equ       $FF80
+ endif
+
+ ifndef DISKNUM
 DISKNUM             equ       0
+ endif
+
+ ifndef LSN24BIT
 LSN24BIT            equ       1
+ endif
+
+ ifndef FLOPPY
 FLOPPY              equ       0
+ endif
 
                     nam       Boot
                     ttl       CoCo Emulator Virtual Hard Disk Boot


### PR DESCRIPTION
Originally emudsk was hardwired for only one disk.
Because that's all you'll ever need, someone declared.

Then in 2011, RG decided it should be 2 disks.

Now I need more, for the TFR9 computer.
And it's easy enough to do with a compile-time definition. 
 