### PR TITLE
Modify version so that it shows date for Wildbits port

### DIFF
--- a/3rdparty/packages/pacos9/makefile
+++ b/3rdparty/packages/pacos9/makefile
@@ -7,6 +7,13 @@ LFLAGS += -L$(NITROS9DIR)/lib -lnos96809l2
 
 DSK = PacOS9.dsk
 
+all: $(TARGET)
+	@$(ECHO) "**************************************************"
+	@$(ECHO) "*                                                *"
+	@$(ECHO) "*                    Pac OS-9                    *"
+	@$(ECHO) "*                                                *"
+	@$(ECHO) "**************************************************"
+
 $(TARGET): $(OBJS)
 	$(LINKER) $(LFLAGS) $^ -o$@
 

--- a/defs/os9.d
+++ b/defs/os9.d
@@ -795,7 +795,8 @@ Feature1            RMB       1                   feature byte 1
 Feature2            RMB       1                   feature byte 2
 OSName              RMB       2                   OS revision name string (nul terminated)
 InstallName         RMB       2                   installation name string (nul terminated)
-                    RMB       4                   reserved for future use
+BuildInfo           RMB       2                   build information string (nul terminated)
+                    RMB       2                   reserved for future use
 
                     IFGT      Level-1
 * -- VTIO area -- (NitrOS-9 Level 2 and above) *

--- a/level1/coco1/modules/makefile
+++ b/level1/coco1/modules/makefile
@@ -37,6 +37,8 @@ CLOCKS          = clock_60hz clock_50hz \
                 clock2_smart clock2_harris clock2_cloud9 clock2_soft \
 		clock2_messemu clock2_jvemu clock2_dw
 
+init:          init.asm buildinfo
+
 RBF		= rbf.mn \
 		rbdw.dr dwio.sb dwio_38400.sb dwio_becker.sb dwio_arduino.sb \
 		dwio_rs232pak.sb dwio_directmodempak.sb dwio_cocolink.sb \

--- a/level1/modules/init.asm
+++ b/level1/modules/init.asm
@@ -113,11 +113,20 @@ OSStr               equ       *
                     fcc       /Level /
                     fcb       '0+Level
                     fcc       / V/
-                    fcb       '0+NOS9VER
+                    ifgt      NOS9VER-25
+                    fcb       '0+(NOS9VER/10)
+                    endc
+                    fcb       '0+(NOS9VER%10)
                     fcc       /./
-                    fcb       '0+NOS9MAJ
+                    ifgt      NOS9VER-25
+                    fcb       '0+(NOS9MAJ/10)
+                    endc
+                    fcb       '0+(NOS9MAJ%10)
                     fcc       /./
-                    fcb       '0+NOS9MIN
+                    ifgt      NOS9VER-25
+                    fcb       '0+(NOS9MIN/10)
+                    endc
+                    fcb       '0+(NOS9MIN%10)
                     fcb       0
 
 InstStr             equ       *

--- a/level1/modules/init.asm
+++ b/level1/modules/init.asm
@@ -79,7 +79,8 @@ start               equ       *
                     fcb       $00                 feature byte #2
                     fdb       OSStr
                     fdb       InstStr
-                    fcb       0,0,0,0             reserved
+                    fdb       BuildStr
+                    fcb       0,0                 reserved
 
                     ifgt      Level-1
 * CC3IO section
@@ -112,25 +113,23 @@ OSStr               equ       *
                     endc
                     fcc       /Level /
                     fcb       '0+Level
+                    ifne      NOS9VER
                     fcc       / V/
-                    ifgt      NOS9VER-25
                     fcb       '0+(NOS9VER/10)
-                    endc
                     fcb       '0+(NOS9VER%10)
                     fcc       /./
-                    ifgt      NOS9VER-25
+                    ifgt      NOS9MAJ/10
                     fcb       '0+(NOS9MAJ/10)
                     endc
                     fcb       '0+(NOS9MAJ%10)
                     fcc       /./
-                    ifgt      NOS9VER-25
+                    ifgt      NOS9MAJ/10
                     fcb       '0+(NOS9MIN/10)
                     endc
                     fcb       '0+(NOS9MIN%10)
-
-* Include commit hash
-                    use       commithash
-                    
+                    else
+                    fcc       "-DEV"
+                    endc
                     fcb       0
 
 InstStr             equ       *
@@ -201,7 +200,10 @@ OSStr               equ       *
 InstStr             equ       *
                     fcb       0                   null-length string
                     endc                          match IFEQ dalpha
-
+BuildStr
+                    use       buildinfo
+                    fcb       0                   null-length string
+                    
                     emod
 eom                 equ       *
                     end

--- a/level1/modules/init.asm
+++ b/level1/modules/init.asm
@@ -127,6 +127,10 @@ OSStr               equ       *
                     fcb       '0+(NOS9MIN/10)
                     endc
                     fcb       '0+(NOS9MIN%10)
+
+* Include commit hash
+                    use       commithash
+                    
                     fcb       0
 
 InstStr             equ       *

--- a/level1/modules/sysgo.asm
+++ b/level1/modules/sysgo.asm
@@ -50,7 +50,7 @@ Banner              equ       *
 CrRtn               fcb       C$CR,C$LF
 
                     ifeq      ROM
-                    ifne      NOS9DBG
+                    ifne      NOS9DEV
                     fcc       "**   DEVELOPMENT BUILD   **"
                     fcb       C$CR,C$LF
                     fcc       "** NOT FOR DISTRIBUTION! **"

--- a/level1/wildbits/modules/makefile
+++ b/level1/wildbits/modules/makefile
@@ -21,6 +21,7 @@ KERNEL		= krn krnp2
 SYSMODS		= ioman init sysgo
 CLOCKS	    = clock clock2_wildbits
 
+init:          init.asm buildinfo
 
 RBF		= rbf.mn rbdw.dr $(DWIO) ddx0.dd x0.dd x1.dd x2.dd x3.dd \
 		rbmem.dr ddc0.dd c0.dd c1.dd f0.dd f1.dd \

--- a/level1/wildbits/modules/sysgo.as
+++ b/level1/wildbits/modules/sysgo.as
@@ -135,6 +135,13 @@ DoInit              ldx       InitAddr,u
                     leax      d,x
                     lbsr      PUTS
                     lbsr      ShowMachType
+                    lbsr      PRINTS
+                    fcc       / - /
+                    fcb       $0
+                    ldx       InitAddr,u
+                    ldd       BuildInfo,x       point to build info in INIT module
+                    leax      d,x
+                    lbsr      PUTS
                     lbsr      PUTCR
                     pshs      u,y
 

--- a/rules.mak
+++ b/rules.mak
@@ -12,6 +12,9 @@
 # NitrOS-9 version, major and minor release numbers are here
 BUILDDATE=$(shell git log -1 --format="%aD") # we can use this as a string in Init
 COMMITHASH=$(shell git log -1 --format="%h")
+ECHOHASH=$(shell echo " fcs / commit "$(COMMITHASH)"/" > $(NITROS9DIR)/defs/commithash)
+ifeq ($(ECHOHASH),0)
+endif
 -include $(NITROS9DIR)/Version
 ifeq ($(NOS9VER),) # Version didn't exist -- use date
 NOS9DBG=1 # 'dev version' enabled
@@ -58,7 +61,7 @@ ASOUT		= -o
 ifdef LISTDIR
 ASOUT		= --list=$(LISTDIR)/$@.lst --symbols -o
 endif
-AFLAGS		= -DNOS9VER=$(NOS9VER) -DNOS9MAJ=$(NOS9MAJ) -DNOS9MIN=$(NOS9MIN) -DNOS9DBG=$(NOS9DBG) -DCOMMITHASH=$(COMMITHASH)
+AFLAGS		= -DNOS9VER=$(NOS9VER) -DNOS9MAJ=$(NOS9MAJ) -DNOS9MIN=$(NOS9MIN) -DNOS9DBG=$(NOS9DBG)
 ifdef PORT
 AFLAGS		+= -D$(PORT)=1
 endif

--- a/rules.mak
+++ b/rules.mak
@@ -9,19 +9,25 @@
 # If the defaults below are fine, then there is no need to set any
 # environment variables.
 
-
 # NitrOS-9 version, major and minor release numbers are here
-ifeq ($(PORT),wildbits)
-  NOS9VER	= $(shell date +%y)
-  NOS9MAJ	= $(shell date +%m)
-  NOS9MIN	= $(shell date +%d)
+BUILDDATE=$(shell git log -1 --format="%aD") # we can use this as a string in Init
+COMMITHASH=$(shell git log -1 --format="%h")
+-include $(NITROS9DIR)/Version
+ifeq ($(NOS9VER),) # Version didn't exist -- use date
+NOS9DBG=1 # 'dev version' enabled
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    # macOS-specific settings
+    NOS9VER=$(shell date -z utc -v "$(BUILDDATE)" +%y)
+    NOS9MAJ=$(shell date -z utc -v "$(BUILDDATE)" +%-m)
+    NOS9MIN=$(shell date -z utc -v "$(BUILDDATE)" +%-d)
 else
-  NOS9VER	= 3
-  NOS9MAJ	= 3
-  NOS9MIN	= 0
+    # Non-macOS (Linux, etc.)
+    NOS9VER=$(shell date --utc --date="$(BUILDDATE)" +%y)
+    NOS9MAJ=$(shell date --utc --date="$(BUILDDATE)" +%-m)
+    NOS9MIN=$(shell date --utc --date="$(BUILDDATE)" +%-d)
 endif
-# Set this to 1 to turn on "DEVELOPMENT" message in sysgo
-NOS9DBG = 1
+endif
 
 #################### DO NOT CHANGE ANYTHING BELOW THIS LINE ####################
 
@@ -52,7 +58,7 @@ ASOUT		= -o
 ifdef LISTDIR
 ASOUT		= --list=$(LISTDIR)/$@.lst --symbols -o
 endif
-AFLAGS		= -DNOS9VER=$(NOS9VER) -DNOS9MAJ=$(NOS9MAJ) -DNOS9MIN=$(NOS9MIN) -DNOS9DBG=$(NOS9DBG)
+AFLAGS		= -DNOS9VER=$(NOS9VER) -DNOS9MAJ=$(NOS9MAJ) -DNOS9MIN=$(NOS9MIN) -DNOS9DBG=$(NOS9DBG) -DCOMMITHASH=$(COMMITHASH)
 ifdef PORT
 AFLAGS		+= -D$(PORT)=1
 endif

--- a/rules.mak
+++ b/rules.mak
@@ -11,10 +11,15 @@
 
 
 # NitrOS-9 version, major and minor release numbers are here
-NOS9VER	= 3
-NOS9MAJ	= 3
-NOS9MIN	= 0
-
+ifeq ($(PORT),wildbits)
+  NOS9VER	= $(shell date +%y)
+  NOS9MAJ	= $(shell date +%m)
+  NOS9MIN	= $(shell date +%d)
+else
+  NOS9VER	= 3
+  NOS9MAJ	= 3
+  NOS9MIN	= 0
+endif
 # Set this to 1 to turn on "DEVELOPMENT" message in sysgo
 NOS9DBG = 1
 


### PR DESCRIPTION
The Wildbits OS-9 team wants to move to a date-based version scheme (e.g. 26.01.18). This affects the `init` module which carries the version numbers both as embedded binary values and part of the version string.

We don't want to affect other ports, so I made the values conditional in `rules.mak`.

- Wildbits port now reports version as YY.MM.DD (e.g. 26.01.18)
- Other ports remain at 3.3.0
- As a result of modifying `init.asm`, its embedded version string now shows two digits for all ports (e.g. `03.03.00` instead of `3.3.0`)