### PR TITLE
Clean up Wildbits recipe platform defaults

### DIFF
--- a/recipes/wildbits/feu/makefile
+++ b/recipes/wildbits/feu/makefile
@@ -5,7 +5,12 @@ vpath %.asm $(NITROS9DIR)/level1/$(PORT)/feu
 vpath %.as $(NITROS9DIR)/level1/$(PORT)/feu
 include ../../rules.mak
 
-ifeq ($(PLATFORM), jr2)
+ifeq ($(strip $(PLATFORM)),)
+  $(info PLATFORM not set; defaulting to jr2)
+  PLATFORM = jr2
+endif
+
+ifneq ($(filter $(PLATFORM),jr jr2),)
   KEYSUB = keydrv_ps2
 else
   KEYSUB = keydrv_k2
@@ -306,7 +311,7 @@ $(MODDIR)/z14: scdwvdesc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DAddr=30
 
 clean:
-	$(RM) *.list *.map bootfile *.dsk booter* *.zip *.csv f0_? sysgo startup
+	$(RM) *.list *.map bootfile *.dsk booter* *.zip *.csv f0_? sysgo startup buildinfo
 	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR)
 
 help:

--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -4,7 +4,12 @@ MODDIR = .mods
 include ../../rules.mak
 -include recipe.mak
 
-ifeq ($(PLATFORM), jr2)
+ifeq ($(strip $(PLATFORM)),)
+  $(info PLATFORM not set; defaulting to jr2)
+  PLATFORM = jr2
+endif
+
+ifneq ($(filter $(PLATFORM),jr jr2),)
   KEYSUB = keydrv_ps2
 else
   KEYSUB = keydrv_k2
@@ -264,7 +269,7 @@ $(MODDIR)/z14: scdwvdesc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DAddr=30
 
 clean:
-	$(RM) *.list *.map bootfile *.dsk
+	$(RM) *.list *.map bootfile *.dsk buildinfo
 	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR)
 
 .PHONY: all clean libs


### PR DESCRIPTION
## Summary
- Default missing Wildbits PLATFORM values to jr2 and report the assumption
- Treat jr and jr2 as PS/2 keyboard platforms
- Include buildinfo in Wildbits recipe clean targets

## Testing
- git diff --check -- recipes/wildbits/wildbits.mak recipes/wildbits/feu/makefile
- make -n -C recipes/wildbits/l1 all | rg "PLATFORM not set|keydrv_|l1_wildbits.*\.dsk"
- make -n -C recipes/wildbits/l1 all PLATFORM=k2 | rg "keydrv_|l1_wildbits.*\.dsk"
- make -n -C recipes/wildbits/feu all | rg "PLATFORM not set|keydrv_|cat \.mods"