### PR TITLE
Update build to cache lwtools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+#
+# Prepare environment with necessary packages.
 # disabled for now, uncomment if need to install package
 #    - name: Setup Requirements
 #      run: |
@@ -34,6 +37,22 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+#
+# Cache LwTools, if no cache key entry exists a new one will be created upon a successful build.
+# This will store the entries in 'path:' in a zip file, conveniently they all start with 'lw'
+#
+    - name: Cache LwTools
+      id: cache-lwtools
+      uses: actions/cache@v5
+      env:
+        cache-name: cache-lwtools
+      with:
+        path: /usr/local/bin/lw*
+        key: lwtools-4.24
+
+#
+# Fetch latest toolshed from the official repo.
+#
     - name: Fetch Toolshed
       uses: robinraju/release-downloader@v1
       with:
@@ -43,14 +62,26 @@ jobs:
         extract: false
         out-file-path: toolshed
 
+#
+# Unzip fetched toolshed binaries directly into /usr/local/bin
+#
+
     - name: Install Toolshed
       run: |
         sudo tar xvf toolshed/toolshed-unix*.tgz --strip-components=1 -C /usr/local/bin
 
-    - name: Install Lwtools
+#
+# If LwTools was cached last time, we can skip this step.
+# otherwise fetch it, build and install to /usr/local/bin.
+#
+    - if: ${{ steps.cache-lwtools.outputs.cache-hit != 'true' }}
+      name: Install Lwtools
       run: |
         sudo bash ./.github/workflows/lwtools.sh
 
+#
+# Trial build all nitros9 targets.
+#
     - name: Build NitrOS9
       run: |
         sudo bash ./.github/workflows/nitros9.sh

--- a/.github/workflows/lwtools.sh
+++ b/.github/workflows/lwtools.sh
@@ -2,6 +2,13 @@
 #
 # Build lwtools from source
 #
+# UPDATING LWTOOLS VERSION
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# To update to a new version of lwtools. Change the version number below
+# AND also in build.yml. The cached copy will be renewed as its based
+# on the "key:"
+#
+#
 mkdir -p lwtools
 cd lwtools
 wget http://www.lwtools.ca/releases//lwtools/lwtools-4.24.tar.gz


### PR DESCRIPTION
This will update the build check to cache lwtools so that its not rebuilt every time there is a build. Retention days is specified in the settings/actions/general under title 'Artifact and log retention'. The default is 90 days, this means if there is no build within 90 days, the cached tools will be re-fetched.

This should almost eliminate the chance of a bad build due to a network issue.

There is instructions for updating to newer lwtools in the lwtools.sh file.

This will also speed up the builds by a few seconds.