### PR TITLE
wildbits: build sysgo from platform source

### DIFF
--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -76,6 +76,12 @@ all: libs $(DSKIMAGE)
 LIB_NAMES = libwildbitsl$(LEVEL).a libnet.a libalib.a
 include ../../libs.mak
 
+$(MODDIR)/sysgo: $(OBJDIR)/sysgo.o | $(MODDIR)
+	$(LINKER) $(LFLAGS) $^ -osysgo
+	$(MOVE) sysgo $@
+
+$(OBJDIR)/sysgo.o: sysgo.as | $(OBJDIR)
+
 ifeq ($(LEVEL),2)
   PADUP ?= ./padup256 bootfile
 endif


### PR DESCRIPTION
## Summary
- make the shared WildBits recipe build  from  via the RMA/RLINK-style object path
- ensure Level 2 WildBits picks up  instead of the generic 
- keep the existing FEU-specific  override behavior aligned with the shared recipe approach

## Why
The shared WildBits recipe could satisfy  through the generic direct-assembly pattern rule, which let Make resolve  from . WildBits Level 2 should instead build from the platform-specific  source.

## Testing
- not run