### PR TITLE
Modify makefile so that gfx2 is dependent on creation of coco3vtio.d

### DIFF
--- a/3rdparty/packages/basic09/makefile
+++ b/3rdparty/packages/basic09/makefile
@@ -29,7 +29,7 @@ banner:
 coco3vtio.d: $(DEFSDIR)/cocovtio.d
 	$(AS) $(AFLAGS) $(DEFOPTS) -DCOCOVTIO.D=0 $< > $@
 
-gfx2: gfx2.asm
+gfx2: gfx2.asm coco3vtio.d
 	$(AS) $(ASOUT)$@ $< $(M6809) -DLevel=2
 
 basic09_6309: basic09.asm


### PR DESCRIPTION
(otherwise, Makefile can fail if one does: make clean gfx2)