### PR TITLE
wildbits: fix shared Level 2 recipe command builds

### DIFF
--- a/defs/wildbits_vtio.d
+++ b/defs/wildbits_vtio.d
@@ -170,7 +170,6 @@ V.LY                RMB      1                    line coordinate for Y
 V.GCADDR            RMB      3                    address of cursor on screen
 V.GCAD8K            RMB      2                    address in 8K window
 V.GMAPBLK           RMB      2                    mapped in logical address of block
-V.FONTPATH          FCC      \/dd/sys/fonts/\
 V.FONTNAME          RMB      33
 
 * Start of Line Interrupt Handling

--- a/level2/wildbits/cmds/wild.asm
+++ b/level2/wildbits/cmds/wild.asm
@@ -12,11 +12,11 @@
 *
 
                   IFP1
+                    use       defsfile
                     use       ../defs/os9.d
                     use       scf.d
                     use       ../defs/wildbits.d
                     use       wildbits_vtio.d
-                    *use      defsfile
                   ENDC
 
 tylg                set       Sbrtn+Objct
@@ -3377,4 +3377,3 @@ tm2reg	            equ	      $1118
                     emod
 eom                 equ       *
                     end
-

--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -22,6 +22,7 @@ DSKIMAGE ?= l$(LEVEL)_$(RECIPE)$(PLATFORM).dsk
 
 AFLAGS += -I.
 ifeq ($(LEVEL),2)
+AFLAGS += -I$(L2PD)
 AFLAGS += -I$(L2MD)/kernel -I$(L2PMD)
 endif
 AFLAGS += -I$(L1MD)/kernel -I$(L1PMD)
@@ -59,9 +60,16 @@ BOOTMODS = krn krnp2 ioman init \
 endif
 
 CMDS += $(STDCMDS) \
-	bootos9 wbinfo wbreset modem \
+	bootos9 scfg wbinfo wbreset modem \
 	inetd telnet dw httpd $(BASIC09) $(BF) \
 	$(CMDS_EXTRA)
+
+ifeq ($(LEVEL),2)
+CMDS += dmem minted mmap modpatch \
+	proc pmap smap \
+	gfxstatus xtclut drawtest play wild \
+	shellbg shellbgoff ntptime view
+endif
 
 BASIC09 = basic09 runb inkey syscall
 BASIC09_FILES = $(wildcard $(3RDPARTY)/packages/basic09/samples/*.b09)


### PR DESCRIPTION
Summary
- add the missing Level 2 port include path to the shared WildBits recipe
- bring the WildBits Level 2-only command set into recipes/wildbits/wildbits.mak
- fix level2/wildbits/cmds/wild.asm so defsfile is loaded before os9.d

Details
The shared WildBits recipe was missing several commands that the dedicated WildBits Level 2 build used to include, and wild would fail to assemble because Level equ 2 was not defined before os9.d was read.

This change:
- adds -I$(L2PD) for Level 2 WildBits recipe builds
- adds the Level 2-only commands dmem, minted, mmap, modpatch, proc, pmap, smap, gfxstatus, xtclut, drawtest, play, wild, shellbg, shellbgoff, ntptime, and view
- leaves out cpm and rogue for now
- moves use defsfile ahead of use ../defs/os9.d in wild.asm so F$MapBlk and F$ClrBlk resolve correctly

Verification
- make -C recipes/wildbits/l2 PLATFORM=jr2