### PR TITLE
Upgrade actions to newer versions for node24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 env:
   # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: .
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: read
@@ -32,7 +33,7 @@ jobs:
 #        sudo apt-get install mingw-w64
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Fetch Toolshed
       uses: robinraju/release-downloader@v1


### PR DESCRIPTION
To resolve the build warning message that node20 will be deprecated come June.