### PR TITLE
fix(wildbits): Correct CurRght column boundary wrap check

### DIFF
--- a/level1/wildbits/modules/vtio.asm
+++ b/level1/wildbits/modules/vtio.asm
@@ -790,7 +790,7 @@ ex@                 rts
 CurRght             ldd       V.CurRow,u
                     incb                          increment the column
                     cmpb      V.WWidth,u          is it >= the number of columns?
-                    bgt       nextrow@
+                    bge       nextrow@
 ex@                 std       V.CurRow,u
 bye@                rts
 nextrow@            ldb       V.WHeight,u


### PR DESCRIPTION
# Pull Request: Correct `CurRght` Column Boundary Wrap Check

## Description
This PR fixes a boundary condition bug in the `CurRght` routine of the Wildbits `vtio` driver.

## Problem
The driver previously used a `bgt` (Branch if Greater Than) instruction when comparing the incremented column index against the screen width (`V.WWidth`). This allowed the cursor to sit at a column index equal to the width (e.g., column 80 on an 80-column screen) before triggering a line wrap. This out-of-bounds index could lead to incorrect memory addressing or visual corruption.

## Solution
Updated the branch instruction to `bge` (Branch if Greater than or Equal). This ensures that the cursor correctly wraps to the first column of the next row as soon as it reaches the screen width boundary.

## Validation
- Verified the fix by successfully rebuilding the Wildbits FEU platform (`PLATFORM=jr2`).
- Manually audited the `ChkESC` dispatch logic to confirm that other control code ranges (specifically `0x0E-0x1A`) are properly guarded by existing bounds checks.

## Impact
Improves terminal stability and ensures consistent cursor behavior at the right edge of the screen.