### PR TITLE
wildbits: add utilpak1 to shared Level 2 recipe

### DIFF
--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -65,10 +65,12 @@ CMDS += $(STDCMDS) \
 	$(CMDS_EXTRA)
 
 ifeq ($(LEVEL),2)
+UTILPAK1_MODS = attr copy date del deiniz dir display list makdir mdir \
+	merge mfree procs rename tmode unlink
 CMDS += dmem minted mmap modpatch \
 	proc pmap smap \
 	gfxstatus xtclut drawtest play \
-	shellbg shellbgoff ntptime view
+	shellbg shellbgoff ntptime view utilpak1
 endif
 
 BASIC09 = basic09 runb inkey syscall wild
@@ -182,6 +184,12 @@ $(MODDIR)/xmode: xmode.asm | $(MODDIR)
 
 $(MODDIR)/tmode: xmode.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DTMODE=1
+
+ifeq ($(LEVEL),2)
+$(MODDIR)/utilpak1: $(addprefix $(MODDIR)/,$(UTILPAK1_MODS)) | $(MODDIR)
+	$(MERGE) $^ > utilpak1
+	$(MOVE) utilpak1 $@
+endif
 
 # Descriptor rules
 # SD card descriptors


### PR DESCRIPTION
## Summary
- add utilpak1 to the shared WildBits Level 2 command set
- build utilpak1 as a merged module from the same component commands used by the old dedicated WildBits Level 2 build
- copy utilpak1 into CMDS on the generated Level 2 disk image

## Why
The old Level 2 WildBits build produced a merged utilpak1 module, but the shared recipes/wildbits path only packaged the individual commands. This brings the shared recipe into line with the older WildBits-specific behavior without changing the current shell handling.

## Verification
- verified with make -C /Users/boisy/Projects/coco-shelf/nitros9/recipes/wildbits/l2 -n PLATFORM=jr2 .mods/utilpak1
- verified with make -C /Users/boisy/Projects/coco-shelf/nitros9/recipes/wildbits/l2 -n PLATFORM=jr2 l2_wildbitsjr2.dsk
- dry run now shows .mods/utilpak1 being merged and copied into CMDS
