### PR TITLE
basic09: remove dead runbt_6809 makefile target

### DIFF
--- a/3rdparty/packages/basic09/makefile
+++ b/3rdparty/packages/basic09/makefile
@@ -44,8 +44,6 @@ runb_6309: runb.asm
 runb_6809: runb.asm
 	$(AS) $(ASOUT)$@ $< $(M6809)
 
-runbt_6809: basic09.asm
-	$(AS) $(ASOUT)$@ $< $(M6809) -aRUNTIME=1
 
 clean: dskclean
 	$(RM) $(ALLOBJS) *.list *.map


### PR DESCRIPTION
## Summary

- Removes the `runbt_6809` target which built `basic09.asm` with `-aRUNTIME=1`
- `basic09.asm` has no `RUNTIME` conditionals, so this target produced the same binary as `basic09_6809` — it was never useful
- Investigation confirmed that `runb.asm` and `basic09.asm` are independently disassembled binaries with largely different code; consolidation via a single source file is not feasible

## Test plan

- [x] `make basic09_6309 basic09_6809` still assembles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)