### PR TITLE
minor lbra fix to modem, vtio fix for reverse video

### DIFF
--- a/level1/cmds/modem.asm
+++ b/level1/cmds/modem.asm
@@ -195,7 +195,7 @@ do.sx               leax      crlf,pcr
                     lbcs      read.ex             crap out if error
                     lda       <path               get the current path number
                     os9       I$Close             close it
-                    bra       do.opts
+                    lbra       do.opts
 
 ********************************************************************
 do.file             ldx       <param

--- a/level1/f256/modules/vtio.asm
+++ b/level1/f256/modules/vtio.asm
@@ -937,11 +937,11 @@ OneEffHandler2
 ResetHandler        leax      DefaultHandler,pcr
                     bra       SetHandler
 revoff              tst       V.Reverse,u         is reverse already off?
-                    beq       SetHandler          branch if so
+                    beq       ResetHandler          branch if so
                     com       V.Reverse,u
                     bra       DoReverse
 revon               tst       V.Reverse,u         is reverse already on?
-                    bne       SetHandler          branch if so
+                    bne       ResetHandler          branch if so
                     com       V.Reverse,u
 DoReverse
 * swap foreground and background color bits


### PR DESCRIPTION
Added lbra instruction to line 198 of modem.asm to fix compile issues.

vtio reverse video needed to reset to the default handler after setting the reverse video.  Prior version would try to read a second parameter if two reverse video calls were made in a row. 