### PR TITLE
Add repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require code-owner review for every change in this repository.
+* @DrPitre @jamieleecho


### PR DESCRIPTION
## Overview

Adds a repository-wide CODEOWNERS rule so every change in nitros9 requests review from the configured owners.

## Notable Changes

- Adds `.github/CODEOWNERS` with `@DrPitre` and `@jamieleecho` as global owners.
- Leaves pre-existing untracked generated files untouched.

## Verification

```sh
git diff --cached -- .github/CODEOWNERS
```

Verified output:

```text
.github/CODEOWNERS contains: * @DrPitre @jamieleecho
```
