### PR TITLE
ident: skip non-module bytes while scanning

### DIFF
--- a/level1/cmds/ident.asm
+++ b/level1/cmds/ident.asm
@@ -346,8 +346,12 @@ DSKM07 pshs u save data pointer
  
 DSKM08 ldd M$ID,x get the module ID
  cmpd #M$ID12 really a module header?
- lbne IDNT11 no, print error and exit
- 
+ beq DSKM10 ..yes, continue
+ ldd #$0001 skip non-module bytes and continue scanning
+ std <dskmodln
+ lbra DSKM05
+
+DSKM10
  pshs u,x save data pointers
  ldd M$Size,x get the module size
  std <dskmodln save the module length


### PR DESCRIPTION
## Summary
- make  continue scanning when a byte offset is not the start of an OS-9 module
- advance one byte at a time until a valid  header is found
- preserve normal module processing once a real header is encountered

## Why
When scanning blobs that contain padding, garbage, or other non-module bytes between modules,  should not stop at the first invalid header candidate. This change lets it skip over non-module bytes and keep searching for the next real module.

## Verification
- built  successfully with 
