### PR TITLE
Add shared CoCo 3 Sierra recipe

### DIFF
--- a/3rdparty/packages/sierra/objs_kq3/mnln.asm
+++ b/3rdparty/packages/sierra/objs_kq3/mnln.asm
@@ -9258,11 +9258,13 @@ L4E22               fdb       $0000
 
 L4E26               leau      >L4E26,pcr          load our own address
                     ldd       ,s
-                    pshu      u,b,a
+                    std       >L4E22,pcr
+                    stu       >(L4E22+2),pcr
                     rts
 
 L4E2F               leau      >L4E22,pcr          2 data words
-                    pulu      u,b,a
+                    ldd       >L4E22,pcr
+                    ldu       >(L4E22+2),pcr
                     std       ,s
                     rts
 

--- a/recipes/coco3/README.md
+++ b/recipes/coco3/README.md
@@ -33,6 +33,7 @@ From the repository root, ensure:
 
 - [`40d/`](40d/) builds CoCo 3 Level 2 40-track double-sided disk images
 - [`dw/`](dw/) builds a CoCo 3 DriveWire-oriented disk image
+- [`sierra/`](sierra/) builds Sierra AGI CoCo 3 disk images and holds the shared Sierra recipe logic
 
 Each build directory keeps intermediate artifacts local:
 
@@ -68,8 +69,68 @@ This recipe defaults to:
 - `startup.dw`
 - DriveWire disk format settings (`$(OS9FORMAT_DW)`)
 
+## Sierra Build ([`coco3/sierra`](sierra/))
+
+```sh
+cd sierra
+make
+```
+
+Primary output:
+
+- `l2_coco3_kingsquest3.dsk` (default)
+
+This entrypoint currently defaults to `GAME=kingsquest3` and builds:
+
+- a 32-column Sierra-compatible terminal stack (`covdg_small.io` + `term_vdg.dt`)
+- the `vrn.dr` and `vi.dd` modules required by King's Quest III
+- KQ3 command modules (`sierra`, `mnln`, `scrn`, `shdw`)
+- the original Sierra-style root layout with `AutoEx`, `tOC`, and game data at the disk root
+- a minimal startup script that links `shell` and loads `utilpak1`
+
+The shared Sierra base contains:
+
+- common CoCo 3 Sierra boot-module defaults
+- the small Sierra-compatible `shell`
+- rules to package Sierra runtime modules and game data from `3rdparty/packages/sierra/<game>`
+- shared TOC generation
+
+Game-specific values now live in [`sierra/recipe.mak`](sierra/recipe.mak).
+
+Examples:
+
+```sh
+cd sierra
+make GAME=kingsquest1
+make GAME=kingsquest3
+make GAME=goldrush
+```
+
+Currently supported `GAME` values:
+
+- `blackcauldron`
+- `christmas86`
+- `goldrush`
+- `kingsquest1`
+- `kingsquest2`
+- `kingsquest3`
+- `kingsquest4`
+- `leisuresuitlarry`
+- `manhunter1`
+- `manhunter2`
+- `policequest1`
+- `spacequest0`
+- `spacequest1`
+- `spacequest2`
+
+The recipe automatically chooses the appropriate single-image media type for each title:
+
+- `80d` for single-disk 80-track floppy games
+- `dw` for titles that need a single DriveWire-style image
+
 ## Notes
 
-- Shared build logic is in [`coco3.mak`](coco3.mak).
+- Shared CoCo 3 build logic is in [`coco3.mak`](coco3.mak).
+- Shared Sierra recipe logic is in [`sierra/sierra.mak`](sierra/sierra.mak).
 - This recipe targets a practical default CoCo 3 floppy boot configuration.
 - Use `recipe.mak` to extend command/module selections without editing shared makefiles.

--- a/recipes/coco3/sierra/defsfile
+++ b/recipes/coco3/sierra/defsfile
@@ -1,0 +1,5 @@
+Level equ 2
+ use os9.d
+ use scf.d
+ use rbf.d
+ use coco.d

--- a/recipes/coco3/sierra/make_toc.py
+++ b/recipes/coco3/sierra/make_toc.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+
+def parse_entry(token: str) -> int:
+    token = token.strip().lower()
+    if len(token) < 2 or token[0] not in {"d", "s", "v"}:
+        raise ValueError(f"unsupported TOC token: {token}")
+    return int(token[1:])
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: make_toc.py <toc_txt> <toc_bin>", file=sys.stderr)
+        return 2
+
+    src = Path(sys.argv[1])
+    dst = Path(sys.argv[2])
+
+    rows = []
+    for line in src.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("*"):
+            continue
+        rows.append([parse_entry(token) for token in line.split()])
+
+    if not rows:
+        dst.write_bytes(b"")
+        return 0
+
+    header_size = len(rows) * 2
+    payload = bytearray([len(rows)])
+
+    offset = header_size
+    for row in rows:
+        payload.extend(offset.to_bytes(2, "big"))
+        offset += len(row)
+
+    for row in rows:
+        payload.extend(row[:-1])
+        payload.append(row[-1] | 0x80)
+
+    dst.write_bytes(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipes/coco3/sierra/makefile
+++ b/recipes/coco3/sierra/makefile
@@ -1,0 +1,1 @@
+include ./sierra.mak

--- a/recipes/coco3/sierra/recipe.mak
+++ b/recipes/coco3/sierra/recipe.mak
@@ -1,0 +1,84 @@
+# CoCo 3 Sierra AGI recipe defaults.
+
+GAME ?= kingsquest3
+RECIPE = coco3_$(GAME)
+TERM_COLS = 32
+STARTUP = ./startup
+CMDS_BASE = shell utilpak1
+SIERRA_DIR = $(3RDPARTY)/packages/sierra/$(GAME)
+SIERRA_DATA_FILES = $(notdir $(wildcard $(SIERRA_DIR)/logDir $(SIERRA_DIR)/object \
+	$(SIERRA_DIR)/picDir $(SIERRA_DIR)/sndDir $(SIERRA_DIR)/viewDir \
+	$(SIERRA_DIR)/words.tok $(SIERRA_DIR)/vol.*))
+
+ifeq ($(GAME),blackcauldron)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_40d.txt
+else ifeq ($(GAME),christmas86)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC.txt
+else ifeq ($(GAME),goldrush)
+SIERRA_MEDIA = dw
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+else ifeq ($(GAME),kingsquest1)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+else ifeq ($(GAME),kingsquest2)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+else ifeq ($(GAME),kingsquest3)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+else ifeq ($(GAME),kingsquest4)
+SIERRA_MEDIA = dw
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+else ifeq ($(GAME),leisuresuitlarry)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC.txt
+else ifeq ($(GAME),manhunter1)
+SIERRA_MEDIA = dw
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+else ifeq ($(GAME),manhunter2)
+SIERRA_MEDIA = dw
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+else ifeq ($(GAME),policequest1)
+SIERRA_MEDIA = dw
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+else ifeq ($(GAME),spacequest0)
+SIERRA_MEDIA = dw
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+else ifeq ($(GAME),spacequest1)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+else ifeq ($(GAME),spacequest2)
+SIERRA_MEDIA = 80d
+SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+else
+$(error Unsupported Sierra GAME "$(GAME)")
+endif
+
+ifeq ($(SIERRA_MEDIA),80d)
+OS9FORMAT_CMD = $(OS9FORMAT_DS80)
+RBF = rbf.mn rb1773.dr ddd0_80d.dd
+KERNEL_TRACK = rel_32 boot_1773_6ms krn
+else ifeq ($(SIERRA_MEDIA),dw)
+OS9FORMAT_CMD = $(OS9FORMAT_DW)
+RBF = rbf.mn rbdw.dr dwio.sb ddx0.dd
+KERNEL_TRACK = rel_32 boot_dw krn
+else
+$(error Unsupported SIERRA_MEDIA "$(SIERRA_MEDIA)")
+endif
+
+# Sierra's AGI games expect the CoCo 3 VDG-compatible terminal stack plus
+# the VRN and VI modules.
+SCF = scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb covdg_small.io \
+	term_vdg.dt vrn.dr vi.dd
+PIPE =
+BOOTMODS = krnp2 ioman init \
+	$(RBF) \
+	$(SCF) \
+	$(PIPE) \
+	$(CLOCK) \
+	sysgo_dd \
+	$(BOOTMODS_EXTRA)
+
+CMDS_EXTRA += sierra mnln scrn shdw

--- a/recipes/coco3/sierra/sierra.mak
+++ b/recipes/coco3/sierra/sierra.mak
@@ -1,0 +1,82 @@
+LEVEL = 2
+include ../coco3.mak
+
+SHELLMODS = shell_21 date echo link setime
+
+ifeq ($(CPU),6309)
+AFLAGS := $(filter-out -DH6309=1,$(AFLAGS))
+else
+AFLAGS := $(filter-out -DH6309=0,$(AFLAGS))
+endif
+
+vpath %.as $(LEVEL2)/cmds:$(LEVEL1)/cmds
+vpath %.asm $(LEVEL2)/coco3/modules/kernel:$(LEVEL2)/coco3/modules:$(LEVEL2)/modules:$(LEVEL2)/cmds:$(LEVEL1)/coco1/modules:$(LEVEL1)/modules:$(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09
+
+SIERRA_TOC ?= ./tOC
+SIERRA_MAKE_TOC ?= ../sierra/make_toc.py
+DSDD80 = -DCyls=80 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDensity=1
+DSDD40 = -DCyls=40 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDensity=1
+
+$(MODDIR)/covdg_small.io: covdg.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/shell_21: $(LEVEL1)/cmds/shell_21.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/date: $(LEVEL1)/cmds/date.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/echo: $(LEVEL1)/cmds/echo.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/link: $(LEVEL1)/cmds/link.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/setime: $(LEVEL1)/cmds/setime.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/shell: $(addprefix $(MODDIR)/,$(SHELLMODS)) | $(MODDIR)
+	$(MERGE) $(addprefix $(MODDIR)/,$(SHELLMODS)) >$@
+
+$(MODDIR)/sierra: | $(MODDIR)
+	test -f $(SIERRA_DIR)/sierra || $(MAKE) -C $(SIERRA_DIR) sierra
+	$(CP) $(SIERRA_DIR)/sierra $@
+
+$(MODDIR)/mnln: | $(MODDIR)
+	test -f $(SIERRA_DIR)/mnln || $(MAKE) -C $(SIERRA_DIR) mnln
+	$(CP) $(SIERRA_DIR)/mnln $@
+
+$(MODDIR)/scrn: | $(MODDIR)
+	test -f $(SIERRA_DIR)/scrn || $(MAKE) -C $(SIERRA_DIR) scrn
+	$(CP) $(SIERRA_DIR)/scrn $@
+
+$(MODDIR)/shdw: | $(MODDIR)
+	test -f $(SIERRA_DIR)/shdw || $(MAKE) -C $(SIERRA_DIR) shdw
+	$(CP) $(SIERRA_DIR)/shdw $@
+
+$(MODDIR)/ddd0_40d.dd: rb1773desc.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@ $(DSDD40) -DDNum=0 -DDD=1
+
+$(MODDIR)/ddd0_80d.dd: rb1773desc.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@ $(DSDD80) -DDNum=0 -DDD=1
+
+$(SIERRA_TOC): $(SIERRA_TOC_TXT) $(SIERRA_MAKE_TOC)
+	python3 $(SIERRA_MAKE_TOC) $(SIERRA_TOC_TXT) $@
+
+$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(SIERRA_TOC)
+	$(RM) $@
+	$(OS9FORMAT_CMD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
+	$(OS9GEN) $@ -b=bootfile -t=$(KERNELFILE)
+	$(MAKDIR) $@,CMDS
+	$(OS9COPY) $(addprefix $(MODDIR)/,$(CMDS)) $@,CMDS
+	$(OS9ATTR_EXEC) $(foreach file,$(CMDS),$@,CMDS/$(file))
+	$(OS9RENAME) $@,CMDS/sierra AutoEx
+	$(OS9COPY) $(addprefix $(SIERRA_DIR)/,$(SIERRA_DATA_FILES)) $@,.
+	$(CPL) $(SIERRA_TOC_TXT) $@,tOC.txt
+	$(CPL) $(SIERRA_TOC) $@,tOC
+	$(CPL) $(STARTUP) $@,startup
+	$(OS9ATTR_TEXT) $@,startup
+
+clean:
+	$(RM) *.list *.map bootfile $(KERNELFILE) *.dsk buildinfo $(SIERRA_TOC)
+	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR)

--- a/recipes/coco3/sierra/startup
+++ b/recipes/coco3/sierra/startup
@@ -1,0 +1,3 @@
+link shell
+load utilpak1
+sierra -r</1


### PR DESCRIPTION
## Summary
- add a shared recipes/coco3/sierra entrypoint that builds Sierra titles with make GAME=...
- document the new workflow in the CoCo 3 README and remove the per-game KQ3 wrapper layout
- fix objs_kq3/mnln.asm so it assembles with the current stricter lwasm

## Notes
- the shared recipe now supports the Sierra game set through GAME selection
- Sierra startup now invokes sierra -r</1
- the recipe flow no longer uses 40-track floppy images
