### PR TITLE
Guard sys6809 H6309 definitions

### DIFF
--- a/lib/sys6809l1.as
+++ b/lib/sys6809l1.as
@@ -1,7 +1,9 @@
                     section   _constant
 
 Level               equ       1
+                    ifndef    H6309
 H6309               equ       0
+                    endc
 
                     use       ../defs/os9.d
                     use       ../defs/rbf.d

--- a/lib/sys6809l2.as
+++ b/lib/sys6809l2.as
@@ -1,7 +1,9 @@
                     section   _constant
 
 Level               equ       2
+                    ifndef    H6309
 H6309               equ       0
+                    endc
 
                     use       ../defs/os9.d
                     use       ../defs/rbf.d


### PR DESCRIPTION
## Overview

Guard the `H6309 equ 0` defaults in `lib/sys6809l1.as` and `lib/sys6809l2.as` with `ifndef H6309` so recipe builds can pass `-DH6309=0` without tripping duplicate-symbol errors.

## Notable Changes

- Wrap the Level 1 6809 sys library `H6309` default in `ifndef H6309` / `endc`.
- Wrap the Level 2 6809 sys library `H6309` default in `ifndef H6309` / `endc`.

## Verification

```sh
make -C recipes/coco3/40d clean
make -C recipes/coco3/40d
git diff --check
```

Verified output:

```text
lwasm ... -DH6309=0 ... /Users/boisy/Projects/coco-shelf/nitros9/lib/sys6809l2.as -o.obj/sys6809l2.o
...
os9 copy -o=0 ... l2_coco3.dsk,CMDS
```
