### PR TITLE
wildbits: copy FEU startup into recipe disk images

### DIFF
--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -74,6 +74,7 @@ endif
 BASIC09 = basic09 runb inkey syscall wild
 BASIC09_FILES = $(wildcard $(3RDPARTY)/packages/basic09/samples/*.b09)
 STARTUP = $(LEVEL2)/wildbits/startup
+FEU_STARTUP = feu.startup
 SCRIPTS_DIR = $(LEVEL1)/wildbits/scripts
 TESTS_DIR = $(LEVEL1)/wildbits/tests
 SCRIPTS = $(notdir $(wildcard $(SCRIPTS_DIR)/*))
@@ -119,6 +120,11 @@ wildbits-sys-assets:
 	$(MAKE) -C $(FONT_DIR)
 	$(MAKE) -C $(BACKGROUND_DIR)
 
+$(FEU_STARTUP): FORCE
+	echo "bootos9 /s0/OS9Boot" >> $@
+
+FORCE: ;
+
 ifeq ($(LEVEL),2)
   PADUP ?= ./padup256 bootfile
 endif
@@ -127,9 +133,9 @@ bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(PADUP)
 
 ifeq ($(LEVEL),2)
-$(DSKIMAGE): bootfile $(MODDIR)/sysgo $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) wildbits-sys-assets
+$(DSKIMAGE): bootfile $(MODDIR)/sysgo $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(FEU_STARTUP) wildbits-sys-assets
 else
-$(DSKIMAGE): bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) wildbits-sys-assets
+$(DSKIMAGE): bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(FEU_STARTUP) wildbits-sys-assets
 endif
 	$(RM) $@
 	$(OS9FORMAT_SD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
@@ -161,6 +167,8 @@ endif
 	$(foreach file,$(SCRIPTS),$(CPL) $(SCRIPTS_DIR)/$(file) $@,SCRIPTS;)
 	$(MAKDIR) $@,TESTS
 	$(foreach file,$(TESTS),$(CPL) $(TESTS_DIR)/$(file) $@,TESTS;)
+	$(MAKDIR) $@,FEU
+	$(CPL) $(FEU_STARTUP) $@,FEU/startup
 
 # Command rules
 $(MODDIR)/pwd: pd.asm | $(MODDIR)
@@ -327,7 +335,7 @@ $(MODDIR)/z14: scdwvdesc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DAddr=30
 
 clean:
-	$(RM) *.list *.map bootfile *.dsk buildinfo
+	$(RM) *.list *.map bootfile *.dsk buildinfo feu.startup
 	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR)
 
 .PHONY: all clean libs


### PR DESCRIPTION
## Summary
- add FEU folder creation to the shared WildBits recipes
- generate a single FEU startup script for recipe-based disk images
- copy that script into FEU/startup for both Level 1 and Level 2 WildBits builds

## Background
The older WildBits makefiles populate a FEU directory in the generated disk images, but the shared recipes did not. That meant recipe-built WildBits images were missing the FEU startup entry point that the older build flow provided.

## What changed
This updates recipes/wildbits/wildbits.mak to:
- generate one shared FEU startup script during the recipe build
- add FEU as a disk image directory
- copy the generated script into FEU/startup
- clean up the generated startup artifact on clean

This intentionally uses one common startup file rather than the older media-specific FEU startup variants.

## Verification
- make -C recipes/wildbits/l1 -n PLATFORM=jr
- make -C recipes/wildbits/l2 -n PLATFORM=jr2

Both dry runs now show:
- os9 makdir ...,FEU
- os9 copy -o=0 -l feu.startup ...,FEU/startup