### PR TITLE
wildbits: fix wrong naming in bootfile

### DIFF
--- a/recipes/rules.mak
+++ b/recipes/rules.mak
@@ -198,7 +198,8 @@ $(MODDIR)/%: %.asm | $(MODDIR)
 
 # Modules built from RMA/RLINK-format .as files (assemble then link)
 $(MODDIR)/%: $(OBJDIR)/%.o | $(MODDIR)
-	$(LINKER) $(LFLAGS) $^ -o$@
+	$(LINKER) $(LFLAGS) $^ -o$*
+	$(MOVE) $* $@
 
 # Include an optional release file based on the port name that contains
 # release variables set... e.g.:

--- a/recipes/wildbits/feu/makefile
+++ b/recipes/wildbits/feu/makefile
@@ -29,7 +29,8 @@ SC16550 = sc16550 t0_sc16550
 CLOCK = clock clock2_wildbits
 
 $(MODDIR)/sysgo: $(OBJDIR)/sysgo.o | $(MODDIR)
-	$(LINKER) $(LFLAGS) $^ -o$@
+	$(LINKER) $(LFLAGS) $^ -osysgo
+	$(MOVE) sysgo $@
 
 $(OBJDIR)/sysgo.o: sysgo.as
 


### PR DESCRIPTION
Summary: fix WildBits linked-command module names so OS-9 headers do not pick up the output path like .mods/sysgo.

Changes:
- link RMA/RLINK-built modules to the bare basename first, then move them into .mods
- apply the same fix to the FEU-specific sysgo rule

Verification:
- rebuilt the WildBits FEU bootfile
- verified with os9 ident -s bootfile that sysgo, wbreset, and bootos9 no longer carry a .mods/ prefix in their module headers