### PR TITLE
Add repository CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all repository changes.
+* @tlindner @strickyak @Deek @DrPitre @rlucente-retro @n6il @nitrorobotics @jfed6000 @MatthewMassie


### PR DESCRIPTION
## Overview

Add a repository-level CODEOWNERS file under `.github/CODEOWNERS` so GitHub can identify default reviewers for changes across the nitros9 repository.

The initial default owner rule assigns all paths to repository admins, maintainers, and requested collaborators: `@tlindner`, `@strickyak`, `@Deek`, `@DrPitre`, `@rlucente-retro`, `@n6il`, `@nitrorobotics`, `@jfed6000`, and `@MatthewMassie`.

## Verification

```sh
git diff --cached --stat
git check-ignore -v .github/CODEOWNERS
git diff --check
```

Verified output:

```text
.github/CODEOWNERS | 2 ++
1 file changed, 2 insertions(+)
```

`git check-ignore` returned no match, confirming the CODEOWNERS file is not ignored.
