### PR TITLE
wildbits: copy startup into disk images

### DIFF
--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -6,7 +6,12 @@ include ../../rules.mak
 
 vpath %.asm $(3RDPARTY)/packages/basic09
 
-ifeq ($(PLATFORM), jr2)
+ifeq ($(strip $(PLATFORM)),)
+  $(info PLATFORM not set; defaulting to jr2)
+  PLATFORM = jr2
+endif
+
+ifneq ($(filter $(PLATFORM),jr jr2),)
   KEYSUB = keydrv_ps2
 else
   KEYSUB = keydrv_k2
@@ -60,6 +65,7 @@ CMDS += $(STDCMDS) \
 
 BASIC09 = basic09 runb inkey syscall
 BASIC09_FILES = $(wildcard $(3RDPARTY)/packages/basic09/samples/*.b09)
+STARTUP = $(LEVEL2)/wildbits/startup
 SCRIPTS_DIR = $(LEVEL1)/wildbits/scripts
 TESTS_DIR = $(LEVEL1)/wildbits/tests
 SCRIPTS = $(notdir $(wildcard $(SCRIPTS_DIR)/*))
@@ -78,9 +84,9 @@ bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(PADUP)
 
 ifeq ($(LEVEL),2)
-$(DSKIMAGE): bootfile $(MODDIR)/sysgo $(addprefix $(MODDIR)/,$(CMDS))
+$(DSKIMAGE): bootfile $(MODDIR)/sysgo $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP)
 else
-$(DSKIMAGE): bootfile $(addprefix $(MODDIR)/,$(CMDS))
+$(DSKIMAGE): bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP)
 endif
 	$(RM) $@
 	$(OS9FORMAT_SD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
@@ -95,6 +101,8 @@ endif
 	$(OS9COPY) $(addprefix $(MODDIR)/,$(CMDS)) $@,CMDS
 	$(OS9ATTR_EXEC) $(foreach file,$(CMDS),$@,CMDS/$(file))
 	$(OS9RENAME) $@,CMDS/shellplus shell
+	$(CPL) $(STARTUP) $@,startup
+	$(OS9ATTR_TEXT) $@,startup
 	$(MAKDIR) $@,BASIC09
 	$(CPL) $(BASIC09_FILES) $@,BASIC09
 	$(MAKDIR) $@,SCRIPTS
@@ -267,7 +275,7 @@ $(MODDIR)/z14: scdwvdesc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DAddr=30
 
 clean:
-	$(RM) *.list *.map bootfile *.dsk
+	$(RM) *.list *.map bootfile *.dsk buildinfo
 	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR)
 
 .PHONY: all clean libs


### PR DESCRIPTION
## Summary
- copy the WildBits startup file into Level 1 and Level 2 disk images
- make the shared WildBits disk image targets depend on the startup source
- preserve the existing BASIC09, scripts, and tests packaging flow

## Testing
- make -C recipes/wildbits/l1 PLATFORM=jr -n | rg "startup|OS9Boot"
- make -C recipes/wildbits/l2 PLATFORM=jr2 -n | rg "startup|OS9Boot|sysgo"