### PR TITLE
wildbits: include mousedrv in Level 2 boot modules

### DIFF
--- a/level1/wildbits/modules/mousedrv_ps2.asm
+++ b/level1/wildbits/modules/mousedrv_ps2.asm
@@ -442,6 +442,6 @@ mspointerdata       fcb       255,2,0,14
                     fcb       255,1,1,1,255,4,1,2,255,1,0,7
                     fcb       255,2,0,4,255,3,0,7,0,0
 
-emod
+                    emod
 eom                 equ       *
                     end

--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -33,6 +33,9 @@ LFLAGS += $(LFLAGS_EXTRA)
 
 RBF = rbf rbsuper llwbsd rbmem dds0 s1 f0 f1
 SCF = scf vtio $(KEYSUB) term bannerfont palette
+ifeq ($(LEVEL),2)
+SCF += mousedrv_ps2
+endif
 DRIVEWIRE_RBF = rbdw x0 x1 x2 x3
 DRIVEWIRE_SCF = scdwv n1 n2 n3 n4 n5
 DRIVEWIRE = dwio_serial $(DRIVEWIRE_RBF) $(DRIVEWIRE_SCF)


### PR DESCRIPTION
## Summary
- add mousedrv_ps2 to the shared WildBits Level 2 SCF boot module list
- fix mousedrv_ps2.asm so emod is parsed as the assembler directive instead of a label
- ensure the mouse driver is built and merged into the Level 2 bootfile with the proper OS-9 module terminator and CRC emission

## Why
The shared recipes/wildbits build path was omitting mousedrv_ps2 from the Level 2 boot module list, so the module was not part of the generated bootfile even though the older dedicated WildBits-specific build included it.

Separately, the trailing emod line in mousedrv_ps2.asm was written in a way that could be interpreted as a label instead of the assembler directive. That is not cosmetic here: emod is the directive that emits the OS-9 module terminator and CRC, so it needs to be parsed correctly.

## Verification
- verified with make -C /Users/boisy/Projects/coco-shelf/nitros9/recipes/wildbits/l2 -n PLATFORM=jr2 bootfile
- dry run now shows .mods/mousedrv_ps2 being built and merged into bootfile
- confirmed the source change restores emod to directive position in level1/wildbits/modules/mousedrv_ps2.asm
