### PR TITLE
Pau param for uarts

### DIFF
--- a/level1/coco1/modules/boot_emu.asm
+++ b/level1/coco1/modules/boot_emu.asm
@@ -15,11 +15,22 @@
 *   0      2024/02/15  E J Jaquay
 * Created.
 
-* Defines for boot device
+* Defines for boot device can be overridden with `-D` flags.
+ ifndef DEVADDR
 DEVADDR             equ       $FF80
+ endif
+
+ ifndef DISKNUM
 DISKNUM             equ       0
+ endif
+
+ ifndef LSN24BIT
 LSN24BIT            equ       1
+ endif
+
+ ifndef FLOPPY
 FLOPPY              equ       0
+ endif
 
                     nam       Boot
                     ttl       CoCo Emulator Virtual Hard Disk Boot

--- a/level1/modules/term_mc6850.asm
+++ b/level1/modules/term_mc6850.asm
@@ -4,7 +4,9 @@
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
-
+ ifndef Pauses
+Pauses equ 1        ; Default for IT.PAU pause:0=no end of page pause
+ endif
                     nam       Term
                     ttl       mc6850 Device Descriptor
 
@@ -41,7 +43,7 @@ rev                 set       $00
                     fcb       $01                 IT.EKO echo:0=no echo
                     fcb       $01                 IT.ALF auto line feed:0=off
                     fcb       $00                 IT.NUL end of line null count
-                    fcb       $01                 IT.PAU pause:0=no end of page pause
+                    fcb       Pauses              IT.PAU pause:0=no end of page pause
 * IT.PAG and IT.ROW are set to 25 to match the Multicomp6809 hardware
 * terminal. Applications (eg scred) inspect this value and need it to be
 * correct. In the case of a "glass teletype" (aka terminal emulator)

--- a/level1/modules/term_sc6551.asm
+++ b/level1/modules/term_sc6551.asm
@@ -4,6 +4,9 @@
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
+ ifndef Pauses
+Pauses equ 1        ; Default for IT.PAU pause:0=no end of page pause
+ endif
 
                     nam       Term
                     ttl       6551 Device Descriptor
@@ -31,7 +34,7 @@ rev                 set       $00
                     fcb       $01                 echo:0=no echo
                     fcb       $01                 auto line feed:0=off
                     fcb       $00                 end of line null count
-                    fcb       $01                 pause:0=no end of page pause
+                    fcb       Pauses              pause:0=no end of page pause
                     fcb       24                  lines per page
                     fcb       C$BSP               backspace character
                     fcb       C$DEL               delete line character

--- a/level1/modules/term_sc6850.asm
+++ b/level1/modules/term_sc6850.asm
@@ -4,7 +4,9 @@
 * Edt/Rev  YYYY/MM/DD  Modified by
 * Comment
 * ------------------------------------------------------------------
-
+ ifndef Pauses
+Pauses equ 1        ; Default for IT.PAU pause:0=no end of page pause
+ endif
                     nam       Term
                     ttl       sc6850 Device Descriptor
 
@@ -33,7 +35,7 @@ rev                 set       $00
                     fcb       $01                 IT.EKO echo:0=no echo
                     fcb       $01                 IT.ALF auto line feed:0=off
                     fcb       $00                 IT.NUL end of line null count
-                    fcb       $01                 IT.PAU pause:0=no end of page pause
+                    fcb       Pauses              IT.PAU pause:0=no end of page pause
 * IT.PAG and IT.ROW are set to 25 to match the Multicomp6809 hardware
 * terminal. Applications (eg scred) inspect this value and need it to be
 * correct. In the case of a "glass teletype" (aka terminal emulator)


### PR DESCRIPTION
Param to allow Pausing to default off on UARTS.
With modern terminal emulators, the need for automatic pausing
is less than its annoyance factor.  It also interferes
with automatic testing and benchmarking.

This does not change the default value,
but lets you change it with -D from your makefile.

This is for the /TERM device with three UART drivers,
mc6850, sc6850, and sc6551.