### PR TITLE
basic09: fix duplicate DONE/ERROR labels causing CI build failure

### DIFF
--- a/3rdparty/packages/basic09/basic09.asm
+++ b/3rdparty/packages/basic09/basic09.asm
@@ -13247,12 +13247,12 @@ BannerGo            leax      NEWLN,pcr
                     ldy       #NEWLNLEN
                     lda       #1
                     os9       I$Writln
-                    bcs       ERROR
+                    bcs       BNRERR
                     leax      OUTSTR,pcr
                     ldy       #STRLEN
                     lda       #1
                     os9       I$Write
-                    bcs       ERROR
+                    bcs       BNRERR
                     ldx       #$FE00
                     lda       7,x
                     cmpa      #$02
@@ -13261,7 +13261,7 @@ BannerGo            leax      NEWLN,pcr
                     ldy       #STRLEN2
                     lda       #1
                     os9       I$Writln
-                    bcs       ERROR
+                    bcs       BNRERR
                     bra       CONT
 isItK           cmpa      #$12
                     bne       isItK2
@@ -13269,7 +13269,7 @@ isItK           cmpa      #$12
                     ldy       #STRLEN3
                     lda       #1
                     os9       I$Writln
-                    bcs       ERROR
+                    bcs       BNRERR
                     bra       CONT
 isItK2          cmpa      #$16
                     bne       isItJrJr
@@ -13277,22 +13277,22 @@ isItK2          cmpa      #$16
                     ldy       #STRLEN4
                     lda       #1
                     os9       I$Writln
-                    bcs       ERROR
+                    bcs       BNRERR
                     bra       CONT
 isItJrJr            cmpa      #$1A
-                    bne       ERROR
+                    bne       BNRERR
                     leax      OUTSTR5,pcr
                     ldy       #STRLEN5
                     lda       #1
                     os9       I$Writln
-                    bcs       ERROR
+                    bcs       BNRERR
 CONT                leax      BASL2,pcr
                     ldy       #BASLEN2
                     lda       #1
                     os9       I$Write
-                    bcs       ERROR
-DONE                ldb       #0
-ERROR               lbra      COMAND
+                    bcs       BNRERR
+BNRDONE                ldb       #0
+BNRERR               lbra      COMAND
 OUTSTR              fcb       $1b,$32,$07,$1c,$13,$1c,$11,$1c,$11
                     fcb       $1c,$11,$1c,$11,$1c,$11,$1c,$05
                     fcb       $1b,$32,$06,$20,$20,$1b,$32,$08,$1c,$10,$1c,$11


### PR DESCRIPTION
## Summary

- `DONE` and `ERROR` were defined twice in `basic09.asm` — once in the main BASIC09 code and again in the `BannerGo` (wildbits startup) block
- The duplicate symbols caused the assembler to fail with exit code 2 in CI
- Renamed the conflicting definitions in the BannerGo block to `BNRDONE` and `BNRERR`

## Test plan

- [x] `basic09_6309` assembles cleanly locally
- [x] `basic09_6809` assembles cleanly locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)