### PR TITLE
Add CoCo 3 Rogue disk recipe

### DIFF
--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -42,6 +42,8 @@ TERM_ALTCOLOR_FLAGS =
 endif
 
 DSKIMAGE ?= l$(LEVEL)_$(RECIPE).dsk
+DSK_EXTRA_DEPS ?=
+DSK_POST_COPY ?= @:
 OS9FORMAT_CMD ?= $(OS9FORMAT_DS40)
 
 AFLAGS += -I.
@@ -89,7 +91,7 @@ kernelfile: $(addprefix $(MODDIR)/,$(KERNEL_TRACK))
 bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(MERGE) $(addprefix $(MODDIR)/,$(BOOTMODS))>$@
 
-$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP)
+$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(DSK_EXTRA_DEPS)
 	$(RM) $@
 	$(OS9FORMAT_CMD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
 	$(OS9GEN) $@ -b=bootfile -t=$(KERNELFILE)
@@ -100,6 +102,7 @@ $(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP)
 	$(OS9ATTR_EXEC) $(foreach file,$(CMDS),$@,CMDS/$(file))
 	$(CPL) $(STARTUP) $@,startup
 	$(OS9ATTR_TEXT) $@,startup
+	$(DSK_POST_COPY)
 
 # /TERM window descriptors — column count and colors controlled by TERM_COLS and TERM_ALTCOLOR
 $(MODDIR)/term_win40.dt: term_win40.asm | $(MODDIR)

--- a/recipes/coco3/rogue/defsfile
+++ b/recipes/coco3/rogue/defsfile
@@ -1,0 +1,6 @@
+Level equ 2
+ use os9.d
+ use scf.d
+ use rbf.d
+ use coco.d
+ use cocovtio.d

--- a/recipes/coco3/rogue/makefile
+++ b/recipes/coco3/rogue/makefile
@@ -1,0 +1,29 @@
+LEVEL = 2
+RECIPE = coco3_rogue
+ROGUE_DIR = $(3RDPARTY)/packages/rogue
+ROGUE_FILES = rogue.dat rogue.hlp rogue.scr rogue.chr
+CMDS_BASE =
+CMDS_EXTRA += dir grfdrv list mdir mfree shell rogue
+DSK_EXTRA_DEPS = $(addprefix $(ROGUE_DIR)/,$(ROGUE_FILES))
+DSK_POST_COPY = $(MAKE) copy-rogue-files DSKIMAGE=$@
+STARTUP = ./startup
+
+include ../coco3.mak
+
+vpath %.asm $(ROGUE_DIR)
+
+MAME         ?= mame
+MAME_MACHINE ?= coco3
+MAME_FLAGS   ?= -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd
+
+run: $(DSKIMAGE)
+	$(MAME) $(MAME_MACHINE) $(MAME_FLAGS) -flop1 $(DSKIMAGE)
+
+copy-rogue-files:
+	$(OS9COPY) $(MODDIR)/sysgo_dd $(DSKIMAGE),sysgo
+	$(OS9ATTR_EXEC) $(DSKIMAGE),sysgo
+	$(MAKDIR) $(DSKIMAGE),ROGUE
+	$(OS9COPY) $(addprefix $(ROGUE_DIR)/,$(ROGUE_FILES)) $(DSKIMAGE),ROGUE
+	$(OS9ATTR_TEXT) $(foreach file,$(ROGUE_FILES),$(DSKIMAGE),ROGUE/$(file))
+
+.PHONY: copy-rogue-files run

--- a/recipes/coco3/rogue/startup
+++ b/recipes/coco3/rogue/startup
@@ -1,0 +1,2 @@
+link shell
+rogue </1


### PR DESCRIPTION
## Overview

Add a real CoCo 3 Rogue recipe under `recipes/coco3/rogue` so plain `make` builds `l2_coco3_rogue.dsk`. The recipe uses the shared CoCo 3 build rules to assemble `3rdparty/packages/rogue/rogue.asm` directly into `CMDS/rogue`, so it does not depend on the legacy `3rdparty/packages/rogue/makefile` continuing to exist.

This PR is stacked on #345, which isolates the `H6309` definition guard needed by recipe builds that pass `-DH6309=0`.

The generated disk is stripped down for Rogue: root contains `sysgo`, `CMDS` contains `dir`, `grfdrv`, `list`, `mdir`, `mfree`, merged `shell`, and `rogue`, the Rogue support files are copied into `ROGUE`, and startup links the shell then runs `rogue </1`. A `run` target launches the image in MAME like the CMOC OS-9 recipe.

## Notable Changes

- Add `recipes/coco3/rogue/makefile`, `defsfile`, and a Rogue-local `startup`.
- Build the Rogue command from `rogue.asm` through the recipe makefile and place it in `CMDS`.
- Strip the recipe command set down to `dir`, `grfdrv`, `list`, `mdir`, `mfree`, merged `shell`, and `rogue`.
- Copy `sysgo_dd` into the disk root as executable `sysgo`.
- Copy `rogue.dat`, `rogue.hlp`, `rogue.scr`, and `rogue.chr` into `ROGUE`.
- Make startup run `link shell` and then `rogue </1`.
- Add a `run` target with MAME floppy launch flags matching the CMOC OS-9 recipe.
- Add `DSK_EXTRA_DEPS` and `DSK_POST_COPY` hooks to `recipes/coco3/coco3.mak`.

## Verification

```sh
make -C recipes/coco3/rogue
os9 list recipes/coco3/rogue/l2_coco3_rogue.dsk,startup
os9 dir recipes/coco3/rogue/l2_coco3_rogue.dsk,CMDS
git diff --check
```

Verified output:

```text
lwasm ... -DH6309=0 ... /Users/boisy/Projects/coco-shelf/nitros9/lib/sys6809l2.as -o.obj/sys6809l2.o
os9 copy -o=0 .mods/dir .mods/grfdrv .mods/list .mods/mdir .mods/mfree .mods/shell .mods/rogue l2_coco3_rogue.dsk,CMDS

link shell
rogue </1

Directory of recipes/coco3/rogue/l2_coco3_rogue.dsk,CMDS
dir             grfdrv          list            mdir            mfree
shell           rogue
```
