### PR TITLE
Clean up Sierra recipe after rework of source code

### DIFF
--- a/3rdparty/packages/sierra/objs/shdw.asm
+++ b/3rdparty/packages/sierra/objs/shdw.asm
@@ -1,5 +1,6 @@
 ********************************************************************
-* SHDW - Sierra AGI screen rendering module
+* shdw - Sierra AGI screen rendering module
+*
 * Note the header shows a data size of 0 called from the sierra
 * module and accesses data set up in that module.
 *
@@ -1394,6 +1395,7 @@ PriTableBase
 
 * table_init()   obj_pic_buff.c
 TableInit
+
                     fcb       $B6,$05,$EE         lda $05EE (priority table address)
                     fcb       $81,$FF             cmpa #$FF
                     fcb       $26,$15             bne +21

--- a/recipes/coco3/sierra/defsfile
+++ b/recipes/coco3/sierra/defsfile
@@ -3,3 +3,5 @@ Level equ 2
  use scf.d
  use rbf.d
  use coco.d
+ use cocovtio.d
+ use vdgdefs

--- a/recipes/coco3/sierra/sierra.mak
+++ b/recipes/coco3/sierra/sierra.mak
@@ -10,7 +10,7 @@ AFLAGS := $(filter-out -DH6309=0,$(AFLAGS))
 endif
 
 vpath %.as $(LEVEL2)/cmds:$(LEVEL1)/cmds
-vpath %.asm $(LEVEL2)/coco3/modules/kernel:$(LEVEL2)/coco3/modules:$(LEVEL2)/modules:$(LEVEL2)/cmds:$(LEVEL1)/coco1/modules:$(LEVEL1)/modules:$(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09
+vpath %.asm $(LEVEL2)/coco3/modules/kernel:$(LEVEL2)/coco3/modules:$(LEVEL2)/modules:$(LEVEL2)/cmds:$(LEVEL1)/coco1/modules:$(LEVEL1)/modules:$(LEVEL1)/cmds:$(3RDPARTY)/packages/basic09:$(3RDPARTY)/packages/sierra/objs
 
 SIERRA_TOC ?= ./tOC
 SIERRA_MAKE_TOC ?= ../sierra/make_toc.py
@@ -38,21 +38,17 @@ $(MODDIR)/setime: $(LEVEL1)/cmds/setime.asm | $(MODDIR)
 $(MODDIR)/shell: $(addprefix $(MODDIR)/,$(SHELLMODS)) | $(MODDIR)
 	$(MERGE) $(addprefix $(MODDIR)/,$(SHELLMODS)) >$@
 
-$(MODDIR)/sierra: | $(MODDIR)
-	test -f $(SIERRA_DIR)/sierra || $(MAKE) -C $(SIERRA_DIR) sierra
-	$(CP) $(SIERRA_DIR)/sierra $@
+$(MODDIR)/sierra: sierra.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
 
-$(MODDIR)/mnln: | $(MODDIR)
-	test -f $(SIERRA_DIR)/mnln || $(MAKE) -C $(SIERRA_DIR) mnln
-	$(CP) $(SIERRA_DIR)/mnln $@
+$(MODDIR)/mnln: mnln.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
 
-$(MODDIR)/scrn: | $(MODDIR)
-	test -f $(SIERRA_DIR)/scrn || $(MAKE) -C $(SIERRA_DIR) scrn
-	$(CP) $(SIERRA_DIR)/scrn $@
+$(MODDIR)/scrn: scrn.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
 
-$(MODDIR)/shdw: | $(MODDIR)
-	test -f $(SIERRA_DIR)/shdw || $(MAKE) -C $(SIERRA_DIR) shdw
-	$(CP) $(SIERRA_DIR)/shdw $@
+$(MODDIR)/shdw: shdw.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
 
 $(MODDIR)/ddd0_40d.dd: rb1773desc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ $(DSDD40) -DDNum=0 -DDD=1


### PR DESCRIPTION
## Summary

- Wire Sierra modules (`sierra`, `mnln`, `scrn`, `shdw`) to build directly from annotated assembly sources in `3rdparty/packages/sierra/objs` instead of copying pre-built binaries from a separate make target
- Add `3rdparty/packages/sierra/objs` to `vpath` in `sierra.mak` so the assembler can find the source files
- Add `cocovtio.d` and `vdgdefs` to `defsfile` for proper definition inclusion
- Minor whitespace/formatting fixes in `shdw.asm`

## Test plan

- [ ] Build the Sierra recipe and verify all four modules (`sierra`, `mnln`, `scrn`, `shdw`) assemble successfully
- [ ] Confirm the resulting binaries are binary-identical to the previous pre-built copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)