### PR TITLE
Update 40d recipe run and boot setup

### DIFF
--- a/recipes/coco/40d/makefile
+++ b/recipes/coco/40d/makefile
@@ -1,2 +1,11 @@
 LEVEL = 1
 include ../coco.mak
+
+MAME         ?= mame
+MAME_MACHINE ?= coco
+MAME_FLAGS   ?= -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd
+
+run: $(DSKIMAGE)
+	$(MAME) $(MAME_MACHINE) $(MAME_FLAGS) -flop1 $(DSKIMAGE)
+
+.PHONY: run

--- a/recipes/coco3/40d/makefile
+++ b/recipes/coco3/40d/makefile
@@ -1,2 +1,24 @@
 LEVEL = 2
+BOOTMODS = krnp2 ioman init \
+	$(RBF) \
+	$(SCF) \
+	$(PIPE) \
+	$(CLOCK) \
+	$(BOOTMODS_EXTRA)
+DSK_EXTRA_DEPS = $(MODDIR)/sysgo_dd
+DSK_POST_COPY = $(MAKE) copy-sysgo-root DSKIMAGE=$@
+
 include ../coco3.mak
+
+MAME         ?= mame
+MAME_MACHINE ?= coco3
+MAME_FLAGS   ?= -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd
+
+run: $(DSKIMAGE)
+	$(MAME) $(MAME_MACHINE) $(MAME_FLAGS) -flop1 $(DSKIMAGE)
+
+copy-sysgo-root:
+	$(OS9COPY) $(MODDIR)/sysgo_dd $(DSKIMAGE),sysgo
+	$(OS9ATTR_EXEC) $(DSKIMAGE),sysgo
+
+.PHONY: copy-sysgo-root run

--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -42,6 +42,8 @@ TERM_ALTCOLOR_FLAGS =
 endif
 
 DSKIMAGE ?= l$(LEVEL)_$(RECIPE).dsk
+DSK_EXTRA_DEPS ?=
+DSK_POST_COPY ?= @:
 OS9FORMAT_CMD ?= $(OS9FORMAT_DS40)
 
 AFLAGS += -I.
@@ -89,7 +91,7 @@ kernelfile: $(addprefix $(MODDIR)/,$(KERNEL_TRACK))
 bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(MERGE) $(addprefix $(MODDIR)/,$(BOOTMODS))>$@
 
-$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP)
+$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(DSK_EXTRA_DEPS)
 	$(RM) $@
 	$(OS9FORMAT_CMD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
 	$(OS9GEN) $@ -b=bootfile -t=$(KERNELFILE)
@@ -100,6 +102,7 @@ $(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP)
 	$(OS9ATTR_EXEC) $(foreach file,$(CMDS),$@,CMDS/$(file))
 	$(CPL) $(STARTUP) $@,startup
 	$(OS9ATTR_TEXT) $@,startup
+	$(DSK_POST_COPY)
 
 # /TERM window descriptors — column count and colors controlled by TERM_COLS and TERM_ALTCOLOR
 $(MODDIR)/term_win40.dt: term_win40.asm | $(MODDIR)


### PR DESCRIPTION
## Overview

Add `run` targets to the 40-track CoCo and CoCo 3 recipes so each recipe can build its disk image and launch it in MAME.

The CoCo recipe launches `l1_coco.dsk` with the `coco` MAME machine, while the CoCo 3 recipe launches `l2_coco3.dsk` with the `coco3` MAME machine. The CoCo 3 40d recipe also removes `sysgo_dd` and `shell_21` from its bootfile and copies `sysgo_dd` into the disk root as executable `sysgo`.

## Notable Changes

- Add configurable `MAME`, `MAME_MACHINE`, and `MAME_FLAGS` variables to `recipes/coco/40d/makefile`.
- Add configurable `MAME`, `MAME_MACHINE`, and `MAME_FLAGS` variables to `recipes/coco3/40d/makefile`.
- Add `run: $(DSKIMAGE)` targets that mount the generated disk image on `-flop1`.
- Add generic `DSK_EXTRA_DEPS` and `DSK_POST_COPY` hooks to `recipes/coco3/coco3.mak`.
- Override CoCo 3 40d `BOOTMODS` so `sysgo_dd` and `shell_21` are not merged into the bootfile.
- Copy CoCo 3 40d `sysgo_dd` into the disk root as executable `sysgo`.

## Verification

```sh
make -C recipes/coco/40d -n run
make -C recipes/coco3/40d clean
make -C recipes/coco3/40d
make -C recipes/coco3/40d -n run
os9 ident recipes/coco3/40d/bootfile
os9 dir recipes/coco3/40d/l2_coco3.dsk,
os9 dir recipes/coco3/40d/l2_coco3.dsk,CMDS
git diff --check
```

Verified output:

```text
mame coco -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd -flop1 l1_coco.dsk
mame coco3 -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd -flop1 l2_coco3.dsk

cat .mods/krnp2 .mods/ioman .mods/init .mods/rbf.mn .mods/rb1773.dr ... .mods/clock_60hz .mods/clock2_soft>bootfile
os9 copy -o=0 .mods/sysgo_dd l2_coco3.dsk,sysgo

Directory of recipes/coco3/40d/l2_coco3.dsk,.
OS9Boot         CMDS            SYS             DEFS            startup
sysgo
```

`os9 ident recipes/coco3/40d/bootfile` lists the boot modules through `Clock2`; it no longer lists `sysgo` or `shell_21`.
