### PR TITLE
Annotate kernel assembly comments

### DIFF
--- a/level1/modules/kernel/fall64.asm
+++ b/level1/modules/kernel/fall64.asm
@@ -48,17 +48,17 @@
 ;;; The next 256 byte page at $3600 has three of its four 64 byte blocks allocated and one remaining free. The first byte
 ;;; of each of the allocated 64 byte blocks contains the MSB of the 256 byte address of its block.
 
-FAll64         ldx       R$X,u               get base address of page table
-               bne       notempty@           branch if not empty
-               bsr       Alloc256Bytes       otherwise allocate memory for a new page table
-               bcs       ex@                 exit if error
-               stx       ,x                  save off address of page table in newly allocated page
-               stx       R$X,u               and in caller's X
-notempty@      bsr       Alloc64Bytes        find a free 64 byte block to allocate
-               bcs       ex@                 branch if error
-               sta       R$A,u               save the block number to caller's A
-               sty       R$Y,u               and the address to the caller's Y
-ex@            rts                           return to caller  
+FAll64              ldx       R$X,u     ; get base address of page table
+                    bne       notempty@ ; branch if not empty
+                    bsr       Alloc256Bytes ; otherwise allocate memory for a new page table
+                    bcs       ex@       ; exit if error
+                    stx       ,x        ; save off address of page table in newly allocated page
+                    stx       R$X,u     ; and in caller's X
+notempty@           bsr       Alloc64Bytes ; find a free 64 byte block to allocate
+                    bcs       ex@       ; branch if error
+                    sta       R$A,u     ; save the block number to caller's A
+                    sty       R$Y,u     ; and the address to the caller's Y
+ex@                 rts                 ; return to caller
 
 * Allocate a 256 byte page from system RAM
 *
@@ -68,19 +68,19 @@ ex@            rts                           return to caller
 *
 * Error:  B = A non-zero error code.
 *        CC = Carry flag set to indicate error.
-Alloc256Bytes  pshs      u                   save off caller's registers
-               ldd       #256                we want to allocate 256 bytes
-               os9       F$SRqMem            request from system memory
-               leax      ,u                  point X to start of newly allocated area
-               puls      u                   and recover U saved earlier
-               bcs       ex@                 branch if error
+Alloc256Bytes       pshs      u         ; save off caller's registers
+                    ldd       #256      ; we want to allocate 256 bytes
+                    os9       F$SRqMem  ; request from system memory
+                    leax      ,u        ; point X to start of newly allocated area
+                    puls      u         ; and recover U saved earlier
+                    bcs       ex@       ; branch if error
 * clear out the newly allocated area
-               clra                          A = 0 (used to for clearing byte)
-               clrb                          B = 0 (used for 256 loop counter)
-loop@          sta       d,x                 clear byte at ,X
-               incb                          count loop up
-               bne       loop@               branch not zero (more to clear)
-ex@            rts                           return to caller
+                    clra                ; A = 0 (used to for clearing byte)
+                    clrb                ; B = 0 (used for 256 loop counter)
+loop@               sta       d,x       ; clear byte at ,X
+                    incb                ; count loop up
+                    bne       loop@     ; branch not zero (more to clear)
+ex@                 rts                 ; return to caller
 
 * Walk the 64 byte page table to allocate a 64 byte block of memory.
 *
@@ -88,52 +88,52 @@ ex@            rts                           return to caller
 *
 * Exit:  A = The allocated block number.
 *        Y = The address of the allocated 64 byte block.
-Alloc64Bytes   pshs      u,x                 save caller's regs and base address of page table
-               clra                          A = 0
-searchnext@    pshs      a                   save on stack
-               clrb                          B = 0
-               lda       a,x                 get byte at page table from index A; D now is address
-               beq       pagefree@           branch if zero (no page allocated)
-               tfr       d,y                 else put D in Y
-               clra                          clear A
-checkpage@     tst       d,y                 is this 64 byte page available?
-               beq       pagefree2@          branch if it is
-               addb      #64                 else add block size of 64 to B
-               bcc       checkpage@          and go check next block if B < 256
-pagefree@      orcc      #Carry              set carry flag to indicate this page is free and can be allocated
-pagefree2@     leay      d,y                 point Y to the free 64 byte block
-               puls      a                   recover A from stack
-               bcc       mark2@              branch if no page allocated (carry set earlier)
-               inca                          increment A
-               cmpa      #64                 at 64?
-               bcs       searchnext@         branch if less than 64
-               clra                          A = 0
-testnext@      tst       a,x                 test value at A,X
-               beq       mark@               branch if 0
-               inca                          increment A
-               cmpa      #64                 at 64?
-               bcs       testnext@           branch if less than
-               ldb       #E$PthFul           otherwise the path table is full (all 64 bytes hold MSB addresses)
-               coma                          set carry
-               bra       ex1@                return to caller
-mark@          pshs      x,a                 save X (address of page table) and A (current offset in page table)
-               bsr       Alloc256Bytes       go allocate 256 bytes
-               bcs       ex2@                branch if error
-               leay      ,x                  point Y to the newly allocated 256 bytes
-               tfr       x,d                 put X into D
-               tfr       a,b                 put MSB of address into B
-               puls      x,a                 recover X and A saved earlier
-               stb       a,x                 store MSB of address (B) into location in 64 byte page table
-               clrb                          B = 0
-mark2@         lslb                          multiply D times 2
-               rola                          then...
-               lslb                          multiply D times 2 again (D = D*4)
-               rola                          A now holds MSB of address of the 256 byte page that this 64 byte block is in
-               ldb       #64-1               get block size minus 1 (clear remaining 63 bytes)
-loop@          clr       b,y                 clear the byte in the block
-               decb                          decrement b
-               bne       loop@               continue if more to clear
-               sta       ,y                  save MSB of block address in first byte of 64 byte block
-ex1@           puls      pc,u,x              pull registers and return
-ex2@           leas      3,s                 recover stack
-               puls      pc,u,x              pull registers and return
+Alloc64Bytes        pshs      u,x       ; save caller's regs and base address of page table
+                    clra                ; A = 0
+searchnext@         pshs      a         ; save on stack
+                    clrb                ; B = 0
+                    lda       a,x       ; get byte at page table from index A; D now is address
+                    beq       pagefree@ ; branch if zero (no page allocated)
+                    tfr       d,y       ; else put D in Y
+                    clra                ; clear A
+checkpage@          tst       d,y       ; is this 64 byte page available?
+                    beq       pagefree2@ ; branch if it is
+                    addb      #64       ; else add block size of 64 to B
+                    bcc       checkpage@ ; and go check next block if B < 256
+pagefree@           orcc      #Carry    ; set carry flag to indicate this page is free and can be allocated
+pagefree2@          leay      d,y       ; point Y to the free 64 byte block
+                    puls      a         ; recover A from stack
+                    bcc       mark2@    ; branch if no page allocated (carry set earlier)
+                    inca                ; increment A
+                    cmpa      #64       ; at 64?
+                    bcs       searchnext@ ; branch if less than 64
+                    clra                ; A = 0
+testnext@           tst       a,x       ; test value at A,X
+                    beq       mark@     ; branch if 0
+                    inca                ; increment A
+                    cmpa      #64       ; at 64?
+                    bcs       testnext@ ; branch if less than
+                    ldb       #E$PthFul ; otherwise the path table is full (all 64 bytes hold MSB addresses)
+                    coma                ; set carry
+                    bra       ex1@      ; return to caller
+mark@               pshs      x,a       ; save X (address of page table) and A (current offset in page table)
+                    bsr       Alloc256Bytes ; go allocate 256 bytes
+                    bcs       ex2@      ; branch if error
+                    leay      ,x        ; point Y to the newly allocated 256 bytes
+                    tfr       x,d       ; put X into D
+                    tfr       a,b       ; put MSB of address into B
+                    puls      x,a       ; recover X and A saved earlier
+                    stb       a,x       ; store MSB of address (B) into location in 64 byte page table
+                    clrb                ; B = 0
+mark2@              lslb                ; multiply D times 2
+                    rola                ; then...
+                    lslb                ; multiply D times 2 again (D = D*4)
+                    rola                ; A now holds MSB of address of the 256 byte page that this 64 byte block is in
+                    ldb       #64-1     ; get block size minus 1 (clear remaining 63 bytes)
+loop@               clr       b,y       ; clear the byte in the block
+                    decb                ; decrement b
+                    bne       loop@     ; continue if more to clear
+                    sta       ,y        ; save MSB of block address in first byte of 64 byte block
+ex1@                puls      pc,u,x    ; pull registers and return
+ex2@                leas      3,s       ; recover stack
+                    puls      pc,u,x    ; pull registers and return

--- a/level1/modules/kernel/fallbit.asm
+++ b/level1/modules/kernel/fallbit.asm
@@ -311,13 +311,13 @@ SkpBit2             cmpy      #$0008    ; compare Y with #$0008
                     beq       BitStEx   ; exactly 1 byte left, do final store & exit
 
 * Last byte: Not a full byte left loop
-L085A               lsra                ; bump out least sig. bit
+FAllbitBumpOutLeastSigBit lsra                ; bump out least sig. bit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec the bit counter
                   ELSE
                     leay      -1,y      ; compute -1,y into Y
                   ENDC
-                    bne       L085A     ; keep going until last one is shifted out
+                    bne       FAllbitBumpOutLeastSigBit ; keep going until last one is shifted out
                     coma                ; invert byte to get proper result
                     sta       ,s        ; preserve a sec
                   IFGT    Level-1 ; begin conditional assembly for Level-1
@@ -402,16 +402,16 @@ DoDelBit            equ       *         ; define assembler symbol
                   ELSE
                     ldy       R$Y,u     ; get # bits to clear
                   ENDC
-                    beq       L08E0     ; none, return
+                    beq       FAllbitReturn ; none, return
                     coma                ; invert current bit mask
                     sta       ,-s       ; preserve on stack
-                    bpl       L08BC     ; if high bit clear, skip ahead
+                    bpl       FAllbitPreloadCleared ; if high bit clear, skip ahead
                   IFGT    Level-1 ; begin conditional assembly for Level-1
                     os9       F$LDABX   ; go get byte from user's map
                   ELSE
                     lda       ,x        ; load A from ,x
                   ENDC
-L08AD               anda      ,s        ; aND it with current mask
+FAllbitMask         anda      ,s        ; aND it with current mask
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec the bits left counter
                   ELSE
@@ -419,16 +419,16 @@ L08AD               anda      ,s        ; aND it with current mask
                   ENDC
                     beq       BitDone   ; done, store finished byte back in task's map
                     asr       ,s        ; shift out lowest bit, leaving highest alone
-                    bcs       L08AD     ; if it is a 1, do next bit
+                    bcs       FAllbitMask ; if it is a 1, do next bit
                   IFGT    Level-1 ; begin conditional assembly for Level-1
                     os9       F$STABX   ; if it was a 0 (which means whole byte done),
                   ELSE
                     sta       ,x        ; store A at ,x
                   ENDC
                     leax      1,x       ; store finished byte & inc. ptr
-L08BC               clra                ; preload a cleared byte
+FAllbitPreloadCleared clra                ; preload a cleared byte
                     bra       ChkFull   ; skip ahead
-L08BF               equ       *         ; define assembler symbol
+FAllbitJoin         equ       *         ; define assembler symbol
                   IFGT    Level-1 ; begin conditional assembly for Level-1
                     os9       F$STABX   ; store full byte
                   ELSE
@@ -442,16 +442,16 @@ ChkFull             cmpw      #8        at least 1 full byte left?
                     leay      -8,y      ; compute -8,y into Y
 ChkFull             cmpy      #8        ; compare Y with #8
                   ENDC
-                    bhi       L08BF     ; yes, do a whole byte in 1 shot
+                    bhi       FAllbitJoin ; yes, do a whole byte in 1 shot
                     beq       BitDone   ; exactly 1, store byte & exit
                     coma                ; < full byte left, invert bits
-L08CF               lsra                ; shift out rightmost bit
+FAllbitShiftOutRightmostBit lsra                ; shift out rightmost bit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec bits left counter
                   ELSE
                     leay      -1,y      ; compute -1,y into Y
                   ENDC
-                    bne       L08CF     ; keep doing till done
+                    bne       FAllbitShiftOutRightmostBit ; keep doing till done
                     sta       ,s        ; save finished mask
                   IFGT    Level-1 ; begin conditional assembly for Level-1
                     os9       F$LDABX   ; get original byte from task
@@ -466,7 +466,7 @@ BitDone             equ       *         ; define assembler symbol
                     sta       ,x        ; store A at ,x
                   ENDC
                     leas      1,s       ; eat working copy of mask
-L08E0               clrb                ; eat error & return
+FAllbitReturn       clrb                ; eat error & return
                     rts                 ; return to caller
 
 

--- a/level1/modules/kernel/fallbit.asm
+++ b/level1/modules/kernel/fallbit.asm
@@ -311,13 +311,13 @@ SkpBit2             cmpy      #$0008    ; compare Y with #$0008
                     beq       BitStEx   ; exactly 1 byte left, do final store & exit
 
 * Last byte: Not a full byte left loop
-FAllbitBumpOutLeastSigBit lsra                ; bump out least sig. bit
+FAllbitBumpOutLst   lsra                ; bump out least sig. bit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec the bit counter
                   ELSE
                     leay      -1,y      ; compute -1,y into Y
                   ENDC
-                    bne       FAllbitBumpOutLeastSigBit ; keep going until last one is shifted out
+                    bne       FAllbitBumpOutLst ; keep going until last one is shifted out
                     coma                ; invert byte to get proper result
                     sta       ,s        ; preserve a sec
                   IFGT    Level-1 ; begin conditional assembly for Level-1
@@ -405,7 +405,7 @@ DoDelBit            equ       *         ; define assembler symbol
                     beq       FAllbitReturn ; none, return
                     coma                ; invert current bit mask
                     sta       ,-s       ; preserve on stack
-                    bpl       FAllbitPreloadCleared ; if high bit clear, skip ahead
+                    bpl       FAllbitPrldClrd ; if high bit clear, skip ahead
                   IFGT    Level-1 ; begin conditional assembly for Level-1
                     os9       F$LDABX   ; go get byte from user's map
                   ELSE
@@ -426,7 +426,7 @@ FAllbitMask         anda      ,s        ; aND it with current mask
                     sta       ,x        ; store A at ,x
                   ENDC
                     leax      1,x       ; store finished byte & inc. ptr
-FAllbitPreloadCleared clra                ; preload a cleared byte
+FAllbitPrldClrd     clra                ; preload a cleared byte
                     bra       ChkFull   ; skip ahead
 FAllbitJoin         equ       *         ; define assembler symbol
                   IFGT    Level-1 ; begin conditional assembly for Level-1
@@ -445,13 +445,13 @@ ChkFull             cmpy      #8        ; compare Y with #8
                     bhi       FAllbitJoin ; yes, do a whole byte in 1 shot
                     beq       BitDone   ; exactly 1, store byte & exit
                     coma                ; < full byte left, invert bits
-FAllbitShiftOutRightmostBit lsra                ; shift out rightmost bit
+FAllbitShftOutRghtm lsra                ; shift out rightmost bit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec bits left counter
                   ELSE
                     leay      -1,y      ; compute -1,y into Y
                   ENDC
-                    bne       FAllbitShiftOutRightmostBit ; keep doing till done
+                    bne       FAllbitShftOutRghtm ; keep doing till done
                     sta       ,s        ; save finished mask
                   IFGT    Level-1 ; begin conditional assembly for Level-1
                     os9       F$LDABX   ; get original byte from task

--- a/level1/modules/kernel/fallbit.asm
+++ b/level1/modules/kernel/fallbit.asm
@@ -16,41 +16,41 @@
 ;;;
 ;;; Don't call F$AllBit with Y set to 0 (a bit count of 0).
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FAllBit        ldd       R$D,u               get bit number to start with
-               leau      R$X,u               point U to the caller's R$X
-               pulu      y,x                 load caller's R$X and R$Y into X and Y in one call
-AllocBit       pshs      y,x,b,a             preserve registers
-               bsr       CalcBit             calculate byte and position, and get first bit mask
-               tsta                          test the mask
-               pshs      a                   then preserve the mask on the stack
-_mask@         set       0
-               bmi       whole@              branch if the hi-bit of the mask is set
-               lda       ,x                  else get the next byte in the bitmap
-loop@          ora       _mask@,s            OR it with the mask on the stack
-               leay      -1,y                decrement the bits to set counter
-               beq       ex@                 branch if we're done
-               lsr       _mask@,s            else shift the mask on the stack to the right
-               bcc       loop@               branch if low bit on mask was 0
-               sta       ,x+                 save the updated byte with the appropriate bits set
-whole@         tfr       y,d                 pass the current bit count to D
-               sta       _mask@,s            and save off the A as the mask
-               lda       #%11111111          load A with all new set of bits set
-               bra       loopstart@          and now set whole bytes at a time
-loop2@         sta       ,x+                 save the updated byte with the appropriate bits set
-loopstart@     subb      #$08                subtract 8 from B
-               bcc       loop2@              branch if B is >= 0
-               dec       _mask@,s            else decrement mask byte
-               bpl       loop2@              and branch if hi bit not set
-loop3@         lsla                          divide A by 2
-               incb                          increment B
-               bne       loop3@              continue if B is not 0
-               ora       ,x                  OR A with value at X
-ex@            sta       ,x                  and store it at X
-               clra                          clear carry
-               leas      _mask@+1,s          fix stack
-               puls      pc,y,x,b,a          restore registers and return
+FAllBit             ldd       R$D,u     ; get bit number to start with
+                    leau      R$X,u     ; point U to the caller's R$X
+                    pulu      y,x       ; load caller's R$X and R$Y into X and Y in one call
+AllocBit            pshs      y,x,b,a   ; preserve registers
+                    bsr       CalcBit   ; calculate byte and position, and get first bit mask
+                    tsta                ; test the mask
+                    pshs      a         ; then preserve the mask on the stack
+_mask@              set       0         ; define assembler symbol
+                    bmi       whole@    ; branch if the hi-bit of the mask is set
+                    lda       ,x        ; else get the next byte in the bitmap
+loop@               ora       _mask@,s  ; oR it with the mask on the stack
+                    leay      -1,y      ; decrement the bits to set counter
+                    beq       ex@       ; branch if we're done
+                    lsr       _mask@,s  ; else shift the mask on the stack to the right
+                    bcc       loop@     ; branch if low bit on mask was 0
+                    sta       ,x+       ; save the updated byte with the appropriate bits set
+whole@              tfr       y,d       ; pass the current bit count to D
+                    sta       _mask@,s  ; and save off the A as the mask
+                    lda       #%11111111 ; load A with all new set of bits set
+                    bra       loopstart@ ; and now set whole bytes at a time
+loop2@              sta       ,x+       ; save the updated byte with the appropriate bits set
+loopstart@          subb      #$08      ; subtract 8 from B
+                    bcc       loop2@    ; branch if B is >= 0
+                    dec       _mask@,s  ; else decrement mask byte
+                    bpl       loop2@    ; and branch if hi bit not set
+loop3@              lsla                ; divide A by 2
+                    incb                ; increment B
+                    bne       loop3@    ; continue if B is not 0
+                    ora       ,x        ; oR A with value at X
+ex@                 sta       ,x        ; and store it at X
+                    clra                ; clear carry
+                    leas      _mask@+1,s ; fix stack
+                    puls      pc,y,x,b,a ; restore registers and return
 
 * Calculate address of first byte we want, and which bit in that byte, from
 * a bit allocation map given the address of the map & the bit # we want to point to.
@@ -69,33 +69,33 @@ ex@            sta       ,x                  and store it at X
 * We want bit 5 starting at address 3000. Pass 5 to D and 3000 to X.
 * We get back 8 in A (bit 3 set) and 3000 in D (the address of the bit).
 
-CalcBit        pshs      b                   preserve B
-               ifne      H6309
-*>>>>>>>>>> H6309
-               lsrd                          divide D by 2
-               lsrd                          then divide D by 2 again
-               lsrd                          and again, now D = D / 8
-               addr      d,x                 get the address of the byte in the bitmap to start
-*<<<<<<<<<< H6309
-               else
-*>>>>>>>>>> M6809
-               lsra                          divide D
-               rorb                          by 2
-               lsra                          then divide D
-               rorb                          by 2
-               lsra                          and divide D
-               rorb                          again by 2, now D = D/8, which is the byte offset
-               leax      d,x                 get the address of the byte in the bitmap to start
-*<<<<<<<<<< M6809
-               endc
-               puls      b                   recover B to compute the bit
-               lda       #$80                load A with hi bit set
-               andb      #%0000111           mask out all but the lower 3 bits (0-7, the bit number)
-               beq       ex@                 branch if 0 (the 0th bit)
-loop@          lsra                          else right shift A
-               decb                          and decrement B (the bit counter)
-               bne       loop@               until B reaches 0
-ex@            rts                           return to the caller
+CalcBit             pshs      b         ; preserve B
+                  IFNE    H6309   ; begin conditional assembly for H6309
+*[[[ H6309
+                    lsrd                ; divide D by 2
+                    lsrd                ; then divide D by 2 again
+                    lsrd                ; and again, now D = D / 8
+                    addr      d,x       ; get the address of the byte in the bitmap to start
+*]]] H6309
+                  ELSE
+*[[[ M6809
+                    lsra                ; divide D
+                    rorb                ; by 2
+                    lsra                ; then divide D
+                    rorb                ; by 2
+                    lsra                ; and divide D
+                    rorb                ; again by 2, now D = D/8, which is the byte offset
+                    leax      d,x       ; get the address of the byte in the bitmap to start
+*]]] M6809
+                  ENDC
+                    puls      b         ; recover B to compute the bit
+                    lda       #$80      ; load A with hi bit set
+                    andb      #%0000111 ; mask out all but the lower 3 bits (0-7, the bit number)
+                    beq       ex@       ; branch if 0 (the 0th bit)
+loop@               lsra                ; else right shift A
+                    decb                ; and decrement B (the bit counter)
+                    bne       loop@     ; until B reaches 0
+ex@                 rts                 ; return to the caller
 
 ;;; F$DelBit
 ;;;
@@ -115,36 +115,36 @@ ex@            rts                           return to the caller
 ;;;
 ;;; Don't call F$DelBit with Y set to 0 (a bit count of 0).
 
-FDelBit        ldd       R$D,u               get bit number to start with
-               leau      R$X,u               point U to the address of the caller's register pointer
-               pulu      y,x                 load X/Y/U with this slick trick
-DelBit         pshs      y,x,b,a             preserve registers
-               bsr       CalcBit             calculate byte and position, and get first bit mask
-               coma                          complement the mask
-               pshs      a                   then preserve the mask on the stack
-_mask@         set       0
-               bpl       delstart@           branch if high bit in A is clear
-               lda       ,x                  get byte to clear bits of
-loop@          anda      _mask@,s            AND with mask on stack
-               leay      -1,y                decrement the bits to clear counter
-               beq       ex@                 if zero, we're done, so return to caller
-               asr       _mask@,s            else shift right the mask byte on the stack (bit 7 remains constant, bit 0 goe sinto the carry)
-               bcs       loop@               and continue if carry set (bit 0 was 1 in the mask)
-               sta       ,x+                 else store the updated byte and increment to the next
-delstart@      tfr       y,d                 transfer bit clear count from Y into D
-               bra       loopstart@          start the loop
-loop2@         clr       ,x+                 clear this byte and move X to next
-loopstart@     subd      #$0008              subtract 8 from the clear count
-               bhi       loop2@              branch if D > 0
-               beq       ex@                 branch if D = 0
-loop3@         lsla                          shift A left one bit, filling LSB with 0
-               incb                          increment B
-               bne       loop3@              if not zero, keep shifting
-               coma                          complement A
-               anda      ,x                  and it with byte at X
-ex@            sta       ,x                  and store it
-               clr       ,s+                 eat the byte at the stack
-               puls      pc,y,x,b,a          pull remaining registers and return to the caller
+FDelBit             ldd       R$D,u     ; get bit number to start with
+                    leau      R$X,u     ; point U to the address of the caller's register pointer
+                    pulu      y,x       ; load X/Y/U with this slick trick
+DelBit              pshs      y,x,b,a   ; preserve registers
+                    bsr       CalcBit   ; calculate byte and position, and get first bit mask
+                    coma                ; complement the mask
+                    pshs      a         ; then preserve the mask on the stack
+_mask@              set       0         ; define assembler symbol
+                    bpl       delstart@ ; branch if high bit in A is clear
+                    lda       ,x        ; get byte to clear bits of
+loop@               anda      _mask@,s  ; aND with mask on stack
+                    leay      -1,y      ; decrement the bits to clear counter
+                    beq       ex@       ; if zero, we're done, so return to caller
+                    asr       _mask@,s  ; else shift right the mask byte on the stack (bit 7 remains constant, bit 0 goe sinto the carry)
+                    bcs       loop@     ; and continue if carry set (bit 0 was 1 in the mask)
+                    sta       ,x+       ; else store the updated byte and increment to the next
+delstart@           tfr       y,d       ; transfer bit clear count from Y into D
+                    bra       loopstart@ ; start the loop
+loop2@              clr       ,x+       ; clear this byte and move X to next
+loopstart@          subd      #$0008    ; subtract 8 from the clear count
+                    bhi       loop2@    ; branch if D > 0
+                    beq       ex@       ; branch if D = 0
+loop3@              lsla                ; shift A left one bit, filling LSB with 0
+                    incb                ; increment B
+                    bne       loop3@    ; if not zero, keep shifting
+                    coma                ; complement A
+                    anda      ,x        ; and it with byte at X
+ex@                 sta       ,x        ; and store it
+                    clr       ,s+       ; eat the byte at the stack
+                    puls      pc,y,x,b,a ; pull remaining registers and return to the caller
 
 ;;; F$SchBit
 ;;;
@@ -165,72 +165,72 @@ ex@            sta       ,x                  and store it
 ;;; starts at the starting bit number. If no block of the specified size exists, the call returns with the carry set,
 ;;; starting bit number, and size of the largest block.
 
-FSchBit        pshs      u                   save off caller's registers
-               ldd       R$D,u               get bit number to start with
-               ldx       R$X,u               get the address of allocation bit map
-               ldy       R$Y,u               get the number of cleared contiguous bits to search for
-               ldu       R$U,u               get the address of the end of the allocation map
-               bsr       SchBit              perform the search
-               puls      u                   recover the caller's registers
-               std       R$D,u               save the starting bit number in the caller's D
-               sty       R$Y,u               and the number of bits cleared at that point in caller's Y
-               rts                           return
-SchBit         pshs      u,y,x,b,a           preserve registers
-               pshs      y,b,a               preserve more
-_stk2A@        set       0
-_stk2B@        set       1
-_stk2Y@        set       2
-_stk1A@        set       4
-_stk1B@        set       5
-_stk1X@        set       6
-_stk1Y@        set       8
-_stk1U@        set       10
-               clr       _stk1Y@,s
-               clr       _stk1Y@+1,s
-               tfr       d,y
-               bsr       CalcBit             calculate the bit location
-               pshs      a                   save the mask that points to bit number within byte we are starting on.
-_stk3A@        set       0
-_stk2A@        set       _stk2A@+1
-_stk2B@        set       _stk2B@+1
-_stk2Y@        set       _stk2Y@+1
-_stk1A@        set       _stk1A@+1
-_stk1B@        set       _stk1B@+1
-_stk1X@        set       _stk1X@+1
-_stk1Y@        set       _stk1Y@+1
-_stk1U@        set       _stk1U@+1
-               bra       looptop@            start at the top of the loop
-loop@          leay      1,y                 increment Y
-               sty       _stk1A@,s           save onto the stack
-loop2@         lsr       _stk3A@,s           shift the byte on the stack right (bit 0 goes into carry)
-               bcc       looptop2@           branch if carry is clear (more to do)
-               ror       _stk3A@,s           else rotate right byte on stack
-               leax      1,x                 advance X by 1
-looptop@       cmpx      _stk1U@,s           compare X to the end of the bitmap on the stack
-               bcc       loopout@            branch if equal (we're finished)
-looptop2@      lda       ,x                  get the byte in the bitmap at X into A
-               anda      _stk3A@,s           AND with bit mask on stack
-               bne       loop@               branch if not zero
-               leay      $01,y               else advance Y by 1 byte
-               tfr       y,d                 transfer it to D
-               subd      _stk1A@,s           subract bit number to start with the on the stack from D
-               cmpd      _stk2Y@,s           compare to our counter
-               bcc       saveandex@          branch if equal
-               cmpd      _stk1Y@,s           compare against the number of bits cleared on the stack with D
-               bls       loop2@              branch if the value on the stack is lower or same as D
-               std       _stk1Y@,s           else save D into the number of bits cleared position on the stack
-               ldd       _stk1A@,s           get the bit number to start with on the stack into D
-               std       _stk2A@,s           save off into the next position on the stack
-               bra       loop2@              and continue working
-loopout@       ldd       _stk2A@,s           get the next position on the stack
-               std       _stk1A@,s           store it
-               coma                          complement A
-               bra       ex@                 and prepare to return to the caller
-saveandex@     std       _stk1Y@,s           get the number of bits cleared
-ex@            leas      _stk1A@,s           clean up the stack
-               puls      pc,u,y,x,b,a        restore registers and return to the caller
+FSchBit             pshs      u         ; save off caller's registers
+                    ldd       R$D,u     ; get bit number to start with
+                    ldx       R$X,u     ; get the address of allocation bit map
+                    ldy       R$Y,u     ; get the number of cleared contiguous bits to search for
+                    ldu       R$U,u     ; get the address of the end of the allocation map
+                    bsr       SchBit    ; perform the search
+                    puls      u         ; recover the caller's registers
+                    std       R$D,u     ; save the starting bit number in the caller's D
+                    sty       R$Y,u     ; and the number of bits cleared at that point in caller's Y
+                    rts                 ; return
+SchBit              pshs      u,y,x,b,a ; preserve registers
+                    pshs      y,b,a     ; preserve more
+_stk2A@             set       0         ; define assembler symbol
+_stk2B@             set       1         ; define assembler symbol
+_stk2Y@             set       2         ; define assembler symbol
+_stk1A@             set       4         ; define assembler symbol
+_stk1B@             set       5         ; define assembler symbol
+_stk1X@             set       6         ; define assembler symbol
+_stk1Y@             set       8         ; define assembler symbol
+_stk1U@             set       10        ; define assembler symbol
+                    clr       _stk1Y@,s ; clear _stk1Y@,s
+                    clr       _stk1Y@+1,s ; clear _stk1Y@+1,s
+                    tfr       d,y       ; transfer register value d,y
+                    bsr       CalcBit   ; calculate the bit location
+                    pshs      a         ; save the mask that points to bit number within byte we are starting on.
+_stk3A@             set       0         ; define assembler symbol
+_stk2A@             set       _stk2A@+1 ; define assembler symbol
+_stk2B@             set       _stk2B@+1 ; define assembler symbol
+_stk2Y@             set       _stk2Y@+1 ; define assembler symbol
+_stk1A@             set       _stk1A@+1 ; define assembler symbol
+_stk1B@             set       _stk1B@+1 ; define assembler symbol
+_stk1X@             set       _stk1X@+1 ; define assembler symbol
+_stk1Y@             set       _stk1Y@+1 ; define assembler symbol
+_stk1U@             set       _stk1U@+1 ; define assembler symbol
+                    bra       looptop@  ; start at the top of the loop
+loop@               leay      1,y       ; increment Y
+                    sty       _stk1A@,s ; save onto the stack
+loop2@              lsr       _stk3A@,s ; shift the byte on the stack right (bit 0 goes into carry)
+                    bcc       looptop2@ ; branch if carry is clear (more to do)
+                    ror       _stk3A@,s ; else rotate right byte on stack
+                    leax      1,x       ; advance X by 1
+looptop@            cmpx      _stk1U@,s ; compare X to the end of the bitmap on the stack
+                    bcc       loopout@  ; branch if equal (we're finished)
+looptop2@           lda       ,x        ; get the byte in the bitmap at X into A
+                    anda      _stk3A@,s ; aND with bit mask on stack
+                    bne       loop@     ; branch if not zero
+                    leay      $01,y     ; else advance Y by 1 byte
+                    tfr       y,d       ; transfer it to D
+                    subd      _stk1A@,s ; subract bit number to start with the on the stack from D
+                    cmpd      _stk2Y@,s ; compare to our counter
+                    bcc       saveandex@ ; branch if equal
+                    cmpd      _stk1Y@,s ; compare against the number of bits cleared on the stack with D
+                    bls       loop2@    ; branch if the value on the stack is lower or same as D
+                    std       _stk1Y@,s ; else save D into the number of bits cleared position on the stack
+                    ldd       _stk1A@,s ; get the bit number to start with on the stack into D
+                    std       _stk2A@,s ; save off into the next position on the stack
+                    bra       loop2@    ; and continue working
+loopout@            ldd       _stk2A@,s ; get the next position on the stack
+                    std       _stk1A@,s ; store it
+                    coma                ; complement A
+                    bra       ex@       ; and prepare to return to the caller
+saveandex@          std       _stk1Y@,s ; get the number of bits cleared
+ex@                 leas      _stk1A@,s ; clean up the stack
+                    puls      pc,u,y,x,b,a ; restore registers and return to the caller
 
-               else
+                  ELSE
 
 **************************************************
 * System Call: F$AllBit
@@ -245,96 +245,96 @@ ex@            leas      _stk1A@,s           clean up the stack
 *
 * Error:  CC = C bit set; B = error code
 *
-FAllBit  ldd   R$D,u        get bit # to start with
-         ldx   R$X,u        get address of allocation bit map
-         bsr   CalcBit      calculate byte & position & get first bit mask
-         IFGT  Level-1
-         ldy   <D.Proc      get current task #
-         ldb   P$Task,y     get task number
-         bra   DoAllBit     go do it
+FAllBit             ldd       R$D,u     ; get bit # to start with
+                    ldx       R$X,u     ; get address of allocation bit map
+                    bsr       CalcBit   ; calculate byte & position & get first bit mask
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    ldy       <D.Proc   ; get current task #
+                    ldb       P$Task,y  ; get task number
+                    bra       DoAllBit  ; go do it
 
 * F$AllBit (System State)
-FSAllBit ldd   R$D,u        get bit # to start with
-         ldx   R$X,u        get address of allocation bit map
-         bsr   CalcBit      calculate byte & pos & get first bit mask
-         ldb   <D.SysTsk    Get system task #
-         ENDC
+FSAllBit            ldd       R$D,u     ; get bit # to start with
+                    ldx       R$X,u     ; get address of allocation bit map
+                    bsr       CalcBit   ; calculate byte & pos & get first bit mask
+                    ldb       <D.SysTsk ; get system task #
+                  ENDC
 
 * Main bit setting loop
-DoAllBit equ   *
-         IFNE  H6309
-         ldw   R$Y,u        get # bits to set
-         ELSE
-         ldy   R$Y,u        get # bits to set
-         ENDC
-         beq   BitEx        nothing to set, return
-         sta   ,-s          preserve current mask
-         bmi   SkpBit       If high bit set, skip ahead
-         IFGT  Level-1
-         os9   F$LDABX      go get original value from bit map
-         ELSE
-         lda   ,x
-         ENDC
-NxtBitLp ora   ,s           OR it with the current mask
-         IFNE  H6309
-         decw               dec the bit counter
-         ELSE
-         leay  -1,y
-         ENDC
-         beq   BitStEx      done, go put the byte back into the task's map
-         lsr   ,s           shift out the lowest bit of original
-         bcc   NxtBitLp     if it is a 0, do next bit
-         IFGT  Level-1
-         os9   F$STABX      if it was a 1 (which means whole byte done),
-         ELSE
-         sta   ,x
-         ENDC
-         leax  1,x          store finished byte and bump ptr
-SkpBit   lda   #$FF         preload a finished byte
-         bra   SkpBit2      skip ahead
+DoAllBit            equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       R$Y,u     get # bits to set
+                  ELSE
+                    ldy       R$Y,u     ; get # bits to set
+                  ENDC
+                    beq       BitEx     ; nothing to set, return
+                    sta       ,-s       ; preserve current mask
+                    bmi       SkpBit    ; if high bit set, skip ahead
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$LDABX   ; go get original value from bit map
+                  ELSE
+                    lda       ,x        ; load A from ,x
+                  ENDC
+NxtBitLp            ora       ,s        ; oR it with the current mask
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; dec the bit counter
+                  ELSE
+                    leay      -1,y      ; compute -1,y into Y
+                  ENDC
+                    beq       BitStEx   ; done, go put the byte back into the task's map
+                    lsr       ,s        ; shift out the lowest bit of original
+                    bcc       NxtBitLp  ; if it is a 0, do next bit
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$STABX   ; if it was a 1 (which means whole byte done),
+                  ELSE
+                    sta       ,x        ; store A at ,x
+                  ENDC
+                    leax      1,x       ; store finished byte and bump ptr
+SkpBit              lda       #$FF      ; preload a finished byte
+                    bra       SkpBit2   ; skip ahead
 
-StFulByt equ   *
-         IFGT  Level-1
-         os9   F$STABX      store full byte
-         ELSE
-         sta   ,x
-         ENDC
-         leax  1,x          bump ptr up 1
-         IFNE  H6309
-         subw  #8           bump counter down by 8
-SkpBit2  cmpw  #8           is there at least 8 more (a full byte) to do?
-         ELSE
-         leay  -8,y
-SkpBit2  cmpy  #$0008
-         ENDC
-         bhi   StFulByt     more than 1, go do current
-         beq   BitStEx      exactly 1 byte left, do final store & exit
+StFulByt            equ       *         ; define assembler symbol
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$STABX   ; store full byte
+                  ELSE
+                    sta       ,x        ; store A at ,x
+                  ENDC
+                    leax      1,x       ; bump ptr up 1
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    subw      #8        bump counter down by 8
+SkpBit2             cmpw      #8        is there at least 8 more (a full byte) to do?
+                  ELSE
+                    leay      -8,y      ; compute -8,y into Y
+SkpBit2             cmpy      #$0008    ; compare Y with #$0008
+                  ENDC
+                    bhi       StFulByt  ; more than 1, go do current
+                    beq       BitStEx   ; exactly 1 byte left, do final store & exit
 
 * Last byte: Not a full byte left loop
-L085A    lsra               bump out least sig. bit
-         IFNE  H6309
-         decw               dec the bit counter
-         ELSE
-         leay  -1,y
-         ENDC
-         bne   L085A        keep going until last one is shifted out
-         coma               invert byte to get proper result
-         sta   ,s           preserve a sec
-         IFGT  Level-1
-         os9   F$LDABX      get byte for original map
-         ELSE
-         lda   ,x
-         ENDC
-         ora   ,s           merge with new mask
-BitStEx  equ   *
-         IFGT  Level-1
-         os9   F$STABX      store finished byte into task
-         ELSE
-         sta   ,x
-         ENDC
-         leas  1,s          eat the working copy of the mask
-BitEx    clrb               no error & return
-         rts
+L085A               lsra                ; bump out least sig. bit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; dec the bit counter
+                  ELSE
+                    leay      -1,y      ; compute -1,y into Y
+                  ENDC
+                    bne       L085A     ; keep going until last one is shifted out
+                    coma                ; invert byte to get proper result
+                    sta       ,s        ; preserve a sec
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$LDABX   ; get byte for original map
+                  ELSE
+                    lda       ,x        ; load A from ,x
+                  ENDC
+                    ora       ,s        ; merge with new mask
+BitStEx             equ       *         ; define assembler symbol
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$STABX   ; store finished byte into task
+                  ELSE
+                    sta       ,x        ; store A at ,x
+                  ENDC
+                    leas      1,s       ; eat the working copy of the mask
+BitEx               clrb                ; no error & return
+                    rts                 ; return to caller
 
 * Calculate address of first byte we want, and which bit in that byte, from
 *   a bit allocation map given the address of the map & the bit # we want to
@@ -343,29 +343,29 @@ BitEx    clrb               no error & return
 *        X=Ptr to bit mask table
 * Exit:  A=Mask to point to bit # within byte we are starting on
 *        X=Ptr in allocation map to first byte we are starting on
-CalcBit  pshs  b,y          preserve registers
-         IFNE  H6309
-         lsrd               divide bit # by 8 to calculate byte # to start
-         lsrd               allocating at
-         lsrd
-         addr  d,x          offset that far into the map
-         ELSE
-         lsra
-         rorb
-         lsra
-         rorb
-         lsra
-         rorb
-         leax  d,x
-         ENDC
-         puls  b            restore bit position LSB
-         leay  <MaskTbl,pc  point to mask table
-         andb  #7           round it down to nearest bit
-         lda   b,y          get bit mask
-         puls  y,pc         restore & return
+CalcBit             pshs      b,y       ; preserve registers
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lsrd                ; divide bit # by 8 to calculate byte # to start
+                    lsrd                ; allocating at
+                    lsrd                ; shift or rotate and update condition codes
+                    addr      d,x       ; offset that far into the map
+                  ELSE
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    leax      d,x       ; compute d,x into X
+                  ENDC
+                    puls      b         ; restore bit position LSB
+                    leay      <MaskTbl,pc ; point to mask table
+                    andb      #7        ; round it down to nearest bit
+                    lda       b,y       ; get bit mask
+                    puls      y,pc      ; restore & return
 
 * Bit position table (NOTE that bit #'s are done by left to right)
-MaskTbl  fcb   $80,$40,$20,$10,$08,$04,$02,$01
+MaskTbl             fcb       $80,$40,$20,$10,$08,$04,$02,$01 ; define byte value(s) $80,$40,$20,$10,$08,$04,$02,$01
 
 
 **************************************************
@@ -381,93 +381,93 @@ MaskTbl  fcb   $80,$40,$20,$10,$08,$04,$02,$01
 *
 * Error:  CC = C bit set; B = error code
 *
-FDelBit  ldd   R$D,u        get bit # to start with
-         ldx   R$X,u        get addr. of bit allocation map
-         bsr   CalcBit      point to starting bit
-         IFGT  Level-1
-         ldy   <D.Proc      get current Task #
-         ldb   P$Task,y     get task #
-         bra   DoDelBit     do rest of 0 bits
+FDelBit             ldd       R$D,u     ; get bit # to start with
+                    ldx       R$X,u     ; get addr. of bit allocation map
+                    bsr       CalcBit   ; point to starting bit
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    ldy       <D.Proc   ; get current Task #
+                    ldb       P$Task,y  ; get task #
+                    bra       DoDelBit  ; do rest of 0 bits
 
 * F$DelBit entry point for system state
-FSDelBit ldd   R$D,u        get bit # to start with
-         ldx   R$X,u        get addr. of bit allocation map
-         bsr   CalcBit      point to starting bit
-         ldb   <D.SysTsk    get system task #
-         ENDC
+FSDelBit            ldd       R$D,u     ; get bit # to start with
+                    ldx       R$X,u     ; get addr. of bit allocation map
+                    bsr       CalcBit   ; point to starting bit
+                    ldb       <D.SysTsk ; get system task #
+                  ENDC
 
-DoDelBit equ   *
-         IFNE  H6309
-         ldw   R$Y,u        get # bits to clear
-         ELSE
-         ldy   R$Y,u        get # bits to clear
-         ENDC
-         beq   L08E0        none, return
-         coma               invert current bit mask
-         sta   ,-s          preserve on stack
-         bpl   L08BC        if high bit clear, skip ahead
-         IFGT  Level-1
-         os9   F$LDABX      go get byte from user's map
-         ELSE
-         lda   ,x
-         ENDC
-L08AD    anda  ,s           AND it with current mask
-         IFNE  H6309
-         decw               dec the bits left counter
-         ELSE
-         leay  -1,y
-         ENDC
-         beq   BitDone      done, store finished byte back in task's map
-         asr   ,s           shift out lowest bit, leaving highest alone
-         bcs   L08AD        if it is a 1, do next bit
-         IFGT  Level-1
-         os9   F$STABX      if it was a 0 (which means whole byte done),
-         ELSE
-         sta   ,x
-         ENDC
-         leax  1,x          store finished byte & inc. ptr
-L08BC    clra               preload a cleared byte
-         bra   ChkFull      skip ahead
-L08BF    equ   *
-         IFGT  Level-1
-         os9   F$STABX      store full byte
-         ELSE
-         sta   ,x
-         ENDC
-         leax  1,x          bump ptr up by 1
-         IFNE  H6309
-         subw  #8           dec bits left counter by 8
-ChkFull  cmpw  #8           at least 1 full byte left?
-         ELSE
-         leay  -8,y
-ChkFull  cmpy  #8
-         ENDC
-         bhi   L08BF        yes, do a whole byte in 1 shot
-         beq   BitDone      exactly 1, store byte & exit
-         coma               < full byte left, invert bits
-L08CF    lsra               shift out rightmost bit
-         IFNE  H6309
-         decw               dec bits left counter
-         ELSE
-         leay  -1,y
-         ENDC
-         bne   L08CF        keep doing till done
-         sta   ,s           save finished mask
-         IFGT  Level-1
-         os9   F$LDABX      get original byte from task
-         ELSE
-         lda   ,x
-         ENDC
-         anda  ,s           merge cleared bits with it
-BitDone  equ   *
-         IFGT  Level-1
-         os9   F$STABX      store finished byte into task
-         ELSE
-         sta   ,x
-         ENDC
-         leas  1,s          eat working copy of mask
-L08E0    clrb               eat error & return
-         rts
+DoDelBit            equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       R$Y,u     get # bits to clear
+                  ELSE
+                    ldy       R$Y,u     ; get # bits to clear
+                  ENDC
+                    beq       L08E0     ; none, return
+                    coma                ; invert current bit mask
+                    sta       ,-s       ; preserve on stack
+                    bpl       L08BC     ; if high bit clear, skip ahead
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$LDABX   ; go get byte from user's map
+                  ELSE
+                    lda       ,x        ; load A from ,x
+                  ENDC
+L08AD               anda      ,s        ; aND it with current mask
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; dec the bits left counter
+                  ELSE
+                    leay      -1,y      ; compute -1,y into Y
+                  ENDC
+                    beq       BitDone   ; done, store finished byte back in task's map
+                    asr       ,s        ; shift out lowest bit, leaving highest alone
+                    bcs       L08AD     ; if it is a 1, do next bit
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$STABX   ; if it was a 0 (which means whole byte done),
+                  ELSE
+                    sta       ,x        ; store A at ,x
+                  ENDC
+                    leax      1,x       ; store finished byte & inc. ptr
+L08BC               clra                ; preload a cleared byte
+                    bra       ChkFull   ; skip ahead
+L08BF               equ       *         ; define assembler symbol
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$STABX   ; store full byte
+                  ELSE
+                    sta       ,x        ; store A at ,x
+                  ENDC
+                    leax      1,x       ; bump ptr up by 1
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    subw      #8        dec bits left counter by 8
+ChkFull             cmpw      #8        at least 1 full byte left?
+                  ELSE
+                    leay      -8,y      ; compute -8,y into Y
+ChkFull             cmpy      #8        ; compare Y with #8
+                  ENDC
+                    bhi       L08BF     ; yes, do a whole byte in 1 shot
+                    beq       BitDone   ; exactly 1, store byte & exit
+                    coma                ; < full byte left, invert bits
+L08CF               lsra                ; shift out rightmost bit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; dec bits left counter
+                  ELSE
+                    leay      -1,y      ; compute -1,y into Y
+                  ENDC
+                    bne       L08CF     ; keep doing till done
+                    sta       ,s        ; save finished mask
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$LDABX   ; get original byte from task
+                  ELSE
+                    lda       ,x        ; load A from ,x
+                  ENDC
+                    anda      ,s        ; merge cleared bits with it
+BitDone             equ       *         ; define assembler symbol
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$STABX   ; store finished byte into task
+                  ELSE
+                    sta       ,x        ; store A at ,x
+                  ENDC
+                    leas      1,s       ; eat working copy of mask
+L08E0               clrb                ; eat error & return
+                    rts                 ; return to caller
 
 
 **************************************************
@@ -485,119 +485,119 @@ L08E0    clrb               eat error & return
 *
 * Error:  CC = C bit set; B = error code
 *
-FSchBit  ldd   R$D,u        get start bit #
-         ldx   R$X,u        get addr. of allocation bit map
-         bsr   CalcBit      point to starting bit
-         IFGT  Level-1
-         ldy   <D.Proc      get task #
-         ldb   P$Task,y
-         bra   DoSchBit     skip ahead
+FSchBit             ldd       R$D,u     ; get start bit #
+                    ldx       R$X,u     ; get addr. of allocation bit map
+                    bsr       CalcBit   ; point to starting bit
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    ldy       <D.Proc   ; get task #
+                    ldb       P$Task,y  ; load B from P$Task,y
+                    bra       DoSchBit  ; skip ahead
 
 * F$SchBit entry point for system
-FSSchBit ldd   R$D,u        get start bit #
-         ldx   R$X,u        get addr. of allocation bit map
-         lbsr  CalcBit      point to starting bit
-         ldb   <D.SysTsk    get task #
+FSSchBit            ldd       R$D,u     ; get start bit #
+                    ldx       R$X,u     ; get addr. of allocation bit map
+                    lbsr      CalcBit   ; point to starting bit
+                    ldb       <D.SysTsk ; get task #
 * Stack: 0,s : byte we are working on (from original map)
 *        1,s : Mask of which bit in current byte to start on
 *        2,s : Task number the allocation bit map is in
 *        3,s : Largest block found so far
 *        5,s : Starting bit # of requested (or closest) size found
 *        7,s : Starting bit # of current block being checked (2 bytes) (NOW IN Y)
-         ENDC
-DoSchBit equ  *
-         IFNE  H6309
-         pshs  cc,d,x,y     preserve task # & bit mask & reserve stack space
-         clrd               faster than 2 memory clears
-         ELSE
-         pshs  cc,d,x,y,u   preserve task # & bit mask & reserve stack space
-         clra
-         clrb
-         ENDC
-         std   3,s          preserve it
-         IFNE  H6309
-         ldw   R$D,u        get start bit #
-         tfr   w,y          save as current block starting bit #
-         ELSE
-         ldy   R$D,u
-         sty   7,s
-         ENDC
-         bra   Skipper      skip ahead
+                  ENDC
+DoSchBit            equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    pshs      cc,d,x,y  ; preserve task # & bit mask & reserve stack space
+                    clrd                ; faster than 2 memory clears
+                  ELSE
+                    pshs      cc,d,x,y,u ; preserve task # & bit mask & reserve stack space
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    std       3,s       ; preserve it
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       R$D,u     get start bit #
+                    tfr       w,y       ; save as current block starting bit #
+                  ELSE
+                    ldy       R$D,u     ; load Y from R$D,u
+                    sty       7,s       ; store Y at 7,s
+                  ENDC
+                    bra       Skipper   ; skip ahead
 
 * New start point for search at current location
-RstSrch  equ   *
-         IFNE  H6309
-         tfr   w,y          preserve current block bit # start
-         ELSE
-         sty   7,s
-         ENDC
+RstSrch             equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       w,y       ; preserve current block bit # start
+                  ELSE
+                    sty       7,s       ; store Y at 7,s
+                  ENDC
 * Move to next bit position, and to next byte if current byte is done
-MoveBit  lsr   1,s          move to next bit position
-         bcc   CheckBit     if not the last one, check it
-         ror   1,s          move bit position marker to 1st bit again
-         leax  1,x          move byte ptr (in map) to next byte
+MoveBit             lsr       1,s       ; move to next bit position
+                    bcc       CheckBit  ; if not the last one, check it
+                    ror       1,s       ; move bit position marker to 1st bit again
+                    leax      1,x       ; move byte ptr (in map) to next byte
 
 * Check if we are finished allocation map
-Skipper  cmpx  R$U,u        done entire map?
-         bhs   BadNews      yes, couldn't fit in 1 block, notify caller
-         ldb   2,s          get task number
-         IFGT  Level-1
-         os9   F$LDABX      get byte from bit allocation map
-         ELSE
-         lda   ,x
-         ENDC
-         sta   ,s           preserve in scratch area
+Skipper             cmpx      R$U,u     ; done entire map?
+                    bhs       BadNews   ; yes, couldn't fit in 1 block, notify caller
+                    ldb       2,s       ; get task number
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    os9       F$LDABX   ; get byte from bit allocation map
+                  ELSE
+                    lda       ,x        ; load A from ,x
+                  ENDC
+                    sta       ,s        ; preserve in scratch area
 
 * Main checking
-CheckBit equ   *
-         IFNE  H6309
-         incw               increment current bit #
-         ELSE
-         leay  1,y
-         ENDC
-         lda   ,s           get current byte
-         anda  1,s          mask out all but current bit position
-         bne   RstSrch      if bit not free, restart search from next bit
-         IFNE  H6309
-         tfr   w,d          dup current bit # into D
-         subr  y,d          calculate size we have free so far
-         ELSE
-         tfr   y,d
-         subd  7,s
-         ENDC
-         cmpd  R$Y,u        as big as user requested?
-         bhs   WereDone     yes, we are done
-         cmpd  $03,s        as big as the largest one we have found so far?
-         bls   MoveBit      no, move to next bit and keep going
-         std   $03,s        it is the largest, save current size
-         IFNE  H6309
-         sty   $05,s        save as start bit # of largest block found so far
-         ELSE
-         ldd   7,s
-         std   5,s
-         ENDC
-         bra   MoveBit      move to next bit and keep going
+CheckBit            equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    incw                ; increment current bit #
+                  ELSE
+                    leay      1,y       ; compute 1,y into Y
+                  ENDC
+                    lda       ,s        ; get current byte
+                    anda      1,s       ; mask out all but current bit position
+                    bne       RstSrch   ; if bit not free, restart search from next bit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       w,d       ; dup current bit # into D
+                    subr      y,d       calculate size we have free so far
+                  ELSE
+                    tfr       y,d       ; transfer register value y,d
+                    subd      7,s       ; subtract 7,s from D
+                  ENDC
+                    cmpd      R$Y,u     ; as big as user requested?
+                    bhs       WereDone  ; yes, we are done
+                    cmpd      $03,s     ; as big as the largest one we have found so far?
+                    bls       MoveBit   ; no, move to next bit and keep going
+                    std       $03,s     ; it is the largest, save current size
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    sty       $05,s     ; save as start bit # of largest block found so far
+                  ELSE
+                    ldd       7,s       ; load D from 7,s
+                    std       5,s       ; store D at 5,s
+                  ENDC
+                    bra       MoveBit   ; move to next bit and keep going
 
 * Couldn't find requested size block; tell user where the closest was found
 *   and how big it was
-BadNews  ldd   $03,s        get size of largest block we found
-         std   R$Y,u        put into callers Y register
-         comb               set carry to indicate we couldn't get full size
-         ldd   5,s          get starting bit # of largest block we found
-         bra   BadSkip      skip ahead
+BadNews             ldd       $03,s     ; get size of largest block we found
+                    std       R$Y,u     ; put into callers Y register
+                    comb                ; set carry to indicate we couldn't get full size
+                    ldd       5,s       ; get starting bit # of largest block we found
+                    bra       BadSkip   ; skip ahead
 * Found one, tell user where it is
-WereDone equ   *
-         IFNE  H6309
-         tfr   y,d          get start bit # of the block we found
-         ELSE
-         ldd   7,s
-         ENDC
-BadSkip  std   R$D,u        put starting bit # of block into callers D register
-         IFNE  H6309
-         leas  $07,s        eat our temporary stack area & return
-         ELSE
-         leas  $09,s
-         ENDC
-         rts
+WereDone            equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       y,d       ; get start bit # of the block we found
+                  ELSE
+                    ldd       7,s       ; load D from 7,s
+                  ENDC
+BadSkip             std       R$D,u     ; put starting bit # of block into callers D register
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leas      $07,s     ; eat our temporary stack area & return
+                  ELSE
+                    leas      $09,s     ; adjust stack pointer by $09,s
+                  ENDC
+                    rts                 ; return to caller
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/faproc.asm
+++ b/level1/modules/kernel/faproc.asm
@@ -49,24 +49,24 @@ ex@                 stu       P$Queue,x ; insert process with lower age as the n
                   ELSE
 
 FAProc              ldx       R$X,u     ; get ptr to process to activate
-L0D11               clrb                ; clear B
+FAprocTarget        clrb                ; clear B
                     pshs      cc,b,x,y,u ; save cc,b,x,y,u on the stack
                     lda       P$Prior,x ; get process priority
                     sta       P$Age,x   ; save it as age (How long it's been around)
                     orcc      #IntMasks ; shut down IRQ's
                     ldu       #(D.AProcQ-P$Queue) ; get ptr to active process queue
-                    bra       L0D29     ; go through the chain
+                    bra       FAprocProcess ; go through the chain
 * Update active process queue
 *  X=Process to activate
 *  U=Current process in queue links
-L0D1F               inc       P$Age,u   ; update current process age
-                    bne       L0D25     ; wrap?
+FAprocProcessAge    inc       P$Age,u   ; update current process age
+                    bne       FAprocMatchProcessAges ; wrap?
                     dec       P$Age,u   ; yes, reset it to max.
-L0D25               cmpa      P$Age,u   ; match process ages??
-                    bhi       L0D2B     ; no, skip update
-L0D29               leay      ,u        ; point Y to current process
-L0D2B               ldu       P$Queue,u ; get pointer to next process in chain
-                    bne       L0D1F     ; still more in chain, keep going
+FAprocMatchProcessAges cmpa      P$Age,u   ; match process ages??
+                    bhi       FAprocProcessChain ; no, skip update
+FAprocProcess       leay      ,u        ; point Y to current process
+FAprocProcessChain  ldu       P$Queue,u ; get pointer to next process in chain
+                    bne       FAprocProcessAge ; still more in chain, keep going
                     ldd       P$Queue,y ; load D from P$Queue,y
                     stx       P$Queue,y ; save new process to chain
                     std       P$Queue,x ; store D at P$Queue,x

--- a/level1/modules/kernel/faproc.asm
+++ b/level1/modules/kernel/faproc.asm
@@ -60,9 +60,9 @@ FAprocTarget        clrb                ; clear B
 *  X=Process to activate
 *  U=Current process in queue links
 FAprocProcessAge    inc       P$Age,u   ; update current process age
-                    bne       FAprocMatchProcessAges ; wrap?
+                    bne       FAprocMtchProcAges ; wrap?
                     dec       P$Age,u   ; yes, reset it to max.
-FAprocMatchProcessAges cmpa      P$Age,u   ; match process ages??
+FAprocMtchProcAges  cmpa      P$Age,u   ; match process ages??
                     bhi       FAprocProcessChain ; no, skip update
 FAprocProcess       leay      ,u        ; point Y to current process
 FAprocProcessChain  ldu       P$Queue,u ; get pointer to next process in chain

--- a/level1/modules/kernel/faproc.asm
+++ b/level1/modules/kernel/faproc.asm
@@ -17,59 +17,59 @@
 ;;; An exception is a newly active process that was deactivated while in the system state. The kernel gives such a process
 ;;; higher priority because it's typically executing critical routines that affect shared system resources.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FAProc         ldx       R$X,u               get the pointer to process the to insert
-SFAProc        pshs      u,y                 save U/Y on stack
-               ldu       #(D.AProcQ-P$Queue) load U with D.AProcQ-P$Queue so we're at the first process in the queue later
-               bra       getqueue@           start processing the active queue
+FAProc              ldx       R$X,u     ; get the pointer to process the to insert
+SFAProc             pshs      u,y       ; save U/Y on stack
+                    ldu       #(D.AProcQ-P$Queue) ; load U with D.AProcQ-P$Queue so we're at the first process in the queue later
+                    bra       getqueue@ ; start processing the active queue
 * This loop increases the age of all active processes by 1.
-ageloop@       ldb       P$Age,u             get process age
-               incb                          update it
-               beq       getqueue@           branch if wrap
-               stb       P$Age,u             save it back to proc desc
-getqueue@      ldu       P$Queue,u           get pointer to next process in queue
-               bne       ageloop@            branch if process is in active queue
-               ldu       #(D.AProcQ-P$Queue) load U with D.AProcQ-P$Queue so we're at the first process in the queue later
-               lda       P$Prior,x           get process priority of process to insert
-               sta       P$Age,x             save it as its age
-               orcc      #IntMasks           mask interrupts
+ageloop@            ldb       P$Age,u   ; get process age
+                    incb                ; update it
+                    beq       getqueue@ ; branch if wrap
+                    stb       P$Age,u   ; save it back to proc desc
+getqueue@           ldu       P$Queue,u ; get pointer to next process in queue
+                    bne       ageloop@  ; branch if process is in active queue
+                    ldu       #(D.AProcQ-P$Queue) ; load U with D.AProcQ-P$Queue so we're at the first process in the queue later
+                    lda       P$Prior,x ; get process priority of process to insert
+                    sta       P$Age,x   ; save it as its age
+                    orcc      #IntMasks ; mask interrupts
 * This loop finds the process with the age lower than our age in the queue and inserts us
 * in front of them.
-loop2@         leay      ,u                  point Y to process descriptor
-               ldu       P$Queue,u           get pointer to next process in active queue
-               beq       ex@                 branch if empty
-               cmpa      P$Age,u             compare passed process' age to current in queue
-               bls       loop2@              if lower or same, keep going
-ex@            stu       P$Queue,x           insert process with lower age as the next one in P$Queue of passed process
-               stx       P$Queue,y           and put passed process descriptor pointer in current
-               clrb                          clear carry
-               puls      pc,u,y              restore U/Y and return
+loop2@              leay      ,u        ; point Y to process descriptor
+                    ldu       P$Queue,u ; get pointer to next process in active queue
+                    beq       ex@       ; branch if empty
+                    cmpa      P$Age,u   ; compare passed process' age to current in queue
+                    bls       loop2@    ; if lower or same, keep going
+ex@                 stu       P$Queue,x ; insert process with lower age as the next one in P$Queue of passed process
+                    stx       P$Queue,y ; and put passed process descriptor pointer in current
+                    clrb                ; clear carry
+                    puls      pc,u,y    ; restore U/Y and return
 
-               else
+                  ELSE
 
-FAProc   ldx   R$X,u        Get ptr to process to activate
-L0D11    clrb
-         pshs  cc,b,x,y,u
-         lda   P$Prior,x    Get process priority
-         sta   P$Age,x      Save it as age (How long it's been around)
-         orcc  #IntMasks    Shut down IRQ's
-         ldu   #(D.AProcQ-P$Queue)  Get ptr to active process queue
-         bra   L0D29        Go through the chain
+FAProc              ldx       R$X,u     ; get ptr to process to activate
+L0D11               clrb                ; clear B
+                    pshs      cc,b,x,y,u ; save cc,b,x,y,u on the stack
+                    lda       P$Prior,x ; get process priority
+                    sta       P$Age,x   ; save it as age (How long it's been around)
+                    orcc      #IntMasks ; shut down IRQ's
+                    ldu       #(D.AProcQ-P$Queue) ; get ptr to active process queue
+                    bra       L0D29     ; go through the chain
 * Update active process queue
 *  X=Process to activate
 *  U=Current process in queue links
-L0D1F    inc   P$Age,u      update current process age
-         bne   L0D25        wrap?
-         dec   P$Age,u      yes, reset it to max.
-L0D25    cmpa  P$Age,u      match process ages??
-         bhi   L0D2B        no, skip update
-L0D29    leay  ,u           point Y to current process
-L0D2B    ldu   P$Queue,u    get pointer to next process in chain
-         bne   L0D1F        Still more in chain, keep going
-         ldd   P$Queue,y
-         stx   P$Queue,y    save new process to chain
-         std   P$Queue,x
-         puls  cc,b,x,y,u,pc
+L0D1F               inc       P$Age,u   ; update current process age
+                    bne       L0D25     ; wrap?
+                    dec       P$Age,u   ; yes, reset it to max.
+L0D25               cmpa      P$Age,u   ; match process ages??
+                    bhi       L0D2B     ; no, skip update
+L0D29               leay      ,u        ; point Y to current process
+L0D2B               ldu       P$Queue,u ; get pointer to next process in chain
+                    bne       L0D1F     ; still more in chain, keep going
+                    ldd       P$Queue,y ; load D from P$Queue,y
+                    stx       P$Queue,y ; save new process to chain
+                    std       P$Queue,x ; store D at P$Queue,x
+                    puls      cc,b,x,y,u,pc ; restore cc,b,x,y,u,pc from the stack
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fchain.asm
+++ b/level1/modules/kernel/fchain.asm
@@ -232,11 +232,11 @@ FChainThem          stu       ,y++      ; do all of them
                   ENDC
                     puls      y         ; size
                     bhi       FChainDataOver ; to < From: do F$Move
-                    beq       FChainSystemTaskNumber ; to == From, skip F$Move
+                    beq       FChainSysTaskNum ; to == From, skip F$Move
 
 * To > From: do special copy
                     leay      ,y        ; any bytes to move?
-                    beq       FChainSystemTaskNumber ; no, skip ahead
+                    beq       FChainSysTaskNum ; no, skip ahead
                   IFNE    H6309   ; begin conditional assembly for H6309
                     pshs      x         ; save address
                     addr      y,x       ; add size to FROM address
@@ -277,10 +277,10 @@ FChainGrab          ldb       ,s        ; grab ??
                     bne       FChainGrab ; branch if zero is clear to FChainGrab
 
                     puls      d,x,y,u   ; restore regs
-                    bra       FChainSystemTaskNumber ; skip over F$Move
+                    bra       FChainSysTaskNum ; skip over F$Move
 
 FChainDataOver      os9       F$Move    ; move data over?
-FChainSystemTaskNumber lda       <D.SysTsk ; get system task number
+FChainSysTaskNum    lda       <D.SysTsk ; get system task number
                     ldx       ,s        ; old process dsc ptr
                     ldu       P$SP,x    ; load U from P$SP,x
                     leax      >(P$Stack-R$Size),x ; compute >(P$Stack-R$Size),x into X
@@ -341,15 +341,15 @@ FChainModule        stu       2,s       ; save pointer to module
                     std       P$PModul,x ; save it into process descriptor
                     puls      a         ; restore module type
                     cmpa      #Prgrm+Objct ; regular module?
-                    beq       FChainOffsetModuleMemorySize ; yes, go
+                    beq       FChainOffModMem ; yes, go
                     cmpa      #Systm+Objct ; system module?
-                    beq       FChainOffsetModuleMemorySize ; branch if zero is set to FChainOffsetModuleMemorySize
+                    beq       FChainOffModMem ; branch if zero is set to FChainOffModMem
                   IFNE    H6309   ; begin conditional assembly for H6309
 *--- these lines added to allow 6309 native mode modules to be executed
                     cmpa      #Prgrm+Obj6309 ; regular module?
-                    beq       FChainOffsetModuleMemorySize ; yes, go
+                    beq       FChainOffModMem ; yes, go
                     cmpa      #Systm+Obj6309 ; system module?
-                    beq       FChainOffsetModuleMemorySize ; branch if zero is set to FChainOffsetModuleMemorySize
+                    beq       FChainOffModMem ; branch if zero is set to FChainOffModMem
 *---
                   ENDC
                     ldb       #E$NEMod  ; return unknown module
@@ -358,7 +358,7 @@ FChainPurge         leas      2,s       ; purge stack
                     comb                ; set carry
                     bra       FChainProcess2 ; return
 * Setup up data memory
-FChainOffsetModuleMemorySize ldd       #M$Mem    ; get offset to module memory size
+FChainOffModMem     ldd       #M$Mem    ; get offset to module memory size
                     leay      P$DATImg,x ; get pointer to DAT image
                     ldx       P$PModul,x ; get pointer to module header
                     os9       F$LDDDXY  ; get module memory size

--- a/level1/modules/kernel/fchain.asm
+++ b/level1/modules/kernel/fchain.asm
@@ -24,373 +24,373 @@
 ;;; F$Chain then reconfigures the data memory area to the size specified in the new primary module’s header. Finally, it intercepts
 ;;; and erases any pending signals.
 
-                    ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
 * F$Chain user state entry point.
-FChain              bsr       DoChain             do the F$Chain
-                    bcs       chainerr@           branch if error
-                    orcc      #IntMasks           mask interrupts
-                    ldb       P$State,x           get process state
-                    andb      #^SysState          turn off system state
-                    stb       P$State,x           save new state
-resched@            ldu       <P$PModul,x         get pointer to the module for the current process
-                    os9       F$Unlink            unlink it
-                    os9       F$AProc             add it to active process queue
-                    os9       F$NProc             activate it
+FChain              bsr       DoChain   ; do the F$Chain
+                    bcs       chainerr@ ; branch if error
+                    orcc      #IntMasks ; mask interrupts
+                    ldb       P$State,x ; get process state
+                    andb      #^SysState ; turn off system state
+                    stb       P$State,x ; save new state
+resched@            ldu       <P$PModul,x ; get pointer to the module for the current process
+                    os9       F$Unlink  ; unlink it
+                    os9       F$AProc   ; add it to active process queue
+                    os9       F$NProc   ; activate it
 * F$Chain system state entry point.
-SFChain             bsr       DoChain             do the F$Chain
-                    bcc       resched@            branch if OK
-chainerr@           pshs      b                   save off B for now
-                    stb       <P$Signal,x         save off error code
-                    ldb       P$State,x           get process state
-                    orb       #Condem             set the condemn bit
-                    stb       P$State,x           save new state
-                    ldb       #255                get highest priority
-                    stb       P$Prior,x           set priority
-                    comb                          set carry
-                    puls      pc,b                return error
-DoChain             pshs      u                   save off caller's SP
-                    ldx       <D.Proc             get current process descriptor
-                    ldu       ,s                  get saved caller's SP
-                    bsr       SetupPrc            create new child process
-                    puls      pc,u                recover U and return
+SFChain             bsr       DoChain   ; do the F$Chain
+                    bcc       resched@  ; branch if OK
+chainerr@           pshs      b         ; save off B for now
+                    stb       <P$Signal,x ; save off error code
+                    ldb       P$State,x ; get process state
+                    orb       #Condem   ; set the condemn bit
+                    stb       P$State,x ; save new state
+                    ldb       #255      ; get highest priority
+                    stb       P$Prior,x ; set priority
+                    comb                ; set carry
+                    puls      pc,b      ; return error
+DoChain             pshs      u         ; save off caller's SP
+                    ldx       <D.Proc   ; get current process descriptor
+                    ldu       ,s        ; get saved caller's SP
+                    bsr       SetupPrc  ; create new child process
+                    puls      pc,u      ; recover U and return
 
-SetupPrc            ldx       <D.Proc             get current process descriptor
-                    pshs      u,x                 save off
-                    ldd       <D.UsrSvc           get user service table
-                    std       <P$SWI,x            save off as process' SWI vector
-                    std       <P$SWI2,x           ... and SWI2 vector
-                    std       <P$SWI3,x           ... and SWI3 vector
-                    clra                          A = 0
-                    clrb                          D = 0
-                    sta       <P$Signal,x         clear the signal
-                    std       <P$SigVec,x         clear signal vector
-                    lda       R$A,u               get caller's A
-                    ldx       R$X,u               ... and X
-                    os9       F$Link              link the module to chain to
-                    bcc       chktype@            branch if OK
-                    os9       F$Load              ... else load the module to chain to
-                    bcs       ex@                 ... and branch if error
-chktype@            ldy       <D.Proc             get current process
-                    stu       <P$PModul,y         save off module pointer
-                    cmpa      #Prgrm+Objct        is this a program module?
-                    beq       cmpmem@             branch if so
-                    cmpa      #Systm+Objct        is it a system module?
-                    beq       cmpmem@             branch if so
-                    comb                          else set carry
-                    ldb       #E$NEMod            set error in B
-                    bra       ex@                 and return
-cmpmem@             leay      ,u                  Y = address of module
-                    ldu       2,s                 get U off stack (caller regs)
-                    stx       R$X,u               update X to point past name
-                    lda       R$B,u               get caller's requested memory size in 256 byte pages
-                    clrb                          clear lower 8 bits of D
-                    cmpd      M$Mem,y             compare passed memory to module's
-                    bcc       alloc@              branch if requested amount is the same or greater than the module's memory
-                    ldd       M$Mem,y             else load D with module's memory
-alloc@              addd      #$0000              is this needed??
-                    bne       allcmem@            and this???
-allcmem@            os9       F$Mem               allocate requested memory
-                    bcs       ex@                 branch if error
-                    subd      #R$Size             subtract registers
-                    subd      R$Y,u               subtract parameter area
-                    bcs       badfork@            branch if < 0
-                    ldx       R$U,u               get parameter area
-                    ldd       R$Y,u               get parameter size
-                    pshs      b,a                 save onto the stack
-                    beq       setregs@            branch if parameter area is zero (nothing to copy)
-                    leax      d,x                 point to end of param area
-loop@               lda       ,-x                 get parameter byte and decrement X
-                    sta       ,-y                 save byte in data area and decrement Y
-                    cmpx      R$U,u               at top of parameter area?
-                    bhi       loop@               branch if not
+SetupPrc            ldx       <D.Proc   ; get current process descriptor
+                    pshs      u,x       ; save off
+                    ldd       <D.UsrSvc ; get user service table
+                    std       <P$SWI,x  ; save off as process' SWI vector
+                    std       <P$SWI2,x ; ... and SWI2 vector
+                    std       <P$SWI3,x ; ... and SWI3 vector
+                    clra                ; A = 0
+                    clrb                ; D = 0
+                    sta       <P$Signal,x ; clear the signal
+                    std       <P$SigVec,x ; clear signal vector
+                    lda       R$A,u     ; get caller's A
+                    ldx       R$X,u     ; ... and X
+                    os9       F$Link    ; link the module to chain to
+                    bcc       chktype@  ; branch if OK
+                    os9       F$Load    ; ... else load the module to chain to
+                    bcs       ex@       ; ... and branch if error
+chktype@            ldy       <D.Proc   ; get current process
+                    stu       <P$PModul,y ; save off module pointer
+                    cmpa      #Prgrm+Objct ; is this a program module?
+                    beq       cmpmem@   ; branch if so
+                    cmpa      #Systm+Objct ; is it a system module?
+                    beq       cmpmem@   ; branch if so
+                    comb                ; else set carry
+                    ldb       #E$NEMod  ; set error in B
+                    bra       ex@       ; and return
+cmpmem@             leay      ,u        ; Y = address of module
+                    ldu       2,s       ; get U off stack (caller regs)
+                    stx       R$X,u     ; update X to point past name
+                    lda       R$B,u     ; get caller's requested memory size in 256 byte pages
+                    clrb                ; clear lower 8 bits of D
+                    cmpd      M$Mem,y   ; compare passed memory to module's
+                    bcc       alloc@    ; branch if requested amount is the same or greater than the module's memory
+                    ldd       M$Mem,y   ; else load D with module's memory
+alloc@              addd      #$0000    ; is this needed??
+                    bne       allcmem@  ; and this???
+allcmem@            os9       F$Mem     ; allocate requested memory
+                    bcs       ex@       ; branch if error
+                    subd      #R$Size   ; subtract registers
+                    subd      R$Y,u     ; subtract parameter area
+                    bcs       badfork@  ; branch if < 0
+                    ldx       R$U,u     ; get parameter area
+                    ldd       R$Y,u     ; get parameter size
+                    pshs      b,a       ; save onto the stack
+                    beq       setregs@  ; branch if parameter area is zero (nothing to copy)
+                    leax      d,x       ; point to end of param area
+loop@               lda       ,-x       ; get parameter byte and decrement X
+                    sta       ,-y       ; save byte in data area and decrement Y
+                    cmpx      R$U,u     ; at top of parameter area?
+                    bhi       loop@     ; branch if not
 * Set up registers for return of F$Fork/F$Chain.
-setregs@            ldx       <D.Proc             get pointer to current process descriptor
-                    sty       -R$Size+R$X,y       put in X on caller stack
-                    leay      -R$Size,y           back up the size of the register file
-                    sty       P$SP,x              save Y as the stack pointer
-                    lda       P$ADDR,x            get the starting page number
-                    clrb                          clear lower 8 bits of D
-                    std       R$U,y               save it as the lowest address in the caller's U
-                    sta       R$DP,y              and set direct page in the caller's DP
-                    adda      P$PagCnt,x          add the memory page count
-                    std       R$Y,y               store it in the caller's Y
-                    puls      b,a                 recover the size of the parameter area
-                    std       R$D,y               and store it in the caller's D
-                    ldb       #Entire             set the entire flag
-                    stb       R$CC,y              in the caller's CC
-                    ldu       <P$PModul,x         get the address of the primary module
-                    ldd       M$Exec,u            get the execution offset
-                    leau      d,u                 point U to that
-                    stu       R$PC,y              put that offset in the caller's PC
-                    clrb                          B = 0
-badfork@            ldb       #E$IForkP           illegal fork parameter
-ex@                 puls      pc,u,x              return to caller
+setregs@            ldx       <D.Proc   ; get pointer to current process descriptor
+                    sty       -R$Size+R$X,y ; put in X on caller stack
+                    leay      -R$Size,y ; back up the size of the register file
+                    sty       P$SP,x    ; save Y as the stack pointer
+                    lda       P$ADDR,x  ; get the starting page number
+                    clrb                ; clear lower 8 bits of D
+                    std       R$U,y     ; save it as the lowest address in the caller's U
+                    sta       R$DP,y    ; and set direct page in the caller's DP
+                    adda      P$PagCnt,x ; add the memory page count
+                    std       R$Y,y     ; store it in the caller's Y
+                    puls      b,a       ; recover the size of the parameter area
+                    std       R$D,y     ; and store it in the caller's D
+                    ldb       #Entire   ; set the entire flag
+                    stb       R$CC,y    ; in the caller's CC
+                    ldu       <P$PModul,x ; get the address of the primary module
+                    ldd       M$Exec,u  ; get the execution offset
+                    leau      d,u       ; point U to that
+                    stu       R$PC,y    ; put that offset in the caller's PC
+                    clrb                ; B = 0
+badfork@            ldb       #E$IForkP ; illegal fork parameter
+ex@                 puls      pc,u,x    ; return to caller
 
-                    else
+                  ELSE
 
-FChain              pshs      u                   preserve register stack pointer
-                    lbsr      AllPrc              allocate a new process descriptor
-                    bcc       L03B7               do the chain if no error
-                    puls      u,pc                return to caller with error
+FChain              pshs      u         ; preserve register stack pointer
+                    lbsr      AllPrc    ; allocate a new process descriptor
+                    bcc       L03B7     ; do the chain if no error
+                    puls      u,pc      ; return to caller with error
 
 * Copy Process Descriptor Data
-L03B7               ldx       <D.Proc             get pointer to current process
-                    pshs      x,u                 save old & new descriptor pointers
-                    ifne      H6309
-                    leax      P$SP,x              point to source
-                    leau      P$SP,u              point to destination
-                    ldw       #$00fc              get size (P$SP+$FC)
-                    tfm       x+,u+               move it
-                    else
+L03B7               ldx       <D.Proc   ; get pointer to current process
+                    pshs      x,u       ; save old & new descriptor pointers
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leax      P$SP,x    ; point to source
+                    leau      P$SP,u    ; point to destination
+                    ldw       #$00fc    get size (P$SP+$FC)
+                    tfm       x+,u+     move it
+                  ELSE
 *
 * LCB Proposed new 6809 code approx 750 cycles faster
 * Appears to work (boot calls F$Chain twice).
-                    leay      P$SP,u              Point to destination
-                    leau      P$SP,x              Point to source
-                    ldb       #84                 # of 3 byte sets to copy
-L03C3               pulu      a,x                 Get 3 bytes
-                    sta       ,y+                 copy them
-                    stx       ,y++
-                    decb                          Dec 3 byte ctr
-                    bne       L03C3
-                    endc
-L03CB               ldu       2,s                 get new descriptor pointer
-                    leau      <P$DATImg,u
-                    ldx       ,s                  get old descriptor pointer
-                    lda       P$Task,x            get task #
-                    lsla                          2 bytes per entry
-                    ldx       <D.TskIpt           get task image table pointer
-                    stu       a,x                 save updated DAT image pointer for later
+                    leay      P$SP,u    ; point to destination
+                    leau      P$SP,x    ; point to source
+                    ldb       #84       ; # of 3 byte sets to copy
+L03C3               pulu      a,x       ; get 3 bytes
+                    sta       ,y+       ; copy them
+                    stx       ,y++      ; store X at ,y++
+                    decb                ; dec 3 byte ctr
+                    bne       L03C3     ; branch if zero is clear to L03C3
+                  ENDC
+L03CB               ldu       2,s       ; get new descriptor pointer
+                    leau      <P$DATImg,u ; compute <P$DATImg,u into U
+                    ldx       ,s        ; get old descriptor pointer
+                    lda       P$Task,x  ; get task #
+                    lsla                ; 2 bytes per entry
+                    ldx       <D.TskIpt ; get task image table pointer
+                    stu       a,x       ; save updated DAT image pointer for later
 * Question: are the previous 7 lines necessary? The F$AllTsk call, below
 * should take care of everything!
-                    ldx       <D.Proc             get process descriptor
-                    ifne      H6309
-                    clrd                          Faster than 2 memory clears
-                    else
-                    clra
-                    clrb
-                    endc
-                    stb       P$Task,x            old process has no task number
-                    std       <P$SWI,x            clear out all sorts of signals and vectors
-                    std       <P$SWI2,x
-                    std       <P$SWI3,x
-                    sta       <P$Signal,x
-                    std       <P$SigVec,x
-                    ldu       <P$PModul,x
-                    os9       F$UnLink            unlink from the primary module
-                    ldb       P$PagCnt,x          grab the page count
-                    addb      #$1F                round up to the nearest block
-                    lsrb
-                    lsrb
-                    lsrb
-                    lsrb
-                    lsrb                          get number of blocks used
-                    lda       #$08
-                    ifne      H6309
-                    subr      b,a                 A=number of blocks unused
-                    else
-                    pshs      b
-                    suba      ,s+
-                    endc
-                    leay      <P$DATImg,x         set up the initial DAT image
-                    lslb
-                    leay      b,y                 go to the offset
-                    ldu       #DAT.Free           mark the blocks as free
-L040C               stu       ,y++                do all of them
-                    deca
-                    bne       L040C
-                    ldu       2,s                 get new process descriptor pointer
-                    stu       <D.Proc             make it the new process
-                    ldu       4,s
-                    lbsr      L04B1               link to new module & setup register stack
-                    ifne      H6309
-                    bcs       L04A1
-                    else
-                    lbcs      L04A1
-                    endc
-                    pshs      d                   somehow D = memory size? Or parameter size?
-                    os9       F$AllTsk            allocate a new task number
+                    ldx       <D.Proc   ; get process descriptor
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; faster than 2 memory clears
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    stb       P$Task,x  ; old process has no task number
+                    std       <P$SWI,x  ; clear out all sorts of signals and vectors
+                    std       <P$SWI2,x ; store D at <P$SWI2,x
+                    std       <P$SWI3,x ; store D at <P$SWI3,x
+                    sta       <P$Signal,x ; store A at <P$Signal,x
+                    std       <P$SigVec,x ; store D at <P$SigVec,x
+                    ldu       <P$PModul,x ; load U from <P$PModul,x
+                    os9       F$UnLink  ; unlink from the primary module
+                    ldb       P$PagCnt,x ; grab the page count
+                    addb      #$1F      ; round up to the nearest block
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; get number of blocks used
+                    lda       #$08      ; load A from #$08
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    subr      b,a       A=number of blocks unused
+                  ELSE
+                    pshs      b         ; save b on the stack
+                    suba      ,s+       ; subtract ,s+ from A
+                  ENDC
+                    leay      <P$DATImg,x ; set up the initial DAT image
+                    lslb                ; shift or rotate and update condition codes
+                    leay      b,y       ; go to the offset
+                    ldu       #DAT.Free ; mark the blocks as free
+L040C               stu       ,y++      ; do all of them
+                    deca                ; decrement A
+                    bne       L040C     ; branch if zero is clear to L040C
+                    ldu       2,s       ; get new process descriptor pointer
+                    stu       <D.Proc   ; make it the new process
+                    ldu       4,s       ; load U from 4,s
+                    lbsr      L04B1     ; link to new module & setup register stack
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    bcs       L04A1     ; branch if carry is set to L04A1
+                  ELSE
+                    lbcs      L04A1     ; branch if carry is set to L04A1
+                  ENDC
+                    pshs      d         ; somehow D = memory size? Or parameter size?
+                    os9       F$AllTsk  ; allocate a new task number
 * ignore errors here
 * Hmmm.. the code above FORCES the new process to have the same DAT image ptr
 * as the old process, not that it matters...
 
-                    ifne      H6309
-                    fcb       $24,$00             TODO: Identify this!
-                    endc
-                    ldu       <D.Proc             get nre process
-                    lda       P$Task,u            new task number
-                    ldb       P$Task,x            old task number
-                    leau      >(P$Stack-R$Size),x set up the stack for the new process
-                    leax      ,y
-                    ldu       R$X,u               where to copy from
-                    ifne      H6309
-                    cmpr      x,u                 check From/To addresses
-                    else
-                    pshs      x                   src ptr
-                    cmpu      ,s++                dest ptr
-                    endc
-                    puls      y                   size
-                    bhi       L0471               To < From: do F$Move
-                    beq       L0474               To == From, skip F$Move
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    fcb       $24,$00   ; tODO: Identify this!
+                  ENDC
+                    ldu       <D.Proc   ; get nre process
+                    lda       P$Task,u  ; new task number
+                    ldb       P$Task,x  ; old task number
+                    leau      >(P$Stack-R$Size),x ; set up the stack for the new process
+                    leax      ,y        ; compute ,y into X
+                    ldu       R$X,u     ; where to copy from
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    cmpr      x,u       check From/To addresses
+                  ELSE
+                    pshs      x         ; src ptr
+                    cmpu      ,s++      ; dest ptr
+                  ENDC
+                    puls      y         ; size
+                    bhi       L0471     ; to < From: do F$Move
+                    beq       L0474     ; to == From, skip F$Move
 
 * To > From: do special copy
-                    leay      ,y                  any bytes to move?
-                    beq       L0474               no, skip ahead
-                    ifne      H6309
-                    pshs      x                   save address
-                    addr      y,x                 add size to FROM address
-                    cmpr      x,u                 is it
-                    puls      x
-                    else
-                    pshs      d,x
-                    tfr       y,d
-                    leax      d,x
-                    pshs      x
-                    cmpu      ,s++
-                    puls      d,x
-                    endc
-                    bls       L0471               end of FROM <= start of TO: do F$Move
+                    leay      ,y        ; any bytes to move?
+                    beq       L0474     ; no, skip ahead
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    pshs      x         ; save address
+                    addr      y,x       ; add size to FROM address
+                    cmpr      x,u       is it
+                    puls      x         ; restore x from the stack
+                  ELSE
+                    pshs      d,x       ; save d,x on the stack
+                    tfr       y,d       ; transfer register value y,d
+                    leax      d,x       ; compute d,x into X
+                    pshs      x         ; save x on the stack
+                    cmpu      ,s++      ; compare U with ,s++
+                    puls      d,x       ; restore d,x from the stack
+                  ENDC
+                    bls       L0471     ; end of FROM <= start of TO: do F$Move
 
 * The areas to copy overlap: do special move routine
-                    pshs      d,x,y,u             save regs
-                    ifne      H6309
-                    addr      y,x                 go to the END of the area to copy FROM
-                    addr      y,u                 end of area to copy TO
-                    else
-                    tfr       y,d
-                    leax      d,x
-                    leau      d,u
-                    endc
+                    pshs      d,x,y,u   ; save regs
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      y,x       ; go to the END of the area to copy FROM
+                    addr      y,u       ; end of area to copy TO
+                  ELSE
+                    tfr       y,d       ; transfer register value y,d
+                    leax      d,x       ; compute d,x into X
+                    leau      d,u       ; compute d,u into U
+                  ENDC
 
 * This all appears to be doing a copy where destination <= source,
 * in the same address space.
-L0457               ldb       ,s                  grab ??
-                    leax      -1,x                back up one
-                    os9       F$LDABX
-                    exg       x,u
-                    ldb       1,s
-                    leax      -1,x                back up another one
-                    os9       F$STABX
-                    exg       x,u
-                    leay      -1,y
-                    bne       L0457
+L0457               ldb       ,s        ; grab ??
+                    leax      -1,x      ; back up one
+                    os9       F$LDABX   ; call OS-9 service F$LDABX
+                    exg       x,u       ; exchange register values x,u
+                    ldb       1,s       ; load B from 1,s
+                    leax      -1,x      ; back up another one
+                    os9       F$STABX   ; call OS-9 service F$STABX
+                    exg       x,u       ; exchange register values x,u
+                    leay      -1,y      ; compute -1,y into Y
+                    bne       L0457     ; branch if zero is clear to L0457
 
-                    puls      d,x,y,u             restore regs
-                    bra       L0474               skip over F$Move
+                    puls      d,x,y,u   ; restore regs
+                    bra       L0474     ; skip over F$Move
 
-L0471               os9       F$Move              move data over?
-L0474               lda       <D.SysTsk           get system task number
-                    ldx       ,s                  old process dsc ptr
-                    ldu       P$SP,x
-                    leax      >(P$Stack-R$Size),x
-                    ldy       #R$Size
-                    os9       F$Move              move the stack over
-                    puls      u,x                 restore new, old process dsc's
-                    lda       P$ID,u
-                    lbsr      L0386               check alarms
-                    os9       F$DelTsk            delete the old task
-                    orcc      #IntMasks
-                    ldd       <D.SysPrc
-                    std       <D.Proc
-                    ifne      H6309
+L0471               os9       F$Move    ; move data over?
+L0474               lda       <D.SysTsk ; get system task number
+                    ldx       ,s        ; old process dsc ptr
+                    ldu       P$SP,x    ; load U from P$SP,x
+                    leax      >(P$Stack-R$Size),x ; compute >(P$Stack-R$Size),x into X
+                    ldy       #R$Size   ; load Y from #R$Size
+                    os9       F$Move    ; move the stack over
+                    puls      u,x       ; restore new, old process dsc's
+                    lda       P$ID,u    ; load A from P$ID,u
+                    lbsr      L0386     ; check alarms
+                    os9       F$DelTsk  ; delete the old task
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+                    ldd       <D.SysPrc ; load D from <D.SysPrc
+                    std       <D.Proc   ; store D at <D.Proc
+                  IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^SysState,P$State,x
-                    else
-                    lda       P$State,x
-                    anda      #^SysState
-                    sta       P$State,x
-                    endc
-                    os9       F$AProc             activate the process
-                    os9       F$NProc             go to it
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    anda      #^SysState ; mask A with #^SysState
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+                    os9       F$AProc   ; activate the process
+                    os9       F$NProc   ; go to it
 
 * comes here on error with link to new module
-L04A1               puls      u,x
-                    stx       <D.Proc
-                    pshs      b
-                    lda       ,u
-                    lbsr      L0386               kill signals
-                    puls      b
-                    os9       F$Exit              exit from the process with error condition
+L04A1               puls      u,x       ; restore u,x from the stack
+                    stx       <D.Proc   ; store X at <D.Proc
+                    pshs      b         ; save b on the stack
+                    lda       ,u        ; load A from ,u
+                    lbsr      L0386     ; kill signals
+                    puls      b         ; restore b from the stack
+                    os9       F$Exit    ; exit from the process with error condition
 
 * Setup new process DAT image with module
-L04B1               pshs      d,x,y,u             preserve everything
-                    ldd       <D.Proc             get pointer to current process
-                    pshs      d                   save it
-                    stx       <D.Proc             save pointer to new process
-                    lda       R$A,u               get module type
-                    ldx       R$X,u               get pointer to module name
-                    ldy       ,s                  get pointer to current process
-                    leay      P$DATImg,y          point to DAT image
-                    os9       F$SLink             map it into new process DAT image
-                    bcc       L04D7               no error, keep going
-                    ldd       ,s                  restore to current process
-                    std       <D.Proc
-                    ldu       4,s                 get pointer to new process
-                    os9       F$Load              try & load it
-                    bcc       L04D7               no error, keep going
-                    leas      4,s                 purge stack
-                    puls      x,y,u,pc            restore & return
+L04B1               pshs      d,x,y,u   ; preserve everything
+                    ldd       <D.Proc   ; get pointer to current process
+                    pshs      d         ; save it
+                    stx       <D.Proc   ; save pointer to new process
+                    lda       R$A,u     ; get module type
+                    ldx       R$X,u     ; get pointer to module name
+                    ldy       ,s        ; get pointer to current process
+                    leay      P$DATImg,y ; point to DAT image
+                    os9       F$SLink   ; map it into new process DAT image
+                    bcc       L04D7     ; no error, keep going
+                    ldd       ,s        ; restore to current process
+                    std       <D.Proc   ; store D at <D.Proc
+                    ldu       4,s       ; get pointer to new process
+                    os9       F$Load    ; try & load it
+                    bcc       L04D7     ; no error, keep going
+                    leas      4,s       ; purge stack
+                    puls      x,y,u,pc  ; restore & return
 *
-L04D7               stu       2,s                 save pointer to module
-                    pshs      a,y                 save module type & entry point
-                    ldu       $0B,s               restore register stack pointer
-                    stx       R$X,u               save updated name pointer
-                    ldx       $07,s               restore process pointer
-                    stx       <D.Proc             make it current
-                    ldd       5,s                 get pointer to new module
-                    std       P$PModul,x          save it into process descriptor
-                    puls      a                   restore module type
-                    cmpa      #Prgrm+Objct        regular module?
-                    beq       L04FB               yes, go
-                    cmpa      #Systm+Objct        system module?
-                    beq       L04FB
-                    ifne      H6309
+L04D7               stu       2,s       ; save pointer to module
+                    pshs      a,y       ; save module type & entry point
+                    ldu       $0B,s     ; restore register stack pointer
+                    stx       R$X,u     ; save updated name pointer
+                    ldx       $07,s     ; restore process pointer
+                    stx       <D.Proc   ; make it current
+                    ldd       5,s       ; get pointer to new module
+                    std       P$PModul,x ; save it into process descriptor
+                    puls      a         ; restore module type
+                    cmpa      #Prgrm+Objct ; regular module?
+                    beq       L04FB     ; yes, go
+                    cmpa      #Systm+Objct ; system module?
+                    beq       L04FB     ; branch if zero is set to L04FB
+                  IFNE    H6309   ; begin conditional assembly for H6309
 *--- these lines added to allow 6309 native mode modules to be executed
-                    cmpa      #Prgrm+Obj6309      regular module?
-                    beq       L04FB               yes, go
-                    cmpa      #Systm+Obj6309      system module?
-                    beq       L04FB
+                    cmpa      #Prgrm+Obj6309 ; regular module?
+                    beq       L04FB     ; yes, go
+                    cmpa      #Systm+Obj6309 ; system module?
+                    beq       L04FB     ; branch if zero is set to L04FB
 *---
-                    endc
-                    ldb       #E$NEMod            return unknown module
-L04F4               leas      2,s                 purge stack
-                    stb       3,s                 save error
-                    comb                          set carry
-                    bra       L053E               return
+                  ENDC
+                    ldb       #E$NEMod  ; return unknown module
+L04F4               leas      2,s       ; purge stack
+                    stb       3,s       ; save error
+                    comb                ; set carry
+                    bra       L053E     ; return
 * Setup up data memory
-L04FB               ldd       #M$Mem              get offset to module memory size
-                    leay      P$DATImg,x          get pointer to DAT image
-                    ldx       P$PModul,x          get pointer to module header
-                    os9       F$LDDDXY            get module memory size
-                    cmpa      R$B,u               bigger or smaller than callers request?
-                    bcc       L050E               bigger, use it instead
-                    lda       R$B,u               get callers memory size instead
-                    clrb                          clear LSB of mem size
-L050E               os9       F$Mem               try & get the data memory
-                    bcs       L04F4               can't do it, exit with error
-                    ldx       6,s                 restore process pointer
-                    leay      (P$Stack-R$Size),x  point to new register stack
-                    pshs      d                   preserve memory size
-                    subd      R$Y,u               take off size of paramater area
-                    std       R$X,y               save pointer to parameter area
-                    subd      #R$Size             take off size of register stack
-                    std       P$SP,x              save new SP
-                    ldd       R$Y,u               get parameter count
-                    std       R$A,y               save it to new process
-                    std       6,s                 save it for myself to
-                    puls      d,x                 restore top of mem & program entry point
-                    std       R$Y,y               set top of mem pointer
-                    ldd       R$U,u               get pointer to parameters
-                    std       6,s
-                    lda       #Entire
-                    sta       R$CC,y              save condition code
-                    clra
-                    sta       R$DP,y              save direct page
-                    clrb
-                    std       R$U,y               save data area start
-                    stx       R$PC,y              save program entry point
-L053E               puls      d                   restore process pointer
-                    std       <D.Proc             save it as current
-                    puls      d,x,y,u,pc
+L04FB               ldd       #M$Mem    ; get offset to module memory size
+                    leay      P$DATImg,x ; get pointer to DAT image
+                    ldx       P$PModul,x ; get pointer to module header
+                    os9       F$LDDDXY  ; get module memory size
+                    cmpa      R$B,u     ; bigger or smaller than callers request?
+                    bcc       L050E     ; bigger, use it instead
+                    lda       R$B,u     ; get callers memory size instead
+                    clrb                ; clear LSB of mem size
+L050E               os9       F$Mem     ; try & get the data memory
+                    bcs       L04F4     ; can't do it, exit with error
+                    ldx       6,s       ; restore process pointer
+                    leay      (P$Stack-R$Size),x ; point to new register stack
+                    pshs      d         ; preserve memory size
+                    subd      R$Y,u     ; take off size of paramater area
+                    std       R$X,y     ; save pointer to parameter area
+                    subd      #R$Size   ; take off size of register stack
+                    std       P$SP,x    ; save new SP
+                    ldd       R$Y,u     ; get parameter count
+                    std       R$A,y     ; save it to new process
+                    std       6,s       ; save it for myself to
+                    puls      d,x       ; restore top of mem & program entry point
+                    std       R$Y,y     ; set top of mem pointer
+                    ldd       R$U,u     ; get pointer to parameters
+                    std       6,s       ; store D at 6,s
+                    lda       #Entire   ; load A from #Entire
+                    sta       R$CC,y    ; save condition code
+                    clra                ; clear A
+                    sta       R$DP,y    ; save direct page
+                    clrb                ; clear B
+                    std       R$U,y     ; save data area start
+                    stx       R$PC,y    ; save program entry point
+L053E               puls      d         ; restore process pointer
+                    std       <D.Proc   ; save it as current
+                    puls      d,x,y,u,pc ; restore d,x,y,u,pc from the stack
 
-                    endc
+                  ENDC

--- a/level1/modules/kernel/fchain.asm
+++ b/level1/modules/kernel/fchain.asm
@@ -131,11 +131,11 @@ ex@                 puls      pc,u,x    ; return to caller
 
 FChain              pshs      u         ; preserve register stack pointer
                     lbsr      AllPrc    ; allocate a new process descriptor
-                    bcc       L03B7     ; do the chain if no error
+                    bcc       FChainProcess ; do the chain if no error
                     puls      u,pc      ; return to caller with error
 
 * Copy Process Descriptor Data
-L03B7               ldx       <D.Proc   ; get pointer to current process
+FChainProcess       ldx       <D.Proc   ; get pointer to current process
                     pshs      x,u       ; save old & new descriptor pointers
                   IFNE    H6309   ; begin conditional assembly for H6309
                     leax      P$SP,x    ; point to source
@@ -149,13 +149,13 @@ L03B7               ldx       <D.Proc   ; get pointer to current process
                     leay      P$SP,u    ; point to destination
                     leau      P$SP,x    ; point to source
                     ldb       #84       ; # of 3 byte sets to copy
-L03C3               pulu      a,x       ; get 3 bytes
+FChainBytes         pulu      a,x       ; get 3 bytes
                     sta       ,y+       ; copy them
                     stx       ,y++      ; store X at ,y++
                     decb                ; dec 3 byte ctr
-                    bne       L03C3     ; branch if zero is clear to L03C3
+                    bne       FChainBytes ; branch if zero is clear to FChainBytes
                   ENDC
-L03CB               ldu       2,s       ; get new descriptor pointer
+FChainNewDescriptor ldu       2,s       ; get new descriptor pointer
                     leau      <P$DATImg,u ; compute <P$DATImg,u into U
                     ldx       ,s        ; get old descriptor pointer
                     lda       P$Task,x  ; get task #
@@ -197,17 +197,17 @@ L03CB               ldu       2,s       ; get new descriptor pointer
                     lslb                ; shift or rotate and update condition codes
                     leay      b,y       ; go to the offset
                     ldu       #DAT.Free ; mark the blocks as free
-L040C               stu       ,y++      ; do all of them
+FChainThem          stu       ,y++      ; do all of them
                     deca                ; decrement A
-                    bne       L040C     ; branch if zero is clear to L040C
+                    bne       FChainThem ; branch if zero is clear to FChainThem
                     ldu       2,s       ; get new process descriptor pointer
                     stu       <D.Proc   ; make it the new process
                     ldu       4,s       ; load U from 4,s
-                    lbsr      L04B1     ; link to new module & setup register stack
+                    lbsr      FChainEverything ; link to new module & setup register stack
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    bcs       L04A1     ; branch if carry is set to L04A1
+                    bcs       FChainTarget ; branch if carry is set to FChainTarget
                   ELSE
-                    lbcs      L04A1     ; branch if carry is set to L04A1
+                    lbcs      FChainTarget ; branch if carry is set to FChainTarget
                   ENDC
                     pshs      d         ; somehow D = memory size? Or parameter size?
                     os9       F$AllTsk  ; allocate a new task number
@@ -231,12 +231,12 @@ L040C               stu       ,y++      ; do all of them
                     cmpu      ,s++      ; dest ptr
                   ENDC
                     puls      y         ; size
-                    bhi       L0471     ; to < From: do F$Move
-                    beq       L0474     ; to == From, skip F$Move
+                    bhi       FChainDataOver ; to < From: do F$Move
+                    beq       FChainSystemTaskNumber ; to == From, skip F$Move
 
 * To > From: do special copy
                     leay      ,y        ; any bytes to move?
-                    beq       L0474     ; no, skip ahead
+                    beq       FChainSystemTaskNumber ; no, skip ahead
                   IFNE    H6309   ; begin conditional assembly for H6309
                     pshs      x         ; save address
                     addr      y,x       ; add size to FROM address
@@ -250,7 +250,7 @@ L040C               stu       ,y++      ; do all of them
                     cmpu      ,s++      ; compare U with ,s++
                     puls      d,x       ; restore d,x from the stack
                   ENDC
-                    bls       L0471     ; end of FROM <= start of TO: do F$Move
+                    bls       FChainDataOver ; end of FROM <= start of TO: do F$Move
 
 * The areas to copy overlap: do special move routine
                     pshs      d,x,y,u   ; save regs
@@ -265,7 +265,7 @@ L040C               stu       ,y++      ; do all of them
 
 * This all appears to be doing a copy where destination <= source,
 * in the same address space.
-L0457               ldb       ,s        ; grab ??
+FChainGrab          ldb       ,s        ; grab ??
                     leax      -1,x      ; back up one
                     os9       F$LDABX   ; call OS-9 service F$LDABX
                     exg       x,u       ; exchange register values x,u
@@ -274,13 +274,13 @@ L0457               ldb       ,s        ; grab ??
                     os9       F$STABX   ; call OS-9 service F$STABX
                     exg       x,u       ; exchange register values x,u
                     leay      -1,y      ; compute -1,y into Y
-                    bne       L0457     ; branch if zero is clear to L0457
+                    bne       FChainGrab ; branch if zero is clear to FChainGrab
 
                     puls      d,x,y,u   ; restore regs
-                    bra       L0474     ; skip over F$Move
+                    bra       FChainSystemTaskNumber ; skip over F$Move
 
-L0471               os9       F$Move    ; move data over?
-L0474               lda       <D.SysTsk ; get system task number
+FChainDataOver      os9       F$Move    ; move data over?
+FChainSystemTaskNumber lda       <D.SysTsk ; get system task number
                     ldx       ,s        ; old process dsc ptr
                     ldu       P$SP,x    ; load U from P$SP,x
                     leax      >(P$Stack-R$Size),x ; compute >(P$Stack-R$Size),x into X
@@ -288,7 +288,7 @@ L0474               lda       <D.SysTsk ; get system task number
                     os9       F$Move    ; move the stack over
                     puls      u,x       ; restore new, old process dsc's
                     lda       P$ID,u    ; load A from P$ID,u
-                    lbsr      L0386     ; check alarms
+                    lbsr      FAllprcTarget2 ; check alarms
                     os9       F$DelTsk  ; delete the old task
                     orcc      #IntMasks ; set condition-code bits using #IntMasks
                     ldd       <D.SysPrc ; load D from <D.SysPrc
@@ -304,16 +304,16 @@ L0474               lda       <D.SysTsk ; get system task number
                     os9       F$NProc   ; go to it
 
 * comes here on error with link to new module
-L04A1               puls      u,x       ; restore u,x from the stack
+FChainTarget        puls      u,x       ; restore u,x from the stack
                     stx       <D.Proc   ; store X at <D.Proc
                     pshs      b         ; save b on the stack
                     lda       ,u        ; load A from ,u
-                    lbsr      L0386     ; kill signals
+                    lbsr      FAllprcTarget2 ; kill signals
                     puls      b         ; restore b from the stack
                     os9       F$Exit    ; exit from the process with error condition
 
 * Setup new process DAT image with module
-L04B1               pshs      d,x,y,u   ; preserve everything
+FChainEverything    pshs      d,x,y,u   ; preserve everything
                     ldd       <D.Proc   ; get pointer to current process
                     pshs      d         ; save it
                     stx       <D.Proc   ; save pointer to new process
@@ -322,16 +322,16 @@ L04B1               pshs      d,x,y,u   ; preserve everything
                     ldy       ,s        ; get pointer to current process
                     leay      P$DATImg,y ; point to DAT image
                     os9       F$SLink   ; map it into new process DAT image
-                    bcc       L04D7     ; no error, keep going
+                    bcc       FChainModule ; no error, keep going
                     ldd       ,s        ; restore to current process
                     std       <D.Proc   ; store D at <D.Proc
                     ldu       4,s       ; get pointer to new process
                     os9       F$Load    ; try & load it
-                    bcc       L04D7     ; no error, keep going
+                    bcc       FChainModule ; no error, keep going
                     leas      4,s       ; purge stack
                     puls      x,y,u,pc  ; restore & return
 *
-L04D7               stu       2,s       ; save pointer to module
+FChainModule        stu       2,s       ; save pointer to module
                     pshs      a,y       ; save module type & entry point
                     ldu       $0B,s     ; restore register stack pointer
                     stx       R$X,u     ; save updated name pointer
@@ -341,33 +341,33 @@ L04D7               stu       2,s       ; save pointer to module
                     std       P$PModul,x ; save it into process descriptor
                     puls      a         ; restore module type
                     cmpa      #Prgrm+Objct ; regular module?
-                    beq       L04FB     ; yes, go
+                    beq       FChainOffsetModuleMemorySize ; yes, go
                     cmpa      #Systm+Objct ; system module?
-                    beq       L04FB     ; branch if zero is set to L04FB
+                    beq       FChainOffsetModuleMemorySize ; branch if zero is set to FChainOffsetModuleMemorySize
                   IFNE    H6309   ; begin conditional assembly for H6309
 *--- these lines added to allow 6309 native mode modules to be executed
                     cmpa      #Prgrm+Obj6309 ; regular module?
-                    beq       L04FB     ; yes, go
+                    beq       FChainOffsetModuleMemorySize ; yes, go
                     cmpa      #Systm+Obj6309 ; system module?
-                    beq       L04FB     ; branch if zero is set to L04FB
+                    beq       FChainOffsetModuleMemorySize ; branch if zero is set to FChainOffsetModuleMemorySize
 *---
                   ENDC
                     ldb       #E$NEMod  ; return unknown module
-L04F4               leas      2,s       ; purge stack
+FChainPurge         leas      2,s       ; purge stack
                     stb       3,s       ; save error
                     comb                ; set carry
-                    bra       L053E     ; return
+                    bra       FChainProcess2 ; return
 * Setup up data memory
-L04FB               ldd       #M$Mem    ; get offset to module memory size
+FChainOffsetModuleMemorySize ldd       #M$Mem    ; get offset to module memory size
                     leay      P$DATImg,x ; get pointer to DAT image
                     ldx       P$PModul,x ; get pointer to module header
                     os9       F$LDDDXY  ; get module memory size
                     cmpa      R$B,u     ; bigger or smaller than callers request?
-                    bcc       L050E     ; bigger, use it instead
+                    bcc       FChainTryDataMemory ; bigger, use it instead
                     lda       R$B,u     ; get callers memory size instead
                     clrb                ; clear LSB of mem size
-L050E               os9       F$Mem     ; try & get the data memory
-                    bcs       L04F4     ; can't do it, exit with error
+FChainTryDataMemory os9       F$Mem     ; try & get the data memory
+                    bcs       FChainPurge ; can't do it, exit with error
                     ldx       6,s       ; restore process pointer
                     leay      (P$Stack-R$Size),x ; point to new register stack
                     pshs      d         ; preserve memory size
@@ -389,7 +389,7 @@ L050E               os9       F$Mem     ; try & get the data memory
                     clrb                ; clear B
                     std       R$U,y     ; save data area start
                     stx       R$PC,y    ; save program entry point
-L053E               puls      d         ; restore process pointer
+FChainProcess2      puls      d         ; restore process pointer
                     std       <D.Proc   ; save it as current
                     puls      d,x,y,u,pc ; restore d,x,y,u,pc from the stack
 

--- a/level1/modules/kernel/fcmpnam.asm
+++ b/level1/modules/kernel/fcmpnam.asm
@@ -31,7 +31,7 @@ GetName2            ldx       R$Y,u     ; get pointer to the second name
                     ldd       R$D,u     ; get length
                     leax      4,s       ; point to the first name's info packet
                     leay      ,s        ; point to the second name's info packet
-                    bsr       L07DE     ; go compare 'em
+                    bsr       FCmpnamTarget ; go compare 'em
                     leas      8,s       ; purge stack
                     rts                 ; return to caller
 
@@ -45,7 +45,7 @@ GetName2            ldx       R$Y,u     ; get pointer to the second name
 *             0,Y = DAT image pointer
 *             2,Y = Pointer to name
 *         U = Register stack ptr
-L07DE               pshs      d,x,y,u   ; preserve registers
+FCmpnamTarget       pshs      d,x,y,u   ; preserve registers
                     tfr       x,u       ; U=pointer to the first name packet
                     pulu      x,y       ; get DAT pointer to Y and name pointer to X
                     lbsr      AdjBlk0   ; adjust X to use block 0
@@ -53,11 +53,11 @@ L07DE               pshs      d,x,y,u   ; preserve registers
                     ldu       4,s       ; get pointer to the second name's packet
                     pulu      x,y       ; get DAT pointer to Y and name pointer to X
                     lbsr      AdjBlk0   ; adjust X to block 0
-                    bra       L07F6     ; go compare the names
+                    bra       FCmpnamMapBlockGrabName ; go compare the names
 
-L07F2               ldu       4,s       ; get pointer to second name's packet
+FCmpnamSecondNamesPacket ldu       4,s       ; get pointer to second name's packet
                     pulu      x,y       ; get DAT pointer to Y and name pointer to X
-L07F6               lbsr      LDAXY     ; map in the block & grab a byte from name
+FCmpnamMapBlockGrabName lbsr      LDAXY     ; map in the block & grab a byte from name
                     pshu      x,y       ; put updated DAT & name pointer back
                     pshs      a         ; save the character
                     ldu       3,s       ; pointer to the first name packet
@@ -66,18 +66,18 @@ L07F6               lbsr      LDAXY     ; map in the block & grab a byte from na
                     pshu      y,x       ; put pointers back
                     eora      ,s        ; exclusive-OR A with ,s
                     tst       ,s+       ; was it high bit?
-                    bmi       L0816     ; yes, check if last character in the second name
+                    bmi       FCmpnamName ; yes, check if last character in the second name
                     decb                ; decrement B
-                    beq       L0813     ; branch if zero is set to L0813
+                    beq       FCmpnamCarry ; branch if zero is set to FCmpnamCarry
                     anda      #$DF      ; match?
-                    beq       L07F2     ; yes, check next character
-L0813               comb                ; set carry
+                    beq       FCmpnamSecondNamesPacket ; yes, check next character
+FCmpnamCarry        comb                ; set carry
                     puls      d,x,y,u,pc ; restore d,x,y,u,pc from the stack
 
-L0816               decb                ; done whole name?
-                    bne       L0813     ; no, exit with no match
+FCmpnamName         decb                ; done whole name?
+                    bne       FCmpnamCarry ; no, exit with no match
                     anda      #$5F      ; match?
-                    bne       L0813     ; yes, keep checking
+                    bne       FCmpnamCarry ; yes, keep checking
                     clrb                ; names match, clear carry
                     puls      d,x,y,u,pc ; restore & return to caller
 

--- a/level1/modules/kernel/fcmpnam.asm
+++ b/level1/modules/kernel/fcmpnam.asm
@@ -11,29 +11,29 @@
 ;;; F$CmpNam compares two names and indicates whether they match. Use this call with F$PrsNam. The second name
 ;;; must have the most significant bit (bit 7) of the last character set.
 
-               ifgt      Level-1
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
 
 * User state entry
-               ldy       M$Size,x            get module size in module header
-FCmpNam        ldx       <D.Proc             get current process ptr
-               leay      P$DATImg,x          point to the DAT image
-               ldx       R$X,u               get pointer to the first name
-               pshs      y,x                 preserve 'em
-               bra       GetName2
+                    ldy       M$Size,x  ; get module size in module header
+FCmpNam             ldx       <D.Proc   ; get current process ptr
+                    leay      P$DATImg,x ; point to the DAT image
+                    ldx       R$X,u     ; get pointer to the first name
+                    pshs      y,x       ; preserve 'em
+                    bra       GetName2  ; branch unconditionally to GetName2
 * System state entry
-FSCmpNam       ldx       <D.Proc             get current process descriptor pointer
-               leay      P$DATImg,x          point to its DAT image
-               ldx       R$X,u               get pointer to the first name
-               pshs      x,y
-               ldy       <D.SysDAT           get pointer to system DAT
-GetName2       ldx       R$Y,u               get pointer to the second name
-               pshs      y,x                 preserve them
-               ldd       R$D,u               get length
-               leax      4,s                 point to the first name's info packet
-               leay      ,s                  point to the second name's info packet
-               bsr       L07DE               go compare 'em
-               leas      8,s                 purge stack
-               rts                           return to caller
+FSCmpNam            ldx       <D.Proc   ; get current process descriptor pointer
+                    leay      P$DATImg,x ; point to its DAT image
+                    ldx       R$X,u     ; get pointer to the first name
+                    pshs      x,y       ; save x,y on the stack
+                    ldy       <D.SysDAT ; get pointer to system DAT
+GetName2            ldx       R$Y,u     ; get pointer to the second name
+                    pshs      y,x       ; preserve them
+                    ldd       R$D,u     ; get length
+                    leax      4,s       ; point to the first name's info packet
+                    leay      ,s        ; point to the second name's info packet
+                    bsr       L07DE     ; go compare 'em
+                    leas      8,s       ; purge stack
+                    rts                 ; return to caller
 
 * Compare 2 names
 *
@@ -45,43 +45,43 @@ GetName2       ldx       R$Y,u               get pointer to the second name
 *             0,Y = DAT image pointer
 *             2,Y = Pointer to name
 *         U = Register stack ptr
-L07DE          pshs      d,x,y,u             preserve registers
-               tfr       x,u                 U=pointer to the first name packet
-               pulu      x,y                 get DAT pointer to Y and name pointer to X
-               lbsr      AdjBlk0             adjust X to use block 0
-               pshu      x,y                 put them back
-               ldu       4,s                 get pointer to the second name's packet
-               pulu      x,y                 get DAT pointer to Y and name pointer to X
-               lbsr      AdjBlk0             adjust X to block 0
-               bra       L07F6               go compare the names
+L07DE               pshs      d,x,y,u   ; preserve registers
+                    tfr       x,u       ; U=pointer to the first name packet
+                    pulu      x,y       ; get DAT pointer to Y and name pointer to X
+                    lbsr      AdjBlk0   ; adjust X to use block 0
+                    pshu      x,y       ; put them back
+                    ldu       4,s       ; get pointer to the second name's packet
+                    pulu      x,y       ; get DAT pointer to Y and name pointer to X
+                    lbsr      AdjBlk0   ; adjust X to block 0
+                    bra       L07F6     ; go compare the names
 
-L07F2          ldu       4,s                 get pointer to second name's packet
-               pulu      x,y                 get DAT pointer to Y and name pointer to X
-L07F6          lbsr      LDAXY               map in the block & grab a byte from name
-               pshu      x,y                 put updated DAT & name pointer back
-               pshs      a                   save the character
-               ldu       3,s                 pointer to the first name packet
-               pulu      x,y                 get DAT pointer to Y and name pointer to X
-               lbsr      LDAXY               get byte from the first name
-               pshu      y,x                 put pointers back
-               eora      ,s
-               tst       ,s+                 was it high bit?
-               bmi       L0816               yes, check if last character in the second name
-               decb      
-               beq       L0813
-               anda      #$DF                match?
-               beq       L07F2               yes, check next character
-L0813          comb                          set carry
-               puls      d,x,y,u,pc
+L07F2               ldu       4,s       ; get pointer to second name's packet
+                    pulu      x,y       ; get DAT pointer to Y and name pointer to X
+L07F6               lbsr      LDAXY     ; map in the block & grab a byte from name
+                    pshu      x,y       ; put updated DAT & name pointer back
+                    pshs      a         ; save the character
+                    ldu       3,s       ; pointer to the first name packet
+                    pulu      x,y       ; get DAT pointer to Y and name pointer to X
+                    lbsr      LDAXY     ; get byte from the first name
+                    pshu      y,x       ; put pointers back
+                    eora      ,s        ; exclusive-OR A with ,s
+                    tst       ,s+       ; was it high bit?
+                    bmi       L0816     ; yes, check if last character in the second name
+                    decb                ; decrement B
+                    beq       L0813     ; branch if zero is set to L0813
+                    anda      #$DF      ; match?
+                    beq       L07F2     ; yes, check next character
+L0813               comb                ; set carry
+                    puls      d,x,y,u,pc ; restore d,x,y,u,pc from the stack
 
-L0816          decb                          done whole name?
-               bne       L0813               no, exit with no match
-               anda      #$5F                match?
-               bne       L0813               yes, keep checking
-               clrb                          names match, clear carry
-               puls      d,x,y,u,pc          restore & return to caller
+L0816               decb                ; done whole name?
+                    bne       L0813     ; no, exit with no match
+                    anda      #$5F      ; match?
+                    bne       L0813     ; yes, keep checking
+                    clrb                ; names match, clear carry
+                    puls      d,x,y,u,pc ; restore & return to caller
 
-               else      
+                  ELSE
 
 ;;; F$CmpNam
 ;;;
@@ -96,26 +96,26 @@ L0816          decb                          done whole name?
 ;;; F$CmpNam compares two names and indicates whether they match. Use this call with F$PrsNam. The second name
 ;;; must have the most significant bit of the last character set.
 
-FCmpNam        ldb       R$B,u               get length of the first name
-               leau      R$X,u               point U to the caller's R$X
-               pulu      y,x                 load caller's R$X and R$Y into X and Y in one call
-CmpNam         pshs      y,x,b,a             save registers
-loop@          lda       ,y+                 get character of second name and increment pointer
-               bmi       hibitset@           branch if hi-bit set
-               decb                          decrement length
-               beq       nomatch@            if counter is zero, length is different, so not a match
-               eora      ,x+                 XOR with character in same position from first name and increment pointer
-               anda      #$DF                make result case insensitive
-               beq       loop@               if zero, characters match, so continue to next character
-nomatch@       orcc      #Carry              set carry to indicate no match
-               puls      pc,y,x,b,a          restore registers and return to caller
-hibitset@      decb                          more?
-               bne       nomatch@            branch if so, length is different so not a match.
-               eora      ,x                  XOR with character in same position from first name
-               anda      #$5F                make result case insensitive
-               bne       nomatch@            if not zero, not a match
-               puls      y,x,b,a             restore registers
-Match          andcc     #^Carry             clear carry to indicate a match
-               rts                           return to caller
+FCmpNam             ldb       R$B,u     ; get length of the first name
+                    leau      R$X,u     ; point U to the caller's R$X
+                    pulu      y,x       ; load caller's R$X and R$Y into X and Y in one call
+CmpNam              pshs      y,x,b,a   ; save registers
+loop@               lda       ,y+       ; get character of second name and increment pointer
+                    bmi       hibitset@ ; branch if hi-bit set
+                    decb                ; decrement length
+                    beq       nomatch@  ; if counter is zero, length is different, so not a match
+                    eora      ,x+       ; xOR with character in same position from first name and increment pointer
+                    anda      #$DF      ; make result case insensitive
+                    beq       loop@     ; if zero, characters match, so continue to next character
+nomatch@            orcc      #Carry    ; set carry to indicate no match
+                    puls      pc,y,x,b,a ; restore registers and return to caller
+hibitset@           decb                ; more?
+                    bne       nomatch@  ; branch if so, length is different so not a match.
+                    eora      ,x        ; xOR with character in same position from first name
+                    anda      #$5F      ; make result case insensitive
+                    bne       nomatch@  ; if not zero, not a match
+                    puls      y,x,b,a   ; restore registers
+Match               andcc     #^Carry   ; clear carry to indicate a match
+                    rts                 ; return to caller
 
-               endc      
+                  ENDC

--- a/level1/modules/kernel/fcmpnam.asm
+++ b/level1/modules/kernel/fcmpnam.asm
@@ -53,11 +53,11 @@ FCmpnamTarget       pshs      d,x,y,u   ; preserve registers
                     ldu       4,s       ; get pointer to the second name's packet
                     pulu      x,y       ; get DAT pointer to Y and name pointer to X
                     lbsr      AdjBlk0   ; adjust X to block 0
-                    bra       FCmpnamMapBlockGrabName ; go compare the names
+                    bra       FCmpnamMapBlkGrab ; go compare the names
 
-FCmpnamSecondNamesPacket ldu       4,s       ; get pointer to second name's packet
+FCmpnamScndNmsPckt  ldu       4,s       ; get pointer to second name's packet
                     pulu      x,y       ; get DAT pointer to Y and name pointer to X
-FCmpnamMapBlockGrabName lbsr      LDAXY     ; map in the block & grab a byte from name
+FCmpnamMapBlkGrab   lbsr      LDAXY     ; map in the block & grab a byte from name
                     pshu      x,y       ; put updated DAT & name pointer back
                     pshs      a         ; save the character
                     ldu       3,s       ; pointer to the first name packet
@@ -70,7 +70,7 @@ FCmpnamMapBlockGrabName lbsr      LDAXY     ; map in the block & grab a byte fro
                     decb                ; decrement B
                     beq       FCmpnamCarry ; branch if zero is set to FCmpnamCarry
                     anda      #$DF      ; match?
-                    beq       FCmpnamSecondNamesPacket ; yes, check next character
+                    beq       FCmpnamScndNmsPckt ; yes, check next character
 FCmpnamCarry        comb                ; set carry
                     puls      d,x,y,u,pc ; restore d,x,y,u,pc from the stack
 

--- a/level1/modules/kernel/fcrc.asm
+++ b/level1/modules/kernel/fcrc.asm
@@ -16,53 +16,53 @@
 ;;; The updated accumulator doesn't include the last three bytes of the module. The 3 CRC bytes are stored there.
 ;;; Initialize the CRC accumulator only once for each module check.
 
-FCRC           ldx       R$X,u               get the starting address in X
-               ldy       R$Y,u               and the number of bytes in Y
-               beq       FCRCEx              if number of bytes is zero, return
-               ldu       R$U,u               get the address of the 3 byte accumulator in U
-FCRCLoop       lda       ,x+                 get the next byte at X and increment X
-               bsr       CRCAlgo             perform the CRC algorithm
-               leay      -1,y                decrement the count
-               bne       FCRCLoop            branch if there are more bytes
-FCRCEx         clrb                          clear the error code and carry
-               rts                           return to the caller
+FCRC                ldx       R$X,u     ; get the starting address in X
+                    ldy       R$Y,u     ; and the number of bytes in Y
+                    beq       FCRCEx    ; if number of bytes is zero, return
+                    ldu       R$U,u     ; get the address of the 3 byte accumulator in U
+FCRCLoop            lda       ,x+       ; get the next byte at X and increment X
+                    bsr       CRCAlgo   ; perform the CRC algorithm
+                    leay      -1,y      ; decrement the count
+                    bne       FCRCLoop  ; branch if there are more bytes
+FCRCEx              clrb                ; clear the error code and carry
+                    rts                 ; return to the caller
 
-CRCAlgo        eora      ,u                  XOR A with first byte of accumulator
-               pshs      a                   push the result
-               ldd       $01,u               get the second and third bytes of the accumulator
-               std       ,u                  save in the first and second accumulator locations
-               clra                          clear A
-               ldb       ,s                  get XOR'ed value pushed earlier
-               lslb                          left shift B
-               rola                          left roll A
-               eora      1,u                 XOR A with the second byte of the accumulator
-               std       1,u                 and store D in the second and third bytes of the accumulator
-               clrb                          clear B
-               lda       ,s                  get the XOR'ed value pushed earlier
-               lsra                          right shift A
-               rorb                          right roll B
-               lsra                          right shift A
-               rorb                          right roll B
-               eora      1,u                 XOR A with the second byte of the accumulator
-               eorb      2,u                 XOR B with the third byte of the accumulator
-               std       1,u                 store the result in the second and third bytes of the accumulator
-               lda       ,s                  get the XOR'ed value pushed earlier
-               lsla                          left shift A
-               eora      ,s                  XOR A with the XOR'ed value pushed earlier
-               sta       ,s                  and update the value on the stack
-               lsla                          left shift A
-               lsla                          left shift A
-               eora      ,s                  XOR A with the XOR'ed value pushed earlier
-               sta       ,s                  and update the value on the stack
-               lsla                          left shift A
-               lsla                          left shift A
-               lsla                          left shift A
-               lsla                          left shift A
-               eora      ,s+                 XOR A with the XOR'ed value pushed earlier and pop the value
-               bpl       ex@                 branch if the hi-bit is clear
-               ldd       #$8021              else load D with this value
-               eora      ,u                  XOR A with the first byte of the accumulator
-               sta       ,u                  and save the result to the first byte of the accumulator
-               eorb      2,u                 XOR B with the third byte of the accumulator
-               stb       2,u                 and save the result to the third byte of the accumulator
-ex@            rts                           return to the caller
+CRCAlgo             eora      ,u        ; xOR A with first byte of accumulator
+                    pshs      a         ; push the result
+                    ldd       $01,u     ; get the second and third bytes of the accumulator
+                    std       ,u        ; save in the first and second accumulator locations
+                    clra                ; clear A
+                    ldb       ,s        ; get XOR'ed value pushed earlier
+                    lslb                ; left shift B
+                    rola                ; left roll A
+                    eora      1,u       ; xOR A with the second byte of the accumulator
+                    std       1,u       ; and store D in the second and third bytes of the accumulator
+                    clrb                ; clear B
+                    lda       ,s        ; get the XOR'ed value pushed earlier
+                    lsra                ; right shift A
+                    rorb                ; right roll B
+                    lsra                ; right shift A
+                    rorb                ; right roll B
+                    eora      1,u       ; xOR A with the second byte of the accumulator
+                    eorb      2,u       ; xOR B with the third byte of the accumulator
+                    std       1,u       ; store the result in the second and third bytes of the accumulator
+                    lda       ,s        ; get the XOR'ed value pushed earlier
+                    lsla                ; left shift A
+                    eora      ,s        ; xOR A with the XOR'ed value pushed earlier
+                    sta       ,s        ; and update the value on the stack
+                    lsla                ; left shift A
+                    lsla                ; left shift A
+                    eora      ,s        ; xOR A with the XOR'ed value pushed earlier
+                    sta       ,s        ; and update the value on the stack
+                    lsla                ; left shift A
+                    lsla                ; left shift A
+                    lsla                ; left shift A
+                    lsla                ; left shift A
+                    eora      ,s+       ; xOR A with the XOR'ed value pushed earlier and pop the value
+                    bpl       ex@       ; branch if the hi-bit is clear
+                    ldd       #$8021    ; else load D with this value
+                    eora      ,u        ; xOR A with the first byte of the accumulator
+                    sta       ,u        ; and save the result to the first byte of the accumulator
+                    eorb      2,u       ; xOR B with the third byte of the accumulator
+                    stb       2,u       ; and save the result to the third byte of the accumulator
+ex@                 rts                 ; return to the caller

--- a/level1/modules/kernel/fdebug.asm
+++ b/level1/modules/kernel/fdebug.asm
@@ -11,40 +11,40 @@
 ;;; Current valid function codes are:
 ;;    255 = Reboot the computer
 
-FDebug                   
+FDebug
 * Determine if this is a system process or super user
 * Only they have permission to reboot
-               lda       R$A,u               get the function code
-               cmpa      #255                is it a reboot request?
-               bne       DebugEx@            branch if not
-               ldx       <D.Proc             ... else get current process descriptor
-               ldd       P$User,x            and obtain user ID
-               beq       Reboot              reboot only if super user
-               comb                          else set carry
-               ldb       #E$UnkSvc           load error
-DebugEx@       rts                           return to caller
+                    lda       R$A,u     ; get the function code
+                    cmpa      #255      ; is it a reboot request?
+                    bne       DebugEx@  ; branch if not
+                    ldx       <D.Proc   ; ... else get current process descriptor
+                    ldd       P$User,x  ; and obtain user ID
+                    beq       Reboot    ; reboot only if super user
+                    comb                ; else set carry
+                    ldb       #E$UnkSvc ; load error
+DebugEx@            rts                 ; return to caller
 
 * NOTE: HIGHLY MACHINE DEPENDENT CODE!
 * THIS CODE IS SPECIFIC TO THE COCO!
-Reboot         orcc      #IntMasks           mask interrupts
+Reboot              orcc      #IntMasks ; mask interrupts
 *         clrb
 *         stb   >$FFA0              map in block 0
 *         stb   >$0071              cold reboot
 *         lda   #$38                bottom of DECB block mapping
 *         sta   >$FFA0              map in block zero
-               stb       >$0071              cold reboot BASIC
-               ldu       #$0000              force code to go at offset $0000
-               leax      ReBootLoc,pc        point to reboot code
-               ldy       #CodeSize           and get size
-RCpLoop@       lda       ,x+
-               sta       ,u+
-               leay      -1,y
-               bne       RCpLoop@
+                    stb       >$0071    ; cold reboot BASIC
+                    ldu       #$0000    ; force code to go at offset $0000
+                    leax      ReBootLoc,pc ; point to reboot code
+                    ldy       #CodeSize ; and get size
+RCpLoop@            lda       ,x+       ; load A from ,x+
+                    sta       ,u+       ; store A at ,u+
+                    leay      -1,y      ; compute -1,y into Y
+                    bne       RCpLoop@  ; branch if zero is clear to RCpLoop@
 *         clr   >$FEED     cold reboot
 *         clr   >$FFD8     go to low speed
-               jmp       >$0000              jump to the reset code
+                    jmp       >$0000    ; jump to the reset code
 
-ReBootLoc                
+ReBootLoc
 *         ldd   #$3808       block $38, 8 times
 *         ldx   #$FFA0       where to put it
 *Lp       sta   8,x        put into map 1
@@ -56,13 +56,13 @@ ReBootLoc
 *         lda   #$4C       standard DECB mapping
 *         sta   >$FF90
 *         clr   >$FF91     go to map type 0
-               clr       >$FFDE              and to all-ROM mode
-               ldd       #$FFFF
+                    clr       >$FFDE    ; and to all-ROM mode
+                    ldd       #$FFFF    ; load D from #$FFFF
 *         clrd               executes as CLRA on a 6809
-               fdb       $104F               'clrd' executes as a 'clra' on a 6809
-               tstb                          is it a 6809?
-               bne       Reset               yup, skip ahead
-               fcb       $11,$3D,$00         this is a 'ldmd #$00' to go into 6809 mode
-Reset          jmp       [$FFFE]             perform a complete reset
-CodeSize       equ       *-ReBootLoc
+                    fdb       $104F     ; 'clrd' executes as a 'clra' on a 6809
+                    tstb                ; is it a 6809?
+                    bne       Reset     ; yup, skip ahead
+                    fcb       $11,$3D,$00 ; this is a 'ldmd #$00' to go into 6809 mode
+Reset               jmp       [$FFFE]   ; perform a complete reset
+CodeSize            equ       *-ReBootLoc ; define assembler symbol
 

--- a/level1/modules/kernel/fexit.asm
+++ b/level1/modules/kernel/fexit.asm
@@ -121,29 +121,29 @@ FExitChildID2       lda       P$SID,y   ; get child ID
                     puls      cc        ; restore CC
                     lda       P$ID,y    ; get our ID
                     lbsr      FAllprcTarget2 ; give up our proc desc
-                    bra       FExitStartProcActiveQueue ; and start next active process
+                    bra       FExitStartProcAct ; and start next active process
 
 * Search for Waiting Parent
-FExitProcDescOurParents cmpa      P$ID,x    ; is proc desc our parent's?
-                    beq       FExitTakeParentOutWaitQueue ; ...yes!
+FExitProcDescOur    cmpa      P$ID,x    ; is proc desc our parent's?
+                    beq       FExitTakeParOut ; ...yes!
 
 FExitBaseDesc       leau      ,x        ; U is base desc
                     ldx       P$Queue,x ; X is next waiter
-                    bne       FExitProcDescOurParents ; see if parent
+                    bne       FExitProcDescOur ; see if parent
                     puls      cc        ; restore CC
                     lda       #(SysState!Dead) ; set us to system state
                     sta       P$State,y ; and mark us as dead
-                    bra       FExitStartProcActiveQueue ; so F$Wait will find us; next proc
+                    bra       FExitStartProcAct ; so F$Wait will find us; next proc
 
 * Found Parent (X)
-FExitTakeParentOutWaitQueue ldd       P$Queue,x ; take parent out of wait queue
+FExitTakeParOut     ldd       P$Queue,x ; take parent out of wait queue
                     std       P$Queue,u ; store D at P$Queue,u
                     puls      cc        ; restore CC
                     ldu       P$SP,x    ; get parent's stack register
                     ldu       R$U,u     ; load U from R$U,u
-                    lbsr      FAllprcProcessIDDeadChild ; get child's death signal to parent
+                    lbsr      FAllprcProcIDDead ; get child's death signal to parent
                     os9       F$AProc   ; move parent to active queue
-FExitStartProcActiveQueue os9       F$NProc   ; start next proc in active queue
+FExitStartProcAct   os9       F$NProc   ; start next proc in active queue
 
 * Close Proc I/O Paths & Unlink Mem
 * Entry: U=Register stack pointer

--- a/level1/modules/kernel/fexit.asm
+++ b/level1/modules/kernel/fexit.asm
@@ -15,170 +15,170 @@
 ;;; Exit unlinks only the primary module. Unlink any module that is loaded or linked to by the process before
 ;;; calling F$Exit.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FExit          ldx       <D.Proc             get pointer to current process descriptor
-               ldb       R$B,u               get exit code
-               stb       P$Signal,x          save it as the process' signal
+FExit               ldx       <D.Proc   ; get pointer to current process descriptor
+                    ldb       R$B,u     ; get exit code
+                    stb       P$Signal,x ; save it as the process' signal
 * Close all open paths that this process has
-               ldb       #NumPaths           get the number pf paths
-               leay      P$PATH,x            point Y to the base of the path table in the process descriptor
-loop@          lda       ,y+                 get a path
-               beq       empty@              branch if empty
-               pshs      b                   else save off counter
-               os9       I$Close             close the path
-               puls      b                   recover the counter
-empty@         decb                          decrement
-               bne       loop@               branch if more paths to close
+                    ldb       #NumPaths ; get the number pf paths
+                    leay      P$PATH,x  ; point Y to the base of the path table in the process descriptor
+loop@               lda       ,y+       ; get a path
+                    beq       empty@    ; branch if empty
+                    pshs      b         ; else save off counter
+                    os9       I$Close   ; close the path
+                    puls      b         ; recover the counter
+empty@              decb                ; decrement
+                    bne       loop@     ; branch if more paths to close
 * Free any allocated memory associated with this process
-               lda       P$ADDR,x            get 256 byte page number of allocated memory
-               tfr       d,u                 transfer to D to U
-               lda       P$PagCnt,x          get allocated page count in A
-               os9       F$SRtMem            return that memory to the system
-               ldu       P$PModul,x          get the pointer to the primary module
-               os9       F$UnLink            unlink it
+                    lda       P$ADDR,x  ; get 256 byte page number of allocated memory
+                    tfr       d,u       ; transfer to D to U
+                    lda       P$PagCnt,x ; get allocated page count in A
+                    os9       F$SRtMem  ; return that memory to the system
+                    ldu       P$PModul,x ; get the pointer to the primary module
+                    os9       F$UnLink  ; unlink it
 * Go through the siblings of this process
-               ldu       <D.Proc             get the current process pointer
-               leay      P$PID,u             point Y to the start of the process descriptor
-               ldx       <D.PrcDBT           and X to the process descriptor table
-               bra       clearsid@           go clear the sibling ID
-retprocdesc@   clr       P$SID,y             clear the sibling ID
-               os9       F$Find64            find the sibling's process descriptor and put it in Y
-               lda       P$State,y           load the sibling process' state
-               bita      #Dead               is it dead?
-               beq       clearids@           branch if not
-               lda       P$ID,y              else get the sibling's process ID
-               os9       F$Ret64             and free the sibling's process descriptor
-clearids@      clr       P$PID,y             clear the parent ID
-clearsid@      lda       P$SID,y             get the sibling ID
-               bne       retprocdesc@        branch if there is one
+                    ldu       <D.Proc   ; get the current process pointer
+                    leay      P$PID,u   ; point Y to the start of the process descriptor
+                    ldx       <D.PrcDBT ; and X to the process descriptor table
+                    bra       clearsid@ ; go clear the sibling ID
+retprocdesc@        clr       P$SID,y   ; clear the sibling ID
+                    os9       F$Find64  ; find the sibling's process descriptor and put it in Y
+                    lda       P$State,y ; load the sibling process' state
+                    bita      #Dead     ; is it dead?
+                    beq       clearids@ ; branch if not
+                    lda       P$ID,y    ; else get the sibling's process ID
+                    os9       F$Ret64   ; and free the sibling's process descriptor
+clearids@           clr       P$PID,y   ; clear the parent ID
+clearsid@           lda       P$SID,y   ; get the sibling ID
+                    bne       retprocdesc@ ; branch if there is one
 * Start sifting through the wait queue if there's a parent
-               ldx       #(D.WProcQ-P$Queue) load U with D.WProcQ-P$Queue so we're at the first process in the queue later
-               lda       P$PID,u             get the parent ID
-               bne       fixparent@          branch if there is a parent
+                    ldx       #(D.WProcQ-P$Queue) ; load U with D.WProcQ-P$Queue so we're at the first process in the queue later
+                    lda       P$PID,u   ; get the parent ID
+                    bne       fixparent@ ; branch if there is a parent
 * This process doesn't have a parent. Just return its process descriptor and exit
-               ldx       <D.PrcDBT           get process descriptor pointer table in X
-               lda       P$ID,u              get ID of process
-               os9       F$Ret64             and return the 64 byte block for this process descriptor
-               bra       ex@                 then return to the caller
+                    ldx       <D.PrcDBT ; get process descriptor pointer table in X
+                    lda       P$ID,u    ; get ID of process
+                    os9       F$Ret64   ; and return the 64 byte block for this process descriptor
+                    bra       ex@       ; then return to the caller
 * Go through wait queue and alert the parent
-loop2@         cmpa      P$ID,x              is this the parent?
-               beq       foundparent@        branch if so
-fixparent@     leay      ,x                  point Y to the process descriptor
-               ldx       P$Queue,x           get the queue this process is in
-               bne       loop2@              branch if not empty
-               lda       P$State,u           get state
-               ora       #Dead               mark it as dead
-               sta       P$State,u           save state
-               bra       ex@                 then exit
+loop2@              cmpa      P$ID,x    ; is this the parent?
+                    beq       foundparent@ ; branch if so
+fixparent@          leay      ,x        ; point Y to the process descriptor
+                    ldx       P$Queue,x ; get the queue this process is in
+                    bne       loop2@    ; branch if not empty
+                    lda       P$State,u ; get state
+                    ora       #Dead     ; mark it as dead
+                    sta       P$State,u ; save state
+                    bra       ex@       ; then exit
 * X = parent process descriptor for process that is exiting
 * Y = process descriptor in front of parent process in queue
 * U = ???
-foundparent@   ldd       P$Queue,x           get the queue that the parent is in
-               std       P$Queue,y           and store it in the previous process descriptor (removes the parent from the qeue)
-               os9       F$AProc             then put parent process back in the active queue
-               leay      ,u                  point Y to U
-               ldu       P$SP,x              get caller's stack pointer
-               ldu       R$D,u               get caller's D register
-               lbsr      SignalProcess       signal the process
-ex@            clra                          clear A
-               clrb                          clear B
-               std       <D.Proc             clear out current process descriptor
-               rts                           return to caller
+foundparent@        ldd       P$Queue,x ; get the queue that the parent is in
+                    std       P$Queue,y ; and store it in the previous process descriptor (removes the parent from the qeue)
+                    os9       F$AProc   ; then put parent process back in the active queue
+                    leay      ,u        ; point Y to U
+                    ldu       P$SP,x    ; get caller's stack pointer
+                    ldu       R$D,u     ; get caller's D register
+                    lbsr      SignalProcess ; signal the process
+ex@                 clra                ; clear A
+                    clrb                ; clear B
+                    std       <D.Proc   ; clear out current process descriptor
+                    rts                 ; return to caller
 
-               else
+                  ELSE
 
-FExit          ldx       <D.Proc             get current process pointer
-               bsr       L05A5               close all the paths
-               ldb       R$B,u               get exit signal
-               stb       <P$Signal,x         and save in proc desc
-               leay      P$PID,x
-               bra       L0563               go find kids...
+FExit               ldx       <D.Proc   ; get current process pointer
+                    bsr       L05A5     ; close all the paths
+                    ldb       R$B,u     ; get exit signal
+                    stb       <P$Signal,x ; and save in proc desc
+                    leay      P$PID,x   ; compute P$PID,x into Y
+                    bra       L0563     ; go find kids...
 
-L0551          clr       P$SID,y             clear child ID
-               lbsr      L0B2E               find its proc desc
-               clr       1,y                 clear sibling ID
-               ifne      H6309
-               tim       #Dead,P$State,y
-               else
-               lda       P$State,y           get child's state
-               bita      #Dead               is it dead?
-               endc
-               beq       L0563               ...no
-               lda       P$ID,y              else get its ID
-               lbsr      L0386               and destroy its proc desc
-L0563          lda       P$SID,y             get child ID
-               bne       L0551               ...yes, loop
+L0551               clr       P$SID,y   ; clear child ID
+                    lbsr      L0B2E     ; find its proc desc
+                    clr       1,y       ; clear sibling ID
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #Dead,P$State,y
+                  ELSE
+                    lda       P$State,y ; get child's state
+                    bita      #Dead     ; is it dead?
+                  ENDC
+                    beq       L0563     ; ...no
+                    lda       P$ID,y    ; else get its ID
+                    lbsr      L0386     ; and destroy its proc desc
+L0563               lda       P$SID,y   ; get child ID
+                    bne       L0551     ; ...yes, loop
 
-               leay      ,x                  kid's proc desc
-               ldx       #D.WProcQ-P$Queue
-               lds       <D.SysStk           use system stack
-               pshs      cc                  save CC
-               orcc      #IntMasks           halt interrupts
-               lda       P$PID,y             get our parent ID
-               bne       L0584               and wake him up
+                    leay      ,x        ; kid's proc desc
+                    ldx       #D.WProcQ-P$Queue ; load X from #D.WProcQ-P$Queue
+                    lds       <D.SysStk ; use system stack
+                    pshs      cc        ; save CC
+                    orcc      #IntMasks ; halt interrupts
+                    lda       P$PID,y   ; get our parent ID
+                    bne       L0584     ; and wake him up
 
-               puls      cc                  restore CC
-               lda       P$ID,y              get our ID
-               lbsr      L0386               give up our proc desc
-               bra       L05A2               and start next active process
+                    puls      cc        ; restore CC
+                    lda       P$ID,y    ; get our ID
+                    lbsr      L0386     ; give up our proc desc
+                    bra       L05A2     ; and start next active process
 
 * Search for Waiting Parent
-L0580          cmpa      P$ID,x              is proc desc our parent's?
-               beq       L0592               ...yes!
+L0580               cmpa      P$ID,x    ; is proc desc our parent's?
+                    beq       L0592     ; ...yes!
 
-L0584          leau      ,x                  U is base desc
-               ldx       P$Queue,x           X is next waiter
-               bne       L0580               see if parent
-               puls      cc                  restore CC
-               lda       #(SysState!Dead)    set us to system state
-               sta       P$State,y           and mark us as dead
-               bra       L05A2               so F$Wait will find us; next proc
+L0584               leau      ,x        ; U is base desc
+                    ldx       P$Queue,x ; X is next waiter
+                    bne       L0580     ; see if parent
+                    puls      cc        ; restore CC
+                    lda       #(SysState!Dead) ; set us to system state
+                    sta       P$State,y ; and mark us as dead
+                    bra       L05A2     ; so F$Wait will find us; next proc
 
 * Found Parent (X)
-L0592          ldd       P$Queue,x           take parent out of wait queue
-               std       P$Queue,u
-               puls      cc                  restore CC
-               ldu       P$SP,x              get parent's stack register
-               ldu       R$U,u
-               lbsr      L036C               get child's death signal to parent
-               os9       F$AProc             move parent to active queue
-L05A2          os9       F$NProc             start next proc in active queue
+L0592               ldd       P$Queue,x ; take parent out of wait queue
+                    std       P$Queue,u ; store D at P$Queue,u
+                    puls      cc        ; restore CC
+                    ldu       P$SP,x    ; get parent's stack register
+                    ldu       R$U,u     ; load U from R$U,u
+                    lbsr      L036C     ; get child's death signal to parent
+                    os9       F$AProc   ; move parent to active queue
+L05A2               os9       F$NProc   ; start next proc in active queue
 
 * Close Proc I/O Paths & Unlink Mem
 * Entry: U=Register stack pointer
-L05A5          pshs      u                   preserve register stack pointer
-               ldb       #NumPaths           get maximum # of paths
-               leay      P$Path,x            point to path table
-L05AC          lda       ,y+                 path open?
-               beq       L05B9               no, skip ahead
-               clr       -1,y                clear the path block #
-               pshs      b                   preserve count
-               os9       I$Close             close the path
-               puls      b                   restore count
-L05B9          decb                          done?
-               bne       L05AC               no, continue looking
+L05A5               pshs      u         ; preserve register stack pointer
+                    ldb       #NumPaths ; get maximum # of paths
+                    leay      P$Path,x  ; point to path table
+L05AC               lda       ,y+       ; path open?
+                    beq       L05B9     ; no, skip ahead
+                    clr       -1,y      ; clear the path block #
+                    pshs      b         ; preserve count
+                    os9       I$Close   ; close the path
+                    puls      b         ; restore count
+L05B9               decb                ; done?
+                    bne       L05AC     ; no, continue looking
 
 * Clean up memory process had
-               clra                          get starting block
-               ldb       P$PagCnt,x          get page count
-               beq       L05CB               none there, skip ahead
-               addb      #$1F                round it up
-               lsrb                          divide by 32 to get block count
-               lsrb
-               lsrb
-               lsrb
-               lsrb
-               os9       F$DelImg            delete the ram & DAT image
+                    clra                ; get starting block
+                    ldb       P$PagCnt,x ; get page count
+                    beq       L05CB     ; none there, skip ahead
+                    addb      #$1F      ; round it up
+                    lsrb                ; divide by 32 to get block count
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    os9       F$DelImg  ; delete the ram & DAT image
 * Unlink the module
-L05CB          ldd       <D.Proc
-               pshs      d
-               stx       <D.Proc             set bad proc
-               ldu       P$PModul,x          program pointer
-               os9       F$UnLink            unlink aborted program
-               puls      u,b,a
-               std       <D.Proc             reset parent proc
-               os9       F$DelTsk            release X's task #
-               rts
+L05CB               ldd       <D.Proc   ; load D from <D.Proc
+                    pshs      d         ; save d on the stack
+                    stx       <D.Proc   ; set bad proc
+                    ldu       P$PModul,x ; program pointer
+                    os9       F$UnLink  ; unlink aborted program
+                    puls      u,b,a     ; restore u,b,a from the stack
+                    std       <D.Proc   ; reset parent proc
+                    os9       F$DelTsk  ; release X's task #
+                    rts                 ; return to caller
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fexit.asm
+++ b/level1/modules/kernel/fexit.asm
@@ -89,14 +89,14 @@ ex@                 clra                ; clear A
                   ELSE
 
 FExit               ldx       <D.Proc   ; get current process pointer
-                    bsr       L05A5     ; close all the paths
+                    bsr       FExitTarget ; close all the paths
                     ldb       R$B,u     ; get exit signal
                     stb       <P$Signal,x ; and save in proc desc
                     leay      P$PID,x   ; compute P$PID,x into Y
-                    bra       L0563     ; go find kids...
+                    bra       FExitChildID2 ; go find kids...
 
-L0551               clr       P$SID,y   ; clear child ID
-                    lbsr      L0B2E     ; find its proc desc
+FExitChildID        clr       P$SID,y   ; clear child ID
+                    lbsr      FGprocpTarget ; find its proc desc
                     clr       1,y       ; clear sibling ID
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #Dead,P$State,y
@@ -104,11 +104,11 @@ L0551               clr       P$SID,y   ; clear child ID
                     lda       P$State,y ; get child's state
                     bita      #Dead     ; is it dead?
                   ENDC
-                    beq       L0563     ; ...no
+                    beq       FExitChildID2 ; ...no
                     lda       P$ID,y    ; else get its ID
-                    lbsr      L0386     ; and destroy its proc desc
-L0563               lda       P$SID,y   ; get child ID
-                    bne       L0551     ; ...yes, loop
+                    lbsr      FAllprcTarget2 ; and destroy its proc desc
+FExitChildID2       lda       P$SID,y   ; get child ID
+                    bne       FExitChildID ; ...yes, loop
 
                     leay      ,x        ; kid's proc desc
                     ldx       #D.WProcQ-P$Queue ; load X from #D.WProcQ-P$Queue
@@ -116,53 +116,53 @@ L0563               lda       P$SID,y   ; get child ID
                     pshs      cc        ; save CC
                     orcc      #IntMasks ; halt interrupts
                     lda       P$PID,y   ; get our parent ID
-                    bne       L0584     ; and wake him up
+                    bne       FExitBaseDesc ; and wake him up
 
                     puls      cc        ; restore CC
                     lda       P$ID,y    ; get our ID
-                    lbsr      L0386     ; give up our proc desc
-                    bra       L05A2     ; and start next active process
+                    lbsr      FAllprcTarget2 ; give up our proc desc
+                    bra       FExitStartProcActiveQueue ; and start next active process
 
 * Search for Waiting Parent
-L0580               cmpa      P$ID,x    ; is proc desc our parent's?
-                    beq       L0592     ; ...yes!
+FExitProcDescOurParents cmpa      P$ID,x    ; is proc desc our parent's?
+                    beq       FExitTakeParentOutWaitQueue ; ...yes!
 
-L0584               leau      ,x        ; U is base desc
+FExitBaseDesc       leau      ,x        ; U is base desc
                     ldx       P$Queue,x ; X is next waiter
-                    bne       L0580     ; see if parent
+                    bne       FExitProcDescOurParents ; see if parent
                     puls      cc        ; restore CC
                     lda       #(SysState!Dead) ; set us to system state
                     sta       P$State,y ; and mark us as dead
-                    bra       L05A2     ; so F$Wait will find us; next proc
+                    bra       FExitStartProcActiveQueue ; so F$Wait will find us; next proc
 
 * Found Parent (X)
-L0592               ldd       P$Queue,x ; take parent out of wait queue
+FExitTakeParentOutWaitQueue ldd       P$Queue,x ; take parent out of wait queue
                     std       P$Queue,u ; store D at P$Queue,u
                     puls      cc        ; restore CC
                     ldu       P$SP,x    ; get parent's stack register
                     ldu       R$U,u     ; load U from R$U,u
-                    lbsr      L036C     ; get child's death signal to parent
+                    lbsr      FAllprcProcessIDDeadChild ; get child's death signal to parent
                     os9       F$AProc   ; move parent to active queue
-L05A2               os9       F$NProc   ; start next proc in active queue
+FExitStartProcActiveQueue os9       F$NProc   ; start next proc in active queue
 
 * Close Proc I/O Paths & Unlink Mem
 * Entry: U=Register stack pointer
-L05A5               pshs      u         ; preserve register stack pointer
+FExitTarget         pshs      u         ; preserve register stack pointer
                     ldb       #NumPaths ; get maximum # of paths
                     leay      P$Path,x  ; point to path table
-L05AC               lda       ,y+       ; path open?
-                    beq       L05B9     ; no, skip ahead
+FExitPathOpen       lda       ,y+       ; path open?
+                    beq       FExitTarget2 ; no, skip ahead
                     clr       -1,y      ; clear the path block #
                     pshs      b         ; preserve count
                     os9       I$Close   ; close the path
                     puls      b         ; restore count
-L05B9               decb                ; done?
-                    bne       L05AC     ; no, continue looking
+FExitTarget2        decb                ; done?
+                    bne       FExitPathOpen ; no, continue looking
 
 * Clean up memory process had
                     clra                ; get starting block
                     ldb       P$PagCnt,x ; get page count
-                    beq       L05CB     ; none there, skip ahead
+                    beq       FExitDproc ; none there, skip ahead
                     addb      #$1F      ; round it up
                     lsrb                ; divide by 32 to get block count
                     lsrb                ; shift or rotate and update condition codes
@@ -171,7 +171,7 @@ L05B9               decb                ; done?
                     lsrb                ; shift or rotate and update condition codes
                     os9       F$DelImg  ; delete the ram & DAT image
 * Unlink the module
-L05CB               ldd       <D.Proc   ; load D from <D.Proc
+FExitDproc          ldd       <D.Proc   ; load D from <D.Proc
                     pshs      d         ; save d on the stack
                     stx       <D.Proc   ; set bad proc
                     ldu       P$PModul,x ; program pointer

--- a/level1/modules/kernel/ffind64.asm
+++ b/level1/modules/kernel/ffind64.asm
@@ -14,25 +14,25 @@
 ;;; F$Find64 locates a 64 byte block, such as a path or process descriptor, when
 ;;; given their block number. The block number can be any positive integer.
 
-FFind64        lda       R$A,u               get the caller's block number
-               ldx       R$X,u               and the base address of the page table
-               bsr       FindBlock           perform the location
-               bcs       ex@                 branch if error
-               sty       R$Y,u               save found block to caller's Y
-ex@            rts                           return to caller
+FFind64             lda       R$A,u     ; get the caller's block number
+                    ldx       R$X,u     ; and the base address of the page table
+                    bsr       FindBlock ; perform the location
+                    bcs       ex@       ; branch if error
+                    sty       R$Y,u     ; save found block to caller's Y
+ex@                 rts                 ; return to caller
 
-FindBlock      pshs      b,a                 save off D
-               tsta                          is the block greater than zero?
-               beq       errex@              no; illegal block
-               clrb                          else clear B
-               lsra                          divide D
-               rorb                          by 2 
-               lsra                          then divide D
-               rorb                          by 2 again, now D = D / 4
-               lda       a,x                 move upper 8 bits of 16 bit address from page into A
-               tfr       d,y                 D is now address of 64 byte block; move into Y
-               beq       errex@              branch if Y is zero; error
-               tst       ,y                  is first byte at block zero?
-               bne       ex@                 branch if not; Y is our address!
-errex@         coma                          set carry to indicate error
-ex@            puls      pc,b,a              restore registers and return
+FindBlock           pshs      b,a       ; save off D
+                    tsta                ; is the block greater than zero?
+                    beq       errex@    ; no; illegal block
+                    clrb                ; else clear B
+                    lsra                ; divide D
+                    rorb                ; by 2
+                    lsra                ; then divide D
+                    rorb                ; by 2 again, now D = D / 4
+                    lda       a,x       ; move upper 8 bits of 16 bit address from page into A
+                    tfr       d,y       ; D is now address of 64 byte block; move into Y
+                    beq       errex@    ; branch if Y is zero; error
+                    tst       ,y        ; is first byte at block zero?
+                    bne       ex@       ; branch if not; Y is our address!
+errex@              coma                ; set carry to indicate error
+ex@                 puls      pc,b,a    ; restore registers and return

--- a/level1/modules/kernel/ffork.asm
+++ b/level1/modules/kernel/ffork.asm
@@ -81,199 +81,199 @@
 ;;;
 ;;; Don't call F$Fork with a memory size of zero.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FFork          ldx       <D.PrcDBT           get the pointer to the process descriptor table
-               os9       F$All64             allocate a 64 byte page of RAM
-               bcs       errex@              branch if error
-               ldx       <D.Proc             get the parent (current) process descriptor
-               pshs      x                   save it on the stack
-               ldd       P$User,x            get the user ID of the parent process
-               std       P$User,y            save it in the child process descriptor
-               lda       P$Prior,x           get the priority of the parent process
-               clrb                          B = 0
-               std       P$Prior,y           store it in the child process descriptor
-               ldb       #SysState           get system state flag into B
-               stb       P$State,y           set the System State flag in the child process descriptor
-               sty       <D.Proc             make the child process the current process
+FFork               ldx       <D.PrcDBT ; get the pointer to the process descriptor table
+                    os9       F$All64   ; allocate a 64 byte page of RAM
+                    bcs       errex@    ; branch if error
+                    ldx       <D.Proc   ; get the parent (current) process descriptor
+                    pshs      x         ; save it on the stack
+                    ldd       P$User,x  ; get the user ID of the parent process
+                    std       P$User,y  ; save it in the child process descriptor
+                    lda       P$Prior,x ; get the priority of the parent process
+                    clrb                ; B = 0
+                    std       P$Prior,y ; store it in the child process descriptor
+                    ldb       #SysState ; get system state flag into B
+                    stb       P$State,y ; set the System State flag in the child process descriptor
+                    sty       <D.Proc   ; make the child process the current process
 **** I/O related process descriptor setup
-               ldd       <P$NIO,x            get the parent process' Net I/O pointer
-               std       <P$NIO,y            save it in the child process descriptor
-               ldd       <P$NIO+2,x          copy next two bytes
-               std       <P$NIO+2,y          over to child process descriptor
-               leax      <P$DIO,x            point X to the the parent process' Disk I/O section
-               leay      <P$DIO,y            point Y to the child process' Disk I/O section
-               ldb       #DefIOSiz           get the size of the section
-loop@          lda       ,x+                 get byte at x and increment
-               sta       ,y+                 save byte at y and increment
-               decb                          decrement loop counter
-               bne       loop@               branch if not done
+                    ldd       <P$NIO,x  ; get the parent process' Net I/O pointer
+                    std       <P$NIO,y  ; save it in the child process descriptor
+                    ldd       <P$NIO+2,x ; copy next two bytes
+                    std       <P$NIO+2,y ; over to child process descriptor
+                    leax      <P$DIO,x  ; point X to the the parent process' Disk I/O section
+                    leay      <P$DIO,y  ; point Y to the child process' Disk I/O section
+                    ldb       #DefIOSiz ; get the size of the section
+loop@               lda       ,x+       ; get byte at x and increment
+                    sta       ,y+       ; save byte at y and increment
+                    decb                ; decrement loop counter
+                    bne       loop@     ; branch if not done
 * It so happens that X and Y are now pointing to P$PATH in the process descriptor, so
 * there's no need to load them explicitly.
 * Duplicate stdin/stdout/stderr.
-               ldb       #$03                copy first three paths from parent to child
-duploop@       lda       ,x+                 get next available path in parent process descriptor
-               pshs      b                   save the count (fixes a bug where I$Dup will continue forever if IOMan is not installed)
-               os9       I$Dup               duplicate it
-               bcc       dupok@              branch if ok
-               clra                          else if error, just make it zero
-dupok@         sta       ,y+                 store it in the child process descriptor
-               puls      b                   restore the count
-               decb                          decrement the counter
-               bne       duploop@            and branch back if not done
+                    ldb       #$03      ; copy first three paths from parent to child
+duploop@            lda       ,x+       ; get next available path in parent process descriptor
+                    pshs      b         ; save the count (fixes a bug where I$Dup will continue forever if IOMan is not installed)
+                    os9       I$Dup     ; duplicate it
+                    bcc       dupok@    ; branch if ok
+                    clra                ; else if error, just make it zero
+dupok@              sta       ,y+       ; store it in the child process descriptor
+                    puls      b         ; restore the count
+                    decb                ; decrement the counter
+                    bne       duploop@  ; and branch back if not done
 **** I/O related process descriptor setup
-               bsr       SetupPrc            set up process
-               bcs       ex@                 branch if an error occured
-               puls      y                   get the parent process descriptor
-               sty       <D.Proc             and make it the current process
-               lda       P$ID,x              get the process ID of child process descriptor
-               sta       R$A,u               store it in caller's A
-               ldb       P$CID,y             get child ID of parent process descriptor
-               sta       P$CID,y             store child process ID in parent's child process ID
-               lda       P$ID,y              get process ID of parent process
-               std       P$PID,x             store it in child's process descriptor
-               ldb       P$State,x           update state of the child process descriptor
-               andb      #^SysState          turn off system state
-               stb       P$State,x           save back to process descriptor
-               os9       F$AProc             insert the child process into active queue
-               rts                           return to the caller
-ex@            pshs      b                   save off B to stack
-               os9       F$Exit              and exit
-               comb                          set carry
-               puls      x,b                 restore X and B
-               stx       <D.Proc             save X to process descriptor
-               rts                           return
-errex@         comb                          set carry
-               ldb       #E$PrcFul           error is process table is full
-               rts                           and return
+                    bsr       SetupPrc  ; set up process
+                    bcs       ex@       ; branch if an error occured
+                    puls      y         ; get the parent process descriptor
+                    sty       <D.Proc   ; and make it the current process
+                    lda       P$ID,x    ; get the process ID of child process descriptor
+                    sta       R$A,u     ; store it in caller's A
+                    ldb       P$CID,y   ; get child ID of parent process descriptor
+                    sta       P$CID,y   ; store child process ID in parent's child process ID
+                    lda       P$ID,y    ; get process ID of parent process
+                    std       P$PID,x   ; store it in child's process descriptor
+                    ldb       P$State,x ; update state of the child process descriptor
+                    andb      #^SysState ; turn off system state
+                    stb       P$State,x ; save back to process descriptor
+                    os9       F$AProc   ; insert the child process into active queue
+                    rts                 ; return to the caller
+ex@                 pshs      b         ; save off B to stack
+                    os9       F$Exit    ; and exit
+                    comb                ; set carry
+                    puls      x,b       ; restore X and B
+                    stx       <D.Proc   ; save X to process descriptor
+                    rts                 ; return
+errex@              comb                ; set carry
+                    ldb       #E$PrcFul ; error is process table is full
+                    rts                 ; and return
 
-               else
+                  ELSE
 
-FFork          pshs      u                   preserve register stack pointer
-               lbsr      AllPrc              setup a new process descriptor
-               bcc       GotNPrc             went ok, keep going
-               puls      u,pc                restore & return with error
+FFork               pshs      u         ; preserve register stack pointer
+                    lbsr      AllPrc    ; setup a new process descriptor
+                    bcc       GotNPrc   ; went ok, keep going
+                    puls      u,pc      ; restore & return with error
 
 * Copy user # & priority
-GotNPrc        pshs      u                   save pointer to new descriptor
-               ldx       <D.Proc             get current process pointer
-               ifne      H6309
-               ldq       P$User,x            Get user # & priority from forking process
-               std       P$User,u            Save user # in new process
-               ste       P$Prior,u           Save priority in new process
-               else
-               ldd       P$User,x
-               std       P$User,u
-               lda       P$Prior,x
-               sta       P$Prior,u
-               endc
+GotNPrc             pshs      u         ; save pointer to new descriptor
+                    ldx       <D.Proc   ; get current process pointer
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       P$User,x  Get user # & priority from forking process
+                    std       P$User,u  ; save user # in new process
+                    ste       P$Prior,u Save priority in new process
+                  ELSE
+                    ldd       P$User,x  ; load D from P$User,x
+                    std       P$User,u  ; store D at P$User,u
+                    lda       P$Prior,x ; load A from P$Prior,x
+                    sta       P$Prior,u ; store A at P$Prior,u
+                  ENDC
 * Copy network I/O pointers to new descriptor
-               ifeq      Network-1
-               pshs      x,u
-               leax      >P$NIO,x            point to current NIO pointers
-               leau      >P$NIO,u            point to buffer for new ones
-               ifne      H6309
-               ldw       #NefIOSiz           get size
-               tfm       x+,u+               move 'em
-               else
-               ldb       #NefIOSiz
-L0250          lda       ,x+
-               sta       ,u+
-               decb
-               bne       L0250
-               endc
-               puls      x,u                 restore pointers to descriptors
-               endc
+                  IFEQ    Network-1 ; begin conditional assembly for Network-1
+                    pshs      x,u       ; save x,u on the stack
+                    leax      >P$NIO,x  ; point to current NIO pointers
+                    leau      >P$NIO,u  ; point to buffer for new ones
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #NefIOSiz get size
+                    tfm       x+,u+     move 'em
+                  ELSE
+                    ldb       #NefIOSiz ; load B from #NefIOSiz
+L0250               lda       ,x+       ; load A from ,x+
+                    sta       ,u+       ; store A at ,u+
+                    decb                ; decrement B
+                    bne       L0250     ; branch if zero is clear to L0250
+                  ENDC
+                    puls      x,u       ; restore pointers to descriptors
+                  ENDC
 * Copy CWD and CXD info (Device Entry pointers and directory PSN) to new descriptor
-               leax      P$DIO,x
-               leau      P$DIO,u
-               ifne      H6309
-               ldw       #DefIOSiz           six bytes for CWD, six bytes for CXD
-               tfm       x+,u+
-               lde       #3                  next, child inherits first 3 I/O paths
-               else
-               ldb       #DefIOSiz           six bytes for CWD, six bytes for CXD
-L0261          lda       ,x+
-               sta       ,u+
-               decb
-               bne       L0261
-               ldy       #3                  next, child inherits first 3 I/O paths
-               endc
+                    leax      P$DIO,x   ; compute P$DIO,x into X
+                    leau      P$DIO,u   ; compute P$DIO,u into U
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #DefIOSiz six bytes for CWD, six bytes for CXD
+                    tfm       x+,u+
+                    lde       #3        next, child inherits first 3 I/O paths
+                  ELSE
+                    ldb       #DefIOSiz ; six bytes for CWD, six bytes for CXD
+L0261               lda       ,x+       ; load A from ,x+
+                    sta       ,u+       ; store A at ,u+
+                    decb                ; decrement B
+                    bne       L0261     ; branch if zero is clear to L0261
+                    ldy       #3        ; next, child inherits first 3 I/O paths
+                  ENDC
 
 * Duplicate first 3 I/O paths from parent to child
-GetOPth        lda       ,x+                 get a path #
-               beq       SveNPth             don't exist, go on
-               os9       I$Dup               dupe it
-               bcc       SveNPth             no error, go on
-               clra                          clear it
+GetOPth             lda       ,x+       ; get a path #
+                    beq       SveNPth   ; don't exist, go on
+                    os9       I$Dup     ; dupe it
+                    bcc       SveNPth   ; no error, go on
+                    clra                ; clear it
 
 * As std in/out/err
-SveNPth        sta       ,u+                 save new path #
-               ifne      H6309
-               dece                          count down from 3.  done?
-               else
-               leay      -1,y                count down from 3.  done?
-               endc
-               bne       GetOPth             no, keep going
+SveNPth             sta       ,u+       ; save new path #
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    dece                ; count down from 3.  done?
+                  ELSE
+                    leay      -1,y      ; count down from 3.  done?
+                  ENDC
+                    bne       GetOPth   ; no, keep going
 * Link to new module & setup task map
-               ldx       ,s                  get pointer to new descriptor
-               ldu       2,s                 get pointer to register stack
-               lbsr      L04B1               link to module & setup register stack
-               bcs       L02CF               exit if error
-               pshs      d
-               os9       F$AllTsk            allocate the task & setup MMU
-               bcs       L02CF               Error, skip ahead
+                    ldx       ,s        ; get pointer to new descriptor
+                    ldu       2,s       ; get pointer to register stack
+                    lbsr      L04B1     ; link to module & setup register stack
+                    bcs       L02CF     ; exit if error
+                    pshs      d         ; save d on the stack
+                    os9       F$AllTsk  ; allocate the task & setup MMU
+                    bcs       L02CF     ; error, skip ahead
 
 * Copy parameters to new process
-               lda       P$PagCnt,x          get memory page count
-               clrb
-               subd      ,s                  calculate destination
-               tfr       d,u                 set parameter destination pointer
-               ldb       P$Task,x            get source task #
-               ldx       <D.Proc             get destination task #
-               lda       P$Task,x
-               leax      ,y                  point to parameters
-               puls      y                   restore parameter count
-               os9       F$Move              move parameters to new process
+                    lda       P$PagCnt,x ; get memory page count
+                    clrb                ; clear B
+                    subd      ,s        ; calculate destination
+                    tfr       d,u       ; set parameter destination pointer
+                    ldb       P$Task,x  ; get source task #
+                    ldx       <D.Proc   ; get destination task #
+                    lda       P$Task,x  ; load A from P$Task,x
+                    leax      ,y        ; point to parameters
+                    puls      y         ; restore parameter count
+                    os9       F$Move    ; move parameters to new process
 
 * Setup the new stack
-               ldx       ,s                  get pointer to process descriptor
-               lda       <D.SysTsk           get task #
-               ldu       P$SP,x              get new stack pointer
-               leax      >(P$Stack-R$Size),x point to register stack
-               ldy       #R$Size             get size of register stack
-               os9       F$Move              move the register stack over
-               puls      u,x
-               os9       F$DelTsk
-               ldy       <D.Proc
-               lda       P$ID,x
-               sta       R$A,u
-               ldb       P$CID,y
-               sta       P$CID,y
-               lda       P$ID,y
-               std       P$PID,x
-               ifne      H6309
-               aim       #^SysState,P$State,x switch to non-system state
-               else
-               lda       P$State,x
-               anda      #^SysState
-               sta       P$State,x
-               endc
+                    ldx       ,s        ; get pointer to process descriptor
+                    lda       <D.SysTsk ; get task #
+                    ldu       P$SP,x    ; get new stack pointer
+                    leax      >(P$Stack-R$Size),x ; point to register stack
+                    ldy       #R$Size   ; get size of register stack
+                    os9       F$Move    ; move the register stack over
+                    puls      u,x       ; restore u,x from the stack
+                    os9       F$DelTsk  ; call OS-9 service F$DelTsk
+                    ldy       <D.Proc   ; load Y from <D.Proc
+                    lda       P$ID,x    ; load A from P$ID,x
+                    sta       R$A,u     ; store A at R$A,u
+                    ldb       P$CID,y   ; load B from P$CID,y
+                    sta       P$CID,y   ; store A at P$CID,y
+                    lda       P$ID,y    ; load A from P$ID,y
+                    std       P$PID,x   ; store D at P$PID,x
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^SysState,P$State,x switch to non-system state
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    anda      #^SysState ; mask A with #^SysState
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
 * Put date & time of creation into descriptor
 *         pshs   x          preserve process pointer
 *         leax   P$DatBeg,x point to time buffer
 *         os9    F$Time     put date/time into it
 *         puls   x          restore pointer
-               os9       F$AProc             and start the process
-               rts                           return
+                    os9       F$AProc   ; and start the process
+                    rts                 ; return
 
 * Fork error goes here
-L02CF          puls      x
-               pshs      b                   save error
-               lbsr      L05A5               close paths & unlink mem
-               lda       P$ID,x              get bad ID
-               lbsr      L0386               delete proc desc & task #
-               comb                          set carry
-               puls      pc,u,b              pull error code & u & return
+L02CF               puls      x         ; restore x from the stack
+                    pshs      b         ; save error
+                    lbsr      L05A5     ; close paths & unlink mem
+                    lda       P$ID,x    ; get bad ID
+                    lbsr      L0386     ; delete proc desc & task #
+                    comb                ; set carry
+                    puls      pc,u,b    ; pull error code & u & return
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/ffork.asm
+++ b/level1/modules/kernel/ffork.asm
@@ -177,10 +177,10 @@ GotNPrc             pshs      u         ; save pointer to new descriptor
                     tfm       x+,u+     move 'em
                   ELSE
                     ldb       #NefIOSiz ; load B from #NefIOSiz
-L0250               lda       ,x+       ; load A from ,x+
+FForkTarget         lda       ,x+       ; load A from ,x+
                     sta       ,u+       ; store A at ,u+
                     decb                ; decrement B
-                    bne       L0250     ; branch if zero is clear to L0250
+                    bne       FForkTarget ; branch if zero is clear to FForkTarget
                   ENDC
                     puls      x,u       ; restore pointers to descriptors
                   ENDC
@@ -193,10 +193,10 @@ L0250               lda       ,x+       ; load A from ,x+
                     lde       #3        next, child inherits first 3 I/O paths
                   ELSE
                     ldb       #DefIOSiz ; six bytes for CWD, six bytes for CXD
-L0261               lda       ,x+       ; load A from ,x+
+FForkTarget2        lda       ,x+       ; load A from ,x+
                     sta       ,u+       ; store A at ,u+
                     decb                ; decrement B
-                    bne       L0261     ; branch if zero is clear to L0261
+                    bne       FForkTarget2 ; branch if zero is clear to FForkTarget2
                     ldy       #3        ; next, child inherits first 3 I/O paths
                   ENDC
 
@@ -218,11 +218,11 @@ SveNPth             sta       ,u+       ; save new path #
 * Link to new module & setup task map
                     ldx       ,s        ; get pointer to new descriptor
                     ldu       2,s       ; get pointer to register stack
-                    lbsr      L04B1     ; link to module & setup register stack
-                    bcs       L02CF     ; exit if error
+                    lbsr      FChainEverything ; link to module & setup register stack
+                    bcs       FForkTarget3 ; exit if error
                     pshs      d         ; save d on the stack
                     os9       F$AllTsk  ; allocate the task & setup MMU
-                    bcs       L02CF     ; error, skip ahead
+                    bcs       FForkTarget3 ; error, skip ahead
 
 * Copy parameters to new process
                     lda       P$PagCnt,x ; get memory page count
@@ -268,11 +268,11 @@ SveNPth             sta       ,u+       ; save new path #
                     rts                 ; return
 
 * Fork error goes here
-L02CF               puls      x         ; restore x from the stack
+FForkTarget3        puls      x         ; restore x from the stack
                     pshs      b         ; save error
-                    lbsr      L05A5     ; close paths & unlink mem
+                    lbsr      FExitTarget ; close paths & unlink mem
                     lda       P$ID,x    ; get bad ID
-                    lbsr      L0386     ; delete proc desc & task #
+                    lbsr      FAllprcTarget2 ; delete proc desc & task #
                     comb                ; set carry
                     puls      pc,u,b    ; pull error code & u & return
 

--- a/level1/modules/kernel/ficpt.asm
+++ b/level1/modules/kernel/ficpt.asm
@@ -18,15 +18,15 @@
 ;;;
 ;;; Note: The value of DP cannot be the same as it was when you called F$Icpt.
 
-FIcpt          ldx       <D.Proc             get the current process descriptor
-               ldd       R$X,u               get the address of the intercept routine from the caller
-               ifne      H6309
-               ldw       R$U,u               get the data area pointer for the intercept routine
-               stq       P$SigVec,x          save them in the process descriptor
-               else
-               std       <P$SigVec,x         store it in the process descriptor
-               ldd       R$U,u               get the caller's data pointer
-               std       <P$SigDat,x         store it in the process descriptor
-               endc
-               clrb                          clear carry
-               rts                           return to the caller
+FIcpt               ldx       <D.Proc   ; get the current process descriptor
+                    ldd       R$X,u     ; get the address of the intercept routine from the caller
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       R$U,u     get the data area pointer for the intercept routine
+                    stq       P$SigVec,x save them in the process descriptor
+                  ELSE
+                    std       <P$SigVec,x ; store it in the process descriptor
+                    ldd       R$U,u     ; get the caller's data pointer
+                    std       <P$SigDat,x ; store it in the process descriptor
+                  ENDC
+                    clrb                ; clear carry
+                    rts                 ; return to the caller

--- a/level1/modules/kernel/fid.asm
+++ b/level1/modules/kernel/fid.asm
@@ -11,11 +11,11 @@
 ;;; The process ID is a byte value in the range 1 to 255. The kernel assigns each process a unique process ID.
 ;;; The user ID is an integer from 0 to 65535. Several processes can have the same user ID.
 
-FID            ldx       <D.Proc             get the current process descriptor
-               lda       P$ID,x              get the process ID
-               sta       R$A,u               put in in the caller's A
-               ldd       P$User,x            get the user ID
-               std       R$Y,u               put it in the caller's Y
-               clrb                          clear carry
-               rts                           return to the caller
+FID                 ldx       <D.Proc   ; get the current process descriptor
+                    lda       P$ID,x    ; get the process ID
+                    sta       R$A,u     ; put in in the caller's A
+                    ldd       P$User,x  ; get the user ID
+                    std       R$Y,u     ; put it in the caller's Y
+                    clrb                ; clear carry
+                    rts                 ; return to the caller
 

--- a/level1/modules/kernel/flink.asm
+++ b/level1/modules/kernel/flink.asm
@@ -147,15 +147,15 @@ FLinkModule         ldd       MD$MPtr,x ; get module pointer
                     pshs      a         ; save a on the stack
                     leau      ,y        ; point to module DAT image
                     bsr       FLinkProcess ; is it already linked in process space?
-                    bcc       FLinkMemoryBlockLinkCounts ; yes, skip ahead
+                    bcc       FLinkMemBlkLink ; yes, skip ahead
                     lda       ,s        ; load A from ,s
                     lbsr      FFreehbInvertWithin ; find free low block in process DAT image
-                    bcc       FLinkMemoryBlocksProcessDATImage ; found some, skip ahead
+                    bcc       FLinkMemBlksProc ; found some, skip ahead
                     leas      5,s       ; purge stack
                     bra       LinkErr   ; return error
 
-FLinkMemoryBlocksProcessDATImage lbsr      FFreehbTheseOnto ; copy memory blocks into process DAT image
-FLinkMemoryBlockLinkCounts ldb       #P$Links  ; point to memory block link counts
+FLinkMemBlksProc    lbsr      FFreehbTheseOnto ; copy memory blocks into process DAT image
+FLinkMemBlkLink     ldb       #P$Links  ; point to memory block link counts
                     abx                 ; smaller and faster than leax P$Links,x
                     sta       ,s        ; save block # on stack
                     lsla                ; account for 2 bytes/entry

--- a/level1/modules/kernel/flink.asm
+++ b/level1/modules/kernel/flink.asm
@@ -22,36 +22,36 @@
 ;;; F$Link searches the module directory for a module that has the specified name, language, and type.
 ;;; If it finds the module, it returns the address of the module’s header in U, and the absolute address of the
 ;;; module’s execution entry point in Y. If F$Link can't find the desired module, it returns E$MNF.
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FLink          pshs      u                   save caller regs
-               ldd       R$A,u               get desired type/language byte
-               ldx       R$X,u               get pointer to desired module name to link to
-               lbsr      FindModule          go find the module
-               bcc       ok@                 branch if found
-               ldb       #E$MNF              ...else Module Not Found error
-               bra       ex@                 and return to caller
-ok@            ldy       MD$MPtr,u           get module directory ptr
-               ldb       M$Revs,y            get revision byte
-               bitb      #ReEnt              reentrant?
-               bne       inc@                branch if so
-               tst       MD$Link,u           link count zero?
-               beq       inc@                yep, ok to link to non-reentrant
-               comb                          ...else set carry
-               ldb       #E$ModBsy           load B with Module Busy
-               bra       ex@                 and return to caller
-inc@           inc       MD$Link,u           increment link count
-               ldu       ,s                  get caller register pointer from stack
-               stx       R$X,u               save off updated name pointer
-               sty       R$U,u               save off address of found module
-               ldd       M$Type,y            get type/language byte from found module
-               std       R$D,u               and place it in caller's D register
-               ldd       M$IDSize,y          get the module ID size in D
-               leax      d,y                 advance X to the start of the body of the module
-               stx       R$Y,u               store X in caller's Y register
-ex@            puls      pc,u                return to caller
+FLink               pshs      u         ; save caller regs
+                    ldd       R$A,u     ; get desired type/language byte
+                    ldx       R$X,u     ; get pointer to desired module name to link to
+                    lbsr      FindModule ; go find the module
+                    bcc       ok@       ; branch if found
+                    ldb       #E$MNF    ; ...else Module Not Found error
+                    bra       ex@       ; and return to caller
+ok@                 ldy       MD$MPtr,u ; get module directory ptr
+                    ldb       M$Revs,y  ; get revision byte
+                    bitb      #ReEnt    ; reentrant?
+                    bne       inc@      ; branch if so
+                    tst       MD$Link,u ; link count zero?
+                    beq       inc@      ; yep, ok to link to non-reentrant
+                    comb                ; ...else set carry
+                    ldb       #E$ModBsy ; load B with Module Busy
+                    bra       ex@       ; and return to caller
+inc@                inc       MD$Link,u ; increment link count
+                    ldu       ,s        ; get caller register pointer from stack
+                    stx       R$X,u     ; save off updated name pointer
+                    sty       R$U,u     ; save off address of found module
+                    ldd       M$Type,y  ; get type/language byte from found module
+                    std       R$D,u     ; and place it in caller's D register
+                    ldd       M$IDSize,y ; get the module ID size in D
+                    leax      d,y       ; advance X to the start of the body of the module
+                    stx       R$Y,u     ; store X in caller's Y register
+ex@                 puls      pc,u      ; return to caller
 
-               else
+                  ELSE
 
 ;;; F$SLink
 ;;;
@@ -72,8 +72,8 @@ ex@            puls      pc,u                return to caller
 ;;;        CC = Carry flag set to indicate error.
 ;;;
 
-FSLink         ldy       R$Y,u               get DAT image pointer of name
-               bra       L0398               skip ahead
+FSLink              ldy       R$Y,u     ; get DAT image pointer of name
+                    bra       L0398     ; skip ahead
 
 ;;; F$ELink
 ;;;
@@ -86,10 +86,10 @@ FSLink         ldy       R$Y,u               get DAT image pointer of name
 ;;;        CC = Carry flag set to indicate error.
 ;;;
 
-FELink         pshs      u                   preserve register stack pointer
-               ldb       R$B,u               get module type
-               ldx       R$X,u               get pointer to module directory entry
-               bra       L03AF               skip ahead
+FELink              pshs      u         ; preserve register stack pointer
+                    ldb       R$B,u     ; get module type
+                    ldx       R$X,u     ; get pointer to module directory entry
+                    bra       L03AF     ; skip ahead
 
 **************************************************
 * System Call: F$Link
@@ -107,125 +107,125 @@ FELink         pshs      u                   preserve register stack pointer
 *
 * Error:  CC = C bit set; B = error code
 *
-FLink          equ       *
-               ldx       <D.Proc             get pointer to DAT image
-               leay      P$DATImg,x          point to process DAT image
-L0398          pshs      u                   preserve register stack pointer
-               ldx       R$X,u               get pointer to path name
-               lda       R$A,u               get module type
-               lbsr      L068D               search module directory
-               bcs       LinkErr             not there, exit with error
-               leay      ,u                  point to module directory entry
-               ldu       ,s                  get register stack pointer
-               stx       R$X,u               save updated module name pointer
-               std       R$D,u               save type/language
-               leax      ,y                  point to directory entry
-L03AF          bitb      #ReEnt              is it re-entrant?
-               bne       L03BB               yes, skip ahead
-               ldd       MD$Link,x           is module busy?
-               beq       L03BB               no, go link it
-               ldb       #E$ModBsy           return module busy error
-               bra       LinkErr             return
-L03BB          ldd       MD$MPtr,x           get module pointer
-               pshs      d,x                 preserve that & directory pointer
-               ldy       MD$MPDAT,x          get module DAT image pointer
-               ldd       MD$MBSiz,x          get block size
-               addd      #$1FFF              round it up
-               tfr       a,b
-               lsrb
-               lsrb
-               lsrb
-               lsrb
-               lsrb
+FLink               equ       *         ; define assembler symbol
+                    ldx       <D.Proc   ; get pointer to DAT image
+                    leay      P$DATImg,x ; point to process DAT image
+L0398               pshs      u         ; preserve register stack pointer
+                    ldx       R$X,u     ; get pointer to path name
+                    lda       R$A,u     ; get module type
+                    lbsr      L068D     ; search module directory
+                    bcs       LinkErr   ; not there, exit with error
+                    leay      ,u        ; point to module directory entry
+                    ldu       ,s        ; get register stack pointer
+                    stx       R$X,u     ; save updated module name pointer
+                    std       R$D,u     ; save type/language
+                    leax      ,y        ; point to directory entry
+L03AF               bitb      #ReEnt    ; is it re-entrant?
+                    bne       L03BB     ; yes, skip ahead
+                    ldd       MD$Link,x ; is module busy?
+                    beq       L03BB     ; no, go link it
+                    ldb       #E$ModBsy ; return module busy error
+                    bra       LinkErr   ; return
+L03BB               ldd       MD$MPtr,x ; get module pointer
+                    pshs      d,x       ; preserve that & directory pointer
+                    ldy       MD$MPDAT,x ; get module DAT image pointer
+                    ldd       MD$MBSiz,x ; get block size
+                    addd      #$1FFF    ; round it up
+                    tfr       a,b       ; transfer register value a,b
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
 *         adda   #$02
-               lsra
-               inca                          instead of adda #2, above
-               lsra
-               lsra
-               lsra
-               lsra
-               pshs      a
-               leau      ,y                  point to module DAT image
-               bsr       L0422               is it already linked in process space?
-               bcc       L03EB               yes, skip ahead
-               lda       ,s
-               lbsr      L0A33               find free low block in process DAT image
-               bcc       L03E8               found some, skip ahead
-               leas      5,s                 purge stack
-               bra       LinkErr             return error
+                    lsra                ; shift or rotate and update condition codes
+                    inca                ; instead of adda #2, above
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    pshs      a         ; save a on the stack
+                    leau      ,y        ; point to module DAT image
+                    bsr       L0422     ; is it already linked in process space?
+                    bcc       L03EB     ; yes, skip ahead
+                    lda       ,s        ; load A from ,s
+                    lbsr      L0A33     ; find free low block in process DAT image
+                    bcc       L03E8     ; found some, skip ahead
+                    leas      5,s       ; purge stack
+                    bra       LinkErr   ; return error
 
-L03E8          lbsr      L0A8C               copy memory blocks into process DAT image
-L03EB          ldb       #P$Links            point to memory block link counts
-               abx                           smaller and faster than leax P$Links,x
-               sta       ,s                  save block # on stack
-               lsla                          account for 2 bytes/entry
-               leau      a,x                 point to block # we want
-               ldd       ,u                  get link count for that block
-               ifne      H6309
-               incd                          bump up by 1
-               else
-               addd      #$0001
-               endc
-               beq       L03FC               If wraps to 0, leave at $FFFF
-               std       ,u                  Otherwise, store new link count
-L03FC          ldu       $03,s
-               ldd       MD$Link,u
-               ifne      H6309
-               incd
-               else
-               addd      #$0001
-               endc
-               beq       L0406
-               std       MD$Link,u
-L0406          puls      b,x,y,u
-               lbsr      CmpLBlk
-               stx       R$U,u
-               ldx       MD$MPtr,y
-               ldy       ,y
-               ldd       #M$Exec             get offset to execution address
-               lbsr      L0B02               get execution offset
-               addd      R$U,u               add it to start of module
-               std       R$Y,u               set execution entry point
-               clrb                          No error & return
-               rts
+L03E8               lbsr      L0A8C     ; copy memory blocks into process DAT image
+L03EB               ldb       #P$Links  ; point to memory block link counts
+                    abx                 ; smaller and faster than leax P$Links,x
+                    sta       ,s        ; save block # on stack
+                    lsla                ; account for 2 bytes/entry
+                    leau      a,x       ; point to block # we want
+                    ldd       ,u        ; get link count for that block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    incd                ; bump up by 1
+                  ELSE
+                    addd      #$0001    ; add #$0001 to D
+                  ENDC
+                    beq       L03FC     ; if wraps to 0, leave at $FFFF
+                    std       ,u        ; otherwise, store new link count
+L03FC               ldu       $03,s     ; load U from $03,s
+                    ldd       MD$Link,u ; load D from MD$Link,u
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    incd                ; update processor state
+                  ELSE
+                    addd      #$0001    ; add #$0001 to D
+                  ENDC
+                    beq       L0406     ; branch if zero is set to L0406
+                    std       MD$Link,u ; store D at MD$Link,u
+L0406               puls      b,x,y,u   ; restore b,x,y,u from the stack
+                    lbsr      CmpLBlk   ; call local routine CmpLBlk
+                    stx       R$U,u     ; store X at R$U,u
+                    ldx       MD$MPtr,y ; load X from MD$MPtr,y
+                    ldy       ,y        ; load Y from ,y
+                    ldd       #M$Exec   ; get offset to execution address
+                    lbsr      L0B02     ; get execution offset
+                    addd      R$U,u     ; add it to start of module
+                    std       R$Y,u     ; set execution entry point
+                    clrb                ; no error & return
+                    rts                 ; return to caller
 
-LinkErr        orcc      #Carry              Error & return
-               puls      u,pc
+LinkErr             orcc      #Carry    ; error & return
+                    puls      u,pc      ; restore u,pc from the stack
 
-L0422          ldx       <D.Proc             get pointer to current process
-               leay      P$DATImg,x          point to process DAT image
-               clra
-               pshs      d,x,y
-               subb      #DAT.BlCt
-               negb
-               lslb
-               leay      b,y
-               ifne      H6309
-L0430          ldw       ,s                  Get counter
-               else
-L0430          ldx       ,s
-               endc
-               pshs      u,y
-L0434          ldd       ,y++
-               cmpd      ,u++
-               bne       L0449
-               ifne      H6309
-               decw                          Dec counter
-               else
-               leax      -1,x
-               endc
-               bne       L0434               If not done, keep going
-               puls      d,u
-               subd      4,s
-               lsrb
-               stb       ,s
-               clrb
-               puls      d,x,y,pc            Restore regs & return
+L0422               ldx       <D.Proc   ; get pointer to current process
+                    leay      P$DATImg,x ; point to process DAT image
+                    clra                ; clear A
+                    pshs      d,x,y     ; save d,x,y on the stack
+                    subb      #DAT.BlCt ; subtract #DAT.BlCt from B
+                    negb                ; update processor state
+                    lslb                ; shift or rotate and update condition codes
+                    leay      b,y       ; compute b,y into Y
+                  IFNE    H6309   ; begin conditional assembly for H6309
+L0430               ldw       ,s        Get counter
+                  ELSE
+L0430               ldx       ,s        ; load X from ,s
+                  ENDC
+                    pshs      u,y       ; save u,y on the stack
+L0434               ldd       ,y++      ; load D from ,y++
+                    cmpd      ,u++      ; compare D with ,u++
+                    bne       L0449     ; branch if zero is clear to L0449
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; dec counter
+                  ELSE
+                    leax      -1,x      ; compute -1,x into X
+                  ENDC
+                    bne       L0434     ; if not done, keep going
+                    puls      d,u       ; restore d,u from the stack
+                    subd      4,s       ; subtract 4,s from D
+                    lsrb                ; shift or rotate and update condition codes
+                    stb       ,s        ; store B at ,s
+                    clrb                ; clear B
+                    puls      d,x,y,pc  ; restore regs & return
 
-L0449          puls      u,y
-               leay      -2,y
-               cmpy      4,s
-               bcc       L0430
-               puls      d,x,y,pc
+L0449               puls      u,y       ; restore u,y from the stack
+                    leay      -2,y      ; compute -2,y into Y
+                    cmpy      4,s       ; compare Y with 4,s
+                    bcc       L0430     ; branch if carry is clear to L0430
+                    puls      d,x,y,pc  ; restore d,x,y,pc from the stack
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/flink.asm
+++ b/level1/modules/kernel/flink.asm
@@ -73,7 +73,7 @@ ex@                 puls      pc,u      ; return to caller
 ;;;
 
 FSLink              ldy       R$Y,u     ; get DAT image pointer of name
-                    bra       L0398     ; skip ahead
+                    bra       FLinkTarget ; skip ahead
 
 ;;; F$ELink
 ;;;
@@ -89,7 +89,7 @@ FSLink              ldy       R$Y,u     ; get DAT image pointer of name
 FELink              pshs      u         ; preserve register stack pointer
                     ldb       R$B,u     ; get module type
                     ldx       R$X,u     ; get pointer to module directory entry
-                    bra       L03AF     ; skip ahead
+                    bra       FLinkReEntrant ; skip ahead
 
 **************************************************
 * System Call: F$Link
@@ -110,23 +110,23 @@ FELink              pshs      u         ; preserve register stack pointer
 FLink               equ       *         ; define assembler symbol
                     ldx       <D.Proc   ; get pointer to DAT image
                     leay      P$DATImg,x ; point to process DAT image
-L0398               pshs      u         ; preserve register stack pointer
+FLinkTarget         pshs      u         ; preserve register stack pointer
                     ldx       R$X,u     ; get pointer to path name
                     lda       R$A,u     ; get module type
-                    lbsr      L068D     ; search module directory
+                    lbsr      FFmodulJoin ; search module directory
                     bcs       LinkErr   ; not there, exit with error
                     leay      ,u        ; point to module directory entry
                     ldu       ,s        ; get register stack pointer
                     stx       R$X,u     ; save updated module name pointer
                     std       R$D,u     ; save type/language
                     leax      ,y        ; point to directory entry
-L03AF               bitb      #ReEnt    ; is it re-entrant?
-                    bne       L03BB     ; yes, skip ahead
+FLinkReEntrant      bitb      #ReEnt    ; is it re-entrant?
+                    bne       FLinkModule ; yes, skip ahead
                     ldd       MD$Link,x ; is module busy?
-                    beq       L03BB     ; no, go link it
+                    beq       FLinkModule ; no, go link it
                     ldb       #E$ModBsy ; return module busy error
                     bra       LinkErr   ; return
-L03BB               ldd       MD$MPtr,x ; get module pointer
+FLinkModule         ldd       MD$MPtr,x ; get module pointer
                     pshs      d,x       ; preserve that & directory pointer
                     ldy       MD$MPDAT,x ; get module DAT image pointer
                     ldd       MD$MBSiz,x ; get block size
@@ -146,16 +146,16 @@ L03BB               ldd       MD$MPtr,x ; get module pointer
                     lsra                ; shift or rotate and update condition codes
                     pshs      a         ; save a on the stack
                     leau      ,y        ; point to module DAT image
-                    bsr       L0422     ; is it already linked in process space?
-                    bcc       L03EB     ; yes, skip ahead
+                    bsr       FLinkProcess ; is it already linked in process space?
+                    bcc       FLinkMemoryBlockLinkCounts ; yes, skip ahead
                     lda       ,s        ; load A from ,s
-                    lbsr      L0A33     ; find free low block in process DAT image
-                    bcc       L03E8     ; found some, skip ahead
+                    lbsr      FFreehbInvertWithin ; find free low block in process DAT image
+                    bcc       FLinkMemoryBlocksProcessDATImage ; found some, skip ahead
                     leas      5,s       ; purge stack
                     bra       LinkErr   ; return error
 
-L03E8               lbsr      L0A8C     ; copy memory blocks into process DAT image
-L03EB               ldb       #P$Links  ; point to memory block link counts
+FLinkMemoryBlocksProcessDATImage lbsr      FFreehbTheseOnto ; copy memory blocks into process DAT image
+FLinkMemoryBlockLinkCounts ldb       #P$Links  ; point to memory block link counts
                     abx                 ; smaller and faster than leax P$Links,x
                     sta       ,s        ; save block # on stack
                     lsla                ; account for 2 bytes/entry
@@ -166,24 +166,24 @@ L03EB               ldb       #P$Links  ; point to memory block link counts
                   ELSE
                     addd      #$0001    ; add #$0001 to D
                   ENDC
-                    beq       L03FC     ; if wraps to 0, leave at $FFFF
+                    beq       FLinkTarget2 ; if wraps to 0, leave at $FFFF
                     std       ,u        ; otherwise, store new link count
-L03FC               ldu       $03,s     ; load U from $03,s
+FLinkTarget2        ldu       $03,s     ; load U from $03,s
                     ldd       MD$Link,u ; load D from MD$Link,u
                   IFNE    H6309   ; begin conditional assembly for H6309
                     incd                ; update processor state
                   ELSE
                     addd      #$0001    ; add #$0001 to D
                   ENDC
-                    beq       L0406     ; branch if zero is set to L0406
+                    beq       FLinkTarget3 ; branch if zero is set to FLinkTarget3
                     std       MD$Link,u ; store D at MD$Link,u
-L0406               puls      b,x,y,u   ; restore b,x,y,u from the stack
+FLinkTarget3        puls      b,x,y,u   ; restore b,x,y,u from the stack
                     lbsr      CmpLBlk   ; call local routine CmpLBlk
                     stx       R$U,u     ; store X at R$U,u
                     ldx       MD$MPtr,y ; load X from MD$MPtr,y
                     ldy       ,y        ; load Y from ,y
                     ldd       #M$Exec   ; get offset to execution address
-                    lbsr      L0B02     ; get execution offset
+                    lbsr      FLdTarget ; get execution offset
                     addd      R$U,u     ; add it to start of module
                     std       R$Y,u     ; set execution entry point
                     clrb                ; no error & return
@@ -192,7 +192,7 @@ L0406               puls      b,x,y,u   ; restore b,x,y,u from the stack
 LinkErr             orcc      #Carry    ; error & return
                     puls      u,pc      ; restore u,pc from the stack
 
-L0422               ldx       <D.Proc   ; get pointer to current process
+FLinkProcess        ldx       <D.Proc   ; get pointer to current process
                     leay      P$DATImg,x ; point to process DAT image
                     clra                ; clear A
                     pshs      d,x,y     ; save d,x,y on the stack
@@ -201,20 +201,20 @@ L0422               ldx       <D.Proc   ; get pointer to current process
                     lslb                ; shift or rotate and update condition codes
                     leay      b,y       ; compute b,y into Y
                   IFNE    H6309   ; begin conditional assembly for H6309
-L0430               ldw       ,s        Get counter
+FLinkTarget4        ldw       ,s        Get counter
                   ELSE
-L0430               ldx       ,s        ; load X from ,s
+FLinkTarget4        ldx       ,s        ; load X from ,s
                   ENDC
                     pshs      u,y       ; save u,y on the stack
-L0434               ldd       ,y++      ; load D from ,y++
+FLinkTarget5        ldd       ,y++      ; load D from ,y++
                     cmpd      ,u++      ; compare D with ,u++
-                    bne       L0449     ; branch if zero is clear to L0449
+                    bne       FLinkTarget6 ; branch if zero is clear to FLinkTarget6
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec counter
                   ELSE
                     leax      -1,x      ; compute -1,x into X
                   ENDC
-                    bne       L0434     ; if not done, keep going
+                    bne       FLinkTarget5 ; if not done, keep going
                     puls      d,u       ; restore d,u from the stack
                     subd      4,s       ; subtract 4,s from D
                     lsrb                ; shift or rotate and update condition codes
@@ -222,10 +222,10 @@ L0434               ldd       ,y++      ; load D from ,y++
                     clrb                ; clear B
                     puls      d,x,y,pc  ; restore regs & return
 
-L0449               puls      u,y       ; restore u,y from the stack
+FLinkTarget6        puls      u,y       ; restore u,y from the stack
                     leay      -2,y      ; compute -2,y into Y
                     cmpy      4,s       ; compare Y with 4,s
-                    bcc       L0430     ; branch if carry is clear to L0430
+                    bcc       FLinkTarget4 ; branch if carry is clear to FLinkTarget4
                     puls      d,x,y,pc  ; restore d,x,y,pc from the stack
 
                   ENDC

--- a/level1/modules/kernel/fmem.asm
+++ b/level1/modules/kernel/fmem.asm
@@ -24,7 +24,7 @@ FMem                ldx       <D.Proc   ; get the current process descriptor
                     bsr       RoundUpD  ; round up requested memory area
                     subb      P$PagCnt,x ; subtract the current page count from B
                     beq       returnsize@ ; branch if 0
-                    bcs       L0207     ; branch if less than 0
+                    bcs       FMemProcessorState ; branch if less than 0
                     tfr       d,y       ; else transfer requested memory area to Y
                     ldx       P$ADDR,x  ; get the process' base data address page and page count in X
                     pshs      u,y,x     ; save off registers
@@ -32,44 +32,44 @@ _stkPageAddr@       set       0         ; define assembler symbol
 _stkPageCnt@        set       1         ; define assembler symbol
 _stkReqMem@         set       2         ; define assembler symbol
                     ldb       _stkPageAddr@,s ; get the page address from the stack
-                    beq       L01E1     ; branch if it's 0
+                    beq       FMemStartFreeMemoryBitmap ; branch if it's 0
                     addb      _stkPageCnt@,s ; add it to te page count from the stack
-L01E1               ldx       <D.FMBM   ; get the address of the start of the free memory bitmap
+FMemStartFreeMemoryBitmap ldx       <D.FMBM   ; get the address of the start of the free memory bitmap
                     ldu       <D.FMBM+2 ; and the address of the end of the free memory bitmap
                     os9       F$SchBit  ; search for the location
                     bcs       ex@       ; branch if there was an error
                     stb       _stkReqMem@,s ; save it the location to the stack
                     ldb       _stkPageAddr@,s ; load B from _stkPageAddr@,s
-                    beq       L01F6     ; branch if zero is set to L01F6
+                    beq       FMemStkreqmem ; branch if zero is set to FMemStkreqmem
                     addb      _stkPageCnt@,s ; add _stkPageCnt@,s to B
                     cmpb      _stkReqMem@,s ; compare B with _stkReqMem@,s
                     bne       ex@       ; branch if zero is clear to ex@
-L01F6               ldb       _stkReqMem@,s ; load B from _stkReqMem@,s
+FMemStkreqmem       ldb       _stkReqMem@,s ; load B from _stkReqMem@,s
                     os9       F$AllBit  ; allocate the bits
                     ldd       _stkReqMem@,s ; load D from _stkReqMem@,s
                     suba      _stkPageCnt@,s ; subtract _stkPageCnt@,s from A
                     addb      _stkPageCnt@,s ; add _stkPageCnt@,s to B
                     puls      u,y,x     ; restore u,y,x from the stack
                     ldx       <D.Proc   ; get the current process descriptor
-                    bra       L0225     ; branch unconditionally to L0225
-L0207               negb                ; update processor state
+                    bra       FUnlinkReturn ; branch unconditionally to FUnlinkReturn
+FMemProcessorState  negb                ; update processor state
                     tfr       d,y       ; transfer register value d,y
                     negb                ; update processor state
                     addb      P$PagCnt,x ; add the page count
                     addb      P$ADDR,x  ; and the base data address page
                     cmpb      P$SP,x    ; compare it to the caller's stack pointer
-                    bhi       L0217     ; branch if we're higher
+                    bhi       FMemFreeMemoryBitmap ; branch if we're higher
                     comb                ; else set the carry flag
                     ldb       #E$DelSP  ; return an error indicating the requested size would overrun the stack
                     rts                 ; return to the caller
-L0217               ldx       <D.FMBM   ; get the free memory bitmap pointer
+FMemFreeMemoryBitmap ldx       <D.FMBM   ; get the free memory bitmap pointer
                     os9       F$DelBit  ; delete the bits
                     tfr       y,d       ; transfer register value y,d
                     negb                ; update processor state
                     ldx       <D.Proc   ; get the current process descriptor
                     addb      P$PagCnt,x ; add P$PagCnt,x to B
                     lda       P$ADDR,x  ; get the process' base data address page
-L0225               std       P$ADDR,x  ; store the process' base data address page and page count
+FUnlinkReturn       std       P$ADDR,x  ; store the process' base data address page and page count
 returnsize@         lda       P$PagCnt,x ; get the page count
                     clrb                ; clear B
                     std       R$D,u     ; save off the current memory area in the caller's D
@@ -89,23 +89,23 @@ RoundUpD            addd      #$00FF    ; add 255 to D
 
 FMem                ldx       <D.Proc   ; get current process pointer
                     ldd       R$D,u     ; get requested memory size
-                    beq       L0638     ; he wants current size, return it
+                    beq       FMemPageCount2 ; he wants current size, return it
                     addd      #$00FF    ; round up to nearest page
-                    bcc       L05EE     ; no overflow, skip ahead
+                    bcc       FMemMatchPageCount ; no overflow, skip ahead
                     ldb       #E$MemFul ; get mem full error
                     rts                 ; return
 
-L05EE               cmpa      P$PagCnt,x ; match current page count?
-                    beq       L0638     ; yes, return it
+FMemMatchPageCount  cmpa      P$PagCnt,x ; match current page count?
+                    beq       FMemPageCount2 ; yes, return it
                     pshs      a         ; save page count
-                    bhs       L0602     ; he's requesting more, skip ahead
+                    bhs       FMemPageCount ; he's requesting more, skip ahead
                     deca                ; subtract a page
                     ldb       #($100-R$Size) ; get size of default stack - R$Size
                     cmpd      P$SP,x    ; shrinking it into stack?
-                    bhs       L0602     ; no, skip ahead
+                    bhs       FMemPageCount ; no, skip ahead
                     ldb       #E$DelSP  ; get error code (223)
-                    bra       L0627     ; return error
-L0602               lda       P$PagCnt,x ; get page count
+                    bra       FMemPurge ; return error
+FMemPageCount       lda       P$PagCnt,x ; get page count
                     adda      #$1F      ; round it up
                     lsra                ; divide by 32 to get block count
                     lsra                ; shift or rotate and update condition codes
@@ -114,10 +114,10 @@ L0602               lda       P$PagCnt,x ; get page count
                     lsra                ; shift or rotate and update condition codes
                     ldb       ,s        ; load B from ,s
                     addb      #$1F      ; add #$1F to B
-                    bcc       L0615     ; still have room, skip ahead
+                    bcc       FMemDivideByBlockCount ; still have room, skip ahead
                     ldb       #E$MemFul ; load B from #E$MemFul
-                    bra       L0627     ; branch unconditionally to L0627
-L0615               lsrb                ; divide by 32 to get block count
+                    bra       FMemPurge ; branch unconditionally to FMemPurge
+FMemDivideByBlockCount lsrb                ; divide by 32 to get block count
                     lsrb                ; shift or rotate and update condition codes
                     lsrb                ; shift or rotate and update condition codes
                     lsrb                ; shift or rotate and update condition codes
@@ -128,15 +128,15 @@ L0615               lsrb                ; divide by 32 to get block count
                     pshs      a         ; save a on the stack
                     subb      ,s+       ; subtract ,s+ from B
                   ENDC
-                    beq       L0634     ; yes, save it
-                    bcs       L062C     ; overflow, delete the ram we just got
+                    beq       FMemRequestedPageCount ; yes, save it
+                    bcs       FMemJoin  ; overflow, delete the ram we just got
                     os9       F$AllImg  ; allocate the image in DAT
-                    bcc       L0634     ; no error, skip ahead
-L0627               leas      1,s       ; purge stack
-L0629               orcc      #Carry    ; set carry for error
+                    bcc       FMemRequestedPageCount ; no error, skip ahead
+FMemPurge           leas      1,s       ; purge stack
+FMemCarryError      orcc      #Carry    ; set carry for error
                     rts                 ; return
 
-L062C               equ       *         ; define assembler symbol
+FMemJoin            equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
                     addr      b,a       ; add b,a to R
                   ELSE
@@ -145,9 +145,9 @@ L062C               equ       *         ; define assembler symbol
                   ENDC
                     negb                ; update processor state
                     os9       F$DelImg  ; call OS-9 service F$DelImg
-L0634               puls      a         ; restore requested page count
+FMemRequestedPageCount puls      a         ; restore requested page count
                     sta       P$PagCnt,x ; save it into process descriptor
-L0638               lda       P$PagCnt,x ; get page count
+FMemPageCount2      lda       P$PagCnt,x ; get page count
                     clrb                ; clear LSB
                     std       R$D,u     ; save mem byte count to caller
                     std       R$Y,u     ; save memory upper limit to caller

--- a/level1/modules/kernel/fmem.asm
+++ b/level1/modules/kernel/fmem.asm
@@ -16,141 +16,141 @@
 ;;; F$Mem rounds the size up to the next page boundary. Allocating additional memory continues upward from the previous
 ;;; highest address. Deallocating unneeded memory continues downward from that address.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FMem           ldx       <D.Proc             get the current process descriptor
-               ldd       R$A,u               get the size of the requested memory area
-               beq       returnsize@         branch if 0
-               bsr       RoundUpD            round up requested memory area
-               subb      P$PagCnt,x          subtract the current page count from B
-               beq       returnsize@         branch if 0
-               bcs       L0207               branch if less than 0
-               tfr       d,y                 else transfer requested memory area to Y
-               ldx       P$ADDR,x            get the process' base data address page and page count in X
-               pshs      u,y,x               save off registers
-_stkPageAddr@  set       0
-_stkPageCnt@   set       1
-_stkReqMem@    set       2
-               ldb       _stkPageAddr@,s     get the page address from the stack
-               beq       L01E1               branch if it's 0
-               addb      _stkPageCnt@,s      add it to te page count from the stack
-L01E1          ldx       <D.FMBM             get the address of the start of the free memory bitmap
-               ldu       <D.FMBM+2           and the address of the end of the free memory bitmap
-               os9       F$SchBit            search for the location
-               bcs       ex@                 branch if there was an error
-               stb       _stkReqMem@,s       save it the location to the stack
-               ldb       _stkPageAddr@,s
-               beq       L01F6
-               addb      _stkPageCnt@,s
-               cmpb      _stkReqMem@,s
-               bne       ex@
-L01F6          ldb       _stkReqMem@,s
-               os9       F$AllBit            allocate the bits
-               ldd       _stkReqMem@,s
-               suba      _stkPageCnt@,s
-               addb      _stkPageCnt@,s
-               puls      u,y,x
-               ldx       <D.Proc             get the current process descriptor
-               bra       L0225
-L0207          negb
-               tfr       d,y
-               negb
-               addb      P$PagCnt,x          add the page count
-               addb      P$ADDR,x            and the base data address page
-               cmpb      P$SP,x              compare it to the caller's stack pointer
-               bhi       L0217               branch if we're higher
-               comb                          else set the carry flag
-               ldb       #E$DelSP            return an error indicating the requested size would overrun the stack
-               rts                           return to the caller
-L0217          ldx       <D.FMBM             get the free memory bitmap pointer
-               os9       F$DelBit            delete the bits
-               tfr       y,d
-               negb
-               ldx       <D.Proc             get the current process descriptor
-               addb      P$PagCnt,x
-               lda       P$ADDR,x            get the process' base data address page
-L0225          std       P$ADDR,x            store the process' base data address page and page count
-returnsize@    lda       P$PagCnt,x          get the page count
-               clrb                          clear B
-               std       R$D,u               save off the current memory area in the caller's D
-               adda      P$ADDR,x            add the address to A
-               std       R$Y,u               and store it to the caller's Y
-               rts                           return to the caller
-ex@            comb                          set the carry flag
-               ldb       #E$MemFul           indicate memory is full
-               puls      pc,u,y,x            restore registers and return to the caller
+FMem                ldx       <D.Proc   ; get the current process descriptor
+                    ldd       R$A,u     ; get the size of the requested memory area
+                    beq       returnsize@ ; branch if 0
+                    bsr       RoundUpD  ; round up requested memory area
+                    subb      P$PagCnt,x ; subtract the current page count from B
+                    beq       returnsize@ ; branch if 0
+                    bcs       L0207     ; branch if less than 0
+                    tfr       d,y       ; else transfer requested memory area to Y
+                    ldx       P$ADDR,x  ; get the process' base data address page and page count in X
+                    pshs      u,y,x     ; save off registers
+_stkPageAddr@       set       0         ; define assembler symbol
+_stkPageCnt@        set       1         ; define assembler symbol
+_stkReqMem@         set       2         ; define assembler symbol
+                    ldb       _stkPageAddr@,s ; get the page address from the stack
+                    beq       L01E1     ; branch if it's 0
+                    addb      _stkPageCnt@,s ; add it to te page count from the stack
+L01E1               ldx       <D.FMBM   ; get the address of the start of the free memory bitmap
+                    ldu       <D.FMBM+2 ; and the address of the end of the free memory bitmap
+                    os9       F$SchBit  ; search for the location
+                    bcs       ex@       ; branch if there was an error
+                    stb       _stkReqMem@,s ; save it the location to the stack
+                    ldb       _stkPageAddr@,s ; load B from _stkPageAddr@,s
+                    beq       L01F6     ; branch if zero is set to L01F6
+                    addb      _stkPageCnt@,s ; add _stkPageCnt@,s to B
+                    cmpb      _stkReqMem@,s ; compare B with _stkReqMem@,s
+                    bne       ex@       ; branch if zero is clear to ex@
+L01F6               ldb       _stkReqMem@,s ; load B from _stkReqMem@,s
+                    os9       F$AllBit  ; allocate the bits
+                    ldd       _stkReqMem@,s ; load D from _stkReqMem@,s
+                    suba      _stkPageCnt@,s ; subtract _stkPageCnt@,s from A
+                    addb      _stkPageCnt@,s ; add _stkPageCnt@,s to B
+                    puls      u,y,x     ; restore u,y,x from the stack
+                    ldx       <D.Proc   ; get the current process descriptor
+                    bra       L0225     ; branch unconditionally to L0225
+L0207               negb                ; update processor state
+                    tfr       d,y       ; transfer register value d,y
+                    negb                ; update processor state
+                    addb      P$PagCnt,x ; add the page count
+                    addb      P$ADDR,x  ; and the base data address page
+                    cmpb      P$SP,x    ; compare it to the caller's stack pointer
+                    bhi       L0217     ; branch if we're higher
+                    comb                ; else set the carry flag
+                    ldb       #E$DelSP  ; return an error indicating the requested size would overrun the stack
+                    rts                 ; return to the caller
+L0217               ldx       <D.FMBM   ; get the free memory bitmap pointer
+                    os9       F$DelBit  ; delete the bits
+                    tfr       y,d       ; transfer register value y,d
+                    negb                ; update processor state
+                    ldx       <D.Proc   ; get the current process descriptor
+                    addb      P$PagCnt,x ; add P$PagCnt,x to B
+                    lda       P$ADDR,x  ; get the process' base data address page
+L0225               std       P$ADDR,x  ; store the process' base data address page and page count
+returnsize@         lda       P$PagCnt,x ; get the page count
+                    clrb                ; clear B
+                    std       R$D,u     ; save off the current memory area in the caller's D
+                    adda      P$ADDR,x  ; add the address to A
+                    std       R$Y,u     ; and store it to the caller's Y
+                    rts                 ; return to the caller
+ex@                 comb                ; set the carry flag
+                    ldb       #E$MemFul ; indicate memory is full
+                    puls      pc,u,y,x  ; restore registers and return to the caller
 
-RoundUpD       addd      #$00FF              add 255 to D
-               clrb                          clear B
-               exg       a,b                 swap the registers
-               rts                           return to the caller
+RoundUpD            addd      #$00FF    ; add 255 to D
+                    clrb                ; clear B
+                    exg       a,b       ; swap the registers
+                    rts                 ; return to the caller
 
-               else
+                  ELSE
 
-FMem           ldx       <D.Proc             get current process pointer
-               ldd       R$D,u               get requested memory size
-               beq       L0638               he wants current size, return it
-               addd      #$00FF              round up to nearest page
-               bcc       L05EE               no overflow, skip ahead
-               ldb       #E$MemFul           get mem full error
-               rts                           return
+FMem                ldx       <D.Proc   ; get current process pointer
+                    ldd       R$D,u     ; get requested memory size
+                    beq       L0638     ; he wants current size, return it
+                    addd      #$00FF    ; round up to nearest page
+                    bcc       L05EE     ; no overflow, skip ahead
+                    ldb       #E$MemFul ; get mem full error
+                    rts                 ; return
 
-L05EE          cmpa      P$PagCnt,x          match current page count?
-               beq       L0638               yes, return it
-               pshs      a                   save page count
-               bhs       L0602               he's requesting more, skip ahead
-               deca                          subtract a page
-               ldb       #($100-R$Size)      get size of default stack - R$Size
-               cmpd      P$SP,x              shrinking it into stack?
-               bhs       L0602               no, skip ahead
-               ldb       #E$DelSP            get error code (223)
-               bra       L0627               return error
-L0602          lda       P$PagCnt,x          get page count
-               adda      #$1F                round it up
-               lsra                          divide by 32 to get block count
-               lsra
-               lsra
-               lsra
-               lsra
-               ldb       ,s
-               addb      #$1F
-               bcc       L0615               still have room, skip ahead
-               ldb       #E$MemFul
-               bra       L0627
-L0615          lsrb                          divide by 32 to get block count
-               lsrb
-               lsrb
-               lsrb
-               lsrb
-               ifne      H6309
-               subr      a,b                 same count?
-               else
-               pshs      a
-               subb      ,s+
-               endc
-               beq       L0634               yes, save it
-               bcs       L062C               overflow, delete the ram we just got
-               os9       F$AllImg            allocate the image in DAT
-               bcc       L0634               no error, skip ahead
-L0627          leas      1,s                 purge stack
-L0629          orcc      #Carry              set carry for error
-               rts                           return
+L05EE               cmpa      P$PagCnt,x ; match current page count?
+                    beq       L0638     ; yes, return it
+                    pshs      a         ; save page count
+                    bhs       L0602     ; he's requesting more, skip ahead
+                    deca                ; subtract a page
+                    ldb       #($100-R$Size) ; get size of default stack - R$Size
+                    cmpd      P$SP,x    ; shrinking it into stack?
+                    bhs       L0602     ; no, skip ahead
+                    ldb       #E$DelSP  ; get error code (223)
+                    bra       L0627     ; return error
+L0602               lda       P$PagCnt,x ; get page count
+                    adda      #$1F      ; round it up
+                    lsra                ; divide by 32 to get block count
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    ldb       ,s        ; load B from ,s
+                    addb      #$1F      ; add #$1F to B
+                    bcc       L0615     ; still have room, skip ahead
+                    ldb       #E$MemFul ; load B from #E$MemFul
+                    bra       L0627     ; branch unconditionally to L0627
+L0615               lsrb                ; divide by 32 to get block count
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    subr      a,b       same count?
+                  ELSE
+                    pshs      a         ; save a on the stack
+                    subb      ,s+       ; subtract ,s+ from B
+                  ENDC
+                    beq       L0634     ; yes, save it
+                    bcs       L062C     ; overflow, delete the ram we just got
+                    os9       F$AllImg  ; allocate the image in DAT
+                    bcc       L0634     ; no error, skip ahead
+L0627               leas      1,s       ; purge stack
+L0629               orcc      #Carry    ; set carry for error
+                    rts                 ; return
 
-L062C          equ       *
-               ifne      H6309
-               addr      b,a
-               else
-               pshs      b
-               adda      ,s+
-               endc
-               negb
-               os9       F$DelImg
-L0634          puls      a                   restore requested page count
-               sta       P$PagCnt,x          save it into process descriptor
-L0638          lda       P$PagCnt,x          get page count
-               clrb                          clear LSB
-               std       R$D,u               save mem byte count to caller
-               std       R$Y,u               save memory upper limit to caller
-               rts                           return
+L062C               equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      b,a       ; add b,a to R
+                  ELSE
+                    pshs      b         ; save b on the stack
+                    adda      ,s+       ; add ,s+ to A
+                  ENDC
+                    negb                ; update processor state
+                    os9       F$DelImg  ; call OS-9 service F$DelImg
+L0634               puls      a         ; restore requested page count
+                    sta       P$PagCnt,x ; save it into process descriptor
+L0638               lda       P$PagCnt,x ; get page count
+                    clrb                ; clear LSB
+                    std       R$D,u     ; save mem byte count to caller
+                    std       R$Y,u     ; save memory upper limit to caller
+                    rts                 ; return
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fmem.asm
+++ b/level1/modules/kernel/fmem.asm
@@ -32,9 +32,9 @@ _stkPageAddr@       set       0         ; define assembler symbol
 _stkPageCnt@        set       1         ; define assembler symbol
 _stkReqMem@         set       2         ; define assembler symbol
                     ldb       _stkPageAddr@,s ; get the page address from the stack
-                    beq       FMemStartFreeMemoryBitmap ; branch if it's 0
+                    beq       FMemStartFreeMem ; branch if it's 0
                     addb      _stkPageCnt@,s ; add it to te page count from the stack
-FMemStartFreeMemoryBitmap ldx       <D.FMBM   ; get the address of the start of the free memory bitmap
+FMemStartFreeMem    ldx       <D.FMBM   ; get the address of the start of the free memory bitmap
                     ldu       <D.FMBM+2 ; and the address of the end of the free memory bitmap
                     os9       F$SchBit  ; search for the location
                     bcs       ex@       ; branch if there was an error
@@ -58,11 +58,11 @@ FMemProcessorState  negb                ; update processor state
                     addb      P$PagCnt,x ; add the page count
                     addb      P$ADDR,x  ; and the base data address page
                     cmpb      P$SP,x    ; compare it to the caller's stack pointer
-                    bhi       FMemFreeMemoryBitmap ; branch if we're higher
+                    bhi       FMemFreeMemBtmp ; branch if we're higher
                     comb                ; else set the carry flag
                     ldb       #E$DelSP  ; return an error indicating the requested size would overrun the stack
                     rts                 ; return to the caller
-FMemFreeMemoryBitmap ldx       <D.FMBM   ; get the free memory bitmap pointer
+FMemFreeMemBtmp     ldx       <D.FMBM   ; get the free memory bitmap pointer
                     os9       F$DelBit  ; delete the bits
                     tfr       y,d       ; transfer register value y,d
                     negb                ; update processor state
@@ -114,10 +114,10 @@ FMemPageCount       lda       P$PagCnt,x ; get page count
                     lsra                ; shift or rotate and update condition codes
                     ldb       ,s        ; load B from ,s
                     addb      #$1F      ; add #$1F to B
-                    bcc       FMemDivideByBlockCount ; still have room, skip ahead
+                    bcc       FMemDvdByBlk ; still have room, skip ahead
                     ldb       #E$MemFul ; load B from #E$MemFul
                     bra       FMemPurge ; branch unconditionally to FMemPurge
-FMemDivideByBlockCount lsrb                ; divide by 32 to get block count
+FMemDvdByBlk        lsrb                ; divide by 32 to get block count
                     lsrb                ; shift or rotate and update condition codes
                     lsrb                ; shift or rotate and update condition codes
                     lsrb                ; shift or rotate and update condition codes
@@ -128,10 +128,10 @@ FMemDivideByBlockCount lsrb                ; divide by 32 to get block count
                     pshs      a         ; save a on the stack
                     subb      ,s+       ; subtract ,s+ from B
                   ENDC
-                    beq       FMemRequestedPageCount ; yes, save it
+                    beq       FMemReqPgCnt ; yes, save it
                     bcs       FMemJoin  ; overflow, delete the ram we just got
                     os9       F$AllImg  ; allocate the image in DAT
-                    bcc       FMemRequestedPageCount ; no error, skip ahead
+                    bcc       FMemReqPgCnt ; no error, skip ahead
 FMemPurge           leas      1,s       ; purge stack
 FMemCarryError      orcc      #Carry    ; set carry for error
                     rts                 ; return
@@ -145,7 +145,7 @@ FMemJoin            equ       *         ; define assembler symbol
                   ENDC
                     negb                ; update processor state
                     os9       F$DelImg  ; call OS-9 service F$DelImg
-FMemRequestedPageCount puls      a         ; restore requested page count
+FMemReqPgCnt        puls      a         ; restore requested page count
                     sta       P$PagCnt,x ; save it into process descriptor
 FMemPageCount2      lda       P$PagCnt,x ; get page count
                     clrb                ; clear LSB

--- a/level1/modules/kernel/fnproc.asm
+++ b/level1/modules/kernel/fnproc.asm
@@ -73,56 +73,56 @@ FNProc
                     andcc     #^IntMasks ; re-enable IRQ's (to allow pending one through)
                     fcb       $8C       ; skip the next 2 bytes
 
-L0D91               cwai      #^IntMasks ; re-enable IRQ's and wait for one
-L0D93               orcc      #IntMasks ; shut off interrupts again
+FNprocReEnableIrqsWait cwai      #^IntMasks ; re-enable IRQ's and wait for one
+FNprocShutOffInterruptsAgain orcc      #IntMasks ; shut off interrupts again
                     lda       #Suspend  ; get suspend suspend state flag
                     ldx       #D.AProcQ-P$Queue ; for start of loop, setup to point to current process
 
 * Loop to find next active process that is not Suspended
-L0D9A               leay      ,x        ; point y to previous link (process dsc. ptr)
+FNprocPreviousLinkProcessDesc leay      ,x        ; point y to previous link (process dsc. ptr)
                     ldx       P$Queue,y ; get process dsc. ptr for next active process
-                    beq       L0D91     ; none, allow any pending IRQ thru & try again
+                    beq       FNprocReEnableIrqsWait ; none, allow any pending IRQ thru & try again
                     bita      P$State,x ; there is one, is it Suspended?
-                    bne       L0D9A     ; yes, skip it & try next one
+                    bne       FNprocPreviousLinkProcessDesc ; yes, skip it & try next one
 
 * Found a process in line ready to be started
                     ldd       P$Queue,x ; get next process dsc. ptr in line after found one
                     std       P$Queue,y ; save the next one in line in previous' next ptr
                     stx       <D.Proc   ; make new process dsc. the current one
-                    lbsr      L0C58     ; go check or make a task # for the found process
-                    bcs       L0D83     ; couldn't get one, go to next process in line
+                    lbsr      FAlltskAlreadyHaveTask ; go check or make a task # for the found process
+                    bcs       KrnActivateProcess ; couldn't get one, go to next process in line
                     lda       <D.TSlice ; reload # ticks this process can run
                     sta       <D.Slice  ; save as new tick counter for process
                     ldu       P$SP,x    ; get the process stack pointer
                     lda       P$State,x ; get it's state
-                    lbmi      L0E29     ; if in System State, switch to system task (0)
-L0DB9               bita      #Condem   ; was it condemned by a deadly signal?
-                    bne       L0DFD     ; yes, go exit with Error=the signal code #
+                    lbmi      KrnForceSystemTaskSystem ; if in System State, switch to system task (0)
+FNprocCondemnedByDeadlySignal bita      #Condem   ; was it condemned by a deadly signal?
+                    bne       FNprocJoin2 ; yes, go exit with Error=the signal code #
                     lbsr      TstImg    ; do a F$SetTsk if the ImgChg flag is set
-L0DBD               ldb       <P$Signal,x ; any signals?
-                    beq       L0DF7     ; no, go on
+FNprocSignals       ldb       <P$Signal,x ; any signals?
+                    beq       FNprocJoin ; no, go on
                     decb                ; is it a wake up signal?
-                    beq       L0DEF     ; yes, go wake it up
+                    beq       FNprocSignal ; yes, go wake it up
                     leas      -R$Size,s ; make a register buffer on stack
                     leau      ,s        ; point to it
-                    lbsr      L02CB     ; copy the stack from process to our copy of it
+                    lbsr      CopyUserStackToSystem ; copy the stack from process to our copy of it
                     lda       <P$Signal,x ; get last signal
                     sta       R$B,u     ; save it to process' B
 
                     ldd       <P$SigVec,x ; any intercept trap?
-                    beq       L0DFD     ; no, go force the process to F$Exit
+                    beq       FNprocJoin2 ; no, go force the process to F$Exit
                     std       R$PC,u    ; save vector to it's PC
                     ldd       <P$SigDat,x ; get pointer to intercept data area
                     std       R$U,u     ; save it to it's U
                     ldd       P$SP,x    ; get it's stack pointer
                     subd      #R$Size   ; take off register stack
                     std       P$SP,x    ; save updated SP
-                    lbsr      L02DA     ; copy modified stack back overtop process' stack
+                    lbsr      CopySystemStackToUser ; copy modified stack back overtop process' stack
                     leas      R$Size,s  ; purge temporary stack
-L0DEF               clr       <P$Signal,x ; clear the signal
+FNprocSignal        clr       <P$Signal,x ; clear the signal
 
 * No signals go here
-L0DF7               equ       *         ; define assembler symbol
+FNprocJoin          equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.Quick
                   ELSE
@@ -131,7 +131,7 @@ L0DF7               equ       *         ; define assembler symbol
                     stb       <D.Quick  ; store B at <D.Quick
                   ENDC
 BackTo1             equ       *         ; define assembler symbol
-L0DF2               ldu       <D.UsrSvc ; get current User's system call service routine ptr
+FNprocUsersSystemCallService ldu       <D.UsrSvc ; get current User's system call service routine ptr
                     stu       <D.XSWI2  ; save as SWI2 service routine ptr
                     ldu       <D.UsrIRQ ; get IRQ entry point for user state
                     stu       <D.XIRQ   ; save as IRQ service routine ptr
@@ -139,12 +139,12 @@ L0DF2               ldu       <D.UsrSvc ; get current User's system call service
                     ldb       P$Task,x  ; get task number
                     lslb                ; 2 bytes per entry in D.TskIpt
                     ldy       P$SP,x    ; get stack pointer
-                    lbsr      L0E8D     ; re-map the DAT image, if necessary
+                    lbsr      KrnWeGoingBackSameTask ; re-map the DAT image, if necessary
                     ldb       <D.Quick  ; get quick return flag
-                    bra       L0E4C     ; go switch GIME over to new process & run
+                    bra       KrnJoin2  ; go switch GIME over to new process & run
 
 * Process a signal (process had no signal trap)
-L0DFD               equ       *         ; define assembler symbol
+FNprocJoin2         equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #SysState,P$State,x Put process into system state
                   ELSE

--- a/level1/modules/kernel/fnproc.asm
+++ b/level1/modules/kernel/fnproc.asm
@@ -1,13 +1,13 @@
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
 * This is called when there's no signal handler.
 * The process exits with signal value as exit code.
-NoSigHandler   ldb       P$State,x           get process state in process descriptor
-               orb       #SysState           OR in system state flag
-               stb       P$State,x           and save it back
-               ldb       <P$Signal,x         get the signal sent to the process
-               andcc     #^(IntMasks)        unmask interrupts
-               os9       F$Exit              perform exit on this process
+NoSigHandler        ldb       P$State,x ; get process state in process descriptor
+                    orb       #SysState ; oR in system state flag
+                    stb       P$State,x ; and save it back
+                    ldb       <P$Signal,x ; get the signal sent to the process
+                    andcc     #^(IntMasks) ; unmask interrupts
+                    os9       F$Exit    ; perform exit on this process
 
 ;;; F$NProc
 ;;;
@@ -23,141 +23,141 @@ NoSigHandler   ldb       P$State,x           get process state in process descri
 ;;; If it isn't, it becomes unknown to the system even though the process descriptor still exists
 ;;; and can be displayed by `procs`.
 
-FNProc         clra                          A = 0
-               clrb                          D = $0000
-               std       <D.Proc             clear out current process descriptor pointer
-               bra       nextactive@         branch to get next active process
+FNProc              clra                ; A = 0
+                    clrb                ; D = $0000
+                    std       <D.Proc   ; clear out current process descriptor pointer
+                    bra       nextactive@ ; branch to get next active process
 * Execution goes here when there are no active processes.
-wait@          cwai      #^(IntMasks)        halt processor waiting for an interrupt
-nextactive@    orcc      #IntMasks           mask interrupts
-               ldx       <D.AProcQ           get next active process
-               beq       wait@               CWAI if none
-               ldd       P$Queue,x           get queue ptr
-               std       <D.AProcQ           store in active queue
-               stx       <D.Proc             store in current process
-               lds       P$SP,x              get process' stack ptr
-CheckState     ldb       P$State,x           get state
-               bmi       exit@               branch if system state
-               bitb      #Condem             process condemned?
-               bne       NoSigHandler        branch if so...
-               ldb       <P$Signal,x         get signal no
-               beq       restorevec@         branch if none
-               decb                          decrement
-               beq       savesig@            branch if wake up
-               ldu       <P$SigVec,x         get signal handler address
-               beq       NoSigHandler        branch if none
-               ldy       <P$SigDat,x         get data address
-               ldd       R$Y,s               get caller's Y
+wait@               cwai      #^(IntMasks) ; halt processor waiting for an interrupt
+nextactive@         orcc      #IntMasks ; mask interrupts
+                    ldx       <D.AProcQ ; get next active process
+                    beq       wait@     ; cWAI if none
+                    ldd       P$Queue,x ; get queue ptr
+                    std       <D.AProcQ ; store in active queue
+                    stx       <D.Proc   ; store in current process
+                    lds       P$SP,x    ; get process' stack ptr
+CheckState          ldb       P$State,x ; get state
+                    bmi       exit@     ; branch if system state
+                    bitb      #Condem   ; process condemned?
+                    bne       NoSigHandler ; branch if so...
+                    ldb       <P$Signal,x ; get signal no
+                    beq       restorevec@ ; branch if none
+                    decb                ; decrement
+                    beq       savesig@  ; branch if wake up
+                    ldu       <P$SigVec,x ; get signal handler address
+                    beq       NoSigHandler ; branch if none
+                    ldy       <P$SigDat,x ; get data address
+                    ldd       R$Y,s     ; get caller's Y
 * Set up new return stack for RTI.
-               pshs      u,y,d               new PC (sigvec), new U (sigdat), same Y
-               ldu       6+R$X,s             old X via U
-               lda       <P$Signal,x         signal ...
-               ldb       6+R$DP,s            and old DP ...
-               tfr       d,y                 via Y
-               ldd       6+R$CC,s            old CC and A via D
-               pshs      u,y,d               same X, same DP / new B (signal), same A / CC
-               clrb                          clear B
-savesig@       stb       <P$Signal,x         clear process's signal
-restorevec@    ldd       <P$SWI2,x           get SWI2 vector stored in process descriptor
-               std       <D.SWI2             and restore it to system globals
-               ldd       <D.UsrIRQ           get user state IRQ vector
-               std       <D.SvcIRQ           and restore it to the main service vector
-exit@          rti                           return from the interrupt
+                    pshs      u,y,d     ; new PC (sigvec), new U (sigdat), same Y
+                    ldu       6+R$X,s   ; old X via U
+                    lda       <P$Signal,x ; signal ...
+                    ldb       6+R$DP,s  ; and old DP ...
+                    tfr       d,y       ; via Y
+                    ldd       6+R$CC,s  ; old CC and A via D
+                    pshs      u,y,d     ; same X, same DP / new B (signal), same A / CC
+                    clrb                ; clear B
+savesig@            stb       <P$Signal,x ; clear process's signal
+restorevec@         ldd       <P$SWI2,x ; get SWI2 vector stored in process descriptor
+                    std       <D.SWI2   ; and restore it to system globals
+                    ldd       <D.UsrIRQ ; get user state IRQ vector
+                    std       <D.SvcIRQ ; and restore it to the main service vector
+exit@               rti                 ; return from the interrupt
 
-               else
+                  ELSE
 
 FNProc
-               ldx       <D.SysPrc           get system process descriptor
-               stx       <D.Proc             save it as current
-               lds       <D.SysStk           get system stack pointer
-               andcc     #^IntMasks          re-enable IRQ's (to allow pending one through)
-               fcb       $8C                 skip the next 2 bytes
+                    ldx       <D.SysPrc ; get system process descriptor
+                    stx       <D.Proc   ; save it as current
+                    lds       <D.SysStk ; get system stack pointer
+                    andcc     #^IntMasks ; re-enable IRQ's (to allow pending one through)
+                    fcb       $8C       ; skip the next 2 bytes
 
-L0D91          cwai      #^IntMasks          re-enable IRQ's and wait for one
-L0D93          orcc      #IntMasks           Shut off interrupts again
-               lda       #Suspend            get suspend suspend state flag
-               ldx       #D.AProcQ-P$Queue   For start of loop, setup to point to current process
+L0D91               cwai      #^IntMasks ; re-enable IRQ's and wait for one
+L0D93               orcc      #IntMasks ; shut off interrupts again
+                    lda       #Suspend  ; get suspend suspend state flag
+                    ldx       #D.AProcQ-P$Queue ; for start of loop, setup to point to current process
 
 * Loop to find next active process that is not Suspended
-L0D9A          leay      ,x                  Point y to previous link (process dsc. ptr)
-               ldx       P$Queue,y           Get process dsc. ptr for next active process
-               beq       L0D91               None, allow any pending IRQ thru & try again
-               bita      P$State,x           There is one, is it Suspended?
-               bne       L0D9A               Yes, skip it & try next one
+L0D9A               leay      ,x        ; point y to previous link (process dsc. ptr)
+                    ldx       P$Queue,y ; get process dsc. ptr for next active process
+                    beq       L0D91     ; none, allow any pending IRQ thru & try again
+                    bita      P$State,x ; there is one, is it Suspended?
+                    bne       L0D9A     ; yes, skip it & try next one
 
 * Found a process in line ready to be started
-               ldd       P$Queue,x           Get next process dsc. ptr in line after found one
-               std       P$Queue,y           Save the next one in line in previous' next ptr
-               stx       <D.Proc             Make new process dsc. the current one
-               lbsr      L0C58               Go check or make a task # for the found process
-               bcs       L0D83               Couldn't get one, go to next process in line
-               lda       <D.TSlice           Reload # ticks this process can run
-               sta       <D.Slice            Save as new tick counter for process
-               ldu       P$SP,x              get the process stack pointer
-               lda       P$State,x           get it's state
-               lbmi      L0E29               If in System State, switch to system task (0)
-L0DB9          bita      #Condem             Was it condemned by a deadly signal?
-               bne       L0DFD               Yes, go exit with Error=the signal code #
-               lbsr      TstImg              do a F$SetTsk if the ImgChg flag is set
-L0DBD          ldb       <P$Signal,x         any signals?
-               beq       L0DF7               no, go on
-               decb                          is it a wake up signal?
-               beq       L0DEF               yes, go wake it up
-               leas      -R$Size,s           make a register buffer on stack
-               leau      ,s                  point to it
-               lbsr      L02CB               copy the stack from process to our copy of it
-               lda       <P$Signal,x         get last signal
-               sta       R$B,u               save it to process' B
+                    ldd       P$Queue,x ; get next process dsc. ptr in line after found one
+                    std       P$Queue,y ; save the next one in line in previous' next ptr
+                    stx       <D.Proc   ; make new process dsc. the current one
+                    lbsr      L0C58     ; go check or make a task # for the found process
+                    bcs       L0D83     ; couldn't get one, go to next process in line
+                    lda       <D.TSlice ; reload # ticks this process can run
+                    sta       <D.Slice  ; save as new tick counter for process
+                    ldu       P$SP,x    ; get the process stack pointer
+                    lda       P$State,x ; get it's state
+                    lbmi      L0E29     ; if in System State, switch to system task (0)
+L0DB9               bita      #Condem   ; was it condemned by a deadly signal?
+                    bne       L0DFD     ; yes, go exit with Error=the signal code #
+                    lbsr      TstImg    ; do a F$SetTsk if the ImgChg flag is set
+L0DBD               ldb       <P$Signal,x ; any signals?
+                    beq       L0DF7     ; no, go on
+                    decb                ; is it a wake up signal?
+                    beq       L0DEF     ; yes, go wake it up
+                    leas      -R$Size,s ; make a register buffer on stack
+                    leau      ,s        ; point to it
+                    lbsr      L02CB     ; copy the stack from process to our copy of it
+                    lda       <P$Signal,x ; get last signal
+                    sta       R$B,u     ; save it to process' B
 
-               ldd       <P$SigVec,x         any intercept trap?
-               beq       L0DFD               no, go force the process to F$Exit
-               std       R$PC,u              save vector to it's PC
-               ldd       <P$SigDat,x         get pointer to intercept data area
-               std       R$U,u               save it to it's U
-               ldd       P$SP,x              get it's stack pointer
-               subd      #R$Size             take off register stack
-               std       P$SP,x              save updated SP
-               lbsr      L02DA               Copy modified stack back overtop process' stack
-               leas      R$Size,s            purge temporary stack
-L0DEF          clr       <P$Signal,x         clear the signal
+                    ldd       <P$SigVec,x ; any intercept trap?
+                    beq       L0DFD     ; no, go force the process to F$Exit
+                    std       R$PC,u    ; save vector to it's PC
+                    ldd       <P$SigDat,x ; get pointer to intercept data area
+                    std       R$U,u     ; save it to it's U
+                    ldd       P$SP,x    ; get it's stack pointer
+                    subd      #R$Size   ; take off register stack
+                    std       P$SP,x    ; save updated SP
+                    lbsr      L02DA     ; copy modified stack back overtop process' stack
+                    leas      R$Size,s  ; purge temporary stack
+L0DEF               clr       <P$Signal,x ; clear the signal
 
 * No signals go here
-L0DF7          equ       *
-               ifne      H6309
-               oim       #$01,<D.Quick
-               else
-               ldb       <D.Quick
-               orb       #$01
-               stb       <D.Quick
-               endc
-BackTo1        equ       *
-L0DF2          ldu       <D.UsrSvc           Get current User's system call service routine ptr
-               stu       <D.XSWI2            Save as SWI2 service routine ptr
-               ldu       <D.UsrIRQ           Get IRQ entry point for user state
-               stu       <D.XIRQ             Save as IRQ service routine ptr
+L0DF7               equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.Quick
+                  ELSE
+                    ldb       <D.Quick  ; load B from <D.Quick
+                    orb       #$01      ; merge #$01 into B
+                    stb       <D.Quick  ; store B at <D.Quick
+                  ENDC
+BackTo1             equ       *         ; define assembler symbol
+L0DF2               ldu       <D.UsrSvc ; get current User's system call service routine ptr
+                    stu       <D.XSWI2  ; save as SWI2 service routine ptr
+                    ldu       <D.UsrIRQ ; get IRQ entry point for user state
+                    stu       <D.XIRQ   ; save as IRQ service routine ptr
 
-               ldb       P$Task,x            get task number
-               lslb                          2 bytes per entry in D.TskIpt
-               ldy       P$SP,x              get stack pointer
-               lbsr      L0E8D               re-map the DAT image, if necessary
-               ldb       <D.Quick            get quick return flag
-               bra       L0E4C               Go switch GIME over to new process & run
+                    ldb       P$Task,x  ; get task number
+                    lslb                ; 2 bytes per entry in D.TskIpt
+                    ldy       P$SP,x    ; get stack pointer
+                    lbsr      L0E8D     ; re-map the DAT image, if necessary
+                    ldb       <D.Quick  ; get quick return flag
+                    bra       L0E4C     ; go switch GIME over to new process & run
 
 * Process a signal (process had no signal trap)
-L0DFD          equ       *
-               ifne      H6309
-               oim       #SysState,P$State,x Put process into system state
-               else
-               ldb       P$State,x
-               orb       #SysState
-               stb       P$State,x
-               endc
-               leas      >P$Stack,x          Point SP to process' stack
-               andcc     #^IntMasks          Turn interrupts on
-               ldb       <P$Signal,x         Get signal that process received
-               clr       <P$Signal,x         Clear out the one in process dsc.
-               os9       F$Exit              Exit with signal # being error code
+L0DFD               equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #SysState,P$State,x Put process into system state
+                  ELSE
+                    ldb       P$State,x ; load B from P$State,x
+                    orb       #SysState ; merge #SysState into B
+                    stb       P$State,x ; store B at P$State,x
+                  ENDC
+                    leas      >P$Stack,x ; point SP to process' stack
+                    andcc     #^IntMasks ; turn interrupts on
+                    ldb       <P$Signal,x ; get signal that process received
+                    clr       <P$Signal,x ; clear out the one in process dsc.
+                    os9       F$Exit    ; exit with signal # being error code
 
-S.SvcIRQ       jmp       [>D.Poll]           Call IOMAN for IRQ polling
+S.SvcIRQ            jmp       [>D.Poll] ; call IOMAN for IRQ polling
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fnproc.asm
+++ b/level1/modules/kernel/fnproc.asm
@@ -73,30 +73,30 @@ FNProc
                     andcc     #^IntMasks ; re-enable IRQ's (to allow pending one through)
                     fcb       $8C       ; skip the next 2 bytes
 
-FNprocReEnableIrqsWait cwai      #^IntMasks ; re-enable IRQ's and wait for one
-FNprocShutOffInterruptsAgain orcc      #IntMasks ; shut off interrupts again
+FNprocReEnblIrqs    cwai      #^IntMasks ; re-enable IRQ's and wait for one
+FNprocShutOffInts   orcc      #IntMasks ; shut off interrupts again
                     lda       #Suspend  ; get suspend suspend state flag
                     ldx       #D.AProcQ-P$Queue ; for start of loop, setup to point to current process
 
 * Loop to find next active process that is not Suspended
-FNprocPreviousLinkProcessDesc leay      ,x        ; point y to previous link (process dsc. ptr)
+FNprocPrvsLinkProc  leay      ,x        ; point y to previous link (process dsc. ptr)
                     ldx       P$Queue,y ; get process dsc. ptr for next active process
-                    beq       FNprocReEnableIrqsWait ; none, allow any pending IRQ thru & try again
+                    beq       FNprocReEnblIrqs ; none, allow any pending IRQ thru & try again
                     bita      P$State,x ; there is one, is it Suspended?
-                    bne       FNprocPreviousLinkProcessDesc ; yes, skip it & try next one
+                    bne       FNprocPrvsLinkProc ; yes, skip it & try next one
 
 * Found a process in line ready to be started
                     ldd       P$Queue,x ; get next process dsc. ptr in line after found one
                     std       P$Queue,y ; save the next one in line in previous' next ptr
                     stx       <D.Proc   ; make new process dsc. the current one
-                    lbsr      FAlltskAlreadyHaveTask ; go check or make a task # for the found process
+                    lbsr      FAlltskHasHaveTask ; go check or make a task # for the found process
                     bcs       KrnActivateProcess ; couldn't get one, go to next process in line
                     lda       <D.TSlice ; reload # ticks this process can run
                     sta       <D.Slice  ; save as new tick counter for process
                     ldu       P$SP,x    ; get the process stack pointer
                     lda       P$State,x ; get it's state
-                    lbmi      KrnForceSystemTaskSystem ; if in System State, switch to system task (0)
-FNprocCondemnedByDeadlySignal bita      #Condem   ; was it condemned by a deadly signal?
+                    lbmi      KrnFrcSysTask ; if in System State, switch to system task (0)
+FNprocCndmnByDdly   bita      #Condem   ; was it condemned by a deadly signal?
                     bne       FNprocJoin2 ; yes, go exit with Error=the signal code #
                     lbsr      TstImg    ; do a F$SetTsk if the ImgChg flag is set
 FNprocSignals       ldb       <P$Signal,x ; any signals?
@@ -105,7 +105,7 @@ FNprocSignals       ldb       <P$Signal,x ; any signals?
                     beq       FNprocSignal ; yes, go wake it up
                     leas      -R$Size,s ; make a register buffer on stack
                     leau      ,s        ; point to it
-                    lbsr      CopyUserStackToSystem ; copy the stack from process to our copy of it
+                    lbsr      CpUsrStkTo ; copy the stack from process to our copy of it
                     lda       <P$Signal,x ; get last signal
                     sta       R$B,u     ; save it to process' B
 
@@ -117,7 +117,7 @@ FNprocSignals       ldb       <P$Signal,x ; any signals?
                     ldd       P$SP,x    ; get it's stack pointer
                     subd      #R$Size   ; take off register stack
                     std       P$SP,x    ; save updated SP
-                    lbsr      CopySystemStackToUser ; copy modified stack back overtop process' stack
+                    lbsr      CpSysStkTo ; copy modified stack back overtop process' stack
                     leas      R$Size,s  ; purge temporary stack
 FNprocSignal        clr       <P$Signal,x ; clear the signal
 
@@ -131,7 +131,7 @@ FNprocJoin          equ       *         ; define assembler symbol
                     stb       <D.Quick  ; store B at <D.Quick
                   ENDC
 BackTo1             equ       *         ; define assembler symbol
-FNprocUsersSystemCallService ldu       <D.UsrSvc ; get current User's system call service routine ptr
+FNprocUsrsSysCall   ldu       <D.UsrSvc ; get current User's system call service routine ptr
                     stu       <D.XSWI2  ; save as SWI2 service routine ptr
                     ldu       <D.UsrIRQ ; get IRQ entry point for user state
                     stu       <D.XIRQ   ; save as IRQ service routine ptr
@@ -139,7 +139,7 @@ FNprocUsersSystemCallService ldu       <D.UsrSvc ; get current User's system cal
                     ldb       P$Task,x  ; get task number
                     lslb                ; 2 bytes per entry in D.TskIpt
                     ldy       P$SP,x    ; get stack pointer
-                    lbsr      KrnWeGoingBackSameTask ; re-map the DAT image, if necessary
+                    lbsr      KrnWeGngBack ; re-map the DAT image, if necessary
                     ldb       <D.Quick  ; get quick return flag
                     bra       KrnJoin2  ; go switch GIME over to new process & run
 

--- a/level1/modules/kernel/fprsnam.asm
+++ b/level1/modules/kernel/fprsnam.asm
@@ -40,10 +40,10 @@ FPrsNam             ldx       <D.Proc   ; get the process descriptor
                     ldx       R$X,u     ; get the pathlist from the caller's X
                     bsr       ParseNam  ; parse the pathlist
                     std       R$D,u     ; D contains the length of the name; store it in the caller's D
-                    bcs       L073E     ; branch if an error occurred
+                    bcs       FPrsnamContainsEndNamePlus ; branch if an error occurred
                     stx       R$X,u     ; X contains the start of the name; store it in the caller's X
                     abx                 ; add the length in B to X
-L073E               stx       R$Y,u     ; X contains the end of the name plus one; store it in the caller's Y
+FPrsnamContainsEndNamePlus stx       R$Y,u     ; X contains the end of the name plus one; store it in the caller's Y
                     rts                 ; return to the caller
 
 * Parse name
@@ -54,7 +54,7 @@ ParseNam            equ       *         ; define assembler symbol
                     bsr       GoGetAXY  ; get the byte at X in block Y
                     cmpa      #'.       ; is the first character a period?
                     bne       IsSlash   ; no, do proper first character checking
-                    lbsr      L0AC8     ; do a LDAXY, without changing X or Y
+                    lbsr      FLdMMUBlockData ; do a LDAXY, without changing X or Y
                     bsr       ChkFirst  ; is the next character non-period?
                     lda       #'.       ; restore the period character the LDAXY destroyed
                     bcc       Do.Loop   ; if it's a non-period character, skip first character checks
@@ -88,7 +88,7 @@ NotValid            cmpa      #',       ; is it a comma?
                     ldb       #E$BNam   ; 'Bad Name' error
 RtnValid            equ       *         ; define assembler symbol
                     puls      x,y       ; recover tje offset & pointer
-                    bra       L0720     ; do a similar exit routine
+                    bra       FFmodulChar ; do a similar exit routine
 
 ChkFirst            pshs      a         ; save the character
                     anda      #$7F      ; drop the most significant bit

--- a/level1/modules/kernel/fprsnam.asm
+++ b/level1/modules/kernel/fprsnam.asm
@@ -40,10 +40,10 @@ FPrsNam             ldx       <D.Proc   ; get the process descriptor
                     ldx       R$X,u     ; get the pathlist from the caller's X
                     bsr       ParseNam  ; parse the pathlist
                     std       R$D,u     ; D contains the length of the name; store it in the caller's D
-                    bcs       FPrsnamContainsEndNamePlus ; branch if an error occurred
+                    bcs       FPrsnamHasEndName ; branch if an error occurred
                     stx       R$X,u     ; X contains the start of the name; store it in the caller's X
                     abx                 ; add the length in B to X
-FPrsnamContainsEndNamePlus stx       R$Y,u     ; X contains the end of the name plus one; store it in the caller's Y
+FPrsnamHasEndName   stx       R$Y,u     ; X contains the end of the name plus one; store it in the caller's Y
                     rts                 ; return to the caller
 
 * Parse name

--- a/level1/modules/kernel/fprsnam.asm
+++ b/level1/modules/kernel/fprsnam.asm
@@ -33,150 +33,150 @@
 ;;;          X	     Y              B = 2
 
 
-               ifgt      Level-1
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
 
-FPrsNam        ldx       <D.Proc             get the process descriptor
-               leay      <P$DATImg,x         and the DAT image pointer in it
-               ldx       R$X,u               get the pathlist from the caller's X
-               bsr       ParseNam            parse the pathlist
-               std       R$D,u               D contains the length of the name; store it in the caller's D
-               bcs       L073E               branch if an error occurred
-               stx       R$X,u               X contains the start of the name; store it in the caller's X
-               abx                           add the length in B to X
-L073E          stx       R$Y,u               X contains the end of the name plus one; store it in the caller's Y
-               rts                           return to the caller
+FPrsNam             ldx       <D.Proc   ; get the process descriptor
+                    leay      <P$DATImg,x ; and the DAT image pointer in it
+                    ldx       R$X,u     ; get the pathlist from the caller's X
+                    bsr       ParseNam  ; parse the pathlist
+                    std       R$D,u     ; D contains the length of the name; store it in the caller's D
+                    bcs       L073E     ; branch if an error occurred
+                    stx       R$X,u     ; X contains the start of the name; store it in the caller's X
+                    abx                 ; add the length in B to X
+L073E               stx       R$Y,u     ; X contains the end of the name plus one; store it in the caller's Y
+                    rts                 ; return to the caller
 
 * Parse name
-ParseNam       equ       *
-               pshs      y                   save the DAT image pointer on the stack
-               lbsr      AdjBlk0             go find the map block
-               pshs      x,y                 save the offset within the block (X) and the block pointer (Y)
-               bsr       GoGetAXY            get the byte at X in block Y
-               cmpa      #'.                 is the first character a period?
-               bne       IsSlash             no, do proper first character checking
-               lbsr      L0AC8               do a LDAXY, without changing X or Y
-               bsr       ChkFirst            is the next character non-period?
-               lda       #'.                 restore the period character the LDAXY destroyed
-               bcc       Do.Loop             if it's a non-period character, skip first character checks
+ParseNam            equ       *         ; define assembler symbol
+                    pshs      y         ; save the DAT image pointer on the stack
+                    lbsr      AdjBlk0   ; go find the map block
+                    pshs      x,y       ; save the offset within the block (X) and the block pointer (Y)
+                    bsr       GoGetAXY  ; get the byte at X in block Y
+                    cmpa      #'.       ; is the first character a period?
+                    bne       IsSlash   ; no, do proper first character checking
+                    lbsr      L0AC8     ; do a LDAXY, without changing X or Y
+                    bsr       ChkFirst  ; is the next character non-period?
+                    lda       #'.       ; restore the period character the LDAXY destroyed
+                    bcc       Do.Loop   ; if it's a non-period character, skip first character checks
 
-IsSlash        cmpa      #PDELIM             is it a slash?
-               bne       NotSlash            no, keep X offset and block Y
-               bsr       GetChar             go get character
-NotSlash       bsr       ChkFirst            check if we have a valid first character
-               bcs       NotValid            branch if it isn't valid
-Do.Loop        clrb                          initialize the character counter
-LastLoop       incb                          add one character
-               tsta                          is it the last character of the name?
-               bmi       LastChar            yes, return valid
-               bsr       GoGetAXY            get next character
-               bsr       ChkValid            check if it's valid character
-               bcc       LastLoop            branch if valid
-LastChar       andcc     #^Carry             else set the carry to indicate an error
-               bra       RtnValid            and return to the caller
+IsSlash             cmpa      #PDELIM   ; is it a slash?
+                    bne       NotSlash  ; no, keep X offset and block Y
+                    bsr       GetChar   ; go get character
+NotSlash            bsr       ChkFirst  ; check if we have a valid first character
+                    bcs       NotValid  ; branch if it isn't valid
+Do.Loop             clrb                ; initialize the character counter
+LastLoop            incb                ; add one character
+                    tsta                ; is it the last character of the name?
+                    bmi       LastChar  ; yes, return valid
+                    bsr       GoGetAXY  ; get next character
+                    bsr       ChkValid  ; check if it's valid character
+                    bcc       LastLoop  ; branch if valid
+LastChar            andcc     #^Carry   ; else set the carry to indicate an error
+                    bra       RtnValid  ; and return to the caller
 
 GetChar
-               stx       2,s                 save the current offset over the old offset
-               sty       4,s                 save the current block pointer over the old block pointer
-GoGetAXY       lbra      LDAXY               get the byte at X in block Y in A, then return
+                    stx       2,s       ; save the current offset over the old offset
+                    sty       4,s       ; save the current block pointer over the old block pointer
+GoGetAXY            lbra      LDAXY     ; get the byte at X in block Y in A, then return
 
-NextLoop       bsr       GetChar             get the next character
-NotValid       cmpa      #',                 is it a comma?
-               beq       NextLoop            yes, go get the next character
-               cmpa      #C$SPAC             is it a space?
-               beq       NextLoop            yes, go get the next character
-               comb                          else set the carry to indicate an error condition
-               ldb       #E$BNam             'Bad Name' error
-RtnValid       equ       *
-               puls      x,y                 recover tje offset & pointer
-               bra       L0720               do a similar exit routine
+NextLoop            bsr       GetChar   ; get the next character
+NotValid            cmpa      #',       ; is it a comma?
+                    beq       NextLoop  ; yes, go get the next character
+                    cmpa      #C$SPAC   ; is it a space?
+                    beq       NextLoop  ; yes, go get the next character
+                    comb                ; else set the carry to indicate an error condition
+                    ldb       #E$BNam   ; 'Bad Name' error
+RtnValid            equ       *         ; define assembler symbol
+                    puls      x,y       ; recover tje offset & pointer
+                    bra       L0720     ; do a similar exit routine
 
-ChkFirst       pshs      a                   save the character
-               anda      #$7F                drop the most significant bit
-               bra       ChkRst              skip the dash for the first character check
+ChkFirst            pshs      a         ; save the character
+                    anda      #$7F      ; drop the most significant bit
+                    bra       ChkRst    ; skip the dash for the first character check
 
 * Determine if character in A is a valid filename character.
-ChkValid       pshs      a                   save the character
-               anda      #$7F                drop the most significant bit
-               cmpa      #'.                 is it a period?
-               beq       ValidChr            yes, return valid character
-ChkRest        cmpa      #'-                 is it a dash?
-               beq       ValidChr            yes, it's valid
-ChkRst         cmpa      #'z                 is it greater than "z"?
-               bhi       InvalidC            yes, return an invalid character
-               cmpa      #'a                 is it greater than or equal to "a"?
-               bhs       ValidChr            yes, return a valid character
-               cmpa      #'_                 is it an underscore?
-               beq       ValidChr            yes, return a valid character
-               cmpa      #'Z                 is it greater than "Z"?
-               bhi       InvalidC            yes, return an invalid character
-               cmpa      #'A                 is it greater than or equal to "A"?
-               bhs       ValidChr            yes, return a valid character
-               cmpa      #'9                 is it greater than "9"?
-               bhi       InvalidC            yes, return an invalid character
-               cmpa      #'0                 is it greater than or equal to "0"?
-               bhs       ValidChr            yes, return a valid character
-               cmpa      #'$                 is it a dollar symbol?
-               beq       ValidChr            yes, return a valid character
-InvalidC       coma                          else it's an invalid character; set the carry bit to indicate error
-ValidChr       puls      a,pc                return to the caller
+ChkValid            pshs      a         ; save the character
+                    anda      #$7F      ; drop the most significant bit
+                    cmpa      #'.       ; is it a period?
+                    beq       ValidChr  ; yes, return valid character
+ChkRest             cmpa      #'-       ; is it a dash?
+                    beq       ValidChr  ; yes, it's valid
+ChkRst              cmpa      #'z       ; is it greater than "z"?
+                    bhi       InvalidC  ; yes, return an invalid character
+                    cmpa      #'a       ; is it greater than or equal to "a"?
+                    bhs       ValidChr  ; yes, return a valid character
+                    cmpa      #'_       ; is it an underscore?
+                    beq       ValidChr  ; yes, return a valid character
+                    cmpa      #'Z       ; is it greater than "Z"?
+                    bhi       InvalidC  ; yes, return an invalid character
+                    cmpa      #'A       ; is it greater than or equal to "A"?
+                    bhs       ValidChr  ; yes, return a valid character
+                    cmpa      #'9       ; is it greater than "9"?
+                    bhi       InvalidC  ; yes, return an invalid character
+                    cmpa      #'0       ; is it greater than or equal to "0"?
+                    bhs       ValidChr  ; yes, return a valid character
+                    cmpa      #'$       ; is it a dollar symbol?
+                    beq       ValidChr  ; yes, return a valid character
+InvalidC            coma                ; else it's an invalid character; set the carry bit to indicate error
+ValidChr            puls      a,pc      ; return to the caller
 
-               else
+                  ELSE
 
-FPrsNam        ldx       R$X,u               get pathlist pointer from caller
-               bsr       ParseNam            do the parsing of the name
-               std       R$D,u               save the length
-               bcs       ex@                 branch if the carry is set
-               stx       R$X,u               save the updated pathlist pointer
-ex@            sty       R$Y,u               and the Y
-               rts                           return to the caller
+FPrsNam             ldx       R$X,u     ; get pathlist pointer from caller
+                    bsr       ParseNam  ; do the parsing of the name
+                    std       R$D,u     ; save the length
+                    bcs       ex@       ; branch if the carry is set
+                    stx       R$X,u     ; save the updated pathlist pointer
+ex@                 sty       R$Y,u     ; and the Y
+                    rts                 ; return to the caller
 
-ParseNam       lda       ,x                  get the first character
-               cmpa      #PDELIM             is it the pathlist character?
-               bne       next@               branch if not
-               leax      1,x                 else go past it
-next@          leay      ,x                  point Y to X
-               clrb                          clear B
-               lda       ,y+                 get the next character
-               anda      #$7F                mask out the high bit
-               bsr       chkrest@            go check the rest
-               bcs       comma@              branch if the carry is set
-loop@          incb                          increment B
-               lda       -1,y                get the previous character
-               bmi       ex@                 if high bit is set on this character, we're done
-               lda       ,y+                 else get the next character
-               anda      #$7F                clear the high bit
-               bsr       chkfirst@           and check first
-               bcc       loop@               branch if the carry is clear
-               lda       ,-y                 else get the previous character
-ex@            andcc     #^Carry             clear the carry
-               rts                           return to the caller
-comma@         cmpa      #C$COMA             is it a comma?
-               bne       space@              branch if not
-skip@          lda       ,y+                 else get the next character
-space@         cmpa      #C$SPAC             is it a space?
-               beq       skip@               branch if so
-               lda       ,-y                 else get the previous character
-               comb                          set the carry
-               ldb       #E$BNam             indicate a bad pathname error
-               rts                           and return to the caller
+ParseNam            lda       ,x        ; get the first character
+                    cmpa      #PDELIM   ; is it the pathlist character?
+                    bne       next@     ; branch if not
+                    leax      1,x       ; else go past it
+next@               leay      ,x        ; point Y to X
+                    clrb                ; clear B
+                    lda       ,y+       ; get the next character
+                    anda      #$7F      ; mask out the high bit
+                    bsr       chkrest@  ; go check the rest
+                    bcs       comma@    ; branch if the carry is set
+loop@               incb                ; increment B
+                    lda       -1,y      ; get the previous character
+                    bmi       ex@       ; if high bit is set on this character, we're done
+                    lda       ,y+       ; else get the next character
+                    anda      #$7F      ; clear the high bit
+                    bsr       chkfirst@ ; and check first
+                    bcc       loop@     ; branch if the carry is clear
+                    lda       ,-y       ; else get the previous character
+ex@                 andcc     #^Carry   ; clear the carry
+                    rts                 ; return to the caller
+comma@              cmpa      #C$COMA   ; is it a comma?
+                    bne       space@    ; branch if not
+skip@               lda       ,y+       ; else get the next character
+space@              cmpa      #C$SPAC   ; is it a space?
+                    beq       skip@     ; branch if so
+                    lda       ,-y       ; else get the previous character
+                    comb                ; set the carry
+                    ldb       #E$BNam   ; indicate a bad pathname error
+                    rts                 ; and return to the caller
 * Check for legal characters in a pathlist
-chkfirst@      cmpa      #C$PERD             is the character a period?
-               beq       Match               branch if so
-chkrest@       cmpa      #'0                 is it zero?
-               bcs       errex@              branch if less than
-               cmpa      #'9                 is it a number?
-               bls       Match               branch if it is between 0-9
-               cmpa      #'_                 is it an underscore?
-               beq       Match               branch if so
-               cmpa      #'A                 is it A?
-               bcs       errex@              branch if less than
-               cmpa      #'Z                 is it Z?
-               bls       Match               branch if less than or equal (A-Z)
-               cmpa      #'a                 is it a?
-               bcs       errex@              branch if less than
-               cmpa      #'z                 is it z?
-               bls       Match               branch if less than or equal (a-z)
-errex@         orcc      #Carry              set the carry
-               rts                           return to the caller
+chkfirst@           cmpa      #C$PERD   ; is the character a period?
+                    beq       Match     ; branch if so
+chkrest@            cmpa      #'0       ; is it zero?
+                    bcs       errex@    ; branch if less than
+                    cmpa      #'9       ; is it a number?
+                    bls       Match     ; branch if it is between 0-9
+                    cmpa      #'_       ; is it an underscore?
+                    beq       Match     ; branch if so
+                    cmpa      #'A       ; is it A?
+                    bcs       errex@    ; branch if less than
+                    cmpa      #'Z       ; is it Z?
+                    bls       Match     ; branch if less than or equal (A-Z)
+                    cmpa      #'a       ; is it a?
+                    bcs       errex@    ; branch if less than
+                    cmpa      #'z       ; is it z?
+                    bls       Match     ; branch if less than or equal (a-z)
+errex@              orcc      #Carry    ; set the carry
+                    rts                 ; return to the caller
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fret64.asm
+++ b/level1/modules/kernel/fret64.asm
@@ -12,31 +12,31 @@
 ;;;
 ;;; F$Ret64 returns a previously allocated 64 byte block to the free pool.
 
-FRet64         lda       R$A,u               get the block number to deallocate
-               ldx       R$X,u               and the base address of the page table
-               pshs      u,y,x,b,a           preserve registers
-               clrb                          clear B
-               lsra                          divide D by 2
-               rorb                          then...
-               lsra                          divide D by 2 again
-               rorb                          D = D/4
-               pshs      a                   A now holds the offset in the page table
-               lda       a,x                 get the byte in the page table
-               beq       ex@                 branch if 0; already deallocated, so nothing to do
-               tfr       d,y                 else copy D in to Y
-               clr       ,y                  and clear first byte of 64 byte block at Y to mark it free
-               clrb                          clear B, now D holds address of 256 byte page for this 64 byte block
-               tfr       d,u                 put D into U
-               clra                          clear A
+FRet64              lda       R$A,u     ; get the block number to deallocate
+                    ldx       R$X,u     ; and the base address of the page table
+                    pshs      u,y,x,b,a ; preserve registers
+                    clrb                ; clear B
+                    lsra                ; divide D by 2
+                    rorb                ; then...
+                    lsra                ; divide D by 2 again
+                    rorb                ; D = D/4
+                    pshs      a         ; A now holds the offset in the page table
+                    lda       a,x       ; get the byte in the page table
+                    beq       ex@       ; branch if 0; already deallocated, so nothing to do
+                    tfr       d,y       ; else copy D in to Y
+                    clr       ,y        ; and clear first byte of 64 byte block at Y to mark it free
+                    clrb                ; clear B, now D holds address of 256 byte page for this 64 byte block
+                    tfr       d,u       ; put D into U
+                    clra                ; clear A
 * Check if all 64 byte blocks in this 256 byte page are deallocated. If so, free the entire 256 byte block.
-loop@          tst       d,u                 test first byte of 64 byte block
-               bne       ex@                 if not zero, it's allocated; just exit
-               addb      #64                 else add 64 to B
-               bne       loop@               and check the next 64 byte block
-               inca                          increment A
-               os9       F$SRtMem            return 256 byte block to free pool
-               lda       ,s                  get block number saved earlier
-               clr       a,x                 clear block number in page table to indicate deallocated                  
-ex@            clr       ,s+                 clear byte and increment stack
-               puls      pc,u,y,x,b,a        restore registers and return
+loop@               tst       d,u       ; test first byte of 64 byte block
+                    bne       ex@       ; if not zero, it's allocated; just exit
+                    addb      #64       ; else add 64 to B
+                    bne       loop@     ; and check the next 64 byte block
+                    inca                ; increment A
+                    os9       F$SRtMem  ; return 256 byte block to free pool
+                    lda       ,s        ; get block number saved earlier
+                    clr       a,x       ; clear block number in page table to indicate deallocated
+ex@                 clr       ,s+       ; clear byte and increment stack
+                    puls      pc,u,y,x,b,a ; restore registers and return
 

--- a/level1/modules/kernel/fsend.asm
+++ b/level1/modules/kernel/fsend.asm
@@ -30,211 +30,211 @@
 ;;; If you call F$Send for a process that has a signal pending, the kernel returns an error.
 ;;; In that case, call F$Sleep for a few ticks to save CPU time, then try F$Send again.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FSend          lda       R$A,u               get the process ID of recipient
-               bne       getprocess@         if not 0, go find the process descriptor
-               inca                          else increment A
-L0242          ldx       <D.Proc             get the current process descriptor
-               cmpa      P$ID,x              and the process ID
-               beq       L024A               branch if 0
-               bsr       getprocess@         else go find the process descriptor
-L024A          inca                          increase A by 1
-               bne       L0242               branch if not error
-               clrb                          clear the carry
-               rts                           return to the caller
-getprocess@    ldx       <D.PrcDBT           get the process descriptor table pointer
-               os9       F$Find64            find the 64 byte page associated with the process iD
-               bcc       L025E               branch if found
-               ldb       #E$IPrcID           else return an illegal process ID error
-               rts                           return to the caller
-badid@         comb                          set the carry flag
-               ldb       #E$IPrcID           return an illegal process ID error
-               puls      pc,y,a              recover the stack and return to the caller
+FSend               lda       R$A,u     ; get the process ID of recipient
+                    bne       getprocess@ ; if not 0, go find the process descriptor
+                    inca                ; else increment A
+L0242               ldx       <D.Proc   ; get the current process descriptor
+                    cmpa      P$ID,x    ; and the process ID
+                    beq       L024A     ; branch if 0
+                    bsr       getprocess@ ; else go find the process descriptor
+L024A               inca                ; increase A by 1
+                    bne       L0242     ; branch if not error
+                    clrb                ; clear the carry
+                    rts                 ; return to the caller
+getprocess@         ldx       <D.PrcDBT ; get the process descriptor table pointer
+                    os9       F$Find64  ; find the 64 byte page associated with the process iD
+                    bcc       L025E     ; branch if found
+                    ldb       #E$IPrcID ; else return an illegal process ID error
+                    rts                 ; return to the caller
+badid@              comb                ; set the carry flag
+                    ldb       #E$IPrcID ; return an illegal process ID error
+                    puls      pc,y,a    ; recover the stack and return to the caller
 * Entry: A = recipient process ID
-L025E          pshs      y,a                 save the receipient process descriptor and
-               ldb       R$B,u               get the signal to send from the caller
-               bne       checkpending@       branch if not S$Kill
-               ldx       <D.Proc             else get current process descriptor
-               ldd       P$User,x            and its user id
-               beq       condemn@            branch if super user ID (it can send S$Kill)
-               cmpd      P$User,y            same as user of recipient process?
-               bne       badid@              no, cannot send S$Kill to another user's process
-condemn@       lda       P$State,y           get state of recipient
-               ora       #Condem             set condemn bit
-               sta       P$State,y           and set it back
-checkpending@  orcc      #FIRQMask+IRQMask   mask interrupts
-               lda       <P$Signal,y         get the recipient's pending signal, if any
-               beq       sendit@             branch if there is none
-               deca                          is the pending signal the wake signal?
-               beq       sendit@             branch if so
-               comb                          else set the carry flag
-               ldb       #E$USigP            indicate signal already pending
-               puls      pc,y,a              recover the stack and return to the caller
-sendit@        ldb       R$B,u               get the signal to send from the caller
-               stb       <P$Signal,y         store it in the recipient process descriptor
-               ldx       #(D.SProcQ-P$Queue) get pointer to sleep queue
-               bra       findprocess@        go find the process
-match@         cmpx      $01,s               same as process descriptor of recipient?
-               bne       findprocess@        branch if not
-               lda       P$State,x           else get state of recipient
-               bita      #TimSleep           is it in a timed sleep?
-               beq       activate@           branch if not
-               ldu       P$SP,x              else get recipient stack pointer
-               ldd       R$X,u               get the number of ticks it's sleeping
-               beq       activate@           if X == 0 (sleep forever), then branch
-               ldu       P$Queue,x           get the queue pointer of the recipient
-               beq       activate@           branch if empty
-               pshs      b,a                 save off D temporarily
-               lda       P$State,u           get the process' state
-               bita      #TimSleep           is it in a timed sleep
-               puls      b,a                 restore D
-               beq       activate@           branch if it isn't
-               ldu       P$SP,u              else get recipient stack pointer
-               addd      P$SP,u              add it to D
-               std       P$SP,u              save it back
-               bra       activate@           and continue
-findprocess@   leay      ,x                  point Y to the sender's process descriptor
-               ldx       P$Queue,y           get the pointer to its current queue
-               bne       match@              branch if not empty
-               ldx       #(D.WProcQ-P$Queue) else load X with the wait queue pointer
-loop@          leay      ,x                  set Y to that entry
-               ldx       P$Queue,y           and load X with the queue pointer of that process
-               beq       ex@                 branch if empty
-               cmpx      $01,s               is it the recipient process descriptor?
-               bne       loop@               branch if not
-activate@      ldd       P$Queue,x           get the queue pointer in the first process descriptor
-               std       P$Queue,y           and save it to the second process descriptor
-               lda       <P$Signal,x         get the signal from the first process descriptor
-               deca                          decrement it
-               bne       noclear@            branch if not 0 (wasn't S$Wake)
-               sta       <P$Signal,x         clear the signal in the first process descriptor
-noclear@       os9       F$AProc             insert it into the active queue
-ex@            clrb                          clear carry
-               puls      pc,y,a              restore registers and return to the caller
+L025E               pshs      y,a       ; save the receipient process descriptor and
+                    ldb       R$B,u     ; get the signal to send from the caller
+                    bne       checkpending@ ; branch if not S$Kill
+                    ldx       <D.Proc   ; else get current process descriptor
+                    ldd       P$User,x  ; and its user id
+                    beq       condemn@  ; branch if super user ID (it can send S$Kill)
+                    cmpd      P$User,y  ; same as user of recipient process?
+                    bne       badid@    ; no, cannot send S$Kill to another user's process
+condemn@            lda       P$State,y ; get state of recipient
+                    ora       #Condem   ; set condemn bit
+                    sta       P$State,y ; and set it back
+checkpending@       orcc      #FIRQMask+IRQMask ; mask interrupts
+                    lda       <P$Signal,y ; get the recipient's pending signal, if any
+                    beq       sendit@   ; branch if there is none
+                    deca                ; is the pending signal the wake signal?
+                    beq       sendit@   ; branch if so
+                    comb                ; else set the carry flag
+                    ldb       #E$USigP  ; indicate signal already pending
+                    puls      pc,y,a    ; recover the stack and return to the caller
+sendit@             ldb       R$B,u     ; get the signal to send from the caller
+                    stb       <P$Signal,y ; store it in the recipient process descriptor
+                    ldx       #(D.SProcQ-P$Queue) ; get pointer to sleep queue
+                    bra       findprocess@ ; go find the process
+match@              cmpx      $01,s     ; same as process descriptor of recipient?
+                    bne       findprocess@ ; branch if not
+                    lda       P$State,x ; else get state of recipient
+                    bita      #TimSleep ; is it in a timed sleep?
+                    beq       activate@ ; branch if not
+                    ldu       P$SP,x    ; else get recipient stack pointer
+                    ldd       R$X,u     ; get the number of ticks it's sleeping
+                    beq       activate@ ; if X == 0 (sleep forever), then branch
+                    ldu       P$Queue,x ; get the queue pointer of the recipient
+                    beq       activate@ ; branch if empty
+                    pshs      b,a       ; save off D temporarily
+                    lda       P$State,u ; get the process' state
+                    bita      #TimSleep ; is it in a timed sleep
+                    puls      b,a       ; restore D
+                    beq       activate@ ; branch if it isn't
+                    ldu       P$SP,u    ; else get recipient stack pointer
+                    addd      P$SP,u    ; add it to D
+                    std       P$SP,u    ; save it back
+                    bra       activate@ ; and continue
+findprocess@        leay      ,x        ; point Y to the sender's process descriptor
+                    ldx       P$Queue,y ; get the pointer to its current queue
+                    bne       match@    ; branch if not empty
+                    ldx       #(D.WProcQ-P$Queue) ; else load X with the wait queue pointer
+loop@               leay      ,x        ; set Y to that entry
+                    ldx       P$Queue,y ; and load X with the queue pointer of that process
+                    beq       ex@       ; branch if empty
+                    cmpx      $01,s     ; is it the recipient process descriptor?
+                    bne       loop@     ; branch if not
+activate@           ldd       P$Queue,x ; get the queue pointer in the first process descriptor
+                    std       P$Queue,y ; and save it to the second process descriptor
+                    lda       <P$Signal,x ; get the signal from the first process descriptor
+                    deca                ; decrement it
+                    bne       noclear@  ; branch if not 0 (wasn't S$Wake)
+                    sta       <P$Signal,x ; clear the signal in the first process descriptor
+noclear@            os9       F$AProc   ; insert it into the active queue
+ex@                 clrb                ; clear carry
+                    puls      pc,y,a    ; restore registers and return to the caller
 
-               else
+                  ELSE
 
-FSend          ldx       <D.Proc             get current process pointer
-               lda       R$A,u               get destination ID
-               bne       L0652               it's ok, go on
-               inca                          add one
+FSend               ldx       <D.Proc   ; get current process pointer
+                    lda       R$A,u     ; get destination ID
+                    bne       L0652     ; it's ok, go on
+                    inca                ; add one
 * Send signal to ALL process's
-L0647          cmpa      P$ID,x              find myself?
-               beq       L064D               yes, skip it
-               bsr       L0652               send the signal
-L064D          inca                          move to next process
-               bne       L0647               go send it
-               clrb                          clear errors
-               rts                           return
+L0647               cmpa      P$ID,x    ; find myself?
+                    beq       L064D     ; yes, skip it
+                    bsr       L0652     ; send the signal
+L064D               inca                ; move to next process
+                    bne       L0647     ; go send it
+                    clrb                ; clear errors
+                    rts                 ; return
 
 * X   = process descriptor ptr of singal sender
 * A   = process ID to send signal to
 * R$B = signal code
-L0652          lbsr      L0B2E               get pointer to destination descriptor
-               pshs      cc,a,y,u            preserve registers
-               bcs       L066A               error, can't get pointer return
-               tst       R$B,u               kill signal?
-               bne       L066D               no, go on
-               ldd       P$User,x            get user #
-               beq       L066D               he's super user, go on
-               cmpd      P$User,y            does he own the process?
-               beq       L066D               yes, send the signal
-               ldb       #E$BPrcID           get bad process error
-               inc       ,s                  set Carry in CC on stack
-L066A          puls      cc,a,y,u,pc         return
+L0652               lbsr      L0B2E     ; get pointer to destination descriptor
+                    pshs      cc,a,y,u  ; preserve registers
+                    bcs       L066A     ; error, can't get pointer return
+                    tst       R$B,u     ; kill signal?
+                    bne       L066D     ; no, go on
+                    ldd       P$User,x  ; get user #
+                    beq       L066D     ; he's super user, go on
+                    cmpd      P$User,y  ; does he own the process?
+                    beq       L066D     ; yes, send the signal
+                    ldb       #E$BPrcID ; get bad process error
+                    inc       ,s        ; set Carry in CC on stack
+L066A               puls      cc,a,y,u,pc ; return
 
 * Y = process descriptor of process receiving signal
-L066D          orcc      #IntMasks           shut down IRQ's
-               ldb       R$B,u               get signal code
-               bne       L067B               not a kill signal, skip ahead
-               ldb       #E$PrcAbt           get error 228
-               ifne      H6309
-               oim       #Condem,P$State,y   condem process
-L067B          aim       #^Suspend,P$State,y take process out of suspend state
-               else
-               lda       P$State,y
-               ora       #Condem
-               sta       P$State,y
-L067B          lda       P$State,y
-               anda      #^Suspend
-               sta       P$State,y
-               endc
-               lda       <P$Signal,y         already have a pending signal?
-               beq       L068F               nope, go on
-               deca                          is it a wakeup signal?
-               beq       L068F               yes, skip ahead
-               inc       ,s                  set carry on stack
-               ldb       #E$USigP            get pending signal error
-               puls      cc,a,y,u,pc         return
+L066D               orcc      #IntMasks ; shut down IRQ's
+                    ldb       R$B,u     ; get signal code
+                    bne       L067B     ; not a kill signal, skip ahead
+                    ldb       #E$PrcAbt ; get error 228
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #Condem,P$State,y condem process
+L067B               aim       #^Suspend,P$State,y take process out of suspend state
+                  ELSE
+                    lda       P$State,y ; load A from P$State,y
+                    ora       #Condem   ; merge #Condem into A
+                    sta       P$State,y ; store A at P$State,y
+L067B               lda       P$State,y ; load A from P$State,y
+                    anda      #^Suspend ; mask A with #^Suspend
+                    sta       P$State,y ; store A at P$State,y
+                  ENDC
+                    lda       <P$Signal,y ; already have a pending signal?
+                    beq       L068F     ; nope, go on
+                    deca                ; is it a wakeup signal?
+                    beq       L068F     ; yes, skip ahead
+                    inc       ,s        ; set carry on stack
+                    ldb       #E$USigP  ; get pending signal error
+                    puls      cc,a,y,u,pc ; return
 
 * Update sleeping process queue
-L068F          stb       P$Signal,y          save signal code in descriptor
-               ldx       #(D.SProcQ-P$Queue) get pointer to sleeping process queue
-               ifne      H6309
-               clrd                          Faster than 2 memory clears
-               else
-               clra
-               clrb
-               endc
-L0697          leay      ,x                  point Y to this process
-               ldx       P$Queue,x           get pointer to next process in chain
-               beq       L06D3               last one, go check waiting list
-               ldu       P$SP,x              get process stack pointer
-               addd      R$X,u               add his sleep count
-               cmpx      2,s                 is it destination process?
-               bne       L0697               no, skip to next process
-               pshs      d                   save sleep count
-               ifne      H6309
-               tim       #TimSleep,P$State,x
-               else
-               lda       P$State,x
-               bita      #TimSleep
-               endc
-               beq       L06CF               no, update queue
-               ldd       ,s
-               beq       L06CF
-               ldd       R$X,u
-               ifne      H6309
-               ldw       ,s
-               stw       R$X,u
-               else
-               pshs      d
-               ldd       2,s
-               std       R$X,u
-               puls      d
-               endc
-               ldu       P$Queue,x
-               beq       L06CF
-               std       ,s
-               ifne      H6309
-               tim       #TimSleep,P$State,u
-               else
-               lda       P$State,u
-               bita      #TimSleep
-               endc
-               beq       L06CF
-               ldu       P$SP,u
-               ldd       ,s
-               addd      R$X,u
-               std       R$X,u
-L06CF          leas      2,s
-               bra       L06E0
-L06D3          ldx       #(D.WProcQ-P$Queue)
-L06D6          leay      ,x
-               ldx       P$Queue,x
-               beq       L06F4
-               cmpx      2,s
-               bne       L06D6
-L06E0          ldd       P$Queue,x
-               std       P$Queue,y
-               lda       P$Signal,x
-               deca
-               bne       L06F1
-               sta       P$Signal,x
-               lda       ,s
-               tfr       a,cc
-L06F1          os9       F$AProc             activate the process
-L06F4          puls      cc,a,y,u,pc         restore & return
+L068F               stb       P$Signal,y ; save signal code in descriptor
+                    ldx       #(D.SProcQ-P$Queue) ; get pointer to sleeping process queue
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; faster than 2 memory clears
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+L0697               leay      ,x        ; point Y to this process
+                    ldx       P$Queue,x ; get pointer to next process in chain
+                    beq       L06D3     ; last one, go check waiting list
+                    ldu       P$SP,x    ; get process stack pointer
+                    addd      R$X,u     ; add his sleep count
+                    cmpx      2,s       ; is it destination process?
+                    bne       L0697     ; no, skip to next process
+                    pshs      d         ; save sleep count
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #TimSleep,P$State,x
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    bita      #TimSleep ; test bits in A against #TimSleep
+                  ENDC
+                    beq       L06CF     ; no, update queue
+                    ldd       ,s        ; load D from ,s
+                    beq       L06CF     ; branch if zero is set to L06CF
+                    ldd       R$X,u     ; load D from R$X,u
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       ,s
+                    stw       R$X,u
+                  ELSE
+                    pshs      d         ; save d on the stack
+                    ldd       2,s       ; load D from 2,s
+                    std       R$X,u     ; store D at R$X,u
+                    puls      d         ; restore d from the stack
+                  ENDC
+                    ldu       P$Queue,x ; load U from P$Queue,x
+                    beq       L06CF     ; branch if zero is set to L06CF
+                    std       ,s        ; store D at ,s
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #TimSleep,P$State,u
+                  ELSE
+                    lda       P$State,u ; load A from P$State,u
+                    bita      #TimSleep ; test bits in A against #TimSleep
+                  ENDC
+                    beq       L06CF     ; branch if zero is set to L06CF
+                    ldu       P$SP,u    ; load U from P$SP,u
+                    ldd       ,s        ; load D from ,s
+                    addd      R$X,u     ; add R$X,u to D
+                    std       R$X,u     ; store D at R$X,u
+L06CF               leas      2,s       ; adjust stack pointer by 2,s
+                    bra       L06E0     ; branch unconditionally to L06E0
+L06D3               ldx       #(D.WProcQ-P$Queue) ; load X from #(D.WProcQ-P$Queue)
+L06D6               leay      ,x        ; compute ,x into Y
+                    ldx       P$Queue,x ; load X from P$Queue,x
+                    beq       L06F4     ; branch if zero is set to L06F4
+                    cmpx      2,s       ; compare X with 2,s
+                    bne       L06D6     ; branch if zero is clear to L06D6
+L06E0               ldd       P$Queue,x ; load D from P$Queue,x
+                    std       P$Queue,y ; store D at P$Queue,y
+                    lda       P$Signal,x ; load A from P$Signal,x
+                    deca                ; decrement A
+                    bne       L06F1     ; branch if zero is clear to L06F1
+                    sta       P$Signal,x ; store A at P$Signal,x
+                    lda       ,s        ; load A from ,s
+                    tfr       a,cc      ; transfer register value a,cc
+L06F1               os9       F$AProc   ; activate the process
+L06F4               puls      cc,a,y,u,pc ; restore & return
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fsend.asm
+++ b/level1/modules/kernel/fsend.asm
@@ -35,24 +35,24 @@
 FSend               lda       R$A,u     ; get the process ID of recipient
                     bne       getprocess@ ; if not 0, go find the process descriptor
                     inca                ; else increment A
-L0242               ldx       <D.Proc   ; get the current process descriptor
+FSendProcessDescriptor ldx       <D.Proc   ; get the current process descriptor
                     cmpa      P$ID,x    ; and the process ID
-                    beq       L024A     ; branch if 0
+                    beq       FSendIncreaseBy ; branch if 0
                     bsr       getprocess@ ; else go find the process descriptor
-L024A               inca                ; increase A by 1
-                    bne       L0242     ; branch if not error
+FSendIncreaseBy     inca                ; increase A by 1
+                    bne       FSendProcessDescriptor ; branch if not error
                     clrb                ; clear the carry
                     rts                 ; return to the caller
 getprocess@         ldx       <D.PrcDBT ; get the process descriptor table pointer
                     os9       F$Find64  ; find the 64 byte page associated with the process iD
-                    bcc       L025E     ; branch if found
+                    bcc       FSendReceipientProcessDescriptor ; branch if found
                     ldb       #E$IPrcID ; else return an illegal process ID error
                     rts                 ; return to the caller
 badid@              comb                ; set the carry flag
                     ldb       #E$IPrcID ; return an illegal process ID error
                     puls      pc,y,a    ; recover the stack and return to the caller
 * Entry: A = recipient process ID
-L025E               pshs      y,a       ; save the receipient process descriptor and
+FSendReceipientProcessDescriptor pshs      y,a       ; save the receipient process descriptor and
                     ldb       R$B,u     ; get the signal to send from the caller
                     bne       checkpending@ ; branch if not S$Kill
                     ldx       <D.Proc   ; else get current process descriptor
@@ -117,59 +117,59 @@ ex@                 clrb                ; clear carry
 
 FSend               ldx       <D.Proc   ; get current process pointer
                     lda       R$A,u     ; get destination ID
-                    bne       L0652     ; it's ok, go on
+                    bne       FSendDestinationDescriptor ; it's ok, go on
                     inca                ; add one
 * Send signal to ALL process's
-L0647               cmpa      P$ID,x    ; find myself?
-                    beq       L064D     ; yes, skip it
-                    bsr       L0652     ; send the signal
-L064D               inca                ; move to next process
-                    bne       L0647     ; go send it
+FSendFindMyself     cmpa      P$ID,x    ; find myself?
+                    beq       FSendProcess ; yes, skip it
+                    bsr       FSendDestinationDescriptor ; send the signal
+FSendProcess        inca                ; move to next process
+                    bne       FSendFindMyself ; go send it
                     clrb                ; clear errors
                     rts                 ; return
 
 * X   = process descriptor ptr of singal sender
 * A   = process ID to send signal to
 * R$B = signal code
-L0652               lbsr      L0B2E     ; get pointer to destination descriptor
+FSendDestinationDescriptor lbsr      FGprocpTarget ; get pointer to destination descriptor
                     pshs      cc,a,y,u  ; preserve registers
-                    bcs       L066A     ; error, can't get pointer return
+                    bcs       FSendReturn ; error, can't get pointer return
                     tst       R$B,u     ; kill signal?
-                    bne       L066D     ; no, go on
+                    bne       FSendShutDownIrqs ; no, go on
                     ldd       P$User,x  ; get user #
-                    beq       L066D     ; he's super user, go on
+                    beq       FSendShutDownIrqs ; he's super user, go on
                     cmpd      P$User,y  ; does he own the process?
-                    beq       L066D     ; yes, send the signal
+                    beq       FSendShutDownIrqs ; yes, send the signal
                     ldb       #E$BPrcID ; get bad process error
                     inc       ,s        ; set Carry in CC on stack
-L066A               puls      cc,a,y,u,pc ; return
+FSendReturn         puls      cc,a,y,u,pc ; return
 
 * Y = process descriptor of process receiving signal
-L066D               orcc      #IntMasks ; shut down IRQ's
+FSendShutDownIrqs   orcc      #IntMasks ; shut down IRQ's
                     ldb       R$B,u     ; get signal code
-                    bne       L067B     ; not a kill signal, skip ahead
+                    bne       FSendTarget ; not a kill signal, skip ahead
                     ldb       #E$PrcAbt ; get error 228
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #Condem,P$State,y condem process
-L067B               aim       #^Suspend,P$State,y take process out of suspend state
+FSendTarget         aim       #^Suspend,P$State,y take process out of suspend state
                   ELSE
                     lda       P$State,y ; load A from P$State,y
                     ora       #Condem   ; merge #Condem into A
                     sta       P$State,y ; store A at P$State,y
-L067B               lda       P$State,y ; load A from P$State,y
+FSendTarget         lda       P$State,y ; load A from P$State,y
                     anda      #^Suspend ; mask A with #^Suspend
                     sta       P$State,y ; store A at P$State,y
                   ENDC
                     lda       <P$Signal,y ; already have a pending signal?
-                    beq       L068F     ; nope, go on
+                    beq       FSendSignalDescriptor ; nope, go on
                     deca                ; is it a wakeup signal?
-                    beq       L068F     ; yes, skip ahead
+                    beq       FSendSignalDescriptor ; yes, skip ahead
                     inc       ,s        ; set carry on stack
                     ldb       #E$USigP  ; get pending signal error
                     puls      cc,a,y,u,pc ; return
 
 * Update sleeping process queue
-L068F               stb       P$Signal,y ; save signal code in descriptor
+FSendSignalDescriptor stb       P$Signal,y ; save signal code in descriptor
                     ldx       #(D.SProcQ-P$Queue) ; get pointer to sleeping process queue
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; faster than 2 memory clears
@@ -177,13 +177,13 @@ L068F               stb       P$Signal,y ; save signal code in descriptor
                     clra                ; clear A
                     clrb                ; clear B
                   ENDC
-L0697               leay      ,x        ; point Y to this process
+FSendProcess2       leay      ,x        ; point Y to this process
                     ldx       P$Queue,x ; get pointer to next process in chain
-                    beq       L06D3     ; last one, go check waiting list
+                    beq       FSendDwprocqPqueue ; last one, go check waiting list
                     ldu       P$SP,x    ; get process stack pointer
                     addd      R$X,u     ; add his sleep count
                     cmpx      2,s       ; is it destination process?
-                    bne       L0697     ; no, skip to next process
+                    bne       FSendProcess2 ; no, skip to next process
                     pshs      d         ; save sleep count
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,x
@@ -191,9 +191,9 @@ L0697               leay      ,x        ; point Y to this process
                     lda       P$State,x ; load A from P$State,x
                     bita      #TimSleep ; test bits in A against #TimSleep
                   ENDC
-                    beq       L06CF     ; no, update queue
+                    beq       FSendAdjustBy ; no, update queue
                     ldd       ,s        ; load D from ,s
-                    beq       L06CF     ; branch if zero is set to L06CF
+                    beq       FSendAdjustBy ; branch if zero is set to FSendAdjustBy
                     ldd       R$X,u     ; load D from R$X,u
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       ,s
@@ -205,7 +205,7 @@ L0697               leay      ,x        ; point Y to this process
                     puls      d         ; restore d from the stack
                   ENDC
                     ldu       P$Queue,x ; load U from P$Queue,x
-                    beq       L06CF     ; branch if zero is set to L06CF
+                    beq       FSendAdjustBy ; branch if zero is set to FSendAdjustBy
                     std       ,s        ; store D at ,s
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,u
@@ -213,28 +213,28 @@ L0697               leay      ,x        ; point Y to this process
                     lda       P$State,u ; load A from P$State,u
                     bita      #TimSleep ; test bits in A against #TimSleep
                   ENDC
-                    beq       L06CF     ; branch if zero is set to L06CF
+                    beq       FSendAdjustBy ; branch if zero is set to FSendAdjustBy
                     ldu       P$SP,u    ; load U from P$SP,u
                     ldd       ,s        ; load D from ,s
                     addd      R$X,u     ; add R$X,u to D
                     std       R$X,u     ; store D at R$X,u
-L06CF               leas      2,s       ; adjust stack pointer by 2,s
-                    bra       L06E0     ; branch unconditionally to L06E0
-L06D3               ldx       #(D.WProcQ-P$Queue) ; load X from #(D.WProcQ-P$Queue)
-L06D6               leay      ,x        ; compute ,x into Y
+FSendAdjustBy       leas      2,s       ; adjust stack pointer by 2,s
+                    bra       FSendPqueue ; branch unconditionally to FSendPqueue
+FSendDwprocqPqueue  ldx       #(D.WProcQ-P$Queue) ; load X from #(D.WProcQ-P$Queue)
+FSendTarget2        leay      ,x        ; compute ,x into Y
                     ldx       P$Queue,x ; load X from P$Queue,x
-                    beq       L06F4     ; branch if zero is set to L06F4
+                    beq       FSendReturn2 ; branch if zero is set to FSendReturn2
                     cmpx      2,s       ; compare X with 2,s
-                    bne       L06D6     ; branch if zero is clear to L06D6
-L06E0               ldd       P$Queue,x ; load D from P$Queue,x
+                    bne       FSendTarget2 ; branch if zero is clear to FSendTarget2
+FSendPqueue         ldd       P$Queue,x ; load D from P$Queue,x
                     std       P$Queue,y ; store D at P$Queue,y
                     lda       P$Signal,x ; load A from P$Signal,x
                     deca                ; decrement A
-                    bne       L06F1     ; branch if zero is clear to L06F1
+                    bne       FSendActivateProcess ; branch if zero is clear to FSendActivateProcess
                     sta       P$Signal,x ; store A at P$Signal,x
                     lda       ,s        ; load A from ,s
                     tfr       a,cc      ; transfer register value a,cc
-L06F1               os9       F$AProc   ; activate the process
-L06F4               puls      cc,a,y,u,pc ; restore & return
+FSendActivateProcess os9       F$AProc   ; activate the process
+FSendReturn2        puls      cc,a,y,u,pc ; restore & return
 
                   ENDC

--- a/level1/modules/kernel/fsend.asm
+++ b/level1/modules/kernel/fsend.asm
@@ -35,24 +35,24 @@
 FSend               lda       R$A,u     ; get the process ID of recipient
                     bne       getprocess@ ; if not 0, go find the process descriptor
                     inca                ; else increment A
-FSendProcessDescriptor ldx       <D.Proc   ; get the current process descriptor
+FSendProcDesc       ldx       <D.Proc   ; get the current process descriptor
                     cmpa      P$ID,x    ; and the process ID
                     beq       FSendIncreaseBy ; branch if 0
                     bsr       getprocess@ ; else go find the process descriptor
 FSendIncreaseBy     inca                ; increase A by 1
-                    bne       FSendProcessDescriptor ; branch if not error
+                    bne       FSendProcDesc ; branch if not error
                     clrb                ; clear the carry
                     rts                 ; return to the caller
 getprocess@         ldx       <D.PrcDBT ; get the process descriptor table pointer
                     os9       F$Find64  ; find the 64 byte page associated with the process iD
-                    bcc       FSendReceipientProcessDescriptor ; branch if found
+                    bcc       FSendRecvProcDesc ; branch if found
                     ldb       #E$IPrcID ; else return an illegal process ID error
                     rts                 ; return to the caller
 badid@              comb                ; set the carry flag
                     ldb       #E$IPrcID ; return an illegal process ID error
                     puls      pc,y,a    ; recover the stack and return to the caller
 * Entry: A = recipient process ID
-FSendReceipientProcessDescriptor pshs      y,a       ; save the receipient process descriptor and
+FSendRecvProcDesc   pshs      y,a       ; save the receipient process descriptor and
                     ldb       R$B,u     ; get the signal to send from the caller
                     bne       checkpending@ ; branch if not S$Kill
                     ldx       <D.Proc   ; else get current process descriptor
@@ -117,12 +117,12 @@ ex@                 clrb                ; clear carry
 
 FSend               ldx       <D.Proc   ; get current process pointer
                     lda       R$A,u     ; get destination ID
-                    bne       FSendDestinationDescriptor ; it's ok, go on
+                    bne       FSendDstDesc ; it's ok, go on
                     inca                ; add one
 * Send signal to ALL process's
 FSendFindMyself     cmpa      P$ID,x    ; find myself?
                     beq       FSendProcess ; yes, skip it
-                    bsr       FSendDestinationDescriptor ; send the signal
+                    bsr       FSendDstDesc ; send the signal
 FSendProcess        inca                ; move to next process
                     bne       FSendFindMyself ; go send it
                     clrb                ; clear errors
@@ -131,7 +131,7 @@ FSendProcess        inca                ; move to next process
 * X   = process descriptor ptr of singal sender
 * A   = process ID to send signal to
 * R$B = signal code
-FSendDestinationDescriptor lbsr      FGprocpTarget ; get pointer to destination descriptor
+FSendDstDesc        lbsr      FGprocpTarget ; get pointer to destination descriptor
                     pshs      cc,a,y,u  ; preserve registers
                     bcs       FSendReturn ; error, can't get pointer return
                     tst       R$B,u     ; kill signal?
@@ -161,15 +161,15 @@ FSendTarget         lda       P$State,y ; load A from P$State,y
                     sta       P$State,y ; store A at P$State,y
                   ENDC
                     lda       <P$Signal,y ; already have a pending signal?
-                    beq       FSendSignalDescriptor ; nope, go on
+                    beq       FSendSigDesc ; nope, go on
                     deca                ; is it a wakeup signal?
-                    beq       FSendSignalDescriptor ; yes, skip ahead
+                    beq       FSendSigDesc ; yes, skip ahead
                     inc       ,s        ; set carry on stack
                     ldb       #E$USigP  ; get pending signal error
                     puls      cc,a,y,u,pc ; return
 
 * Update sleeping process queue
-FSendSignalDescriptor stb       P$Signal,y ; save signal code in descriptor
+FSendSigDesc        stb       P$Signal,y ; save signal code in descriptor
                     ldx       #(D.SProcQ-P$Queue) ; get pointer to sleeping process queue
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; faster than 2 memory clears
@@ -230,11 +230,11 @@ FSendPqueue         ldd       P$Queue,x ; load D from P$Queue,x
                     std       P$Queue,y ; store D at P$Queue,y
                     lda       P$Signal,x ; load A from P$Signal,x
                     deca                ; decrement A
-                    bne       FSendActivateProcess ; branch if zero is clear to FSendActivateProcess
+                    bne       FSendActProc ; branch if zero is clear to FSendActProc
                     sta       P$Signal,x ; store A at P$Signal,x
                     lda       ,s        ; load A from ,s
                     tfr       a,cc      ; transfer register value a,cc
-FSendActivateProcess os9       F$AProc   ; activate the process
+FSendActProc        os9       F$AProc   ; activate the process
 FSendReturn2        puls      cc,a,y,u,pc ; restore & return
 
                   ENDC

--- a/level1/modules/kernel/fsleep.asm
+++ b/level1/modules/kernel/fsleep.asm
@@ -116,11 +116,11 @@ FSleep              pshs      cc        ; preserve interupt status
                     beq       SkpSleep  ; skip sleep call
                     orcc      #IntMasks ; disable interupts
                     lda       P$Signal,x ; get pending signal
-                    beq       L0722     ; none there, skip ahead
+                    beq       FSleepContainsSleepTickCount ; none there, skip ahead
                     deca                ; wakeup signal?
-                    bne       L0715     ; no, skip ahead
+                    bne       WakeFromSignal ; no, skip ahead
                     sta       P$Signal,x ; clear pending signal so we can wake up process
-L0715
+WakeFromSignal
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^Suspend,P$State,x
                   ELSE
@@ -128,35 +128,35 @@ L0715
                     anda      #^Suspend ; mask A with #^Suspend
                     sta       P$State,x ; store A at P$State,x
                   ENDC
-L071B               puls      cc        ; restore cc from the stack
+FSleepTarget        puls      cc        ; restore cc from the stack
                     os9       F$AProc   ; activate the process
-                    bra       L0780     ; branch unconditionally to L0780
-L0722               ldd       R$X,u     ; get callers X (contains sleep tick count)
-                    beq       L076D     ; done, wake it up
+                    bra       FSleepTarget4 ; branch unconditionally to FSleepTarget4
+FSleepContainsSleepTickCount ldd       R$X,u     ; get callers X (contains sleep tick count)
+                    beq       FSleepDsprocqPqueue ; done, wake it up
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decd      subtract  1 from tick count
                   ELSE
                     subd      #$0001    ; subtract #$0001 from D
                   ENDC
                     std       R$X,u     ; save it back
-                    beq       L071B     ; zero, wake up process
+                    beq       FSleepTarget ; zero, wake up process
                     pshs      x,y       ; save x,y on the stack
                     ldx       #(D.SProcQ-P$Queue) ; load X from #(D.SProcQ-P$Queue)
-L0732               std       R$X,u     ; store D at R$X,u
+FSleepRx            std       R$X,u     ; store D at R$X,u
                     stx       2,s       ; store X at 2,s
                     ldx       P$Queue,x ; load X from P$Queue,x
-                    beq       L074F     ; branch if zero is set to L074F
+                    beq       FSleepTarget2 ; branch if zero is set to FSleepTarget2
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,x
                   ELSE
                     lda       P$State,x ; load A from P$State,x
                     bita      #TimSleep ; test bits in A against #TimSleep
                   ENDC
-                    beq       L074F     ; branch if zero is set to L074F
+                    beq       FSleepTarget2 ; branch if zero is set to FSleepTarget2
                     ldy       P$SP,x    ; get process stack pointer
                     ldd       R$X,u     ; load D from R$X,u
                     subd      R$X,y     ; subtract R$X,y from D
-                    bcc       L0732     ; branch if carry is clear to L0732
+                    bcc       FSleepRx  ; branch if carry is clear to FSleepRx
                   IFNE    H6309   ; begin conditional assembly for H6309
                     negd                ; update processor state
                   ELSE
@@ -165,7 +165,7 @@ L0732               std       R$X,u     ; store D at R$X,u
                     sbca      #0        ; update processor state
                   ENDC
                     std       R$X,y     ; store D at R$X,y
-L074F               puls      y,x       ; restore y,x from the stack
+FSleepTarget2       puls      y,x       ; restore y,x from the stack
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #TimSleep,P$State,x
                   ELSE
@@ -177,7 +177,7 @@ L074F               puls      y,x       ; restore y,x from the stack
                     stx       P$Queue,y ; store X at P$Queue,y
                     std       P$Queue,x ; store D at P$Queue,x
                     ldx       R$X,u     ; load X from R$X,u
-                    bsr       L0780     ; call local routine L0780
+                    bsr       FSleepTarget4 ; call local routine FSleepTarget4
                     stx       R$X,u     ; store X at R$X,u
                     ldx       <D.Proc   ; load X from <D.Proc
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -189,10 +189,10 @@ L074F               puls      y,x       ; restore y,x from the stack
                   ENDC
 SkpSleep            puls      cc,pc     ; restore cc,pc from the stack
 
-L076D               ldx       #D.SProcQ-P$Queue ; load X from #D.SProcQ-P$Queue
-L0770               leay      ,x        ; compute ,x into Y
+FSleepDsprocqPqueue ldx       #D.SProcQ-P$Queue ; load X from #D.SProcQ-P$Queue
+FSleepTarget3       leay      ,x        ; compute ,x into Y
                     ldx       P$Queue,x ; load X from P$Queue,x
-                    bne       L0770     ; branch if zero is clear to L0770
+                    bne       FSleepTarget3 ; branch if zero is clear to FSleepTarget3
                     ldx       <D.Proc   ; load X from <D.Proc
                     clra                ; clear A
                     clrb                ; clear B
@@ -200,15 +200,15 @@ L0770               leay      ,x        ; compute ,x into Y
                     std       P$Queue,x ; store D at P$Queue,x
                     puls      cc        ; restore cc from the stack
 
-L0780               pshs      dp,x,y,u,pc ; save dp,x,y,u,pc on the stack
-L0782               leax      <L079C,pc ; compute <L079C,pc into X
+FSleepTarget4       pshs      dp,x,y,u,pc ; save dp,x,y,u,pc on the stack
+FSleepL079c         leax      <FSleepTarget5,pc ; compute <FSleepTarget5,pc into X
                     stx       7,s       ; store X at 7,s
                     ldx       <D.Proc   ; load X from <D.Proc
                     ldb       P$Task,x  ; this is related to the 'one-byte hack'
                     cmpb      <D.SysTsk ; that stops OS9p1 from doing an F$AllTsk on
-                    beq       L0792     ; _every_ system call.
+                    beq       FSleepPsp ; _every_ system call.
                     os9       F$DelTsk  ; call OS-9 service F$DelTsk
-L0792               ldd       P$SP,x    ; load D from P$SP,x
+FSleepPsp           ldd       P$SP,x    ; load D from P$SP,x
                   IFNE    H6309   ; begin conditional assembly for H6309
                     pshsw
                   ENDC
@@ -216,7 +216,7 @@ L0792               ldd       P$SP,x    ; load D from P$SP,x
                     sts       P$SP,x    ; store S at P$SP,x
                     os9       F$NProc   ; call OS-9 service F$NProc
 
-L079C               pshs      x         ; save x on the stack
+FSleepTarget5       pshs      x         ; save x on the stack
                     ldx       <D.Proc   ; load X from <D.Proc
                     std       P$SP,x    ; store D at P$SP,x
                     clrb                ; clear B

--- a/level1/modules/kernel/fsleep.asm
+++ b/level1/modules/kernel/fsleep.asm
@@ -116,7 +116,7 @@ FSleep              pshs      cc        ; preserve interupt status
                     beq       SkpSleep  ; skip sleep call
                     orcc      #IntMasks ; disable interupts
                     lda       P$Signal,x ; get pending signal
-                    beq       FSleepContainsSleepTickCount ; none there, skip ahead
+                    beq       FSleepHasSlpTick ; none there, skip ahead
                     deca                ; wakeup signal?
                     bne       WakeFromSignal ; no, skip ahead
                     sta       P$Signal,x ; clear pending signal so we can wake up process
@@ -131,7 +131,7 @@ WakeFromSignal
 FSleepTarget        puls      cc        ; restore cc from the stack
                     os9       F$AProc   ; activate the process
                     bra       FSleepTarget4 ; branch unconditionally to FSleepTarget4
-FSleepContainsSleepTickCount ldd       R$X,u     ; get callers X (contains sleep tick count)
+FSleepHasSlpTick    ldd       R$X,u     ; get callers X (contains sleep tick count)
                     beq       FSleepDsprocqPqueue ; done, wake it up
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decd      subtract  1 from tick count

--- a/level1/modules/kernel/fsleep.asm
+++ b/level1/modules/kernel/fsleep.asm
@@ -24,202 +24,202 @@
 ;;; If the process receives a signal, it awakens before the time has elapsed. When you select processes among
 ;;; multiple windows, you might need to sleep for two ticks.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FSleep         ldx       <D.Proc             get the process descriptor
-               orcc      #FIRQMask+IRQMask   mask interrupts
-               lda       P$Signal,x          get the process' signal
-               beq       nosig@              branch if there is no signal
-               deca                          else decrement the signal number
-               bne       activate@           branch if not 0 (S$Wake)
-               sta       P$Signal,x          clear the process' signal
-activate@      os9       F$AProc             insert into the active queue
-               bra       SetupReturn         and set up the return step
-nosig@         ldd       R$X,u               get the passed timeout
-               beq       sleepforever@       branch if 0 (sleep forever)
-               subd      #$0001              else subtract 1
-               std       R$X,u               save back to caller
-               beq       activate@           branch if 0 (sleep for the remainder of the timeslice)
-               pshs      u,x                 save these registers
-               ldx       #(D.SProcQ-P$Queue) position X so that the next access is at the sleep queue head
-loop@          leay      ,x                  point Y to X
-               ldx       P$Queue,x           get the next queue pointer
-               beq       eoq@                branch if zero (at the end of the queue)
-               pshs      b,a                 save the tick count
-               lda       P$State,x           get the state of the process (ONLY NEED TO PUSH A)
-               bita      #TimSleep           is this process already asleep?
-               puls      b,a                 restore the tick count (ONLY NEED TO PULL A)
-               beq       eoq@                branch if the timed sleep flag was clear
-               ldu       P$SP,x              else get the process' stack pointer in U
-               subd      R$X,u               get the difference in ticks slept
-               bcc       loop@               branch if >= 0
-               addd      R$X,u               else add it back
-eoq@           puls      u,x                 recover the registers saved earlier
-               std       R$X,u               save the tick count back to the caller
+FSleep              ldx       <D.Proc   ; get the process descriptor
+                    orcc      #FIRQMask+IRQMask ; mask interrupts
+                    lda       P$Signal,x ; get the process' signal
+                    beq       nosig@    ; branch if there is no signal
+                    deca                ; else decrement the signal number
+                    bne       activate@ ; branch if not 0 (S$Wake)
+                    sta       P$Signal,x ; clear the process' signal
+activate@           os9       F$AProc   ; insert into the active queue
+                    bra       SetupReturn ; and set up the return step
+nosig@              ldd       R$X,u     ; get the passed timeout
+                    beq       sleepforever@ ; branch if 0 (sleep forever)
+                    subd      #$0001    ; else subtract 1
+                    std       R$X,u     ; save back to caller
+                    beq       activate@ ; branch if 0 (sleep for the remainder of the timeslice)
+                    pshs      u,x       ; save these registers
+                    ldx       #(D.SProcQ-P$Queue) ; position X so that the next access is at the sleep queue head
+loop@               leay      ,x        ; point Y to X
+                    ldx       P$Queue,x ; get the next queue pointer
+                    beq       eoq@      ; branch if zero (at the end of the queue)
+                    pshs      b,a       ; save the tick count
+                    lda       P$State,x ; get the state of the process (ONLY NEED TO PUSH A)
+                    bita      #TimSleep ; is this process already asleep?
+                    puls      b,a       ; restore the tick count (ONLY NEED TO PULL A)
+                    beq       eoq@      ; branch if the timed sleep flag was clear
+                    ldu       P$SP,x    ; else get the process' stack pointer in U
+                    subd      R$X,u     ; get the difference in ticks slept
+                    bcc       loop@     ; branch if >= 0
+                    addd      R$X,u     ; else add it back
+eoq@                puls      u,x       ; recover the registers saved earlier
+                    std       R$X,u     ; save the tick count back to the caller
 * Insert the process descriptor in X in front of the process descriptor in D
-               ldd       P$Queue,y           get the previous queue entry
-               stx       P$Queue,y           store the current queue entry in front
-               std       P$Queue,x           and the previous queue entry after
-               lda       P$State,x           get the process' state byte
-               ora       #TimSleep           set the timed sleep flag
-               sta       P$State,x           save it back
-               ldx       P$Queue,x           get the next process in the queue
-               beq       SetupReturn         branch if we're at the end
-               lda       P$State,x           get the process' state byte
-               bita      #TimSleep           test for the timed sleep flag
-               beq       SetupReturn         branch if clear (this process isn't sleeping)
-               ldx       P$SP,x              else get the process' stack pointer
-               ldd       P$SP,x              get the stack pointer there
-               subd      R$X,u               subtract the caller's X
-               std       P$SP,x              and store the stack pointer
-               bra       SetupReturn         prepare to return
-sleepforever@  lda       P$State,x           get the process' state byte
-               anda      #^TimSleep          turn off the timed sleep flag
-               sta       P$State,x           save it back
-               ldd       #(D.SProcQ-P$Queue) position XDso that the next access is at the sleep queue head
-loop2@         tfr       d,y                 copy the process descriptor pointer to Y
-               ldd       P$Queue,y           get the next queue entry
-               bne       loop2@              branch if we're not at the end
-               stx       P$Queue,y           store this process descriptor at the end of the queue
-               std       P$Queue,x           and terminate it (D = $0000)
-SetupReturn    leay      <callreturn@,pcr    point to the return code
-               pshs      y                   save the pointer as the program counter on the return stack
-               ldy       <D.Proc             get the current process descriptor
-               ldd       P$SP,y              and get the stack pointer
-               ldx       R$X,u               get the caller's X
-               ifne      H6309
-*>>>>>>>>>> H6309
-               pshs      u,y,x,dp            push 6809 registers
-               pshsw                         then the 6309 W
-               pshs      b,a,cc              then the rest
-*<<<<<<<<<< H6309
-               else
-*>>>>>>>>>> M6809
-               pshs      u,y,x,dp,b,a,cc     push registers on the stack
-*<<<<<<<<<< M6809
-               endc
-               sts       P$SP,y              save the stack pointer
-               os9       F$NProc             execute the next process in the active queue
-callreturn@    std       P$SP,y              save off the stack pointer
-               stx       R$X,u               and the updated tick count
-               clrb                          clear the carry
-               rts                           return to the caller
+                    ldd       P$Queue,y ; get the previous queue entry
+                    stx       P$Queue,y ; store the current queue entry in front
+                    std       P$Queue,x ; and the previous queue entry after
+                    lda       P$State,x ; get the process' state byte
+                    ora       #TimSleep ; set the timed sleep flag
+                    sta       P$State,x ; save it back
+                    ldx       P$Queue,x ; get the next process in the queue
+                    beq       SetupReturn ; branch if we're at the end
+                    lda       P$State,x ; get the process' state byte
+                    bita      #TimSleep ; test for the timed sleep flag
+                    beq       SetupReturn ; branch if clear (this process isn't sleeping)
+                    ldx       P$SP,x    ; else get the process' stack pointer
+                    ldd       P$SP,x    ; get the stack pointer there
+                    subd      R$X,u     ; subtract the caller's X
+                    std       P$SP,x    ; and store the stack pointer
+                    bra       SetupReturn ; prepare to return
+sleepforever@       lda       P$State,x ; get the process' state byte
+                    anda      #^TimSleep ; turn off the timed sleep flag
+                    sta       P$State,x ; save it back
+                    ldd       #(D.SProcQ-P$Queue) ; position XDso that the next access is at the sleep queue head
+loop2@              tfr       d,y       ; copy the process descriptor pointer to Y
+                    ldd       P$Queue,y ; get the next queue entry
+                    bne       loop2@    ; branch if we're not at the end
+                    stx       P$Queue,y ; store this process descriptor at the end of the queue
+                    std       P$Queue,x ; and terminate it (D = $0000)
+SetupReturn         leay      <callreturn@,pcr ; point to the return code
+                    pshs      y         ; save the pointer as the program counter on the return stack
+                    ldy       <D.Proc   ; get the current process descriptor
+                    ldd       P$SP,y    ; and get the stack pointer
+                    ldx       R$X,u     ; get the caller's X
+                  IFNE    H6309   ; begin conditional assembly for H6309
+*[[[ H6309
+                    pshs      u,y,x,dp  ; push 6809 registers
+                    pshsw     then      the 6309 W
+                    pshs      b,a,cc    ; then the rest
+*]]] H6309
+                  ELSE
+*[[[ M6809
+                    pshs      u,y,x,dp,b,a,cc ; push registers on the stack
+*]]] M6809
+                  ENDC
+                    sts       P$SP,y    ; save the stack pointer
+                    os9       F$NProc   ; execute the next process in the active queue
+callreturn@         std       P$SP,y    ; save off the stack pointer
+                    stx       R$X,u     ; and the updated tick count
+                    clrb                ; clear the carry
+                    rts                 ; return to the caller
 
-               else
+                  ELSE
 
-FSleep         pshs      cc                  preserve interupt status
-               ldx       <D.Proc             Get current process pointer
+FSleep              pshs      cc        ; preserve interupt status
+                    ldx       <D.Proc   ; get current process pointer
 
 * F$Sleep bug fix.  Check if we're in system state.  If so return because you
 * should never sleep in system state.
-               cmpx      <D.SysPrc           is it system process?
-               beq       SkpSleep            skip sleep call
-               orcc      #IntMasks           disable interupts
-               lda       P$Signal,x          get pending signal
-               beq       L0722               none there, skip ahead
-               deca                          wakeup signal?
-               bne       L0715               no, skip ahead
-               sta       P$Signal,x          clear pending signal so we can wake up process
+                    cmpx      <D.SysPrc ; is it system process?
+                    beq       SkpSleep  ; skip sleep call
+                    orcc      #IntMasks ; disable interupts
+                    lda       P$Signal,x ; get pending signal
+                    beq       L0722     ; none there, skip ahead
+                    deca                ; wakeup signal?
+                    bne       L0715     ; no, skip ahead
+                    sta       P$Signal,x ; clear pending signal so we can wake up process
 L0715
-               ifne      H6309
-               aim       #^Suspend,P$State,x
-               else
-               lda       P$State,x
-               anda      #^Suspend
-               sta       P$State,x
-               endc
-L071B          puls      cc
-               os9       F$AProc             activate the process
-               bra       L0780
-L0722          ldd       R$X,u               get callers X (contains sleep tick count)
-               beq       L076D               done, wake it up
-               ifne      H6309
-               decd                          subtract 1 from tick count
-               else
-               subd      #$0001
-               endc
-               std       R$X,u               save it back
-               beq       L071B               zero, wake up process
-               pshs      x,y
-               ldx       #(D.SProcQ-P$Queue)
-L0732          std       R$X,u
-               stx       2,s
-               ldx       P$Queue,x
-               beq       L074F
-               ifne      H6309
-               tim       #TimSleep,P$State,x
-               else
-               lda       P$State,x
-               bita      #TimSleep
-               endc
-               beq       L074F
-               ldy       P$SP,x              get process stack pointer
-               ldd       R$X,u
-               subd      R$X,y
-               bcc       L0732
-               ifne      H6309
-               negd
-               else
-               nega
-               negb
-               sbca      #0
-               endc
-               std       R$X,y
-L074F          puls      y,x
-               ifne      H6309
-               oim       #TimSleep,P$State,x
-               else
-               lda       P$State,x
-               ora       #TimSleep
-               sta       P$State,x
-               endc
-               ldd       P$Queue,y
-               stx       P$Queue,y
-               std       P$Queue,x
-               ldx       R$X,u
-               bsr       L0780
-               stx       R$X,u
-               ldx       <D.Proc
-               ifne      H6309
-               aim       #^TimSleep,P$State,x
-               else
-               lda       P$State,x
-               anda      #^TimSleep
-               sta       P$State,x
-               endc
-SkpSleep       puls      cc,pc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^Suspend,P$State,x
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    anda      #^Suspend ; mask A with #^Suspend
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+L071B               puls      cc        ; restore cc from the stack
+                    os9       F$AProc   ; activate the process
+                    bra       L0780     ; branch unconditionally to L0780
+L0722               ldd       R$X,u     ; get callers X (contains sleep tick count)
+                    beq       L076D     ; done, wake it up
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decd      subtract  1 from tick count
+                  ELSE
+                    subd      #$0001    ; subtract #$0001 from D
+                  ENDC
+                    std       R$X,u     ; save it back
+                    beq       L071B     ; zero, wake up process
+                    pshs      x,y       ; save x,y on the stack
+                    ldx       #(D.SProcQ-P$Queue) ; load X from #(D.SProcQ-P$Queue)
+L0732               std       R$X,u     ; store D at R$X,u
+                    stx       2,s       ; store X at 2,s
+                    ldx       P$Queue,x ; load X from P$Queue,x
+                    beq       L074F     ; branch if zero is set to L074F
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #TimSleep,P$State,x
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    bita      #TimSleep ; test bits in A against #TimSleep
+                  ENDC
+                    beq       L074F     ; branch if zero is set to L074F
+                    ldy       P$SP,x    ; get process stack pointer
+                    ldd       R$X,u     ; load D from R$X,u
+                    subd      R$X,y     ; subtract R$X,y from D
+                    bcc       L0732     ; branch if carry is clear to L0732
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    negd                ; update processor state
+                  ELSE
+                    nega                ; update processor state
+                    negb                ; update processor state
+                    sbca      #0        ; update processor state
+                  ENDC
+                    std       R$X,y     ; store D at R$X,y
+L074F               puls      y,x       ; restore y,x from the stack
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #TimSleep,P$State,x
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    ora       #TimSleep ; merge #TimSleep into A
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+                    ldd       P$Queue,y ; load D from P$Queue,y
+                    stx       P$Queue,y ; store X at P$Queue,y
+                    std       P$Queue,x ; store D at P$Queue,x
+                    ldx       R$X,u     ; load X from R$X,u
+                    bsr       L0780     ; call local routine L0780
+                    stx       R$X,u     ; store X at R$X,u
+                    ldx       <D.Proc   ; load X from <D.Proc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^TimSleep,P$State,x
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    anda      #^TimSleep ; mask A with #^TimSleep
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+SkpSleep            puls      cc,pc     ; restore cc,pc from the stack
 
-L076D          ldx       #D.SProcQ-P$Queue
-L0770          leay      ,x
-               ldx       P$Queue,x
-               bne       L0770
-               ldx       <D.Proc
-               clra
-               clrb
-               stx       P$Queue,y
-               std       P$Queue,x
-               puls      cc
+L076D               ldx       #D.SProcQ-P$Queue ; load X from #D.SProcQ-P$Queue
+L0770               leay      ,x        ; compute ,x into Y
+                    ldx       P$Queue,x ; load X from P$Queue,x
+                    bne       L0770     ; branch if zero is clear to L0770
+                    ldx       <D.Proc   ; load X from <D.Proc
+                    clra                ; clear A
+                    clrb                ; clear B
+                    stx       P$Queue,y ; store X at P$Queue,y
+                    std       P$Queue,x ; store D at P$Queue,x
+                    puls      cc        ; restore cc from the stack
 
-L0780          pshs      dp,x,y,u,pc
-L0782          leax      <L079C,pc
-               stx       7,s
-               ldx       <D.Proc
-               ldb       P$Task,x            This is related to the 'one-byte hack'
-               cmpb      <D.SysTsk           that stops OS9p1 from doing an F$AllTsk on
-               beq       L0792               _every_ system call.
-               os9       F$DelTsk
-L0792          ldd       P$SP,x
-               ifne      H6309
-               pshsw
-               endc
-               pshs      cc,d
-               sts       P$SP,x
-               os9       F$NProc
+L0780               pshs      dp,x,y,u,pc ; save dp,x,y,u,pc on the stack
+L0782               leax      <L079C,pc ; compute <L079C,pc into X
+                    stx       7,s       ; store X at 7,s
+                    ldx       <D.Proc   ; load X from <D.Proc
+                    ldb       P$Task,x  ; this is related to the 'one-byte hack'
+                    cmpb      <D.SysTsk ; that stops OS9p1 from doing an F$AllTsk on
+                    beq       L0792     ; _every_ system call.
+                    os9       F$DelTsk  ; call OS-9 service F$DelTsk
+L0792               ldd       P$SP,x    ; load D from P$SP,x
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    pshsw
+                  ENDC
+                    pshs      cc,d      ; save cc,d on the stack
+                    sts       P$SP,x    ; store S at P$SP,x
+                    os9       F$NProc   ; call OS-9 service F$NProc
 
-L079C          pshs      x
-               ldx       <D.Proc
-               std       P$SP,x
-               clrb
-               puls      x,pc
+L079C               pshs      x         ; save x on the stack
+                    ldx       <D.Proc   ; load X from <D.Proc
+                    std       P$SP,x    ; store D at P$SP,x
+                    clrb                ; clear B
+                    puls      x,pc      ; restore x,pc from the stack
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fsprior.asm
+++ b/level1/modules/kernel/fsprior.asm
@@ -13,38 +13,38 @@
 ;;; F$SPrior modifies a process’s priority to a value between 0 (lowest) and 255 (highest).
 ;;; A process can change another process’s priority only if it has the same user ID.
 
-               ifeq      Level-1
-FSPrior        lda       R$A,u               get the process ID from the caller
-               ldx       <D.PrcDBT           get the pointer to the process descriptor table
-               os9       F$Find64            find the 64 byte page associated with this process ID
-               bcs       ex@                 branch if it can't be found
-               ldx       <D.Proc             else get the current process descriptor
-               ldd       P$User,x            and its user ID
-               cmpd      P$User,y            is it the same as the process to change?
-               bne       ex@                 branch if not
-               lda       R$B,u               else the owners are the same user ID, so allow the change
-               sta       P$Prior,y           and store the new priority in the target process descriptor
-               rts                           return to the caller
-ex@            comb                          set carry to indicate error
-               ldb       #E$IPrcID           illegal process ID
-               rts                           return to the caller
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
+FSPrior             lda       R$A,u     ; get the process ID from the caller
+                    ldx       <D.PrcDBT ; get the pointer to the process descriptor table
+                    os9       F$Find64  ; find the 64 byte page associated with this process ID
+                    bcs       ex@       ; branch if it can't be found
+                    ldx       <D.Proc   ; else get the current process descriptor
+                    ldd       P$User,x  ; and its user ID
+                    cmpd      P$User,y  ; is it the same as the process to change?
+                    bne       ex@       ; branch if not
+                    lda       R$B,u     ; else the owners are the same user ID, so allow the change
+                    sta       P$Prior,y ; and store the new priority in the target process descriptor
+                    rts                 ; return to the caller
+ex@                 comb                ; set carry to indicate error
+                    ldb       #E$IPrcID ; illegal process ID
+                    rts                 ; return to the caller
 
-               else
+                  ELSE
 
-FSPrior        lda       R$A,u               get process #
-               lbsr      L0B2E               get pointer to it
-               bcs       L07C0               error, return
-               ldx       <D.Proc             get current process
-               ldd       P$User,x            get user #
-               beq       L07B7               super user, go set priority
-               cmpd      P$User,y            user #'s match?
-               bne       L07BD               no, return error
-L07B7          lda       R$B,u               get new priority
-               sta       P$Prior,y           set it
-               clrb                          clear errors
-               rts                           return
-L07BD          comb                          set carry for error
-               ldb       #E$BPrcID
-L07C0          rts
+FSPrior             lda       R$A,u     ; get process #
+                    lbsr      L0B2E     ; get pointer to it
+                    bcs       L07C0     ; error, return
+                    ldx       <D.Proc   ; get current process
+                    ldd       P$User,x  ; get user #
+                    beq       L07B7     ; super user, go set priority
+                    cmpd      P$User,y  ; user #'s match?
+                    bne       L07BD     ; no, return error
+L07B7               lda       R$B,u     ; get new priority
+                    sta       P$Prior,y ; set it
+                    clrb                ; clear errors
+                    rts                 ; return
+L07BD               comb                ; set carry for error
+                    ldb       #E$BPrcID ; load B from #E$BPrcID
+L07C0               rts                 ; return to caller
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fsprior.asm
+++ b/level1/modules/kernel/fsprior.asm
@@ -32,19 +32,19 @@ ex@                 comb                ; set carry to indicate error
                   ELSE
 
 FSPrior             lda       R$A,u     ; get process #
-                    lbsr      L0B2E     ; get pointer to it
-                    bcs       L07C0     ; error, return
+                    lbsr      FGprocpTarget ; get pointer to it
+                    bcs       FSpriorReturn ; error, return
                     ldx       <D.Proc   ; get current process
                     ldd       P$User,x  ; get user #
-                    beq       L07B7     ; super user, go set priority
+                    beq       FSpriorNewPriority ; super user, go set priority
                     cmpd      P$User,y  ; user #'s match?
-                    bne       L07BD     ; no, return error
-L07B7               lda       R$B,u     ; get new priority
+                    bne       FSpriorCarryError ; no, return error
+FSpriorNewPriority  lda       R$B,u     ; get new priority
                     sta       P$Prior,y ; set it
                     clrb                ; clear errors
                     rts                 ; return
-L07BD               comb                ; set carry for error
+FSpriorCarryError   comb                ; set carry for error
                     ldb       #E$BPrcID ; load B from #E$BPrcID
-L07C0               rts                 ; return to caller
+FSpriorReturn       rts                 ; return to caller
 
                   ENDC

--- a/level1/modules/kernel/fsrqmem.asm
+++ b/level1/modules/kernel/fsrqmem.asm
@@ -131,19 +131,19 @@ FSRqMem             ldd       R$D,u     ; get the memory allocation size request
                   IFEQ    1       ; begin conditional assembly for 1
                     ldy       <D.SysMem ; get ptr to SMAP table
 * This loop updates the SMAP table if anything can be marked as unused
-FSrqmemSystemDATBlockList ldx       <D.SysDAT ; get pointer to system DAT block list
+FSrqmemSysDATBlk    ldx       <D.SysDAT ; get pointer to system DAT block list
                     lslb                ; adjust block offset for 2 bytes/entry
                     ldd       b,x       ; get block type/# from system DAT
                     cmpd      #DAT.Free ; unused block?
-                    beq       FSrqmemFillSystemPageMapNot ; yes, mark it free in SMAP table
+                    beq       FSrqmemFillSysPg ; yes, mark it free in SMAP table
                     ldx       <D.BlkMap ; no, get ptr to MMAP table
                     lda       d,x       ; get block marker for 2 meg mem map
                     cmpa      #RAMinUse ; is it in use (not free, ROM or used by module)?
                     bne       FSrqmemPut ; no, mark it as type it is in SMAP table
                     leay      32,y      ; yes, move to next block in pages
-                    bra       FSrqmemBumpUpBlockCheck ; move to next block & try again
+                    bra       FSrqmemBumpUpBlk ; move to next block & try again
 * Free RAM:
-FSrqmemFillSystemPageMapNot clra                ; byte to fill system page map with (0=Not in use)
+FSrqmemFillSysPg    clra                ; byte to fill system page map with (0=Not in use)
 * NOT! RAMinUse:
                   IFNE    H6309   ; begin conditional assembly for H6309
 FSrqmemPut          sta       ,s        ; put it on stack
@@ -155,10 +155,10 @@ FSrqmemMarkRAM      sta       ,y+       ; mark the RAM
                     decb                ; decrement B
                     bne       FSrqmemMarkRAM ; branch if zero is clear to FSrqmemMarkRAM
                   ENDC
-FSrqmemBumpUpBlockCheck inc       1,s       ; bump up to next block to check
+FSrqmemBumpUpBlk    inc       1,s       ; bump up to next block to check
                     ldb       1,s       ; get it
                     cmpb      #DAT.BlCt ; done whole 64k system space?
-                    blo       FSrqmemSystemDATBlockList ; no, keep checking
+                    blo       FSrqmemSysDATBlk ; no, keep checking
                   ENDC
 
 
@@ -178,7 +178,7 @@ FSrqmemBumpUpBlockCheck inc       1,s       ; bump up to next block to check
                   ENDC
                     ldb       #32       ; skip block 0: it's always full
                     abx                 ; update X to point to the starting place to search for
-FSrqmemNumberPagesRequested ldb       R$A,u     ; get the number of 256 byte pages requested
+FSrqmemNumPgsReq    ldb       R$A,u     ; get the number of 256 byte pages requested
 * Loop from the end of the system free memory map) to look for the number continuous pages requested
 FSrqmemJoin         equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -187,13 +187,13 @@ FSrqmemJoin         equ       *         ; define assembler symbol
                     pshs      x         ; save X
                     cmpy      ,s++      ; compare Y to X
                   ENDC
-                    bhi       FSrqmemPageMarkerStartingEndSystem ; if Y (end) is higher than X (start), continue looking
+                    bhi       FSrqmemPgMrkrStrtn ; if Y (end) is higher than X (start), continue looking
                     comb                ; else set the carry
                     ldb       #E$NoRAM  ; load the "no system RAM" error
                     bra       FSrqmemExit ; and branch to return
 
-FSrqmemPageMarkerStartingEndSystem lda       ,-y       ; get the page marker (starting at the end of the system free memory map)
-                    bne       FSrqmemNumberPagesRequested ; branch if it's not zero (the page is allocated, so test the next lower one)
+FSrqmemPgMrkrStrtn  lda       ,-y       ; get the page marker (starting at the end of the system free memory map)
+                    bne       FSrqmemNumPgsReq ; branch if it's not zero (the page is allocated, so test the next lower one)
                     decb                ; found 1 page, decrement the number of pages we need to allocate
                     bne       FSrqmemJoin ; branch if we still more pages needed to see if we can get more
                     sty       ,s        ; here, we've found all of the free contiguous pages, so save the pointer
@@ -242,9 +242,9 @@ ok@                 puls      d,x       ; recover registers
                     ldb       R$A,u     ; else get the number of requested pages
 *         lda   #RAMinUse    Get SMAP in use flag
 *L088A    sta   ,y+          Mark all the pages requested as In Use
-FSrqmemSinceRaminuseWeCanSpace inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
+FSrqmemSncRamUseWe  inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
                     decb                ; decrement the counter
-                    bne       FSrqmemSinceRaminuseWeCanSpace ; continue if not at 0
+                    bne       FSrqmemSncRamUseWe ; continue if not at 0
                     lda       1,s       ; get the MSB of the pointer to the start of the newly allocated system RAM
                     std       R$U,u     ; save to the caller's U
                     clrb                ; clear the error code and carry
@@ -302,11 +302,11 @@ FSrqmemBlockImage   ldd       ,x        ; get the block image
                     addr      d,u       ; point to the offset in the system free memory map
 * Check if we can remove the entire memory block from system map
                     ldf       #16       get the number of pages per block / 2
-FSrqmemEitherThesePagesAllocated ldd       ,u++      ; are either of these 2 pages allocated?
+FSrqmemEthrThsPgs   ldd       ,u++      ; are either of these 2 pages allocated?
                   ELSE
                     leau      d,u       ; point to the offset in the system free memory map
                     ldb       #32       ; set the counter
-FSrqmemEitherThesePagesAllocated lda       ,u+       ; are either of these 2 pages allocated?
+FSrqmemEthrThsPgs   lda       ,u+       ; are either of these 2 pages allocated?
                   ENDC
                     bne       FSrqmemDATBlock ; yes, we can't free this block, so skip to next one
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -314,7 +314,7 @@ FSrqmemEitherThesePagesAllocated lda       ,u+       ; are either of these 2 pag
                   ELSE
                     decb                ; decrement the counter
                   ENDC
-                    bne       FSrqmemEitherThesePagesAllocated ; no, keep looking
+                    bne       FSrqmemEthrThsPgs ; no, keep looking
                     ldd       ,x        ; else get the block number into B; it could be >$80
                     ldu       <D.BlkMap ; point to the allocation table
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -425,7 +425,7 @@ I.VBlock            leau      d,x       ; point to the end of the block
                     lsra                ; A = A / 16: the logical block * 2
                     ldy       <D.SysDAT ; get the pointer to the system DAT image
                     leay      a,y       ; point Y to the offset into the block
-FSrqmemModuleIDSignature ldd       M$ID,x    ; get the module ID signature
+FSrqmemModIDSgntr   ldd       M$ID,x    ; get the module ID signature
                     cmpd      #M$ID12   ; is it a valid module ID?
                     bne       FSrqmemTarget ; no, keep looking
                     ldd       M$Name,x  ; else get the name offset pointer
@@ -451,10 +451,10 @@ name.prt            lda       ,x+       ; get the character of the name
                     bne       FSrqmemTarget ; no, assume a case of mistaken identity and continue
 FSrqmemModuleSize   ldd       M$Size,x  ; else get the module size
                     leax      d,x       ; and step over it
-                    fcb       $8C       ; skip the next 2 bytes (continue at FSrqmemHaveWeGoneThroughBootfile)
+                    fcb       $8C       ; skip the next 2 bytes (continue at FSrqmemHaveWeGone)
 FSrqmemTarget       leax      1,x       ; move to the next byte
-FSrqmemHaveWeGoneThroughBootfile cmpx      2,s       ; have we gone through the whole bootfile?
-                    bcs       FSrqmemModuleIDSignature ; no, keep looking
+FSrqmemHaveWeGone   cmpx      2,s       ; have we gone through the whole bootfile?
+                    bcs       FSrqmemModIDSgntr ; no, keep looking
                     leas      4,s       ; else recover the stack
                     clrb                ; clear the error code and carry
                     rts                 ; return

--- a/level1/modules/kernel/fsrqmem.asm
+++ b/level1/modules/kernel/fsrqmem.asm
@@ -131,34 +131,34 @@ FSRqMem             ldd       R$D,u     ; get the memory allocation size request
                   IFEQ    1       ; begin conditional assembly for 1
                     ldy       <D.SysMem ; get ptr to SMAP table
 * This loop updates the SMAP table if anything can be marked as unused
-L082F               ldx       <D.SysDAT ; get pointer to system DAT block list
+FSrqmemSystemDATBlockList ldx       <D.SysDAT ; get pointer to system DAT block list
                     lslb                ; adjust block offset for 2 bytes/entry
                     ldd       b,x       ; get block type/# from system DAT
                     cmpd      #DAT.Free ; unused block?
-                    beq       L0847     ; yes, mark it free in SMAP table
+                    beq       FSrqmemFillSystemPageMapNot ; yes, mark it free in SMAP table
                     ldx       <D.BlkMap ; no, get ptr to MMAP table
                     lda       d,x       ; get block marker for 2 meg mem map
                     cmpa      #RAMinUse ; is it in use (not free, ROM or used by module)?
-                    bne       L0848     ; no, mark it as type it is in SMAP table
+                    bne       FSrqmemPut ; no, mark it as type it is in SMAP table
                     leay      32,y      ; yes, move to next block in pages
-                    bra       L084F     ; move to next block & try again
+                    bra       FSrqmemBumpUpBlockCheck ; move to next block & try again
 * Free RAM:
-L0847               clra                ; byte to fill system page map with (0=Not in use)
+FSrqmemFillSystemPageMapNot clra                ; byte to fill system page map with (0=Not in use)
 * NOT! RAMinUse:
                   IFNE    H6309   ; begin conditional assembly for H6309
-L0848               sta       ,s        ; put it on stack
+FSrqmemPut          sta       ,s        ; put it on stack
                     ldw       #$0020    Get size of 8K block in pages
                     tfm       s,y+      Mark entire block's worth of pages with A
                   ELSE
-L0848               ldb       #32       ; count = 32 pages
-L084A               sta       ,y+       ; mark the RAM
+FSrqmemPut          ldb       #32       ; count = 32 pages
+FSrqmemMarkRAM      sta       ,y+       ; mark the RAM
                     decb                ; decrement B
-                    bne       L084A     ; branch if zero is clear to L084A
+                    bne       FSrqmemMarkRAM ; branch if zero is clear to FSrqmemMarkRAM
                   ENDC
-L084F               inc       1,s       ; bump up to next block to check
+FSrqmemBumpUpBlockCheck inc       1,s       ; bump up to next block to check
                     ldb       1,s       ; get it
                     cmpb      #DAT.BlCt ; done whole 64k system space?
-                    blo       L082F     ; no, keep checking
+                    blo       FSrqmemSystemDATBlockList ; no, keep checking
                   ENDC
 
 
@@ -178,24 +178,24 @@ L084F               inc       1,s       ; bump up to next block to check
                   ENDC
                     ldb       #32       ; skip block 0: it's always full
                     abx                 ; update X to point to the starting place to search for
-L0857               ldb       R$A,u     ; get the number of 256 byte pages requested
+FSrqmemNumberPagesRequested ldb       R$A,u     ; get the number of 256 byte pages requested
 * Loop from the end of the system free memory map) to look for the number continuous pages requested
-L0859               equ       *         ; define assembler symbol
+FSrqmemJoin         equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
                     cmpr      x,y       do we still have any system RAM left to try?
                   ELSE
                     pshs      x         ; save X
                     cmpy      ,s++      ; compare Y to X
                   ENDC
-                    bhi       L0863     ; if Y (end) is higher than X (start), continue looking
+                    bhi       FSrqmemPageMarkerStartingEndSystem ; if Y (end) is higher than X (start), continue looking
                     comb                ; else set the carry
                     ldb       #E$NoRAM  ; load the "no system RAM" error
-                    bra       L0894     ; and branch to return
+                    bra       FSrqmemExit ; and branch to return
 
-L0863               lda       ,-y       ; get the page marker (starting at the end of the system free memory map)
-                    bne       L0857     ; branch if it's not zero (the page is allocated, so test the next lower one)
+FSrqmemPageMarkerStartingEndSystem lda       ,-y       ; get the page marker (starting at the end of the system free memory map)
+                    bne       FSrqmemNumberPagesRequested ; branch if it's not zero (the page is allocated, so test the next lower one)
                     decb                ; found 1 page, decrement the number of pages we need to allocate
-                    bne       L0859     ; branch if we still more pages needed to see if we can get more
+                    bne       FSrqmemJoin ; branch if we still more pages needed to see if we can get more
                     sty       ,s        ; here, we've found all of the free contiguous pages, so save the pointer
                     lda       1,s       ; get the LSB of the pointer
                     lsra                ; A = A / 2
@@ -237,37 +237,37 @@ l@                  ldb       ,s        ; get the starting block
                     bne       l@        ; and go try next
 ok@                 puls      d,x       ; recover registers
 **************************
-                    lbsr      L09BE     ; allocate an image with our start/end block numbers
-                    bcs       L0894     ; branch if we couldn't do it
+                    lbsr      FAllimgTarget ; allocate an image with our start/end block numbers
+                    bcs       FSrqmemExit ; branch if we couldn't do it
                     ldb       R$A,u     ; else get the number of requested pages
 *         lda   #RAMinUse    Get SMAP in use flag
 *L088A    sta   ,y+          Mark all the pages requested as In Use
-L088A               inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
+FSrqmemSinceRaminuseWeCanSpace inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
                     decb                ; decrement the counter
-                    bne       L088A     ; continue if not at 0
+                    bne       FSrqmemSinceRaminuseWeCanSpace ; continue if not at 0
                     lda       1,s       ; get the MSB of the pointer to the start of the newly allocated system RAM
                     std       R$U,u     ; save to the caller's U
                     clrb                ; clear the error code and carry
-L0894               puls      u,pc      ; return (U is changed after it exits)
+FSrqmemExit         puls      u,pc      ; return (U is changed after it exits)
 
 
 **************************************************
 * F$SRtMem - Level 2 implementation
 *
 FSRtMem             ldd       R$D,u     ; get the number of pages to free up
-                    beq       L08F2     ; branch if the caller passed 0 (nothing to free!)
+                    beq       FSrqmemErrorCarry ; branch if the caller passed 0 (nothing to free!)
                     addd      #$00FF    ; else round up the value to nearest page
                     ldb       R$U+1,u   ; get the LSB of the address
-                    beq       L08A6     ; it's a even page, so skip ahead
+                    beq       FSrqmemMsbPage ; it's a even page, so skip ahead
                     comb                ; else set the carry
                     ldb       #E$BPAddr ; load the "bad page address" error number
                     rts                 ; return
 
-L08A6               ldb       R$U,u     ; get the MSB of the page address
-                    beq       L08F2     ; branc if it's 0 (not a legal page)
+FSrqmemMsbPage      ldb       R$U,u     ; get the MSB of the page address
+                    beq       FSrqmemErrorCarry ; branc if it's 0 (not a legal page)
                     ldx       <D.SysMem ; get the pointer to the system free memory map
                     abx                 ; set the pointer into the map
-L08AD               equ       *         ; define assembler symbol
+FSrqmemJoin2        equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^RAMinUse,,x+ clear the "RAM in use" bit
                   ELSE
@@ -276,7 +276,7 @@ L08AD               equ       *         ; define assembler symbol
                     stb       ,x+       ; save the page byte back and increment the index register
                   ENDC
                     deca                ; decrement the counter
-                    bne       L08AD     ; branch if not done
+                    bne       FSrqmemJoin2 ; branch if not done
 * Scan the DAT image to find the memory blocks to free up.
                     ldx       <D.SysDAT ; get the pointer to the system DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -284,13 +284,13 @@ L08AD               equ       *         ; define assembler symbol
                   ELSE
                     ldy       #DAT.BlCt ; get the number of blocks to check
                   ENDC
-L08BC               ldd       ,x        ; get the block image
+FSrqmemBlockImage   ldd       ,x        ; get the block image
                     cmpd      #DAT.Free ; is it already free?
-                    beq       L08EC     ; yes, skip to the next one
+                    beq       FSrqmemDATBlock ; yes, skip to the next one
                     ldu       <D.BlkMap ; else get the pointer to the MMU block map
                     lda       d,u       ; get the allocation flag for this block: 16-bit offset
                     cmpa      #RAMinUse ; is it being used?
-                    bne       L08EC     ; no, move to the next block
+                    bne       FSrqmemDATBlock ; no, move to the next block
                     tfr       x,d       ; else transfer the pointer to D
                     subd      <D.SysDAT ; set D to the offset in the system DAT image
                     lslb                ; B = B * 2
@@ -302,19 +302,19 @@ L08BC               ldd       ,x        ; get the block image
                     addr      d,u       ; point to the offset in the system free memory map
 * Check if we can remove the entire memory block from system map
                     ldf       #16       get the number of pages per block / 2
-L08DA               ldd       ,u++      ; are either of these 2 pages allocated?
+FSrqmemEitherThesePagesAllocated ldd       ,u++      ; are either of these 2 pages allocated?
                   ELSE
                     leau      d,u       ; point to the offset in the system free memory map
                     ldb       #32       ; set the counter
-L08DA               lda       ,u+       ; are either of these 2 pages allocated?
+FSrqmemEitherThesePagesAllocated lda       ,u+       ; are either of these 2 pages allocated?
                   ENDC
-                    bne       L08EC     ; yes, we can't free this block, so skip to next one
+                    bne       FSrqmemDATBlock ; yes, we can't free this block, so skip to next one
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decf                ; have we checked all pages?
                   ELSE
                     decb                ; decrement the counter
                   ENDC
-                    bne       L08DA     ; no, keep looking
+                    bne       FSrqmemEitherThesePagesAllocated ; no, keep looking
                     ldd       ,x        ; else get the block number into B; it could be >$80
                     ldu       <D.BlkMap ; point to the allocation table
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -324,15 +324,15 @@ L08DA               lda       ,u+       ; are either of these 2 pages allocated?
                   ENDC
                     ldd       #DAT.Free ; get the free block marker
                     std       ,x        ; save it into the DAT image
-L08EC               leax      2,x       ; move to the next DAT block
+FSrqmemDATBlock     leax      2,x       ; move to the next DAT block
                   IFNE    H6309   ; begin conditional assembly for H6309
                     dece                ; are we done?
                   ELSE
                     leay      -1,y      ; are we done?
                   ENDC
-                    bne       L08BC     ; branch if not
-L08F2               clrb                ; clear the error code and carry
-L08F3               rts                 ; return
+                    bne       FSrqmemBlockImage ; branch if not
+FSrqmemErrorCarry   clrb                ; clear the error code and carry
+FSrqmemReturn       rts                 ; return
 
 
 ;;; F$Boot
@@ -355,26 +355,26 @@ FBoot
                     jsr       <D.BtBug  ; call routine at <D.BtBug
                     coma                ; set boot flag
                     lda       <D.Boot   ; we booted once before?
-                    bne       L08F3     ; yes, return
+                    bne       FSrqmemReturn ; yes, return
                     inc       <D.Boot   ; set boot flag
                     ldx       <D.Init   ; get ptr to init module if it exists
-                    beq       L0908     ; it doesn't, point to boot name
+                    beq       FSrqmemBootPcr ; it doesn't, point to boot name
                     ldd       <BootStr,x ; get offset to text
-                    beq       L0908     ; doesn't exist, get hard coded text
+                    beq       FSrqmemBootPcr ; doesn't exist, get hard coded text
                     leax      d,x       ; adjust X to point to boot module
-                    bra       L090C     ; try & link to module
+                    bra       FSrqmemSystmObjct ; try & link to module
 
 boot                fcs       /Boot/
 
-L0908               leax      <boot,pcr ; compute <boot,pcr into X
+FSrqmemBootPcr      leax      <boot,pcr ; compute <boot,pcr into X
 * Link to module and execute
-L090C               lda       #Systm+Objct ; load A from #Systm+Objct
+FSrqmemSystmObjct   lda       #Systm+Objct ; load A from #Systm+Objct
                     os9       F$Link    ; call OS-9 service F$Link
-                    bcs       L08F3     ; return with error.
+                    bcs       FSrqmemReturn ; return with error.
                     lda       #'b       ; calling boot
                     jsr       <D.BtBug  ; call routine at <D.BtBug
                     jsr       ,y        ; load boot file
-                    bcs       L08F3     ; branch if carry is set to L08F3
+                    bcs       FSrqmemReturn ; branch if carry is set to FSrqmemReturn
                     std       <D.BtSz   ; save boot file size
                     stx       <D.BtPtr  ; save start pointer of bootfile
                     lda       #'b       ; boot returns OK
@@ -396,7 +396,7 @@ not.ext             ldd       <D.BtSz   ; load D from <D.BtSz
                     ldb       $0D,x     ; get highest allocated block number
                     incb                ; allocate block 0, too
                     ldx       <D.BlkMap ; point to the memory block map
-                    lbra      L01DF     ; and go mark the blocks as used.
+                    lbra      KrnRAMUseFlag ; and go mark the blocks as used.
                   ENDC
 
 ;;; F$VBlock
@@ -425,9 +425,9 @@ I.VBlock            leau      d,x       ; point to the end of the block
                     lsra                ; A = A / 16: the logical block * 2
                     ldy       <D.SysDAT ; get the pointer to the system DAT image
                     leay      a,y       ; point Y to the offset into the block
-L092D               ldd       M$ID,x    ; get the module ID signature
+FSrqmemModuleIDSignature ldd       M$ID,x    ; get the module ID signature
                     cmpd      #M$ID12   ; is it a valid module ID?
-                    bne       L0954     ; no, keep looking
+                    bne       FSrqmemTarget ; no, keep looking
                     ldd       M$Name,x  ; else get the name offset pointer
                     pshs      x         ; save the address of the module header onto the stack
                     leax      d,x       ; point X to the name in the module
@@ -446,15 +446,15 @@ name.prt            lda       ,x+       ; get the character of the name
                     ldd       1,s       ; get the starting address
                     leax      d,x       ; move X past it
                     puls      b         ; restore B
-                    bcc       L094E     ; branch if the validation succeeded
+                    bcc       FSrqmemModuleSize ; branch if the validation succeeded
                     cmpb      #E$KwnMod ; else an error occurred; is it the "known module" error?
-                    bne       L0954     ; no, assume a case of mistaken identity and continue
-L094E               ldd       M$Size,x  ; else get the module size
+                    bne       FSrqmemTarget ; no, assume a case of mistaken identity and continue
+FSrqmemModuleSize   ldd       M$Size,x  ; else get the module size
                     leax      d,x       ; and step over it
-                    fcb       $8C       ; skip the next 2 bytes (continue at L0956)
-L0954               leax      1,x       ; move to the next byte
-L0956               cmpx      2,s       ; have we gone through the whole bootfile?
-                    bcs       L092D     ; no, keep looking
+                    fcb       $8C       ; skip the next 2 bytes (continue at FSrqmemHaveWeGoneThroughBootfile)
+FSrqmemTarget       leax      1,x       ; move to the next byte
+FSrqmemHaveWeGoneThroughBootfile cmpx      2,s       ; have we gone through the whole bootfile?
+                    bcs       FSrqmemModuleIDSignature ; no, keep looking
                     leas      4,s       ; else recover the stack
                     clrb                ; clear the error code and carry
                     rts                 ; return

--- a/level1/modules/kernel/fsrqmem.asm
+++ b/level1/modules/kernel/fsrqmem.asm
@@ -1,4 +1,4 @@
-                    ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
 ;;; F$SRqMem
 ;;;
@@ -20,57 +20,57 @@
 **************************************************
 * F$SRqMem - Level 1 implementation
 *
-FSRqMem             ldd       R$D,u               get memory allocation size requested from the caller's D
-                    addd      #$00FF              round it up to nearest 256 byte page (e.g. $1FF = $2FE)
-                    clrb                          just keep # of pages (e.g. $2FE = $200)
-                    std       R$D,u               save rounded version back to caller's D
+FSRqMem             ldd       R$D,u     ; get memory allocation size requested from the caller's D
+                    addd      #$00FF    ; round it up to nearest 256 byte page (e.g. $1FF = $2FE)
+                    clrb                ; just keep # of pages (e.g. $2FE = $200)
+                    std       R$D,u     ; save rounded version back to caller's D
 * Start searching from the top of free memory allocation bitmap down, searching for 'D' contiguous bits
-                    ldx       <D.FMBM+2           get the pointer to the end of the free memory allocation bitmap
-                    ldd       #$01FF              A = $01 (RAM IN USE flag), B = $FF ("first free 256 byte page")
-                    pshs      b,a                 save the values on stack
-_stk1A@             set       0                   bit flag indicating RAM IN USE
-_stk1B@             set       1                   offset to first free 256 byte page (assuming enough memory is found)
-_stk1L@             set       2                   length of stack
-                    bra       top@                start the search
-loop@               dec       _stk1B@,s           decrement "first free 256 byte page" value on stack
-                    ldb       _stk1B@,s           and load it into B
-nextbit@            lsl       _stk1A@,s           shift left: bit 7 of _stk1A goes in carry, 0 goes in bit 0 of _stk1A
-                    bcc       checkbit@           branch if high bit in _stk1A was 0
-                    rol       _stk1A@,s           put set carry in bit 0, put MSB of bit (1) in carry
-top@                leax      -1,x                backup into free memory bitmap
-                    cmpx      <D.FMBM             did we move past the beginning?
-                    bcs       doalloc@            branch if so (carry set if X < D.FMBM)
-checkbit@           lda       ,x                  get byte in current location of free memory allocation bitmap
-                    anda      _stk1A@,s           AND with mask on stack
-                    bne       loop@               branch if not 0, meaning there are bits set in A (pages allocated) so continue searching
-                    dec       _stk1B@,s           decrement "first free 256 byte page" value on stack
-                    subb      _stk1B@,s           subtract "first free 256 byte page" value on stack from B
-                    cmpb      R$A,u               compare B to the requested number of pages in caller's A (may set carry)
-                    rora                          shift carry into A's bit 7, and bit 0 of A into carry (saves carry bit in bit 7 of A)
-                    addb      _stk1B@,s           add back "first free 256 byte page" value on stack to B
-                    rola                          roll A's bit 7 into carry, and carry into A's bit 0 (restores original carry)
-                    bcs       nextbit@            branch if the carry is set
-                    ldb       _stk1B@,s           get the contiguous free memory bit count
-                    clra                          clear A
-                    incb                          increment B
-doalloc@            leas      _stk1L@,s           recover stack from earlier push
-                    bcs       ex@                 branch if error
-                    ldx       <D.FMBM             else get pointer to start of free memory bitmap
-                    tfr       d,y                 put D (number of first bit to set) into Y
-                    ldb       R$A,u               get MSB into B (this will be bit count)
-                    clra                          clear A; D now holds number of bits to set
-                    exg       d,y                 swap D and Y so that parameters are correct
+                    ldx       <D.FMBM+2 ; get the pointer to the end of the free memory allocation bitmap
+                    ldd       #$01FF    ; A = $01 (RAM IN USE flag), B = $FF ("first free 256 byte page")
+                    pshs      b,a       ; save the values on stack
+_stk1A@             set       0         ; bit flag indicating RAM IN USE
+_stk1B@             set       1         ; offset to first free 256 byte page (assuming enough memory is found)
+_stk1L@             set       2         ; length of stack
+                    bra       top@      ; start the search
+loop@               dec       _stk1B@,s ; decrement "first free 256 byte page" value on stack
+                    ldb       _stk1B@,s ; and load it into B
+nextbit@            lsl       _stk1A@,s ; shift left: bit 7 of _stk1A goes in carry, 0 goes in bit 0 of _stk1A
+                    bcc       checkbit@ ; branch if high bit in _stk1A was 0
+                    rol       _stk1A@,s ; put set carry in bit 0, put MSB of bit (1) in carry
+top@                leax      -1,x      ; backup into free memory bitmap
+                    cmpx      <D.FMBM   ; did we move past the beginning?
+                    bcs       doalloc@  ; branch if so (carry set if X < D.FMBM)
+checkbit@           lda       ,x        ; get byte in current location of free memory allocation bitmap
+                    anda      _stk1A@,s ; aND with mask on stack
+                    bne       loop@     ; branch if not 0, meaning there are bits set in A (pages allocated) so continue searching
+                    dec       _stk1B@,s ; decrement "first free 256 byte page" value on stack
+                    subb      _stk1B@,s ; subtract "first free 256 byte page" value on stack from B
+                    cmpb      R$A,u     ; compare B to the requested number of pages in caller's A (may set carry)
+                    rora                ; shift carry into A's bit 7, and bit 0 of A into carry (saves carry bit in bit 7 of A)
+                    addb      _stk1B@,s ; add back "first free 256 byte page" value on stack to B
+                    rola                ; roll A's bit 7 into carry, and carry into A's bit 0 (restores original carry)
+                    bcs       nextbit@  ; branch if the carry is set
+                    ldb       _stk1B@,s ; get the contiguous free memory bit count
+                    clra                ; clear A
+                    incb                ; increment B
+doalloc@            leas      _stk1L@,s ; recover stack from earlier push
+                    bcs       ex@       ; branch if error
+                    ldx       <D.FMBM   ; else get pointer to start of free memory bitmap
+                    tfr       d,y       ; put D (number of first bit to set) into Y
+                    ldb       R$A,u     ; get MSB into B (this will be bit count)
+                    clra                ; clear A; D now holds number of bits to set
+                    exg       d,y       ; swap D and Y so that parameters are correct
 * X = address of allocation bitmap
 * D = Number of first bit to set
 * Y = Bit count (number of bits to set)
-                    bsr       AllocBit            call into F$AllBit to allocate Y bits starting at bit D in the table X
-                    exg       a,b                 swap A and B
-                    std       R$U,u               put allocated address into caller's U
-okex                clra                          clear carry
-                    rts                           return to the caller
-ex@                 comb                          set carry
-                    ldb       #E$MemFul           indicate memory is full
-                    rts                           return to the caller
+                    bsr       AllocBit  ; call into F$AllBit to allocate Y bits starting at bit D in the table X
+                    exg       a,b       ; swap A and B
+                    std       R$U,u     ; put allocated address into caller's U
+okex                clra                ; clear carry
+                    rts                 ; return to the caller
+ex@                 comb                ; set carry
+                    ldb       #E$MemFul ; indicate memory is full
+                    rts                 ; return to the caller
 
 ;;; F$SRtMem
 ;;;
@@ -86,23 +86,23 @@ ex@                 comb                          set carry
 ;;;
 ;;; F$SRtMem returns memory allocated by F$SRqMem to the system.
 
-FSRtMem             ldd       R$D,u               get the memory allocation size requested from the caller's D
-                    addd      #$00FF              round it up to nearest 256 byte page (e.g. $1FF = $2FE)
-                    tfr       a,b                 put MSB into B
-                    clra                          now D reflects number of 256 byte pages to return
-                    tfr       d,y                 put the 16 bit page count into Y
-                    ldd       R$U,u               get the address of memory to free from the caller's U
-                    beq       okex                if user passed 0, ignore
-                    tstb                          check for B = 0 (it should!)
-                    beq       returnmem@          it does... return it to the system
-                    comb                          the user has passed B<>0 for the address
-                    ldb       #E$BPAddr           the error is bad page address
-                    rts                           return to the caller
-returnmem@          exg       a,b                 swap A/B
-                    ldx       <D.FMBM             get pointer to free memory bitmap
-                    bra       DelBit              call into F$DelBit to delete bits
+FSRtMem             ldd       R$D,u     ; get the memory allocation size requested from the caller's D
+                    addd      #$00FF    ; round it up to nearest 256 byte page (e.g. $1FF = $2FE)
+                    tfr       a,b       ; put MSB into B
+                    clra                ; now D reflects number of 256 byte pages to return
+                    tfr       d,y       ; put the 16 bit page count into Y
+                    ldd       R$U,u     ; get the address of memory to free from the caller's U
+                    beq       okex      ; if user passed 0, ignore
+                    tstb                ; check for B = 0 (it should!)
+                    beq       returnmem@ ; it does... return it to the system
+                    comb                ; the user has passed B<>0 for the address
+                    ldb       #E$BPAddr ; the error is bad page address
+                    rts                 ; return to the caller
+returnmem@          exg       a,b       ; swap A/B
+                    ldx       <D.FMBM   ; get pointer to free memory bitmap
+                    bra       DelBit    ; call into F$DelBit to delete bits
 
-                    else
+                  ELSE
 
 **************************************************
 * F$SRqMem - Level 2 implementation
@@ -116,11 +116,11 @@ returnmem@          exg       a,b                 swap A/B
 * empty block is found, this routine re-does the 32 entries in the SMAP table to
 * indicate that they are free.
 
-FSRqMem             ldd       R$D,u               get the memory allocation size requested
-                    addd      #$00FF              round it up to the nearest 256 byte page (e.g. $1FF = $2FE)
-                    clrb                          just keep the number of pages (and the starting 8K block number, e.g. $2FE = $200)
-                    std       R$D,u               save the rounded up version back to the user's D
-                    pshs      d                   reserve a byte and put 0 byte on stack
+FSRqMem             ldd       R$D,u     ; get the memory allocation size requested
+                    addd      #$00FF    ; round it up to the nearest 256 byte page (e.g. $1FF = $2FE)
+                    clrb                ; just keep the number of pages (and the starting 8K block number, e.g. $2FE = $200)
+                    std       R$D,u     ; save the rounded up version back to the user's D
+                    pshs      d         ; reserve a byte and put 0 byte on stack
 
 * IMPORTANT!!!
 * The following code was put in some time back to fix a problem.  That problem was not documented
@@ -128,38 +128,38 @@ FSRqMem             ldd       R$D,u               get the memory allocation size
 * memory map based upon the state of the system DAT image.
 * This code really slows down F$SRqMem and since that system call is used quite often in the system,
 * I am commenting it out in the hopes that I can remember what the hell I put it in for. -- Boisy
-                    ifeq      1
-                    ldy       <D.SysMem           get ptr to SMAP table
+                  IFEQ    1       ; begin conditional assembly for 1
+                    ldy       <D.SysMem ; get ptr to SMAP table
 * This loop updates the SMAP table if anything can be marked as unused
-L082F               ldx       <D.SysDAT           get pointer to system DAT block list
-                    lslb                          adjust block offset for 2 bytes/entry
-                    ldd       b,x                 get block type/# from system DAT
-                    cmpd      #DAT.Free           Unused block?
-                    beq       L0847               yes, mark it free in SMAP table
-                    ldx       <D.BlkMap           No, get ptr to MMAP table
-                    lda       d,x                 Get block marker for 2 meg mem map
-                    cmpa      #RAMinUse           Is it in use (not free, ROM or used by module)?
-                    bne       L0848               No, mark it as type it is in SMAP table
-                    leay      32,y                Yes, move to next block in pages
-                    bra       L084F               move to next block & try again
+L082F               ldx       <D.SysDAT ; get pointer to system DAT block list
+                    lslb                ; adjust block offset for 2 bytes/entry
+                    ldd       b,x       ; get block type/# from system DAT
+                    cmpd      #DAT.Free ; unused block?
+                    beq       L0847     ; yes, mark it free in SMAP table
+                    ldx       <D.BlkMap ; no, get ptr to MMAP table
+                    lda       d,x       ; get block marker for 2 meg mem map
+                    cmpa      #RAMinUse ; is it in use (not free, ROM or used by module)?
+                    bne       L0848     ; no, mark it as type it is in SMAP table
+                    leay      32,y      ; yes, move to next block in pages
+                    bra       L084F     ; move to next block & try again
 * Free RAM:
-L0847               clra                          Byte to fill system page map with (0=Not in use)
+L0847               clra                ; byte to fill system page map with (0=Not in use)
 * NOT! RAMinUse:
-                    ifne      H6309
-L0848               sta       ,s                  Put it on stack
-                    ldw       #$0020              Get size of 8K block in pages
-                    tfm       s,y+                Mark entire block's worth of pages with A
-                    else
-L0848               ldb       #32                 count = 32 pages
-L084A               sta       ,y+                 mark the RAM
-                    decb
-                    bne       L084A
-                    endc
-L084F               inc       1,s                 Bump up to next block to check
-                    ldb       1,s                 Get it
-                    cmpb      #DAT.BlCt           Done whole 64k system space?
-                    blo       L082F               no, keep checking
-                    endc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+L0848               sta       ,s        ; put it on stack
+                    ldw       #$0020    Get size of 8K block in pages
+                    tfm       s,y+      Mark entire block's worth of pages with A
+                  ELSE
+L0848               ldb       #32       ; count = 32 pages
+L084A               sta       ,y+       ; mark the RAM
+                    decb                ; decrement B
+                    bne       L084A     ; branch if zero is clear to L084A
+                  ENDC
+L084F               inc       1,s       ; bump up to next block to check
+                    ldb       1,s       ; get it
+                    cmpb      #DAT.BlCt ; done whole 64k system space?
+                    blo       L082F     ; no, keep checking
+                  ENDC
 
 
 * Now we can actually attempt to allocate the system RAM requested
@@ -167,52 +167,52 @@ L084F               inc       1,s                 Bump up to next block to check
 * they are: Kernel (REL/BOOT/KRN - 17 pages), vector RAM & I/O (2 pages)
 * (Already permanently marked @ L01D2)
 * At the start, Y is pointing to the end of the SMAP table+1
-                    ldx       <D.SysMem           get the starting address of the system free memory map
-                    ifne      wildbits
+                    ldx       <D.SysMem ; get the starting address of the system free memory map
+                  IFNE    wildbits ; begin conditional assembly for wildbits
 * Under OS-9 Level 2 for the Wildbits, the entire bootfile is loaded into RAM by FEU.
 * There is no F$Boot. Because of this, we start searching for free memory at the
 * very end of the system free memory map.
-                    leay      256,x               point Y to very end of system free memory map
-                    else
-                    leay      Bt.Start/256,x      point Y to starting page where the bootfile was loaded
-                    endc
-                    ldb       #32                 skip block 0: it's always full
-                    abx                           update X to point to the starting place to search for
-L0857               ldb       R$A,u               get the number of 256 byte pages requested
+                    leay      256,x     ; point Y to very end of system free memory map
+                  ELSE
+                    leay      Bt.Start/256,x ; point Y to starting page where the bootfile was loaded
+                  ENDC
+                    ldb       #32       ; skip block 0: it's always full
+                    abx                 ; update X to point to the starting place to search for
+L0857               ldb       R$A,u     ; get the number of 256 byte pages requested
 * Loop from the end of the system free memory map) to look for the number continuous pages requested
-L0859               equ       *
-                    ifne      H6309
-                    cmpr      x,y                 do we still have any system RAM left to try?
-                    else
-                    pshs      x                   save X
-                    cmpy      ,s++                compare Y to X
-                    endc
-                    bhi       L0863               if Y (end) is higher than X (start), continue looking
-                    comb                          else set the carry
-                    ldb       #E$NoRAM            load the "no system RAM" error
-                    bra       L0894               and branch to return
+L0859               equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    cmpr      x,y       do we still have any system RAM left to try?
+                  ELSE
+                    pshs      x         ; save X
+                    cmpy      ,s++      ; compare Y to X
+                  ENDC
+                    bhi       L0863     ; if Y (end) is higher than X (start), continue looking
+                    comb                ; else set the carry
+                    ldb       #E$NoRAM  ; load the "no system RAM" error
+                    bra       L0894     ; and branch to return
 
-L0863               lda       ,-y                 get the page marker (starting at the end of the system free memory map)
-                    bne       L0857               branch if it's not zero (the page is allocated, so test the next lower one)
-                    decb                          found 1 page, decrement the number of pages we need to allocate
-                    bne       L0859               branch if we still more pages needed to see if we can get more
-                    sty       ,s                  here, we've found all of the free contiguous pages, so save the pointer
-                    lda       1,s                 get the LSB of the pointer
-                    lsra                          A = A / 2
-                    lsra                          A = A / 4
-                    lsra                          A = A / 8
-                    lsra                          A = A / 16
-                    lsra                          A = A / 32 to obtain the starting 8KB block number
-                    ldb       1,s                 get the LSB of the pointer
-                    andb      #%00011111          keep the offset within the 8KB block
-                    addb      R$A,u               add the number of pages requested
-                    addb      #$1F                round up to the nearest 8KB block
-                    lsrb                          B = B / 2
-                    lsrb                          B = B / 4
-                    lsrb                          B = B / 8
-                    lsrb                          B = B / 16
-                    lsrb                          Divide by 32 to obtain the ending 8KB block number
-                    ldx       <D.SysPrc           get the pointer to the system process descriptor
+L0863               lda       ,-y       ; get the page marker (starting at the end of the system free memory map)
+                    bne       L0857     ; branch if it's not zero (the page is allocated, so test the next lower one)
+                    decb                ; found 1 page, decrement the number of pages we need to allocate
+                    bne       L0859     ; branch if we still more pages needed to see if we can get more
+                    sty       ,s        ; here, we've found all of the free contiguous pages, so save the pointer
+                    lda       1,s       ; get the LSB of the pointer
+                    lsra                ; A = A / 2
+                    lsra                ; A = A / 4
+                    lsra                ; A = A / 8
+                    lsra                ; A = A / 16
+                    lsra                ; A = A / 32 to obtain the starting 8KB block number
+                    ldb       1,s       ; get the LSB of the pointer
+                    andb      #%00011111 ; keep the offset within the 8KB block
+                    addb      R$A,u     ; add the number of pages requested
+                    addb      #$1F      ; round up to the nearest 8KB block
+                    lsrb                ; B = B / 2
+                    lsrb                ; B = B / 4
+                    lsrb                ; B = B / 8
+                    lsrb                ; B = B / 16
+                    lsrb                ; divide by 32 to obtain the ending 8KB block number
+                    ldx       <D.SysPrc ; get the pointer to the system process descriptor
 **************************
 * The following code addresses a bug where the call into F$AllImg could fail if the number of blocks
 * in B was 2, thereby crossing an 8KB boundary. The specific case that surfaced this was early on
@@ -224,115 +224,115 @@ L0863               lda       ,-y                 get the page marker (starting 
 * slots that it's asking to obtain 8KB blocks for are indeed available; if not, it decrements the
 * number of blocks to request in B.
 * Boisy - 10/27/23
-                    pshs      d,x                 save registers
-                    leax      P$DATImg,x          point into the DAT image of the process descriptor
-l@                  ldb       ,s                  get the starting block
-                    decb                          decrement it since we're adding the number next
-                    addb      1,s                 add the number of blocks
-                    lslb                          A = A * 2
-                    ldd       b,x                 get the entry in the DAT image
-                    cmpd      #DAT.Free           is it free?
-                    beq       ok@                 branch if so
-                    dec       ,s                  else decrement starting block
-                    bne       l@                  and go try next
-ok@                 puls      d,x                 recover registers
+                    pshs      d,x       ; save registers
+                    leax      P$DATImg,x ; point into the DAT image of the process descriptor
+l@                  ldb       ,s        ; get the starting block
+                    decb                ; decrement it since we're adding the number next
+                    addb      1,s       ; add the number of blocks
+                    lslb                ; A = A * 2
+                    ldd       b,x       ; get the entry in the DAT image
+                    cmpd      #DAT.Free ; is it free?
+                    beq       ok@       ; branch if so
+                    dec       ,s        ; else decrement starting block
+                    bne       l@        ; and go try next
+ok@                 puls      d,x       ; recover registers
 **************************
-                    lbsr      L09BE               allocate an image with our start/end block numbers
-                    bcs       L0894               branch if we couldn't do it
-                    ldb       R$A,u               else get the number of requested pages
+                    lbsr      L09BE     ; allocate an image with our start/end block numbers
+                    bcs       L0894     ; branch if we couldn't do it
+                    ldb       R$A,u     ; else get the number of requested pages
 *         lda   #RAMinUse    Get SMAP in use flag
 *L088A    sta   ,y+          Mark all the pages requested as In Use
-L088A               inc       ,y+                 since RAMinUse is 1, we can save space by INC'ing from 0->1
-                    decb                          decrement the counter
-                    bne       L088A               continue if not at 0
-                    lda       1,s                 get the MSB of the pointer to the start of the newly allocated system RAM
-                    std       R$U,u               save to the caller's U
-                    clrb                          clear the error code and carry
-L0894               puls      u,pc                return (U is changed after it exits)
+L088A               inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
+                    decb                ; decrement the counter
+                    bne       L088A     ; continue if not at 0
+                    lda       1,s       ; get the MSB of the pointer to the start of the newly allocated system RAM
+                    std       R$U,u     ; save to the caller's U
+                    clrb                ; clear the error code and carry
+L0894               puls      u,pc      ; return (U is changed after it exits)
 
 
 **************************************************
 * F$SRtMem - Level 2 implementation
 *
-FSRtMem             ldd       R$D,u               get the number of pages to free up
-                    beq       L08F2               branch if the caller passed 0 (nothing to free!)
-                    addd      #$00FF              else round up the value to nearest page
-                    ldb       R$U+1,u             get the LSB of the address
-                    beq       L08A6               it's a even page, so skip ahead
-                    comb                          else set the carry
-                    ldb       #E$BPAddr           load the "bad page address" error number
-                    rts                           return
+FSRtMem             ldd       R$D,u     ; get the number of pages to free up
+                    beq       L08F2     ; branch if the caller passed 0 (nothing to free!)
+                    addd      #$00FF    ; else round up the value to nearest page
+                    ldb       R$U+1,u   ; get the LSB of the address
+                    beq       L08A6     ; it's a even page, so skip ahead
+                    comb                ; else set the carry
+                    ldb       #E$BPAddr ; load the "bad page address" error number
+                    rts                 ; return
 
-L08A6               ldb       R$U,u               get the MSB of the page address
-                    beq       L08F2               branc if it's 0 (not a legal page)
-                    ldx       <D.SysMem           get the pointer to the system free memory map
-                    abx                           set the pointer into the map
-L08AD               equ       *
-                    ifne      H6309
-                    aim       #^RAMinUse,,x+      clear the "RAM in use" bit
-                    else
-                    ldb       ,x                  get the page byte
-                    andb      #^RAMinUse          clear the "RAM in use" bit
-                    stb       ,x+                 save the page byte back and increment the index register
-                    endc
-                    deca                          decrement the counter
-                    bne       L08AD               branch if not done
+L08A6               ldb       R$U,u     ; get the MSB of the page address
+                    beq       L08F2     ; branc if it's 0 (not a legal page)
+                    ldx       <D.SysMem ; get the pointer to the system free memory map
+                    abx                 ; set the pointer into the map
+L08AD               equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^RAMinUse,,x+ clear the "RAM in use" bit
+                  ELSE
+                    ldb       ,x        ; get the page byte
+                    andb      #^RAMinUse ; clear the "RAM in use" bit
+                    stb       ,x+       ; save the page byte back and increment the index register
+                  ENDC
+                    deca                ; decrement the counter
+                    bne       L08AD     ; branch if not done
 * Scan the DAT image to find the memory blocks to free up.
-                    ldx       <D.SysDAT           get the pointer to the system DAT image
-                    ifne      H6309
-                    lde       #DAT.BlCt           get the number of blocks to check
-                    else
-                    ldy       #DAT.BlCt           get the number of blocks to check
-                    endc
-L08BC               ldd       ,x                  get the block image
-                    cmpd      #DAT.Free           is it already free?
-                    beq       L08EC               yes, skip to the next one
-                    ldu       <D.BlkMap           else get the pointer to the MMU block map
-                    lda       d,u                 get the allocation flag for this block: 16-bit offset
-                    cmpa      #RAMinUse           is it being used?
-                    bne       L08EC               no, move to the next block
-                    tfr       x,d                 else transfer the pointer to D
-                    subd      <D.SysDAT           set D to the offset in the system DAT image
-                    lslb                          B = B * 2
-                    lslb                          B = B * 4
-                    lslb                          B = B * 8
-                    lslb                          B = B * 16
-                    ldu       <D.SysMem           get the pointer to the system map
-                    ifne      H6309
-                    addr      d,u                 point to the offset in the system free memory map
+                    ldx       <D.SysDAT ; get the pointer to the system DAT image
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lde       #DAT.BlCt get the number of blocks to check
+                  ELSE
+                    ldy       #DAT.BlCt ; get the number of blocks to check
+                  ENDC
+L08BC               ldd       ,x        ; get the block image
+                    cmpd      #DAT.Free ; is it already free?
+                    beq       L08EC     ; yes, skip to the next one
+                    ldu       <D.BlkMap ; else get the pointer to the MMU block map
+                    lda       d,u       ; get the allocation flag for this block: 16-bit offset
+                    cmpa      #RAMinUse ; is it being used?
+                    bne       L08EC     ; no, move to the next block
+                    tfr       x,d       ; else transfer the pointer to D
+                    subd      <D.SysDAT ; set D to the offset in the system DAT image
+                    lslb                ; B = B * 2
+                    lslb                ; B = B * 4
+                    lslb                ; B = B * 8
+                    lslb                ; B = B * 16
+                    ldu       <D.SysMem ; get the pointer to the system map
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,u       ; point to the offset in the system free memory map
 * Check if we can remove the entire memory block from system map
-                    ldf       #16                 get the number of pages per block / 2
-L08DA               ldd       ,u++                are either of these 2 pages allocated?
-                    else
-                    leau      d,u                 point to the offset in the system free memory map
-                    ldb       #32                 set the counter
-L08DA               lda       ,u+                 are either of these 2 pages allocated?
-                    endc
-                    bne       L08EC               yes, we can't free this block, so skip to next one
-                    ifne      H6309
-                    decf                          have we checked all pages?
-                    else
-                    decb                          decrement the counter
-                    endc
-                    bne       L08DA               no, keep looking
-                    ldd       ,x                  else get the block number into B; it could be >$80
-                    ldu       <D.BlkMap           point to the allocation table
-                    ifne      H6309
-                    sta       d,u                 clear the block using the 16-bit offset
-                    else
-                    clr       d,u                 clear the block using the 16-bit offset
-                    endc
-                    ldd       #DAT.Free           get the free block marker
-                    std       ,x                  save it into the DAT image
-L08EC               leax      2,x                 move to the next DAT block
-                    ifne      H6309
-                    dece                          are we done?
-                    else
-                    leay      -1,y                are we done?
-                    endc
-                    bne       L08BC               branch if not
-L08F2               clrb                          clear the error code and carry
-L08F3               rts                           return
+                    ldf       #16       get the number of pages per block / 2
+L08DA               ldd       ,u++      ; are either of these 2 pages allocated?
+                  ELSE
+                    leau      d,u       ; point to the offset in the system free memory map
+                    ldb       #32       ; set the counter
+L08DA               lda       ,u+       ; are either of these 2 pages allocated?
+                  ENDC
+                    bne       L08EC     ; yes, we can't free this block, so skip to next one
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decf                ; have we checked all pages?
+                  ELSE
+                    decb                ; decrement the counter
+                  ENDC
+                    bne       L08DA     ; no, keep looking
+                    ldd       ,x        ; else get the block number into B; it could be >$80
+                    ldu       <D.BlkMap ; point to the allocation table
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    sta       d,u       ; clear the block using the 16-bit offset
+                  ELSE
+                    clr       d,u       ; clear the block using the 16-bit offset
+                  ENDC
+                    ldd       #DAT.Free ; get the free block marker
+                    std       ,x        ; save it into the DAT image
+L08EC               leax      2,x       ; move to the next DAT block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    dece                ; are we done?
+                  ELSE
+                    leay      -1,y      ; are we done?
+                  ENDC
+                    bne       L08BC     ; branch if not
+L08F2               clrb                ; clear the error code and carry
+L08F3               rts                 ; return
 
 
 ;;; F$Boot
@@ -348,56 +348,56 @@ L08F3               rts                           return
 ;;;
 
 FBoot
-                    ifne      wildbits
-                    rts                           the Wildbits port doesn't use F$Boot
-                    else
-                    lda       #'t                 tried to boot
-                    jsr       <D.BtBug
-                    coma                          Set boot flag
-                    lda       <D.Boot             we booted once before?
-                    bne       L08F3               Yes, return
-                    inc       <D.Boot             Set boot flag
-                    ldx       <D.Init             Get ptr to init module if it exists
-                    beq       L0908               it doesn't, point to boot name
-                    ldd       <BootStr,x          Get offset to text
-                    beq       L0908               Doesn't exist, get hard coded text
-                    leax      d,x                 Adjust X to point to boot module
-                    bra       L090C               Try & link to module
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    rts                 ; the Wildbits port doesn't use F$Boot
+                  ELSE
+                    lda       #'t       ; tried to boot
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    coma                ; set boot flag
+                    lda       <D.Boot   ; we booted once before?
+                    bne       L08F3     ; yes, return
+                    inc       <D.Boot   ; set boot flag
+                    ldx       <D.Init   ; get ptr to init module if it exists
+                    beq       L0908     ; it doesn't, point to boot name
+                    ldd       <BootStr,x ; get offset to text
+                    beq       L0908     ; doesn't exist, get hard coded text
+                    leax      d,x       ; adjust X to point to boot module
+                    bra       L090C     ; try & link to module
 
 boot                fcs       /Boot/
 
-L0908               leax      <boot,pcr
+L0908               leax      <boot,pcr ; compute <boot,pcr into X
 * Link to module and execute
-L090C               lda       #Systm+Objct
-                    os9       F$Link
-                    bcs       L08F3               return with error.
-                    lda       #'b                 calling boot
-                    jsr       <D.BtBug
-                    jsr       ,y                  load boot file
-                    bcs       L08F3
-                    std       <D.BtSz             save boot file size
-                    stx       <D.BtPtr            save start pointer of bootfile
-                    lda       #'b                 boot returns OK
-                    jsr       <D.BtBug
+L090C               lda       #Systm+Objct ; load A from #Systm+Objct
+                    os9       F$Link    ; call OS-9 service F$Link
+                    bcs       L08F3     ; return with error.
+                    lda       #'b       ; calling boot
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    jsr       ,y        ; load boot file
+                    bcs       L08F3     ; branch if carry is set to L08F3
+                    std       <D.BtSz   ; save boot file size
+                    stx       <D.BtPtr  ; save start pointer of bootfile
+                    lda       #'b       ; boot returns OK
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
 
 * added for IOMan system memory extentions
-                    ifne      H6309
-                    ldd       M$Name,x            grab the name offset
-                    ldd       d,x                 find the first 2 bytes of the first module
-                    cmpd      #$4E69              'Ni' ? (NitrOS9 module?)
-                    bne       not.ext             no, not system memory extensions
-                    ldd       M$Exec,x            grab the execution ptr
-                    jmp       d,x                 and go execute the system memory extension module
-                    endc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldd       M$Name,x  ; grab the name offset
+                    ldd       d,x       ; find the first 2 bytes of the first module
+                    cmpd      #$4E69    ; 'Ni' ? (NitrOS9 module?)
+                    bne       not.ext   ; no, not system memory extensions
+                    ldd       M$Exec,x  ; grab the execution ptr
+                    jmp       d,x       ; and go execute the system memory extension module
+                  ENDC
 
-not.ext             ldd       <D.BtSz
-                    bsr       I.VBlock            internal verify block routine
-                    ldx       <D.SysDAT           get system DAT pointer
-                    ldb       $0D,x               get highest allocated block number
-                    incb                          allocate block 0, too
-                    ldx       <D.BlkMap           point to the memory block map
-                    lbra      L01DF               and go mark the blocks as used.
-                    endc
+not.ext             ldd       <D.BtSz   ; load D from <D.BtSz
+                    bsr       I.VBlock  ; internal verify block routine
+                    ldx       <D.SysDAT ; get system DAT pointer
+                    ldb       $0D,x     ; get highest allocated block number
+                    incb                ; allocate block 0, too
+                    ldx       <D.BlkMap ; point to the memory block map
+                    lbra      L01DF     ; and go mark the blocks as used.
+                  ENDC
 
 ;;; F$VBlock
 ;;;
@@ -412,51 +412,51 @@ not.ext             ldd       <D.BtSz
 ;;;        CC = Carry flag set to indicate error.
 ;;;
 
-FVBlock             ldd       R$D,u               get the size of the block to verify
-                    ldx       R$X,u               get the start address to verify
-I.VBlock            leau      d,x                 point to the end of the block
-                    tfr       x,d                 transfer the start of the block to D
-                    anda      #%11100000          mask out all but the block number bits
-                    clrb                          D is now the block number
-                    pshs      d,u                 save the starting block and the ending block
-                    lsra                          A = A / 2
-                    lsra                          A = A / 4
-                    lsra                          A = A / 8
-                    lsra                          A = A / 16: the logical block * 2
-                    ldy       <D.SysDAT           get the pointer to the system DAT image
-                    leay      a,y                 point Y to the offset into the block
-L092D               ldd       M$ID,x              get the module ID signature
-                    cmpd      #M$ID12             is it a valid module ID?
-                    bne       L0954               no, keep looking
-                    ldd       M$Name,x            else get the name offset pointer
-                    pshs      x                   save the address of the module header onto the stack
-                    leax      d,x                 point X to the name in the module
-name.prt            lda       ,x+                 get the character of the name
-                    jsr       <D.BtBug            print it out
-                    bpl       name.prt            keep printing the character until we've reached the last one
-                    lda       #C$SPAC             get a space
-                    jsr       <D.BtBug            and print it out
-                    puls      x                   retrieve the address of the module header
-                    tfr       x,d                 transfer it to D
-                    subd      ,s                  subtract the starting block address from the module address
-                    tfr       d,x                 X now holds the offset into the block of the module
-                    tfr       y,d                 Y holds the offset into the block
-                    os9       F$VModul            validate the module
-                    pshs      b                   save B
-                    ldd       1,s                 get the starting address
-                    leax      d,x                 move X past it
-                    puls      b                   restore B
-                    bcc       L094E               branch if the validation succeeded
-                    cmpb      #E$KwnMod           else an error occurred; is it the "known module" error?
-                    bne       L0954               no, assume a case of mistaken identity and continue
-L094E               ldd       M$Size,x            else get the module size
-                    leax      d,x                 and step over it
-                    fcb       $8C                 skip the next 2 bytes (continue at L0956)
-L0954               leax      1,x                 move to the next byte
-L0956               cmpx      2,s                 have we gone through the whole bootfile?
-                    bcs       L092D               no, keep looking
-                    leas      4,s                 else recover the stack
-                    clrb                          clear the error code and carry
-                    rts                           return
+FVBlock             ldd       R$D,u     ; get the size of the block to verify
+                    ldx       R$X,u     ; get the start address to verify
+I.VBlock            leau      d,x       ; point to the end of the block
+                    tfr       x,d       ; transfer the start of the block to D
+                    anda      #%11100000 ; mask out all but the block number bits
+                    clrb                ; D is now the block number
+                    pshs      d,u       ; save the starting block and the ending block
+                    lsra                ; A = A / 2
+                    lsra                ; A = A / 4
+                    lsra                ; A = A / 8
+                    lsra                ; A = A / 16: the logical block * 2
+                    ldy       <D.SysDAT ; get the pointer to the system DAT image
+                    leay      a,y       ; point Y to the offset into the block
+L092D               ldd       M$ID,x    ; get the module ID signature
+                    cmpd      #M$ID12   ; is it a valid module ID?
+                    bne       L0954     ; no, keep looking
+                    ldd       M$Name,x  ; else get the name offset pointer
+                    pshs      x         ; save the address of the module header onto the stack
+                    leax      d,x       ; point X to the name in the module
+name.prt            lda       ,x+       ; get the character of the name
+                    jsr       <D.BtBug  ; print it out
+                    bpl       name.prt  ; keep printing the character until we've reached the last one
+                    lda       #C$SPAC   ; get a space
+                    jsr       <D.BtBug  ; and print it out
+                    puls      x         ; retrieve the address of the module header
+                    tfr       x,d       ; transfer it to D
+                    subd      ,s        ; subtract the starting block address from the module address
+                    tfr       d,x       ; X now holds the offset into the block of the module
+                    tfr       y,d       ; Y holds the offset into the block
+                    os9       F$VModul  ; validate the module
+                    pshs      b         ; save B
+                    ldd       1,s       ; get the starting address
+                    leax      d,x       ; move X past it
+                    puls      b         ; restore B
+                    bcc       L094E     ; branch if the validation succeeded
+                    cmpb      #E$KwnMod ; else an error occurred; is it the "known module" error?
+                    bne       L0954     ; no, assume a case of mistaken identity and continue
+L094E               ldd       M$Size,x  ; else get the module size
+                    leax      d,x       ; and step over it
+                    fcb       $8C       ; skip the next 2 bytes (continue at L0956)
+L0954               leax      1,x       ; move to the next byte
+L0956               cmpx      2,s       ; have we gone through the whole bootfile?
+                    bcs       L092D     ; no, keep looking
+                    leas      4,s       ; else recover the stack
+                    clrb                ; clear the error code and carry
+                    rts                 ; return
 
-                    endc
+                  ENDC

--- a/level1/modules/kernel/fssvc.asm
+++ b/level1/modules/kernel/fssvc.asm
@@ -50,45 +50,45 @@
 ;;;          U        $08       R$U
 ;;;         PC        $0A       R$PC
 
-FSSvc          ldy       R$Y,u               get pointer to table
-               bra       InstallSvc          install the service
+FSSvc               ldy       R$Y,u     ; get pointer to table
+                    bra       InstallSvc ; install the service
 * Main move loop
 loop@
-               ifgt      Level-1
-*>>>>>>>> Level 2
-               clra                          clear the MSB of the table offset
-               lslb                          multiply the function # by 2 to get the offset into the table
-               tfr       d,u                 copy it to U
-               ldd       ,y++                get the vector to the function handler
-               leax      d,y                 offset X from current Y
-               ldd       <D.SysDis           get the system dispatch table pointer
-               stx       d,u                 save the vector into place
-               bcs       InstallSvc          if it was a privileged call, skip ahead
-               ldd       <D.UsrDis           else get the user dispatch table pointer
-               stx       d,u                 and save the vector into place
-*<<<<<<<< Level 2
-               else
-*>>>>>>>> Level 1
-               tfr       b,a                 put the system call code in A
-               anda      #$7F                kill the high bit
-               cmpa      #$7F                is the system call code $7F? (I/O handler)
-               beq       ok@                 branch if so
-               cmpa      #$37                compare against highest call allowed
-               bcs       ok@                 branch if less than or equal to the highest call
-               comb                          else set the carry flag
-               ldb       #E$ISWI             and indicate an illegal code
-               rts                           return to the caller
-ok@            lslb                          B = B * 2
-               ldu       <D.SysDis           get the system dispatch table pointer
-               leau      b,u                 U points to entry in table
-               ldd       ,y++                get the address of the routine in the table
-               leax      d,y                 set X to the absolute address
-               stx       ,u                  and store in the system table
-               bcs       InstallSvc          branch if this is a system service call only
-               stx       <$70,u              else store in user table also
-*<<<<<<<< Level 1
-               endc
-InstallSvc     ldb       ,y+                 get the system call code in B
-               cmpb      #$80                are we at the end of the table?
-               bne       loop@               branch if not
-               rts                           return to the caller
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+*[[[ Level 2
+                    clra                ; clear the MSB of the table offset
+                    lslb                ; multiply the function # by 2 to get the offset into the table
+                    tfr       d,u       ; copy it to U
+                    ldd       ,y++      ; get the vector to the function handler
+                    leax      d,y       ; offset X from current Y
+                    ldd       <D.SysDis ; get the system dispatch table pointer
+                    stx       d,u       ; save the vector into place
+                    bcs       InstallSvc ; if it was a privileged call, skip ahead
+                    ldd       <D.UsrDis ; else get the user dispatch table pointer
+                    stx       d,u       ; and save the vector into place
+*]]] Level 2
+                  ELSE
+*[[[ Level 1
+                    tfr       b,a       ; put the system call code in A
+                    anda      #$7F      ; kill the high bit
+                    cmpa      #$7F      ; is the system call code $7F? (I/O handler)
+                    beq       ok@       ; branch if so
+                    cmpa      #$37      ; compare against highest call allowed
+                    bcs       ok@       ; branch if less than or equal to the highest call
+                    comb                ; else set the carry flag
+                    ldb       #E$ISWI   ; and indicate an illegal code
+                    rts                 ; return to the caller
+ok@                 lslb                ; B = B * 2
+                    ldu       <D.SysDis ; get the system dispatch table pointer
+                    leau      b,u       ; U points to entry in table
+                    ldd       ,y++      ; get the address of the routine in the table
+                    leax      d,y       ; set X to the absolute address
+                    stx       ,u        ; and store in the system table
+                    bcs       InstallSvc ; branch if this is a system service call only
+                    stx       <$70,u    ; else store in user table also
+*]]] Level 1
+                  ENDC
+InstallSvc          ldb       ,y+       ; get the system call code in B
+                    cmpb      #$80      ; are we at the end of the table?
+                    bne       loop@     ; branch if not
+                    rts                 ; return to the caller

--- a/level1/modules/kernel/fsswi.asm
+++ b/level1/modules/kernel/fsswi.asm
@@ -19,37 +19,37 @@
 ;;;     3 = SWI3
 ;;;
 ;;; Note: kernel system calls are invoked using SWI2. If you change this vector, system calls stop working.
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FSSWI          ldx       <D.Proc             get current process descriptor
-               leay      P$SWI,x             point to the SWI vectors
-               ldb       R$A,u               get the desired interrupt code to change from the caller's A
-               decb                          decrement it
-               cmpb      #$03                is it higher than the allowed value?
-               bcc       errex@              branch if so, it's an error
-               lslb                          else multiply by 2 to get the 16-bit offset
-               ldx       R$X,u               get the address of the new software interrupt routine from the caller's X
-               stx       b,y                 and store it in the appropriate vector in the process descriptor
-               rts                           return to the caller
-errex@         comb                          set the carry to indicate an error
-               ldb       #E$ISWI             invalid SWI number
-               rts                           return to the caller
+FSSWI               ldx       <D.Proc   ; get current process descriptor
+                    leay      P$SWI,x   ; point to the SWI vectors
+                    ldb       R$A,u     ; get the desired interrupt code to change from the caller's A
+                    decb                ; decrement it
+                    cmpb      #$03      ; is it higher than the allowed value?
+                    bcc       errex@    ; branch if so, it's an error
+                    lslb                ; else multiply by 2 to get the 16-bit offset
+                    ldx       R$X,u     ; get the address of the new software interrupt routine from the caller's X
+                    stx       b,y       ; and store it in the appropriate vector in the process descriptor
+                    rts                 ; return to the caller
+errex@              comb                ; set the carry to indicate an error
+                    ldb       #E$ISWI   ; invalid SWI number
+                    rts                 ; return to the caller
 
-               else
+                  ELSE
 
-FSSWI          ldx       <D.Proc             get current process
-               ldb       R$A,u               get type code
-               decb                          adjust for offset
-               cmpb      #3                  legal value?
-               bcc       BadSWI              no, return error
-               lslb                          account for 2 bytes entry
-               addb      #P$SWI              go to start of P$SWI pointers
-               ldu       R$X,u               get address
-               stu       b,x                 save to descriptor
-               rts                           return
+FSSWI               ldx       <D.Proc   ; get current process
+                    ldb       R$A,u     ; get type code
+                    decb                ; adjust for offset
+                    cmpb      #3        ; legal value?
+                    bcc       BadSWI    ; no, return error
+                    lslb                ; account for 2 bytes entry
+                    addb      #P$SWI    ; go to start of P$SWI pointers
+                    ldu       R$X,u     ; get address
+                    stu       b,x       ; save to descriptor
+                    rts                 ; return
 
-BadSWI         comb
-               ldb       #E$ISWI
-               rts
+BadSWI              comb                ; update processor state
+                    ldb       #E$ISWI   ; load B from #E$ISWI
+                    rts                 ; return to caller
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fstime.asm
+++ b/level1/modules/kernel/fstime.asm
@@ -17,50 +17,50 @@
 ;;;     - Minute (one byte from 0-59 representing the minute)
 ;;;     - Second (one byte from 0-59 representing the second)
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-ClkName        fcs       /Clock/
+ClkName             fcs       /Clock/
 
-FSTime         ldx       R$X,u               get caller's pointer to time packet
-               ldd       ,x                  get year and month
-               std       <D.Year             save to globals
-               ldd       2,x                 get day and hour
-               std       <D.Day              save to globals
-               ldd       4,x                 get minute and second
-               std       <D.Min              save to globals
-               lda       #Systm+Objct        specify type and language
-               leax      <ClkName,pcr        point to module name
-               os9       F$Link              link to the module
-               bcs       ex@                 branch if there's an error
-               jmp       ,y                  jump into the initialization entry point
-               clrb                          else clear B (this is useless and should be removed!)
-ex@            rts
+FSTime              ldx       R$X,u     ; get caller's pointer to time packet
+                    ldd       ,x        ; get year and month
+                    std       <D.Year   ; save to globals
+                    ldd       2,x       ; get day and hour
+                    std       <D.Day    ; save to globals
+                    ldd       4,x       ; get minute and second
+                    std       <D.Min    ; save to globals
+                    lda       #Systm+Objct ; specify type and language
+                    leax      <ClkName,pcr ; point to module name
+                    os9       F$Link    ; link to the module
+                    bcs       ex@       ; branch if there's an error
+                    jmp       ,y        ; jump into the initialization entry point
+                    clrb                ; else clear B (this is useless and should be removed!)
+ex@                 rts                 ; return to caller
 
-               else
+                  ELSE
 
-FSTime         ldx       R$X,u               Get address that user wants time packet
+FSTime              ldx       R$X,u     ; get address that user wants time packet
 ***         tfr   dp,a            Set MSB of D to direct page
 ***         ldb   #D.Time         Offset to Time packet in direct page
 ***         tfr   d,u             Point U to it
-               ldu       #D.Time             --- DP=0 always
-               ldy       <D.Proc             Get ptr to process that called us
-               lda       P$Task,y            Get task # from process
-               ldb       <D.SysTsk           Get task # of system process
-               ldy       #6                  6 byte packet to move
-               os9       F$Move              Go move it
-               ldx       <D.Proc             Get ptr to process that called us
-               pshs      x                   Preserve it
-               ldx       <D.SysPrc           Get ptr to system process
-               stx       <D.Proc             Save as current process
-               lda       #Systm+Objct        Link to Clock module
-               leax      ClockNam,pc
-               os9       F$Link
-               puls      x                   Get back ptr to user's process
-               stx       <D.Proc             Make it the active process again
-               bcs       ex@                 If error in Link, exit with error code
-               jmp       ,y                  Jump into Clock
-ex@            rts
+                    ldu       #D.Time   ; --- DP=0 always
+                    ldy       <D.Proc   ; get ptr to process that called us
+                    lda       P$Task,y  ; get task # from process
+                    ldb       <D.SysTsk ; get task # of system process
+                    ldy       #6        ; 6 byte packet to move
+                    os9       F$Move    ; go move it
+                    ldx       <D.Proc   ; get ptr to process that called us
+                    pshs      x         ; preserve it
+                    ldx       <D.SysPrc ; get ptr to system process
+                    stx       <D.Proc   ; save as current process
+                    lda       #Systm+Objct ; link to Clock module
+                    leax      ClockNam,pc ; compute ClockNam,pc into X
+                    os9       F$Link    ; call OS-9 service F$Link
+                    puls      x         ; get back ptr to user's process
+                    stx       <D.Proc   ; make it the active process again
+                    bcs       ex@       ; if error in Link, exit with error code
+                    jmp       ,y        ; jump into Clock
+ex@                 rts                 ; return to caller
 
-ClockNam       fcs       /Clock/
+ClockNam            fcs       /Clock/
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/funlink.asm
+++ b/level1/modules/kernel/funlink.asm
@@ -26,11 +26,11 @@
 FUnlink             ldd       R$U,u     ; get the pointer to the module to unlink
                     beq       okex@     ; branch if it's empty
                     ldx       <D.ModDir ; get the pointer to the first module in the module directory
-L00B8               cmpd      MD$MPtr,x ; compare the passed module address to the one in this module directory entry
+FUnlinkPassedModuleModuleDirectoryEntry cmpd      MD$MPtr,x ; compare the passed module address to the one in this module directory entry
                     beq       found@    ; if we've found it, branch
                     leax      MD$ESize,x ; else go to next entry
                     cmpx      <D.ModDir+2 ; are we at the end of the module directory?
-                    bcs       L00B8     ; if not, go check next entry for match
+                    bcs       FUnlinkPassedModuleModuleDirectoryEntry ; if not, go check next entry for match
                     bra       okex@     ; else exit
 found@              lda       MD$Link,x ; get the module's link count
                     beq       dealloc@  ; branch if zero
@@ -72,7 +72,7 @@ FUnLink             pshs      d,u       ; preserve register stack pointer and ma
                     lsra                ; shift or rotate and update condition codes
                     lsra                ; shift or rotate and update condition codes
                     sta       ,s        ; save DAT block offset
-                    lbeq      L01D0     ; zero, can't use so exit
+                    lbeq      FUnlinkErrors ; zero, can't use so exit
                     ldu       <D.Proc   ; get pointer to current process
                     leay      P$DATImg,u ; point Y to it's DAT image
                     lsla                ; account for 2 bytes/entry
@@ -84,16 +84,16 @@ FUnLink             pshs      d,u       ; preserve register stack pointer and ma
                     ldb       d,u       ; load B from d,u
                     bitb      #ModBlock ; test bits in B against #ModBlock
                   ENDC
-                    beq       L01D0     ; no, exit without error
+                    beq       FUnlinkErrors ; no, exit without error
                     leau      (P$Links-P$DATImg),y ; point to block link counts
-                    bra       L0161     ; go unlink block
+                    bra       FUnlinkOffset ; go unlink block
 
-L015D               dec       ,s        ; we done?
-                    beq       L01D0     ; yes, go on
-L0161               ldb       ,s        ; get current offset
+FUnlinkWe           dec       ,s        ; we done?
+                    beq       FUnlinkErrors ; yes, go on
+FUnlinkOffset       ldb       ,s        ; get current offset
                     lslb                ; account for 2 bytes entry
                     ldd       b,u       ; get block link count
-                    beq       L015D     ; already zero, get next one
+                    beq       FUnlinkWe ; already zero, get next one
                     lda       ,s        ; get block offset
                     lsla                ; find offset into 64k map by multiplying by 32
                     lsla                ; shift or rotate and update condition codes
@@ -111,39 +111,39 @@ L0161               ldb       ,s        ; get current offset
                     lslb                ; account for 2 bytes/entry
                     ldd       b,y       ; get block #
                     ldu       <D.ModDir ; get module directory pointer
-                    bra       L0185     ; go look for it
+                    bra       FUnlinkModuleSame ; go look for it
 
 * Main module directory search routine
-L017C               leau      MD$ESize,u ; move to next module entry
+FUnlinkModuleEntry  leau      MD$ESize,u ; move to next module entry
                     cmpu      <D.ModEnd ; done entire directory?
-                    bhs       L01D0     ; yes, exit
-L0185               cmpx      MD$MPtr,u ; is module pointer the same?
-                    bne       L017C     ; no, keep looking
+                    bhs       FUnlinkErrors ; yes, exit
+FUnlinkModuleSame   cmpx      MD$MPtr,u ; is module pointer the same?
+                    bne       FUnlinkModuleEntry ; no, keep looking
                     cmpd      [MD$MPDAT,u] ; dAT match?
-                    bne       L017C     ; no, keep looking
+                    bne       FUnlinkModuleEntry ; no, keep looking
 * Module is found decrement link count
 * NOTE: COULD WE USE D?
 *   L0198 - Safe, destroys D immediately
 *   Fall through- safe, destroys D immediately
 *   L01B5 - Seems to be safe
                     ldd       MD$Link,u ; get module link count
-                    beq       L0198     ; it's zero, go unlink it
+                    beq       FUnlinkTarget ; it's zero, go unlink it
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decd      decrement link count
                   ELSE
                     subd      #$0001    ; subtract #$0001 from D
                   ENDC
                     std       MD$Link,u ; save it back
-                    bne       L01B5     ; go on
+                    bne       FUnlinkBlock ; go on
 * Module link count is zero check if he's unlinking a I/O module
-L0198               ldx       2,s       ; get pointer to register stack
+FUnlinkTarget       ldx       2,s       ; get pointer to register stack
                     ldx       R$U,x     ; get pointer to module
                     ldd       #M$Type   ; get offset to module type
                     os9       F$LDDDXY  ; get module type
                     cmpa      #FlMgr    ; is it a I/O module?
-                    blo       L01B3     ; no, don't process for I/O
+                    blo       FUnlinkDeleteModuleMemoryModuleDirectory ; no, don't process for I/O
                     os9       F$IODel   ; device still being used by somebody else?
-                    bcc       L01B3     ; no, go on
+                    bcc       FUnlinkDeleteModuleMemoryModuleDirectory ; no, go on
                     ldd       MD$Link,u ; put the link count back to where it was
                   IFNE    H6309   ; begin conditional assembly for H6309
                     incd                ; update processor state
@@ -151,10 +151,10 @@ L0198               ldx       2,s       ; get pointer to register stack
                     addd      #$0001    ; add #$0001 to D
                   ENDC
                     std       MD$Link,u ; store D at MD$Link,u
-                    bra       L01D1     ; return error
+                    bra       FUnlinkPurgeLocalData ; return error
 * Clear module from memory
-L01B3               bsr       DelMod    ; delete module from memory & module dir
-L01B5               ldb       ,s        ; get block
+FUnlinkDeleteModuleMemoryModuleDirectory bsr       DelMod    ; delete module from memory & module dir
+FUnlinkBlock        ldb       ,s        ; get block
                     lslb                ; account for 2 bytes/entry
                     leay      b,y       ; point to block
                     ldd       (P$Links-P$DATImg),y ; get block link count
@@ -164,16 +164,16 @@ L01B5               ldb       ,s        ; get block
                     subd      #$0001    ; subtract #$0001 from D
                   ENDC
                     std       (P$Links-P$DATImg),y ; save new link count
-                    bne       L01D0     ; not zero, return to user
+                    bne       FUnlinkErrors ; not zero, return to user
 * Clear module blocks in process DAT image
                     ldd       MD$MBSiz,u ; get block size
-                    bsr       L0226     ; calculate # blocks to delete
+                    bsr       FUnlinkRoundUpNearestBlock ; calculate # blocks to delete
                     ldx       #DAT.Free ; get DAT free marker
-L01CB               stx       ,y++      ; save it in DAT image
+FUnlinkDATImage     stx       ,y++      ; save it in DAT image
                     deca                ; done?
-                    bne       L01CB     ; no, keep going
-L01D0               clrb                ; clear errors
-L01D1               leas      2,s       ; purge local data
+                    bne       FUnlinkDATImage ; no, keep going
+FUnlinkErrors       clrb                ; clear errors
+FUnlinkPurgeLocalData leas      2,s       ; purge local data
                     puls      u,pc      ; restore & return
 
 * Delete module from module directory & from memory
@@ -182,35 +182,35 @@ L01D1               leas      2,s       ; purge local data
 DelMod              ldx       <D.BlkMap ; get pointer to memory block map
                     ldd       [MD$MPDAT,u] ; get pointer to module DAT image
                     lda       d,x       ; is block type ROM?
-                    bmi       L0225     ; yes can't delete it, return
+                    bmi       FUnlinkReturn ; yes can't delete it, return
                     ldx       <D.ModDir ; get pointer to module directory
-L01DF               ldd       [MD$MPDAT,x] ; get offset to DAT
+FUnlinkOffsetDAT    ldd       [MD$MPDAT,x] ; get offset to DAT
                     cmpd      [MD$MPDAT,u] ; match what we're looking for?
-                    bne       L01EA     ; no, keep looking
+                    bne       FUnlinkModule ; no, keep looking
                     ldd       MD$Link,x ; get module link count
-                    bne       L0225     ; not zero, return
-L01EA               leax      MD$ESize,x ; move to next module
+                    bne       FUnlinkReturn ; not zero, return
+FUnlinkModule       leax      MD$ESize,x ; move to next module
                     cmpx      <D.ModEnd ; at the end?
-                    bcs       L01DF     ; no, keep going
+                    bcs       FUnlinkOffsetDAT ; no, keep going
                     ldx       <D.BlkMap ; get pointer to block map
                     ldd       MD$MBSiz,u ; get memory block size
-                    bsr       L0226     ; calculate # blocks to clear
+                    bsr       FUnlinkRoundUpNearestBlock ; calculate # blocks to clear
                   IFNE    H6309   ; begin conditional assembly for H6309
                     pshs      u         ; preserve U (faster than original Y below)
                     clrb                ; setup for faster block in use clears
                     ldu       MD$MPDAT,u ; get pointer to module DAT image
-L01FB               ldw       ,u++      Get first block
+FUnlinkTarget2      ldw       ,u++      Get first block
                     stb       -2,u      ; clear it in DAT image
                     stb       -1,u      ; store B at -1,u
                     addr      x,w       ; point to block in block map
                     aim       #^(ModBlock!RAMinUse),,w
                     deca                ; decrement A
-                    bne       L01FB     ; branch if zero is clear to L01FB
+                    bne       FUnlinkTarget2 ; branch if zero is clear to FUnlinkTarget2
                     puls      u         ; restore module ptr
                   ELSE
                     pshs      y         ; save y
                     ldy       MD$MPDAT,u ; module image ptr
-L01FB               pshs      a,x       ; save #blocks, ptr
+FUnlinkTarget2      pshs      a,x       ; save #blocks, ptr
                     ldd       ,y        ; get block number
                     clr       ,y+       ; clear the image
                     clr       ,y+       ; clear ,y+
@@ -220,21 +220,21 @@ L01FB               pshs      a,x       ; save #blocks, ptr
                     stb       ,x        ; store B at ,x
                     puls      a,x       ; restore a,x from the stack
                     deca                ; last block done?
-                    bne       L01FB     ; ..no, loop
+                    bne       FUnlinkTarget2 ; ..no, loop
                     puls      y         ; restore y from the stack
                   ENDC
                     ldx       <D.ModDir ; get module directory pointer
                     ldd       MD$MPDAT,u ; get module DAT pointer
-L0216               cmpd      MD$MPDAT,x ; match?
-                    bne       L021F     ; no, keep looking
+FUnlinkMatch        cmpd      MD$MPDAT,x ; match?
+                    bne       FUnlinkModuleEntry2 ; no, keep looking
                     clr       MD$MPDAT,x ; clear module DAT image pointer
                     clr       MD$MPDAT+1,x ; clear MD$MPDAT+1,x
-L021F               leax      MD$ESize,x ; point to next module entry
+FUnlinkModuleEntry2 leax      MD$ESize,x ; point to next module entry
                     cmpx      <D.ModEnd ; at the end?
-                    blo       L0216     ; no, keep looking
-L0225               rts                 ; return
+                    blo       FUnlinkMatch ; no, keep looking
+FUnlinkReturn       rts                 ; return
 
-L0226               addd      #$1FFF    ; round up to nearest block
+FUnlinkRoundUpNearestBlock addd      #$1FFF    ; round up to nearest block
                     lsra                ; calculate block # within 64k workspace
                     lsra                ; shift or rotate and update condition codes
                     lsra                ; shift or rotate and update condition codes

--- a/level1/modules/kernel/funlink.asm
+++ b/level1/modules/kernel/funlink.asm
@@ -26,11 +26,11 @@
 FUnlink             ldd       R$U,u     ; get the pointer to the module to unlink
                     beq       okex@     ; branch if it's empty
                     ldx       <D.ModDir ; get the pointer to the first module in the module directory
-FUnlinkPassedModuleModuleDirectoryEntry cmpd      MD$MPtr,x ; compare the passed module address to the one in this module directory entry
+FUnlinkPssdModMod   cmpd      MD$MPtr,x ; compare the passed module address to the one in this module directory entry
                     beq       found@    ; if we've found it, branch
                     leax      MD$ESize,x ; else go to next entry
                     cmpx      <D.ModDir+2 ; are we at the end of the module directory?
-                    bcs       FUnlinkPassedModuleModuleDirectoryEntry ; if not, go check next entry for match
+                    bcs       FUnlinkPssdModMod ; if not, go check next entry for match
                     bra       okex@     ; else exit
 found@              lda       MD$Link,x ; get the module's link count
                     beq       dealloc@  ; branch if zero
@@ -141,9 +141,9 @@ FUnlinkTarget       ldx       2,s       ; get pointer to register stack
                     ldd       #M$Type   ; get offset to module type
                     os9       F$LDDDXY  ; get module type
                     cmpa      #FlMgr    ; is it a I/O module?
-                    blo       FUnlinkDeleteModuleMemoryModuleDirectory ; no, don't process for I/O
+                    blo       FUnlinkDltModMem ; no, don't process for I/O
                     os9       F$IODel   ; device still being used by somebody else?
-                    bcc       FUnlinkDeleteModuleMemoryModuleDirectory ; no, go on
+                    bcc       FUnlinkDltModMem ; no, go on
                     ldd       MD$Link,u ; put the link count back to where it was
                   IFNE    H6309   ; begin conditional assembly for H6309
                     incd                ; update processor state
@@ -151,9 +151,9 @@ FUnlinkTarget       ldx       2,s       ; get pointer to register stack
                     addd      #$0001    ; add #$0001 to D
                   ENDC
                     std       MD$Link,u ; store D at MD$Link,u
-                    bra       FUnlinkPurgeLocalData ; return error
+                    bra       FUnlinkPrgLclData ; return error
 * Clear module from memory
-FUnlinkDeleteModuleMemoryModuleDirectory bsr       DelMod    ; delete module from memory & module dir
+FUnlinkDltModMem    bsr       DelMod    ; delete module from memory & module dir
 FUnlinkBlock        ldb       ,s        ; get block
                     lslb                ; account for 2 bytes/entry
                     leay      b,y       ; point to block
@@ -167,13 +167,13 @@ FUnlinkBlock        ldb       ,s        ; get block
                     bne       FUnlinkErrors ; not zero, return to user
 * Clear module blocks in process DAT image
                     ldd       MD$MBSiz,u ; get block size
-                    bsr       FUnlinkRoundUpNearestBlock ; calculate # blocks to delete
+                    bsr       FUnlinkRndUpNear ; calculate # blocks to delete
                     ldx       #DAT.Free ; get DAT free marker
 FUnlinkDATImage     stx       ,y++      ; save it in DAT image
                     deca                ; done?
                     bne       FUnlinkDATImage ; no, keep going
 FUnlinkErrors       clrb                ; clear errors
-FUnlinkPurgeLocalData leas      2,s       ; purge local data
+FUnlinkPrgLclData   leas      2,s       ; purge local data
                     puls      u,pc      ; restore & return
 
 * Delete module from module directory & from memory
@@ -194,7 +194,7 @@ FUnlinkModule       leax      MD$ESize,x ; move to next module
                     bcs       FUnlinkOffsetDAT ; no, keep going
                     ldx       <D.BlkMap ; get pointer to block map
                     ldd       MD$MBSiz,u ; get memory block size
-                    bsr       FUnlinkRoundUpNearestBlock ; calculate # blocks to clear
+                    bsr       FUnlinkRndUpNear ; calculate # blocks to clear
                   IFNE    H6309   ; begin conditional assembly for H6309
                     pshs      u         ; preserve U (faster than original Y below)
                     clrb                ; setup for faster block in use clears
@@ -234,7 +234,7 @@ FUnlinkModuleEntry2 leax      MD$ESize,x ; point to next module entry
                     blo       FUnlinkMatch ; no, keep looking
 FUnlinkReturn       rts                 ; return
 
-FUnlinkRoundUpNearestBlock addd      #$1FFF    ; round up to nearest block
+FUnlinkRndUpNear    addd      #$1FFF    ; round up to nearest block
                     lsra                ; calculate block # within 64k workspace
                     lsra                ; shift or rotate and update condition codes
                     lsra                ; shift or rotate and update condition codes

--- a/level1/modules/kernel/funlink.asm
+++ b/level1/modules/kernel/funlink.asm
@@ -21,225 +21,225 @@
 ;;; A return from F$Wait with the carry bit set indicates failure; otherwise, the call functioned properly and the
 ;;; child's exit status resides in B.
 
-               ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 
-FUnlink        ldd       R$U,u               get the pointer to the module to unlink
-               beq       okex@               branch if it's empty
-               ldx       <D.ModDir           get the pointer to the first module in the module directory
-L00B8          cmpd      MD$MPtr,x           compare the passed module address to the one in this module directory entry
-               beq       found@              if we've found it, branch
-               leax      MD$ESize,x          else go to next entry
-               cmpx      <D.ModDir+2         are we at the end of the module directory?
-               bcs       L00B8               if not, go check next entry for match
-               bra       okex@               else exit
-found@         lda       MD$Link,x           get the module's link count
-               beq       dealloc@            branch if zero
-               deca                          else decrement by one
-               sta       MD$Link,x           and save count
-               bne       okex@               branch if post-dec wasn't zero
+FUnlink             ldd       R$U,u     ; get the pointer to the module to unlink
+                    beq       okex@     ; branch if it's empty
+                    ldx       <D.ModDir ; get the pointer to the first module in the module directory
+L00B8               cmpd      MD$MPtr,x ; compare the passed module address to the one in this module directory entry
+                    beq       found@    ; if we've found it, branch
+                    leax      MD$ESize,x ; else go to next entry
+                    cmpx      <D.ModDir+2 ; are we at the end of the module directory?
+                    bcs       L00B8     ; if not, go check next entry for match
+                    bra       okex@     ; else exit
+found@              lda       MD$Link,x ; get the module's link count
+                    beq       dealloc@  ; branch if zero
+                    deca                ; else decrement by one
+                    sta       MD$Link,x ; and save count
+                    bne       okex@     ; branch if post-dec wasn't zero
 * If here, deallocate module
-dealloc@       ldy       MD$MPtr,x           get the module pointer in the current module directory
-               cmpy      <D.BTLO             compare against the bottom of boot memory
-               bcc       okex@               branch if the branch if the pointer is in the boot memory area; we don't unlink modules there
-               ldb       M$Type,y            get the type of module
-               cmpb      #FlMgr              is it a file manager?
-               bcs       deletemod@          branch if not
-               os9       F$IODel             determine if I/O module is in use
-               bcc       deletemod@          branch if not
-               inc       MD$Link,x           else cancel out prior dec
-               bra       ex@                 and return to the caller
-deletemod@     clra                          clear A
-               clrb                          clear B, D = 0
-               std       MD$MPtr,x           clear out the module directory entry's module address
-               std       M$ID,y              and clear the module's first two sync bytes
-               ldd       M$Size,y            get size of module in D
-               lbsr      RoundUpD            round up D to next 256 byte page
-               exg       d,y                 exchange D and Y
-               exg       a,b                 move the upper 16 bits of the module's memory size into B
-               ldx       <D.FMBM             get the memory allocation bitmap pointer
-               os9       F$DelBit            delete the corresponding bits
-okex@          clra                          clear the carry
-ex@            rts                           return to the caller
+dealloc@            ldy       MD$MPtr,x ; get the module pointer in the current module directory
+                    cmpy      <D.BTLO   ; compare against the bottom of boot memory
+                    bcc       okex@     ; branch if the branch if the pointer is in the boot memory area; we don't unlink modules there
+                    ldb       M$Type,y  ; get the type of module
+                    cmpb      #FlMgr    ; is it a file manager?
+                    bcs       deletemod@ ; branch if not
+                    os9       F$IODel   ; determine if I/O module is in use
+                    bcc       deletemod@ ; branch if not
+                    inc       MD$Link,x ; else cancel out prior dec
+                    bra       ex@       ; and return to the caller
+deletemod@          clra                ; clear A
+                    clrb                ; clear B, D = 0
+                    std       MD$MPtr,x ; clear out the module directory entry's module address
+                    std       M$ID,y    ; and clear the module's first two sync bytes
+                    ldd       M$Size,y  ; get size of module in D
+                    lbsr      RoundUpD  ; round up D to next 256 byte page
+                    exg       d,y       ; exchange D and Y
+                    exg       a,b       ; move the upper 16 bits of the module's memory size into B
+                    ldx       <D.FMBM   ; get the memory allocation bitmap pointer
+                    os9       F$DelBit  ; delete the corresponding bits
+okex@               clra                ; clear the carry
+ex@                 rts                 ; return to the caller
 
-               else
+                  ELSE
 
-FUnLink        pshs      d,u                 preserve register stack pointer and make a buffer
-               ldd       R$U,u               get pointer to module header
-               tfr       d,x                 copy it to X
-               lsra                          divide MSB by 32 to get DAT block offset
-               lsra
-               lsra
-               lsra
-               lsra
-               sta       ,s                  save DAT block offset
-               lbeq      L01D0               zero, can't use so exit
-               ldu       <D.Proc             get pointer to current process
-               leay      P$DATImg,u          point Y to it's DAT image
-               lsla                          account for 2 bytes/entry
-               ldd       a,y                 get block #
-               ldu       <D.BlkMap           get pointer to system block map
-               ifne      H6309
-               tim       #ModBlock,d,u       Is memory block a module type?
-               else
-               ldb       d,u
-               bitb      #ModBlock
-               endc
-               beq       L01D0               no, exit without error
-               leau      (P$Links-P$DATImg),y point to block link counts
-               bra       L0161               go unlink block
+FUnLink             pshs      d,u       ; preserve register stack pointer and make a buffer
+                    ldd       R$U,u     ; get pointer to module header
+                    tfr       d,x       ; copy it to X
+                    lsra                ; divide MSB by 32 to get DAT block offset
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    sta       ,s        ; save DAT block offset
+                    lbeq      L01D0     ; zero, can't use so exit
+                    ldu       <D.Proc   ; get pointer to current process
+                    leay      P$DATImg,u ; point Y to it's DAT image
+                    lsla                ; account for 2 bytes/entry
+                    ldd       a,y       ; get block #
+                    ldu       <D.BlkMap ; get pointer to system block map
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #ModBlock,d,u Is memory block a module type?
+                  ELSE
+                    ldb       d,u       ; load B from d,u
+                    bitb      #ModBlock ; test bits in B against #ModBlock
+                  ENDC
+                    beq       L01D0     ; no, exit without error
+                    leau      (P$Links-P$DATImg),y ; point to block link counts
+                    bra       L0161     ; go unlink block
 
-L015D          dec       ,s                  we done?
-               beq       L01D0               yes, go on
-L0161          ldb       ,s                  get current offset
-               lslb                          account for 2 bytes entry
-               ldd       b,u                 get block link count
-               beq       L015D               already zero, get next one
-               lda       ,s                  get block offset
-               lsla                          find offset into 64k map by multiplying by 32
-               lsla
-               lsla
-               lsla
-               lsla
-               clrb
-               nega
-               ifne      H6309
-               addr      d,x
-               else
-               leax      d,x
-               endc
-               ldb       ,s                  get block offset
-               lslb                          account for 2 bytes/entry
-               ldd       b,y                 get block #
-               ldu       <D.ModDir           get module directory pointer
-               bra       L0185               go look for it
+L015D               dec       ,s        ; we done?
+                    beq       L01D0     ; yes, go on
+L0161               ldb       ,s        ; get current offset
+                    lslb                ; account for 2 bytes entry
+                    ldd       b,u       ; get block link count
+                    beq       L015D     ; already zero, get next one
+                    lda       ,s        ; get block offset
+                    lsla                ; find offset into 64k map by multiplying by 32
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    clrb                ; clear B
+                    nega                ; update processor state
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,x       ; add d,x to R
+                  ELSE
+                    leax      d,x       ; compute d,x into X
+                  ENDC
+                    ldb       ,s        ; get block offset
+                    lslb                ; account for 2 bytes/entry
+                    ldd       b,y       ; get block #
+                    ldu       <D.ModDir ; get module directory pointer
+                    bra       L0185     ; go look for it
 
 * Main module directory search routine
-L017C          leau      MD$ESize,u          move to next module entry
-               cmpu      <D.ModEnd           done entire directory?
-               bhs       L01D0               Yes, exit
-L0185          cmpx      MD$MPtr,u           is module pointer the same?
-               bne       L017C               no, keep looking
-               cmpd      [MD$MPDAT,u]        DAT match?
-               bne       L017C               no, keep looking
+L017C               leau      MD$ESize,u ; move to next module entry
+                    cmpu      <D.ModEnd ; done entire directory?
+                    bhs       L01D0     ; yes, exit
+L0185               cmpx      MD$MPtr,u ; is module pointer the same?
+                    bne       L017C     ; no, keep looking
+                    cmpd      [MD$MPDAT,u] ; dAT match?
+                    bne       L017C     ; no, keep looking
 * Module is found decrement link count
 * NOTE: COULD WE USE D?
 *   L0198 - Safe, destroys D immediately
 *   Fall through- safe, destroys D immediately
 *   L01B5 - Seems to be safe
-               ldd       MD$Link,u           get module link count
-               beq       L0198               it's zero, go unlink it
-               ifne      H6309
-               decd                          decrement link count
-               else
-               subd      #$0001
-               endc
-               std       MD$Link,u           save it back
-               bne       L01B5               go on
+                    ldd       MD$Link,u ; get module link count
+                    beq       L0198     ; it's zero, go unlink it
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decd      decrement link count
+                  ELSE
+                    subd      #$0001    ; subtract #$0001 from D
+                  ENDC
+                    std       MD$Link,u ; save it back
+                    bne       L01B5     ; go on
 * Module link count is zero check if he's unlinking a I/O module
-L0198          ldx       2,s                 get pointer to register stack
-               ldx       R$U,x               get pointer to module
-               ldd       #M$Type             get offset to module type
-               os9       F$LDDDXY            get module type
-               cmpa      #FlMgr              is it a I/O module?
-               blo       L01B3               no, don't process for I/O
-               os9       F$IODel             device still being used by somebody else?
-               bcc       L01B3               no, go on
-               ldd       MD$Link,u           put the link count back to where it was
-               ifne      H6309
-               incd
-               else
-               addd      #$0001
-               endc
-               std       MD$Link,u
-               bra       L01D1               return error
+L0198               ldx       2,s       ; get pointer to register stack
+                    ldx       R$U,x     ; get pointer to module
+                    ldd       #M$Type   ; get offset to module type
+                    os9       F$LDDDXY  ; get module type
+                    cmpa      #FlMgr    ; is it a I/O module?
+                    blo       L01B3     ; no, don't process for I/O
+                    os9       F$IODel   ; device still being used by somebody else?
+                    bcc       L01B3     ; no, go on
+                    ldd       MD$Link,u ; put the link count back to where it was
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    incd                ; update processor state
+                  ELSE
+                    addd      #$0001    ; add #$0001 to D
+                  ENDC
+                    std       MD$Link,u ; store D at MD$Link,u
+                    bra       L01D1     ; return error
 * Clear module from memory
-L01B3          bsr       DelMod              delete module from memory & module dir
-L01B5          ldb       ,s                  get block
-               lslb                          account for 2 bytes/entry
-               leay      b,y                 point to block
-               ldd       (P$Links-P$DATImg),y get block link count
-               ifne      H6309
-               decd                          decrement it
-               else
-               subd      #$0001
-               endc
-               std       (P$Links-P$DATImg),y save new link count
-               bne       L01D0               not zero, return to user
+L01B3               bsr       DelMod    ; delete module from memory & module dir
+L01B5               ldb       ,s        ; get block
+                    lslb                ; account for 2 bytes/entry
+                    leay      b,y       ; point to block
+                    ldd       (P$Links-P$DATImg),y ; get block link count
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decd      decrement it
+                  ELSE
+                    subd      #$0001    ; subtract #$0001 from D
+                  ENDC
+                    std       (P$Links-P$DATImg),y ; save new link count
+                    bne       L01D0     ; not zero, return to user
 * Clear module blocks in process DAT image
-               ldd       MD$MBSiz,u          get block size
-               bsr       L0226               calculate # blocks to delete
-               ldx       #DAT.Free           get DAT free marker
-L01CB          stx       ,y++                save it in DAT image
-               deca                          done?
-               bne       L01CB               no, keep going
-L01D0          clrb                          clear errors
-L01D1          leas      2,s                 purge local data
-               puls      u,pc                restore & return
+                    ldd       MD$MBSiz,u ; get block size
+                    bsr       L0226     ; calculate # blocks to delete
+                    ldx       #DAT.Free ; get DAT free marker
+L01CB               stx       ,y++      ; save it in DAT image
+                    deca                ; done?
+                    bne       L01CB     ; no, keep going
+L01D0               clrb                ; clear errors
+L01D1               leas      2,s       ; purge local data
+                    puls      u,pc      ; restore & return
 
 * Delete module from module directory & from memory
 * Entry: U=Module directory entry pointer to delete
 * Exit : None
-DelMod         ldx       <D.BlkMap           get pointer to memory block map
-               ldd       [MD$MPDAT,u]        get pointer to module DAT image
-               lda       d,x                 is block type ROM?
-               bmi       L0225               yes can't delete it, return
-               ldx       <D.ModDir           get pointer to module directory
-L01DF          ldd       [MD$MPDAT,x]        get offset to DAT
-               cmpd      [MD$MPDAT,u]        match what we're looking for?
-               bne       L01EA               no, keep looking
-               ldd       MD$Link,x           get module link count
-               bne       L0225               not zero, return
-L01EA          leax      MD$ESize,x          move to next module
-               cmpx      <D.ModEnd           at the end?
-               bcs       L01DF               no, keep going
-               ldx       <D.BlkMap           get pointer to block map
-               ldd       MD$MBSiz,u          get memory block size
-               bsr       L0226               calculate # blocks to clear
-               ifne      H6309
-               pshs      u                   Preserve U (faster than original Y below)
-               clrb                          Setup for faster block in use clears
-               ldu       MD$MPDAT,u          get pointer to module DAT image
-L01FB          ldw       ,u++                Get first block
-               stb       -2,u                clear it in DAT image
-               stb       -1,u
-               addr      x,w                 point to block in block map
-               aim       #^(ModBlock!RAMinUse),,w
-               deca
-               bne       L01FB
-               puls      u                   Restore module ptr
-               else
-               pshs      y                   save y
-               ldy       MD$MPDAT,u          module image ptr
-L01FB          pshs      a,x                 save #blocks, ptr
-               ldd       ,y                  get block number
-               clr       ,y+                 clear the image
-               clr       ,y+
-               leax      d,x                 point to blkmap entry
-               ldb       ,x
-               andb      #^(RAMinUse+ModBlock) free block
-               stb       ,x
-               puls      a,x
-               deca                          last block done?
-               bne       L01FB               ..no, loop
-               puls      y
-               endc
-               ldx       <D.ModDir           get module directory pointer
-               ldd       MD$MPDAT,u          get module DAT pointer
-L0216          cmpd      MD$MPDAT,x          match?
-               bne       L021F               no, keep looking
-               clr       MD$MPDAT,x          clear module DAT image pointer
-               clr       MD$MPDAT+1,x
-L021F          leax      MD$ESize,x          point to next module entry
-               cmpx      <D.ModEnd           at the end?
-               blo       L0216               no, keep looking
-L0225          rts                           return
+DelMod              ldx       <D.BlkMap ; get pointer to memory block map
+                    ldd       [MD$MPDAT,u] ; get pointer to module DAT image
+                    lda       d,x       ; is block type ROM?
+                    bmi       L0225     ; yes can't delete it, return
+                    ldx       <D.ModDir ; get pointer to module directory
+L01DF               ldd       [MD$MPDAT,x] ; get offset to DAT
+                    cmpd      [MD$MPDAT,u] ; match what we're looking for?
+                    bne       L01EA     ; no, keep looking
+                    ldd       MD$Link,x ; get module link count
+                    bne       L0225     ; not zero, return
+L01EA               leax      MD$ESize,x ; move to next module
+                    cmpx      <D.ModEnd ; at the end?
+                    bcs       L01DF     ; no, keep going
+                    ldx       <D.BlkMap ; get pointer to block map
+                    ldd       MD$MBSiz,u ; get memory block size
+                    bsr       L0226     ; calculate # blocks to clear
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    pshs      u         ; preserve U (faster than original Y below)
+                    clrb                ; setup for faster block in use clears
+                    ldu       MD$MPDAT,u ; get pointer to module DAT image
+L01FB               ldw       ,u++      Get first block
+                    stb       -2,u      ; clear it in DAT image
+                    stb       -1,u      ; store B at -1,u
+                    addr      x,w       ; point to block in block map
+                    aim       #^(ModBlock!RAMinUse),,w
+                    deca                ; decrement A
+                    bne       L01FB     ; branch if zero is clear to L01FB
+                    puls      u         ; restore module ptr
+                  ELSE
+                    pshs      y         ; save y
+                    ldy       MD$MPDAT,u ; module image ptr
+L01FB               pshs      a,x       ; save #blocks, ptr
+                    ldd       ,y        ; get block number
+                    clr       ,y+       ; clear the image
+                    clr       ,y+       ; clear ,y+
+                    leax      d,x       ; point to blkmap entry
+                    ldb       ,x        ; load B from ,x
+                    andb      #^(RAMinUse+ModBlock) ; free block
+                    stb       ,x        ; store B at ,x
+                    puls      a,x       ; restore a,x from the stack
+                    deca                ; last block done?
+                    bne       L01FB     ; ..no, loop
+                    puls      y         ; restore y from the stack
+                  ENDC
+                    ldx       <D.ModDir ; get module directory pointer
+                    ldd       MD$MPDAT,u ; get module DAT pointer
+L0216               cmpd      MD$MPDAT,x ; match?
+                    bne       L021F     ; no, keep looking
+                    clr       MD$MPDAT,x ; clear module DAT image pointer
+                    clr       MD$MPDAT+1,x ; clear MD$MPDAT+1,x
+L021F               leax      MD$ESize,x ; point to next module entry
+                    cmpx      <D.ModEnd ; at the end?
+                    blo       L0216     ; no, keep looking
+L0225               rts                 ; return
 
-L0226          addd      #$1FFF              round up to nearest block
-               lsra                          calculate block # within 64k workspace
-               lsra
-               lsra
-               lsra
-               lsra
-               rts
+L0226               addd      #$1FFF    ; round up to nearest block
+                    lsra                ; calculate block # within 64k workspace
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    rts                 ; return to caller
 
-               endc
+                  ENDC

--- a/level1/modules/kernel/fvmodul.asm
+++ b/level1/modules/kernel/fvmodul.asm
@@ -248,7 +248,7 @@ ex@                 puls      pc,y,x    ; return to caller
 FVModul             pshs      u         ; preserve register stack pointer
                     ldx       R$X,u     ; get block offset
                     ldy       R$D,u     ; get DAT image pointer
-                    bsr       FVmodulBlockOffsetDATImage ; validate it
+                    bsr       FVmodulBlkOffDAT ; validate it
                     ldx       ,s        ; get register stack pointer
                     stu       R$U,x     ; save address of module directory entry
                     puls      u,pc      ; restore & return
@@ -256,8 +256,8 @@ FVModul             pshs      u         ; preserve register stack pointer
 * Validate module - shortcut for calls within OS9p1 go here (ex. OS9Boot)
 * Entry: X=Module block offset
 *        Y=Module DAT image pointer
-FVmodulBlockOffsetDATImage pshs      x,y       ; save block offset & DAT Image ptr
-                    lbsr      FVmodulBlockOffsetDAT ; go check module ID & header parity
+FVmodulBlkOffDAT    pshs      x,y       ; save block offset & DAT Image ptr
+                    lbsr      FVmodulBlkOffDAT2 ; go check module ID & header parity
                     bcs       FVmodulTarget ; error, exit
                     ldd       #M$Type   ; get offset to module type
                     lbsr      FLdTarget ; go get 2 bytes (module type)
@@ -381,17 +381,17 @@ FVmodulTarget7      puls      x         ; restore x from the stack
 *
                     ldu       MD$MPDAT,u ; get DAT img ptr for module
                     puls      d         ; restore d from the stack
-FVmodulSameDATImageOtherModule cmpx      MD$MPDAT,y ; same as DAT img ptr for other module?
-                    bne       FVmodulBumpModuleDirectoryEntry ; no, check next one
+FVmodulSameDATImg   cmpx      MD$MPDAT,y ; same as DAT img ptr for other module?
+                    bne       FVmodulBumpModDir ; no, check next one
                     stu       MD$MPDAT,y ; match; save current entry ptr here
                     cmpd      MD$MBSiz,y ; >memory block size already here?
 * 6809/6309 LCB - couldn't we change next 2 lines to blo L051B
                     bhs       FVmodulMbsiz ; yes, use new one
                     ldd       MD$MBSiz,y ; no, get original and use that size instead
 FVmodulMbsiz        std       MD$MBSiz,y ; store D at MD$MBSiz,y
-FVmodulBumpModuleDirectoryEntry leay      MD$ESize,y ; bump ptr to next module dir entry
+FVmodulBumpModDir   leay      MD$ESize,y ; bump ptr to next module dir entry
                     cmpy      <D.ModEnd ; are we at end of module dir?
-                    bne       FVmodulSameDATImageOtherModule ; no,keep checking
+                    bne       FVmodulSameDATImg ; no,keep checking
                     puls      x,y,u,pc  ; restore x,y,u,pc from the stack
 
 * Exit: B=MMU block # of some sort
@@ -410,7 +410,7 @@ FVmodulTarget8      pshs      x,y,u     ; save x,y,u on the stack
                     comb                ; one byte shorter than incb;lslb;negb
                     lslb                ; (D=-B is what we are doing)
                     sex                 ; sign-extend B into A
-                    bsr       FVmodulEndModuleDirectoryDATImage ; call local routine FVmodulEndModuleDirectoryDATImage
+                    bsr       FVmodulEndModDir ; call local routine FVmodulEndModDir
                     bcc       FVmodulTarget9 ; branch if carry is clear to FVmodulTarget9
                     os9       F$GCMDir  ; get rid of empty slots in module directory
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -419,16 +419,16 @@ FVmodulTarget8      pshs      x,y,u     ; save x,y,u on the stack
                     ldu       #$0000    ; load U from #$0000
                   ENDC
                     stu       $05,s     ; save $0000 so U is 0 in puls below
-                    bsr       FVmodulEndModuleDirectoryDATImage ; call local routine FVmodulEndModuleDirectoryDATImage
+                    bsr       FVmodulEndModDir ; call local routine FVmodulEndModDir
 FVmodulTarget9      puls      b,x,y,u,pc ; restore b,x,y,u,pc from the stack
 
 * Entry: D=negative offset from end of module Dir DAT Img)
-FVmodulEndModuleDirectoryDATImage ldx       <D.ModDAT ; get end ptr of Module Dir DAT image
+FVmodulEndModDir    ldx       <D.ModDAT ; get end ptr of Module Dir DAT image
                     leax      d,x       ; add our negative offset
                     cmpx      <D.ModEnd ; is that past the end of the module directory?
                     blo       S.Poll    ; no, skip ahead
                     ldu       7,s       ; yes, get U from stack (0 means we compacted mod dir)
-                    bne       FVmodulNewModuleDirectoryDATImage ; not compacted, skip ahead
+                    bne       FVmodulNewModDir ; not compacted, skip ahead
                     ldy       <D.ModEnd ; get ptr to end of module directory
                     leay      MD$ESize,y ; bump up by 1 entry
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -441,7 +441,7 @@ FVmodulEndModuleDirectoryDATImage ldx       <D.ModDAT ; get end ptr of Module Di
                     sty       <D.ModEnd ; no, save new module directory end ptr
                     leay      -MD$ESize,y ; bump ptr back on entry
                     sty       $07,s     ; save that as new U on exit
-FVmodulNewModuleDirectoryDATImage stx       <D.ModDAT ; save new Module Dir DAT image end ptr
+FVmodulNewModDir    stx       <D.ModDAT ; save new Module Dir DAT image end ptr
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldd       $05,s     ; get source ptr
                     stx       $05,s     ; store X at $05,s
@@ -472,7 +472,7 @@ S.Poll              orcc      #Carry    ; set condition-code bits using #Carry
 * Check module ID & calculate module header parity & CRC
 * Entry: X=Block offset of module
 *        Y=DAT image pointer of module
-FVmodulBlockOffsetDAT pshs      x,y       ; save block offset & DAT pointer
+FVmodulBlkOffDAT2   pshs      x,y       ; save block offset & DAT pointer
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; m$ID offset
                   ELSE
@@ -481,11 +481,11 @@ FVmodulBlockOffsetDAT pshs      x,y       ; save block offset & DAT pointer
                   ENDC
                     lbsr      FLdTarget ; get module ID
                     cmpd      #M$ID12   ; legal module?
-                    beq       FVmodulStartLocationHeaderCalc ; yes, calculate header parity
+                    beq       FVmodulStartLctnHdr ; yes, calculate header parity
                     ldb       #E$BMID   ; get bad module ID error
                     bra       FVmodulUpError ; return error
 * Calculate module header parity
-FVmodulStartLocationHeaderCalc leax      2,x       ; point to start location of header calc
+FVmodulStartLctnHdr leax      2,x       ; point to start location of header calc
                     lbsr      AdjBlk0   ; adjust it for block 0
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       #($4A*256+M$Revs) Get initial value & count (7 bytes of header)
@@ -512,7 +512,7 @@ FVmodulModule       sta       ,s        ; save crc
 FVmodulModuleDAT    puls      x,y       ; restore module pointer & DAT pointer
 * this checks if the module CRC checking is on or off
                     lda       <D.CRC    ; is CRC checking on?
-                    bne       FVmodulOffsetModuleSize ; yes - go check it
+                    bne       FVmodulOffModSize ; yes - go check it
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; no, clear out
                   ELSE
@@ -524,7 +524,7 @@ FVmodulModuleDAT    puls      x,y       ; restore module pointer & DAT pointer
 * Begin checking Module CRC
 * Entry: X=Module pointer
 *        Y=DAT image pointer of module
-FVmodulOffsetModuleSize ldd       #M$Size   ; get offset to module size
+FVmodulOffModSize   ldd       #M$Size   ; get offset to module size
                     lbsr      FLdTarget ; get module size
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       d,w       ; move length to W
@@ -565,10 +565,10 @@ FVmodulModule2      lbsr      LDAXY     ; get a byte from module into A
                     puls      b,x,y     ; yes, restore CRC
                   ENDC
                     cmpb      #CRCCon1  ; cRC MSB match constant?
-                    bne       FVmodulBadModuleCRCError ; no, exit with error
+                    bne       FVmodulBadModCRC ; no, exit with error
                     cmpx      #CRCCon23 ; lSW match constant?
                     beq       FVmodulExit ; yes, skip ahead
-FVmodulBadModuleCRCError ldb       #E$BMCRC  ; bad Module CRC error
+FVmodulBadModCRC    ldb       #E$BMCRC  ; bad Module CRC error
 FVmodulUpError      orcc      #Carry    ; set up for error
 FVmodulExit         puls      x,y,pc    ; exit
 

--- a/level1/modules/kernel/fvmodul.asm
+++ b/level1/modules/kernel/fvmodul.asm
@@ -248,7 +248,7 @@ ex@                 puls      pc,y,x    ; return to caller
 FVModul             pshs      u         ; preserve register stack pointer
                     ldx       R$X,u     ; get block offset
                     ldy       R$D,u     ; get DAT image pointer
-                    bsr       L0463     ; validate it
+                    bsr       FVmodulBlockOffsetDATImage ; validate it
                     ldx       ,s        ; get register stack pointer
                     stu       R$U,x     ; save address of module directory entry
                     puls      u,pc      ; restore & return
@@ -256,20 +256,20 @@ FVModul             pshs      u         ; preserve register stack pointer
 * Validate module - shortcut for calls within OS9p1 go here (ex. OS9Boot)
 * Entry: X=Module block offset
 *        Y=Module DAT image pointer
-L0463               pshs      x,y       ; save block offset & DAT Image ptr
-                    lbsr      L0586     ; go check module ID & header parity
-                    bcs       L0495     ; error, exit
+FVmodulBlockOffsetDATImage pshs      x,y       ; save block offset & DAT Image ptr
+                    lbsr      FVmodulBlockOffsetDAT ; go check module ID & header parity
+                    bcs       FVmodulTarget ; error, exit
                     ldd       #M$Type   ; get offset to module type
-                    lbsr      L0B02     ; go get 2 bytes (module type)
+                    lbsr      FLdTarget ; go get 2 bytes (module type)
                     andb      #LangMask ; just keep language mask
                     pshs      d         ; preserve ??? & language
                     ldd       #M$Name   ; get offset to module name
-                    lbsr      L0B02     ; go get 2 bytes (offset)
+                    lbsr      FLdTarget ; go get 2 bytes (offset)
                     leax      d,x       ; point X to module name
                     puls      a         ; restore type/language
-                    lbsr      L068D     ; find module in module directory
+                    lbsr      FFmodulJoin ; find module in module directory
                     puls      a         ; restore a from the stack
-                    bcs       L0497     ; branch if carry is set to L0497
+                    bcs       FVmodulTarget2 ; branch if carry is set to FVmodulTarget2
                     andb      #$0F      ; mask B with #$0F
                   IFNE    H6309   ; begin conditional assembly for H6309
                     subr      a,b
@@ -277,20 +277,20 @@ L0463               pshs      x,y       ; save block offset & DAT Image ptr
                     pshs      a         ; save a on the stack
                     subb      ,s+       ; subtract ,s+ from B
                   ENDC
-                    blo       L0497     ; if wrapped, skip ahead
+                    blo       FVmodulTarget2 ; if wrapped, skip ahead
                     ldb       #E$KwnMod ; load B from #E$KwnMod
                     fcb       $8C       ; skip 2 bytes
-L0491               ldb       #E$DirFul ; load B from #E$DirFul
-L0493               orcc      #Carry    ; set condition-code bits using #Carry
-L0495               puls      x,y,pc    ; restore x,y,pc from the stack
+FVmodulDirful       ldb       #E$DirFul ; load B from #E$DirFul
+FVmodulCarry        orcc      #Carry    ; set condition-code bits using #Carry
+FVmodulTarget       puls      x,y,pc    ; restore x,y,pc from the stack
 
-L0497               ldx       ,s        ; load X from ,s
+FVmodulTarget2      ldx       ,s        ; load X from ,s
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    bsr       L0524     ; call local routine L0524
+                    bsr       FVmodulTarget8 ; call local routine FVmodulTarget8
                   ELSE
-                    lbsr      L0524     ; call local routine L0524
+                    lbsr      FVmodulTarget8 ; call local routine FVmodulTarget8
                   ENDC
-                    bcs       L0491     ; branch if carry is set to L0491
+                    bcs       FVmodulDirful ; branch if carry is set to FVmodulDirful
                     sty       ,u        ; store Y at ,u
                     stx       MD$MPtr,u ; store X at MD$MPtr,u
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -301,7 +301,7 @@ L0497               ldx       ,s        ; load X from ,s
                   ENDC
                     std       MD$Link,u ; store D at MD$Link,u
                     ldd       #M$Size   ; get offset to size of module
-                    lbsr      L0B02     ; get it
+                    lbsr      FLdTarget ; get it
                   IFNE    H6309   ; begin conditional assembly for H6309
                     addr      x,d       ; add it to module ptr
                   ELSE
@@ -314,16 +314,16 @@ L0497               ldx       ,s        ; load X from ,s
                     pshs      u         ; save module pointer
                     fcb       $8C       ; skip 2 bytes
 
-L04BC               leax      MD$ESize,x ; move to next entry
-L04BE               cmpx      <D.ModEnd ; compare X with <D.ModEnd
-                    bcc       L04CD     ; branch if carry is clear to L04CD
+FVmodulEntry        leax      MD$ESize,x ; move to next entry
+FVmodulDmodend      cmpx      <D.ModEnd ; compare X with <D.ModEnd
+                    bcc       FVmodulTarget3 ; branch if carry is clear to FVmodulTarget3
                     cmpx      ,s        ; match?
-                    beq       L04BC     ; no, keep looking
+                    beq       FVmodulEntry ; no, keep looking
                     cmpy      [MD$MPDAT,x] ; dAT match?
-                    bne       L04BC     ; no, keep looking
-                    bsr       L04F2     ; call local routine L04F2
+                    bne       FVmodulEntry ; no, keep looking
+                    bsr       FVmodulTarget5 ; call local routine FVmodulTarget5
 
-L04CD               puls      u         ; restore u from the stack
+FVmodulTarget3      puls      u         ; restore u from the stack
                     ldx       <D.BlkMap ; get ptr to block map
                     ldd       MD$MBSiz,u ; get size of module
                     addd      #$1FFF    ; round up to nearest 8K block
@@ -336,11 +336,11 @@ L04CD               puls      u         ; restore u from the stack
 
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       a,e       ; transfer register value a,e
-L04DE               ldd       ,y++      ; load D from ,y++
+FVmodulTarget4      ldd       ,y++      ; load D from ,y++
                     oim       #ModBlock,d,x
                     dece                ; update processor state
                   ELSE
-L04DE               pshs      a,x       ; save block size, blkmap
+FVmodulTarget4      pshs      a,x       ; save block size, blkmap
                     ldd       ,y++      ; D = image block #
                     leax      d,x       ; X = blkmap ptr
                     ldb       ,x        ; get block marker
@@ -349,55 +349,55 @@ L04DE               pshs      a,x       ; save block size, blkmap
                     puls      x,a       ; restore x,a from the stack
                     deca                ; count--
                   ENDC
-                    bne       L04DE     ; no, keep going
+                    bne       FVmodulTarget4 ; no, keep going
                     clrb                ; clear carry
                     puls      x,y,pc    ; return
 
-L04F2               pshs      d,x,y,u   ; save d,x,y,u on the stack
+FVmodulTarget5      pshs      d,x,y,u   ; save d,x,y,u on the stack
 * LCB - 6809 - this can be slightly sped up by swapping roles
                     ldx       ,x        ; load X from ,x
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       x,w       ; dupe to faster index register
                     clrd                ; update processor state
-L04FA               ldy       ,w        ; load Y from ,w
-                    beq       L0503     ; branch if zero is set to L0503
+FVmodulTarget6      ldy       ,w        ; load Y from ,w
+                    beq       FVmodulTarget7 ; branch if zero is set to FVmodulTarget7
                     std       ,w++      ; store D at ,w++
-                    bra       L04FA     ; branch unconditionally to L04FA
-L0503               ldy       2,s       ; load Y from 2,s
+                    bra       FVmodulTarget6 ; branch unconditionally to FVmodulTarget6
+FVmodulTarget7      ldy       2,s       ; load Y from 2,s
                   ELSE
                     pshs      x         ; save x on the stack
                     clra                ; D=0000
                     clrb                ; clear B
-L04FA               ldy       ,x        ; last entry?
-                    beq       L0503     ; ..yes
+FVmodulTarget6      ldy       ,x        ; last entry?
+                    beq       FVmodulTarget7 ; ..yes
                     std       ,x++      ; no, clear
-                    bra       L04FA     ; and loop
+                    bra       FVmodulTarget6 ; and loop
 
 * Entry: U=Ptr to current entry in module directory
 *        Y=Ptr to entry in module directory we are comparing to
-L0503               puls      x         ; restore x from the stack
+FVmodulTarget7      puls      x         ; restore x from the stack
                     ldy       2,s       ; get ptr to module dir entry we are comparing with
                   ENDC
 *
                     ldu       MD$MPDAT,u ; get DAT img ptr for module
                     puls      d         ; restore d from the stack
-L050C               cmpx      MD$MPDAT,y ; same as DAT img ptr for other module?
-                    bne       L051B     ; no, check next one
+FVmodulSameDATImageOtherModule cmpx      MD$MPDAT,y ; same as DAT img ptr for other module?
+                    bne       FVmodulBumpModuleDirectoryEntry ; no, check next one
                     stu       MD$MPDAT,y ; match; save current entry ptr here
                     cmpd      MD$MBSiz,y ; >memory block size already here?
 * 6809/6309 LCB - couldn't we change next 2 lines to blo L051B
-                    bhs       L0519     ; yes, use new one
+                    bhs       FVmodulMbsiz ; yes, use new one
                     ldd       MD$MBSiz,y ; no, get original and use that size instead
-L0519               std       MD$MBSiz,y ; store D at MD$MBSiz,y
-L051B               leay      MD$ESize,y ; bump ptr to next module dir entry
+FVmodulMbsiz        std       MD$MBSiz,y ; store D at MD$MBSiz,y
+FVmodulBumpModuleDirectoryEntry leay      MD$ESize,y ; bump ptr to next module dir entry
                     cmpy      <D.ModEnd ; are we at end of module dir?
-                    bne       L050C     ; no,keep checking
+                    bne       FVmodulSameDATImageOtherModule ; no,keep checking
                     puls      x,y,u,pc  ; restore x,y,u,pc from the stack
 
 * Exit: B=MMU block # of some sort
-L0524               pshs      x,y,u     ; save x,y,u on the stack
+FVmodulTarget8      pshs      x,y,u     ; save x,y,u on the stack
                     ldd       #M$Size   ; offset to module size
-                    lbsr      L0B02     ; go get module size
+                    lbsr      FLdTarget ; go get module size
                     addd      ,s        ; add to value
                     addd      #$1FFF    ; calc MMU block #
                     lsra                ; shift or rotate and update condition codes
@@ -410,8 +410,8 @@ L0524               pshs      x,y,u     ; save x,y,u on the stack
                     comb                ; one byte shorter than incb;lslb;negb
                     lslb                ; (D=-B is what we are doing)
                     sex                 ; sign-extend B into A
-                    bsr       L054E     ; call local routine L054E
-                    bcc       L054C     ; branch if carry is clear to L054C
+                    bsr       FVmodulEndModuleDirectoryDATImage ; call local routine FVmodulEndModuleDirectoryDATImage
+                    bcc       FVmodulTarget9 ; branch if carry is clear to FVmodulTarget9
                     os9       F$GCMDir  ; get rid of empty slots in module directory
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       0,u       ; transfer register value 0,u
@@ -419,16 +419,16 @@ L0524               pshs      x,y,u     ; save x,y,u on the stack
                     ldu       #$0000    ; load U from #$0000
                   ENDC
                     stu       $05,s     ; save $0000 so U is 0 in puls below
-                    bsr       L054E     ; call local routine L054E
-L054C               puls      b,x,y,u,pc ; restore b,x,y,u,pc from the stack
+                    bsr       FVmodulEndModuleDirectoryDATImage ; call local routine FVmodulEndModuleDirectoryDATImage
+FVmodulTarget9      puls      b,x,y,u,pc ; restore b,x,y,u,pc from the stack
 
 * Entry: D=negative offset from end of module Dir DAT Img)
-L054E               ldx       <D.ModDAT ; get end ptr of Module Dir DAT image
+FVmodulEndModuleDirectoryDATImage ldx       <D.ModDAT ; get end ptr of Module Dir DAT image
                     leax      d,x       ; add our negative offset
                     cmpx      <D.ModEnd ; is that past the end of the module directory?
                     blo       S.Poll    ; no, skip ahead
                     ldu       7,s       ; yes, get U from stack (0 means we compacted mod dir)
-                    bne       L056E     ; not compacted, skip ahead
+                    bne       FVmodulNewModuleDirectoryDATImage ; not compacted, skip ahead
                     ldy       <D.ModEnd ; get ptr to end of module directory
                     leay      MD$ESize,y ; bump up by 1 entry
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -441,7 +441,7 @@ L054E               ldx       <D.ModDAT ; get end ptr of Module Dir DAT image
                     sty       <D.ModEnd ; no, save new module directory end ptr
                     leay      -MD$ESize,y ; bump ptr back on entry
                     sty       $07,s     ; save that as new U on exit
-L056E               stx       <D.ModDAT ; save new Module Dir DAT image end ptr
+FVmodulNewModuleDirectoryDATImage stx       <D.ModDAT ; save new Module Dir DAT image end ptr
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldd       $05,s     ; get source ptr
                     stx       $05,s     ; store X at $05,s
@@ -454,10 +454,10 @@ L056E               stx       <D.ModDAT ; save new Module Dir DAT image end ptr
                     ldy       5,s       ; load Y from 5,s
                     ldb       2,s       ; B=block count
                     stx       5,s       ; return dir datimg ptr
-L0577               ldu       ,y++      ; copy images
+FVmodulImages       ldu       ,y++      ; copy images
                     stu       ,x++      ; to new mod dat entry
                     decb                ; decrement B
-                    bne       L0577     ; branch if zero is clear to L0577
+                    bne       FVmodulImages ; branch if zero is clear to FVmodulImages
 * 6809/6309 LCB - stb ,x - same size, faster (4 vs 6). Still need CLR
 *  for clr 1,x to make sure carry is cleared
                     stb       ,x        ; zero flag
@@ -472,47 +472,47 @@ S.Poll              orcc      #Carry    ; set condition-code bits using #Carry
 * Check module ID & calculate module header parity & CRC
 * Entry: X=Block offset of module
 *        Y=DAT image pointer of module
-L0586               pshs      x,y       ; save block offset & DAT pointer
+FVmodulBlockOffsetDAT pshs      x,y       ; save block offset & DAT pointer
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; m$ID offset
                   ELSE
                     clra                ; m$ID offset
                     clrb                ; clear B
                   ENDC
-                    lbsr      L0B02     ; get module ID
+                    lbsr      FLdTarget ; get module ID
                     cmpd      #M$ID12   ; legal module?
-                    beq       L0597     ; yes, calculate header parity
+                    beq       FVmodulStartLocationHeaderCalc ; yes, calculate header parity
                     ldb       #E$BMID   ; get bad module ID error
-                    bra       L05F3     ; return error
+                    bra       FVmodulUpError ; return error
 * Calculate module header parity
-L0597               leax      2,x       ; point to start location of header calc
+FVmodulStartLocationHeaderCalc leax      2,x       ; point to start location of header calc
                     lbsr      AdjBlk0   ; adjust it for block 0
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       #($4A*256+M$Revs) Get initial value & count (7 bytes of header)
-L05A2               lbsr      LDAXY     ; get a byte from module
+FVmodulModule       lbsr      LDAXY     ; get a byte from module
                     eorr      a,e       add it into running parity
                     decf                ; done full header?
-                    bne       L05A2     ; no, keep going
+                    bne       FVmodulModule ; no, keep going
                     ince                ; valid parity?
                   ELSE
                     leas      -1,s      ; make var
                     ldd       #($4A*256+M$Revs) ; get initial value & count (7 bytes of header)
-L05A2               sta       ,s        ; save crc
+FVmodulModule       sta       ,s        ; save crc
                     lbsr      LDAXY     ; get next byte
                     eora      ,s        ; do crc
                     decb                ; more?
-                    bne       L05A2     ; ..loop
+                    bne       FVmodulModule ; ..loop
                     leas      1,s       ; drop var
                     inca                ; $FF+1 = 00
                   ENDC
-                    beq       L05B5     ; yes, skip ahead
+                    beq       FVmodulModuleDAT ; yes, skip ahead
                     ldb       #E$BMHP   ; get module header parity error
-                    bra       L05F3     ; return with error
+                    bra       FVmodulUpError ; return with error
 
-L05B5               puls      x,y       ; restore module pointer & DAT pointer
+FVmodulModuleDAT    puls      x,y       ; restore module pointer & DAT pointer
 * this checks if the module CRC checking is on or off
                     lda       <D.CRC    ; is CRC checking on?
-                    bne       L05BA     ; yes - go check it
+                    bne       FVmodulOffsetModuleSize ; yes - go check it
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; no, clear out
                   ELSE
@@ -524,8 +524,8 @@ L05B5               puls      x,y       ; restore module pointer & DAT pointer
 * Begin checking Module CRC
 * Entry: X=Module pointer
 *        Y=DAT image pointer of module
-L05BA               ldd       #M$Size   ; get offset to module size
-                    lbsr      L0B02     ; get module size
+FVmodulOffsetModuleSize ldd       #M$Size   ; get offset to module size
+                    lbsr      FLdTarget ; get module size
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       d,w       ; move length to W
                     pshs      y,x       ; preserve [X]=Buffer pointer,[Y]=DAT pointer
@@ -538,18 +538,18 @@ L05BA               ldd       #M$Size   ; get offset to module size
                     lbsr      AdjBlk0   ; adjust module pointer into block 0 for mapping
                     leau      ,s        ; point to CRC accumulator
 * Loop: W=# bytes left to use in CRC calc
-L05CB               equ       *         ; define assembler symbol
+FVmodulJoin         equ       *         ; define assembler symbol
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tstf                ; on 256 byte boundary?
                   ELSE
                     tstb                ; test B and update condition codes
                   ENDC
-                    bne       L05D8     ; no, keep going
+                    bne       FVmodulModule2 ; no, keep going
                     pshs      x         ; give up some time to system
                     ldx       #1        ; load X from #1
                     os9       F$Sleep   ; call OS-9 service F$Sleep
                     puls      x         ; restore module pointer
-L05D8               lbsr      LDAXY     ; get a byte from module into A
+FVmodulModule2      lbsr      LDAXY     ; get a byte from module into A
                     bsr       CRCCalc   ; add it to running CRC
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; dec # bytes left to calculate CRC with
@@ -558,19 +558,19 @@ L05D8               lbsr      LDAXY     ; get a byte from module into A
                     subd      #$0001    ; subtract #$0001 from D
                     std       3,s       ; store D at 3,s
                   ENDC
-                    bne       L05CB     ; still more, continue
+                    bne       FVmodulJoin ; still more, continue
                   IFNE    H6309   ; begin conditional assembly for H6309
                     puls      b,x       ; yes, restore CRC
                   ELSE
                     puls      b,x,y     ; yes, restore CRC
                   ENDC
                     cmpb      #CRCCon1  ; cRC MSB match constant?
-                    bne       L05F1     ; no, exit with error
+                    bne       FVmodulBadModuleCRCError ; no, exit with error
                     cmpx      #CRCCon23 ; lSW match constant?
-                    beq       L05F5     ; yes, skip ahead
-L05F1               ldb       #E$BMCRC  ; bad Module CRC error
-L05F3               orcc      #Carry    ; set up for error
-L05F5               puls      x,y,pc    ; exit
+                    beq       FVmodulExit ; yes, skip ahead
+FVmodulBadModuleCRCError ldb       #E$BMCRC  ; bad Module CRC error
+FVmodulUpError      orcc      #Carry    ; set up for error
+FVmodulExit         puls      x,y,pc    ; exit
 
 * Calculate 24 bit CRC
 * Entry: A=Byte to add to CRC
@@ -620,7 +620,7 @@ CRCCalc             eora      ,u        ; exclusive-OR A with ,u
                     lsla                ; shift or rotate and update condition codes
                     lsla                ; shift or rotate and update condition codes
                     eora      ,s+       ; exclusive-OR A with ,s+
-                    bpl       L0635     ; branch if negative is clear to L0635
+                    bpl       FVmodulReturn ; branch if negative is clear to FVmodulReturn
                   IFNE    H6309   ; begin conditional assembly for H6309
                     eim       #$80,,u
                     eim       #$21,2,u
@@ -631,7 +631,7 @@ CRCCalc             eora      ,u        ; exclusive-OR A with ,u
                     eorb      2,u       ; exclusive-OR B with 2,u
                     stb       2,u       ; store B at 2,u
                   ENDC
-L0635               rts                 ; return to caller
+FVmodulReturn       rts                 ; return to caller
 
 **************************************************
 * System Call: F$CRC
@@ -647,7 +647,7 @@ L0635               rts                 ; return to caller
 * Error:  CC = C bit set; B = error code
 *
 FCRC                ldd       R$Y,u     ; get # bytes to do
-                    beq       L0677     ; nothing there, so nothing to do, return
+                    beq       FVmodulError ; nothing there, so nothing to do, return
                     ldx       R$X,u     ; get caller's buffer pointer
                     pshs      d,x       ; save # bytes & buffer pointer
                     leas      -3,s      ; allocate a 3 byte buffer
@@ -658,7 +658,7 @@ FCRC                ldd       R$Y,u     ; get # bytes to do
                     ldy       #3        ; number of bytes to move
                     leau      ,s        ; point to our temp buffer
                     pshs      d,x,y     ; save [D]=task #'s,[X]=Buff,[Y]=3
-                    lbsr      L0B2C     ; move CRC accumulator to temp buffer
+                    lbsr      FMoveTarget ; move CRC accumulator to temp buffer
                     ldx       <D.Proc   ; point to current process descriptor
                     leay      <P$DATImg,x ; point to its DAT image
                     ldx       11,s      ; restore the buffer pointer
@@ -666,7 +666,7 @@ FCRC                ldd       R$Y,u     ; get # bytes to do
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       9,s       get byte count
                   ENDC
-L065D               lbsr      LDAXY     ; get byte from callers buffer
+FVmodulBuffer       lbsr      LDAXY     ; get byte from callers buffer
                     bsr       CRCCalc   ; add it to CRC
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decw                ; done?
@@ -675,13 +675,13 @@ L065D               lbsr      LDAXY     ; get byte from callers buffer
                     subd      #$0001    ; subtract #$0001 from D
                     std       9,s       ; store D at 9,s
                   ENDC
-                    bne       L065D     ; no, keep going
+                    bne       FVmodulBuffer ; no, keep going
                     puls      d,x,y     ; restore pointers
                     exg       a,b       ; swap around the task numbers
                     exg       x,u       ; and the pointers
-                    lbsr      L0B2C     ; move accumulator back to user
+                    lbsr      FMoveTarget ; move accumulator back to user
                     leas      7,s       ; clean up stack
-L0677               clrb                ; no error
+FVmodulError        clrb                ; no error
                     rts                 ; return to caller
 
                   ENDC

--- a/level1/modules/kernel/fvmodul.asm
+++ b/level1/modules/kernel/fvmodul.asm
@@ -10,90 +10,90 @@
 * Error:  B = A non-zero error code.
 *        CC = Carry flag set to indicate error.
 
-                    ifeq      Level-1
+                  IFEQ    Level-1 ; begin conditional assembly for Level-1
 FindModule
-                    ldu       #$0000              initialize U with $0000
-                    tfr       a,b                 copy A to B
-                    anda      #TypeMask           preserve type bits in A
-                    andb      #LangMask           preserve language bits in B
-                    pshs      u,y,x,b,a           save important registers
-_stk1A@             set       0
-_stk1B@             set       1
-_stk1X@             set       2
-_stk1Y@             set       4
-_stk1U@             set       6
-                    bsr       eatspace@           move X past any spaces
-                    cmpa      #PDELIM             pathlist char?
-                    beq       exerr@              branch if so
-                    lbsr      ParseNam            parse name
-                    bcs       ex@                 branch if error
-                    ldu       <D.ModDir           get pointer to module directory
-FindLoop            pshs      u,y,b               save important registers
-_stk2B@             set       0                   B = pathname length
-_stk2Y@             set       1                   Y =
-_stk2U@             set       3                   U = address of next module in module directory
-_stk1A@             set       0+_stk2U@+2
-_stk1B@             set       1+_stk2U@+2
-_stk1X@             set       2+_stk2U@+2
-_stk1Y@             set       4+_stk2U@+2
-_stk1U@             set       6+_stk2U@+2
-                    ldu       MD$MPtr,u           get pointer to next module to compare names with
-                    beq       CheckEnd            empty entry... continue to next module in list
-                    ldd       M$Name,u            get module name offset in module
-                    leay      d,u                 point Y to module name
-                    ldb       _stk2B@,s           get length of pathname on stack
-                    lbsr      CmpNam              compare name of modules
-                    bcs       NextMod             branch if not same name
-                    lda       _stk1A@,s           get saved type byte on stack
-                    beq       ChkLang             same... now check language
-                    eora      M$Type,u            EOR with type in module
-                    anda      #TypeMask           preserve type bits
-                    bne       NextMod             branch if not same type
-ChkLang             lda       _stk1B@,s           get saved language byte on stack
-                    beq       ModFound            branch if 0
-                    eora      M$Type,u            EOR with language in module
-                    anda      #LangMask           preserve language bits
-                    bne       NextMod             branch if not same language
-ModFound            puls      u,x,b               module found... restore regs
-_stk1A@             set       0
-_stk1B@             set       1
-_stk1X@             set       2
-_stk1Y@             set       4
-_stk1U@             set       6
-                    stu       _stk1U@,s           save off found module in caller's U
-                    bsr       eatspace@           move past any spaces
-                    stx       _stk1X@,s           save off character past module name in caller's X
-                    clra                          clear carry
-                    bra       ex@                 branch to exit of routine
-_stk2B@             set       0
-_stk2Y@             set       1
-_stk2U@             set       3
-_stk1A@             set       0+_stk2U@+2
-_stk1B@             set       1+_stk2U@+2
-_stk1X@             set       2+_stk2U@+2
-_stk1Y@             set       4+_stk2U@+2
-_stk1U@             set       6+_stk2U@+2
-CheckEnd            ldd       _stk1U@,s           get saved pointer in module directory
-                    bne       NextMod             branch to get next module in directory
-                    ldd       _stk2U@,s           get saved U
-                    std       _stk1U@,s           put in saved U in earlier stack
-NextMod             puls      u,y,b               restore pushed regs
-                    leau      MD$ESize,u          advance to next module directory entry
-                    cmpu      <D.ModDir+2         at end of directory?
-                    bcs       FindLoop            no... continue searching
-exerr@              comb                          set carry
-ex@                 puls      pc,u,y,x,b,a        return to caller
+                    ldu       #$0000    ; initialize U with $0000
+                    tfr       a,b       ; copy A to B
+                    anda      #TypeMask ; preserve type bits in A
+                    andb      #LangMask ; preserve language bits in B
+                    pshs      u,y,x,b,a ; save important registers
+_stk1A@             set       0         ; define assembler symbol
+_stk1B@             set       1         ; define assembler symbol
+_stk1X@             set       2         ; define assembler symbol
+_stk1Y@             set       4         ; define assembler symbol
+_stk1U@             set       6         ; define assembler symbol
+                    bsr       eatspace@ ; move X past any spaces
+                    cmpa      #PDELIM   ; pathlist char?
+                    beq       exerr@    ; branch if so
+                    lbsr      ParseNam  ; parse name
+                    bcs       ex@       ; branch if error
+                    ldu       <D.ModDir ; get pointer to module directory
+FindLoop            pshs      u,y,b     ; save important registers
+_stk2B@             set       0         ; B = pathname length
+_stk2Y@             set       1         ; Y =
+_stk2U@             set       3         ; U = address of next module in module directory
+_stk1A@             set       0+_stk2U@+2 ; define assembler symbol
+_stk1B@             set       1+_stk2U@+2 ; define assembler symbol
+_stk1X@             set       2+_stk2U@+2 ; define assembler symbol
+_stk1Y@             set       4+_stk2U@+2 ; define assembler symbol
+_stk1U@             set       6+_stk2U@+2 ; define assembler symbol
+                    ldu       MD$MPtr,u ; get pointer to next module to compare names with
+                    beq       CheckEnd  ; empty entry... continue to next module in list
+                    ldd       M$Name,u  ; get module name offset in module
+                    leay      d,u       ; point Y to module name
+                    ldb       _stk2B@,s ; get length of pathname on stack
+                    lbsr      CmpNam    ; compare name of modules
+                    bcs       NextMod   ; branch if not same name
+                    lda       _stk1A@,s ; get saved type byte on stack
+                    beq       ChkLang   ; same... now check language
+                    eora      M$Type,u  ; eOR with type in module
+                    anda      #TypeMask ; preserve type bits
+                    bne       NextMod   ; branch if not same type
+ChkLang             lda       _stk1B@,s ; get saved language byte on stack
+                    beq       ModFound  ; branch if 0
+                    eora      M$Type,u  ; eOR with language in module
+                    anda      #LangMask ; preserve language bits
+                    bne       NextMod   ; branch if not same language
+ModFound            puls      u,x,b     ; module found... restore regs
+_stk1A@             set       0         ; define assembler symbol
+_stk1B@             set       1         ; define assembler symbol
+_stk1X@             set       2         ; define assembler symbol
+_stk1Y@             set       4         ; define assembler symbol
+_stk1U@             set       6         ; define assembler symbol
+                    stu       _stk1U@,s ; save off found module in caller's U
+                    bsr       eatspace@ ; move past any spaces
+                    stx       _stk1X@,s ; save off character past module name in caller's X
+                    clra                ; clear carry
+                    bra       ex@       ; branch to exit of routine
+_stk2B@             set       0         ; define assembler symbol
+_stk2Y@             set       1         ; define assembler symbol
+_stk2U@             set       3         ; define assembler symbol
+_stk1A@             set       0+_stk2U@+2 ; define assembler symbol
+_stk1B@             set       1+_stk2U@+2 ; define assembler symbol
+_stk1X@             set       2+_stk2U@+2 ; define assembler symbol
+_stk1Y@             set       4+_stk2U@+2 ; define assembler symbol
+_stk1U@             set       6+_stk2U@+2 ; define assembler symbol
+CheckEnd            ldd       _stk1U@,s ; get saved pointer in module directory
+                    bne       NextMod   ; branch to get next module in directory
+                    ldd       _stk2U@,s ; get saved U
+                    std       _stk1U@,s ; put in saved U in earlier stack
+NextMod             puls      u,y,b     ; restore pushed regs
+                    leau      MD$ESize,u ; advance to next module directory entry
+                    cmpu      <D.ModDir+2 ; at end of directory?
+                    bcs       FindLoop  ; no... continue searching
+exerr@              comb                ; set carry
+ex@                 puls      pc,u,y,x,b,a ; return to caller
 * Advance past any leading spaces in a string.
 *
 * Entry: X = Pointer to string.
 *
 * Exit:  A = First non-space character.
 *        X = Pointer to first non-space character.
-eatspace@           lda       #C$SPAC             load A with space character
-loop@               cmpa      ,x+                 compare with character at X and increment
-                    beq       loop@               if space, keep going
-                    lda       ,-x                 else get non-space character at X-1
-                    rts                           return
+eatspace@           lda       #C$SPAC   ; load A with space character
+loop@               cmpa      ,x+       ; compare with character at X and increment
+                    beq       loop@     ; if space, keep going
+                    lda       ,-x       ; else get non-space character at X-1
+                    rts                 ; return
 
 ;;; F$VModul
 ;;;
@@ -114,463 +114,463 @@ loop@               cmpa      ,x+                 compare with character at X an
 ;;; If the module integrity feature flag is turned on at build time, F$VModul will verify the module's header and
 ;;; CRC to ensure the module is completely correct; otherwise, these checks aren't done.
 
-FVModul             pshs      u                   save caller's registers
-                    ldx       R$X,u               get caller's X (address of module name)
-                    bsr       ValMod              perform the validation
-                    puls      y                   pull the caller's registers
-                    stu       R$U,y               save the new (if any) module address
-                    rts                           return to caller
+FVModul             pshs      u         ; save caller's registers
+                    ldx       R$X,u     ; get caller's X (address of module name)
+                    bsr       ValMod    ; perform the validation
+                    puls      y         ; pull the caller's registers
+                    stu       R$U,y     ; save the new (if any) module address
+                    rts                 ; return to caller
 
 * X = address of module to validate
-ValMod              bsr       ChkMHCRC            check the module header and CRC
-                    bcs       ex@                 ... exit if error
-                    lda       M$Type,x            get the type byte
-                    pshs      x,a                 save off module address
-                    ldd       M$Name,x            get module name offset
-                    leax      d,x                 set X to address of name in module
-                    puls      a                   restore type byte
-                    lbsr      FindModule          attempt to locate module in module directory of same name
-                    puls      x                   restore passed module address
+ValMod              bsr       ChkMHCRC  ; check the module header and CRC
+                    bcs       ex@       ; ... exit if error
+                    lda       M$Type,x  ; get the type byte
+                    pshs      x,a       ; save off module address
+                    ldd       M$Name,x  ; get module name offset
+                    leax      d,x       ; set X to address of name in module
+                    puls      a         ; restore type byte
+                    lbsr      FindModule ; attempt to locate module in module directory of same name
+                    puls      x         ; restore passed module address
 * Now, X points to module that was passed by caller, and
 * U points to module dirctory entry of the module of the same name that was found (if any)
 * already in module directory
-                    bcs       isempty@            branch if FindModule returned error (no module found of the same name)
-                    ldb       #E$KwnMod           prepare possible error
-                    cmpx      MD$MPtr,u           is the returned module directory entry the same?
-                    beq       errex@              branch if so
+                    bcs       isempty@  ; branch if FindModule returned error (no module found of the same name)
+                    ldb       #E$KwnMod ; prepare possible error
+                    cmpx      MD$MPtr,u ; is the returned module directory entry the same?
+                    beq       errex@    ; branch if so
 * Here, we've established another module of the same name as the one we're validating already
 * exists in the module directory, and it's NOT this same module.
 * Check the revision to see if this one is newer and should replace the existing one.
-                    lda       M$Revs,x            else get revision byte of passed module
-                    anda      #RevsMask           mask out all but revision
-                    pshs      a                   save off
-                    ldy       MD$MPtr,u           get pointer to found module (different)
-                    lda       M$Revs,y            get revision byte of found module
-                    anda      #RevsMask           mask out all but revision
-                    cmpa      ,s+                 compare revisions
-                    bcc       errex@              if same or lower, return to caller
-                    pshs      y,x                 save off pointer to modules
-                    ldb       MD$Link,u           get link count of module
-                    bne       pulsaveandex@       branch if not zero
-                    ldx       MD$MPtr,u           get address of module into X
-                    cmpx      <D.BTLO             compare against Boot low memory pointer
-                    bcc       pulsaveandex@       branch if higher
+                    lda       M$Revs,x  ; else get revision byte of passed module
+                    anda      #RevsMask ; mask out all but revision
+                    pshs      a         ; save off
+                    ldy       MD$MPtr,u ; get pointer to found module (different)
+                    lda       M$Revs,y  ; get revision byte of found module
+                    anda      #RevsMask ; mask out all but revision
+                    cmpa      ,s+       ; compare revisions
+                    bcc       errex@    ; if same or lower, return to caller
+                    pshs      y,x       ; save off pointer to modules
+                    ldb       MD$Link,u ; get link count of module
+                    bne       pulsaveandex@ ; branch if not zero
+                    ldx       MD$MPtr,u ; get address of module into X
+                    cmpx      <D.BTLO   ; compare against Boot low memory pointer
+                    bcc       pulsaveandex@ ; branch if higher
 * Here, we've determined the module we're validating is newer than the one that already
 * exists in memory.
-                    ldd       M$Size,x            else get module size from module header
-                    addd      #$00FF              round up to next page
-                    tfr       a,b                 divide by 256 (# of pages to clear)
-                    clra                          D = rounded up value of module's memory footprint (number of bits to clear)
-                    tfr       d,y                 transfer to Y
-                    ldb       MD$MPtr,u           put high byte of module address into B (D = first bit in allocation table to clear)
-                    ldx       <D.FMBM             get pointer to free memory bitmap
-                    os9       F$DelBit            delete from allocation table (D = first bit to clear, X = bitmap address, Y = # of bits to clear)
-                    clr       MD$Link,u           clear link count in module directory entry
-pulsaveandex@       puls      y,x                 restore X and Y
-saveandex@          stx       MD$MPtr,u           save newly validated module into module directory entry of deallocated modulke
-                    clrb                          clear carry and error code
-ex@                 rts                           return
-isempty@            leay      MD$MPtr,u           get module pointer in Y
-                    bne       saveandex@          branch if module exists
-                    ldb       #E$DirFul           module directory is full
-errex@              coma                          set carry
-                    rts                           return to caller
+                    ldd       M$Size,x  ; else get module size from module header
+                    addd      #$00FF    ; round up to next page
+                    tfr       a,b       ; divide by 256 (# of pages to clear)
+                    clra                ; D = rounded up value of module's memory footprint (number of bits to clear)
+                    tfr       d,y       ; transfer to Y
+                    ldb       MD$MPtr,u ; put high byte of module address into B (D = first bit in allocation table to clear)
+                    ldx       <D.FMBM   ; get pointer to free memory bitmap
+                    os9       F$DelBit  ; delete from allocation table (D = first bit to clear, X = bitmap address, Y = # of bits to clear)
+                    clr       MD$Link,u ; clear link count in module directory entry
+pulsaveandex@       puls      y,x       ; restore X and Y
+saveandex@          stx       MD$MPtr,u ; save newly validated module into module directory entry of deallocated modulke
+                    clrb                ; clear carry and error code
+ex@                 rts                 ; return
+isempty@            leay      MD$MPtr,u ; get module pointer in Y
+                    bne       saveandex@ ; branch if module exists
+                    ldb       #E$DirFul ; module directory is full
+errex@              coma                ; set carry
+                    rts                 ; return to caller
 
 * Check module header and CRC
 *
 * Entry: X = Address of potential module.
-ChkMHCRC            ldd       ,x                  get two bytes at start of potential module
-                    cmpd      #M$ID12             are these module sync bytes?
-                    bne       errex@              nope, not a module here
-                    leay      M$Parity,x          else point Y to the parity byte in the module
-                    bsr       ChkMHPar            check header parity
-                    bcc       Chk4CRC             branch if ok
-errex@              comb                          else set carry
-                    ldb       #E$BMID             and load B with error
-                    rts                           return to caller
+ChkMHCRC            ldd       ,x        ; get two bytes at start of potential module
+                    cmpd      #M$ID12   ; are these module sync bytes?
+                    bne       errex@    ; nope, not a module here
+                    leay      M$Parity,x ; else point Y to the parity byte in the module
+                    bsr       ChkMHPar  ; check header parity
+                    bcc       Chk4CRC   ; branch if ok
+errex@              comb                ; else set carry
+                    ldb       #E$BMID   ; and load B with error
+                    rts                 ; return to caller
 
 * Check module CRC
 *
 * Entry: X = Address of module to check.
 Chk4CRC
-                    lda       <D.CRC              is CRC checking on?
-                    bne       DoCRCCk             branch if so
-                    clrb                          else clear carry
-                    rts                           return to caller
+                    lda       <D.CRC    ; is CRC checking on?
+                    bne       DoCRCCk   ; branch if so
+                    clrb                ; else clear carry
+                    rts                 ; return to caller
 
 * Check if module CRC checking is on
 *
 * Entry: X = Address of module to check.
-DoCRCCk             pshs      x                   save off module address onto stack
-                    ldy       M$Size,x            get module size in module header
-                    bsr       ChkMCRC             check module CRC
-                    puls      pc,x
+DoCRCCk             pshs      x         ; save off module address onto stack
+                    ldy       M$Size,x  ; get module size in module header
+                    bsr       ChkMCRC   ; check module CRC
+                    puls      pc,x      ; restore pc,x from the stack
 
 * Check module header parity
 *
 * Entry: X = Module header to check.
 *        Y = Pointer to parity byte.
-ChkMHPar            pshs      y,x                 save off X and Y
-_stk1X@             set       0
-_stk1Y@             set       2
-                    clra                          A = 0
-loop@               eora      ,x+                 XOR with
-                    cmpx      _stk1Y@,s           compare to address of parity byte
-                    bls       loop@               branch if not there yet
-                    cmpa      #$FF                parity check done... is it correct?
-                    puls      pc,y,x              restore regs and return
+ChkMHPar            pshs      y,x       ; save off X and Y
+_stk1X@             set       0         ; define assembler symbol
+_stk1Y@             set       2         ; define assembler symbol
+                    clra                ; A = 0
+loop@               eora      ,x+       ; xOR with
+                    cmpx      _stk1Y@,s ; compare to address of parity byte
+                    bls       loop@     ; branch if not there yet
+                    cmpa      #$FF      ; parity check done... is it correct?
+                    puls      pc,y,x    ; restore regs and return
 
 * Check module CRC
 *
 * Entry: X = Address of potential module.
 *        Y = Size of module.
-ChkMCRC             ldd       #$FFFF              initialize D to $FFFF
-                    pshs      b,a                 save off stack
-                    pshs      b,a                 32 bits
-                    leau      1,s                 advance one byte (24 byte CRC)
-loop@               lda       ,x+                 get next byte of module
-                    bsr       CRCAlgo             perform algorithm
-                    leay      -1,y                decrement Y (size of module)
-                    bne       loop@               continue if not at end
-                    clr       -1,u                clear first 8 bits of 32 bits
-                    lda       ,u                  get first byte of CRC
-                    cmpa      #CRCCon1            is it what we expect?
-                    bne       err@                branch if not
-                    ldd       1,u                 get next two bytes of CRC
-                    cmpd      #CRCCon23           is it what we expect?
-                    beq       ex@                 branch if what we expect
-err@                comb                          ...else set carry
-                    ldb       #E$BMCRC            load B with error
-ex@                 puls      pc,y,x              return to caller
+ChkMCRC             ldd       #$FFFF    ; initialize D to $FFFF
+                    pshs      b,a       ; save off stack
+                    pshs      b,a       ; 32 bits
+                    leau      1,s       ; advance one byte (24 byte CRC)
+loop@               lda       ,x+       ; get next byte of module
+                    bsr       CRCAlgo   ; perform algorithm
+                    leay      -1,y      ; decrement Y (size of module)
+                    bne       loop@     ; continue if not at end
+                    clr       -1,u      ; clear first 8 bits of 32 bits
+                    lda       ,u        ; get first byte of CRC
+                    cmpa      #CRCCon1  ; is it what we expect?
+                    bne       err@      ; branch if not
+                    ldd       1,u       ; get next two bytes of CRC
+                    cmpd      #CRCCon23 ; is it what we expect?
+                    beq       ex@       ; branch if what we expect
+err@                comb                ; ...else set carry
+                    ldb       #E$BMCRC  ; load B with error
+ex@                 puls      pc,y,x    ; return to caller
 
-                    else
+                  ELSE
 
-FVModul             pshs      u                   preserve register stack pointer
-                    ldx       R$X,u               get block offset
-                    ldy       R$D,u               get DAT image pointer
-                    bsr       L0463               validate it
-                    ldx       ,s                  get register stack pointer
-                    stu       R$U,x               save address of module directory entry
-                    puls      u,pc                restore & return
+FVModul             pshs      u         ; preserve register stack pointer
+                    ldx       R$X,u     ; get block offset
+                    ldy       R$D,u     ; get DAT image pointer
+                    bsr       L0463     ; validate it
+                    ldx       ,s        ; get register stack pointer
+                    stu       R$U,x     ; save address of module directory entry
+                    puls      u,pc      ; restore & return
 
 * Validate module - shortcut for calls within OS9p1 go here (ex. OS9Boot)
 * Entry: X=Module block offset
 *        Y=Module DAT image pointer
-L0463               pshs      x,y                 save block offset & DAT Image ptr
-                    lbsr      L0586               Go check module ID & header parity
-                    bcs       L0495               Error, exit
-                    ldd       #M$Type             Get offset to module type
-                    lbsr      L0B02               go get 2 bytes (module type)
-                    andb      #LangMask           Just keep language mask
-                    pshs      d                   Preserve ??? & language
-                    ldd       #M$Name             get offset to module name
-                    lbsr      L0B02               go get 2 bytes (offset)
-                    leax      d,x                 Point X to module name
-                    puls      a                   Restore type/language
-                    lbsr      L068D               Find module in module directory
-                    puls      a
-                    bcs       L0497
-                    andb      #$0F
-                    ifne      H6309
+L0463               pshs      x,y       ; save block offset & DAT Image ptr
+                    lbsr      L0586     ; go check module ID & header parity
+                    bcs       L0495     ; error, exit
+                    ldd       #M$Type   ; get offset to module type
+                    lbsr      L0B02     ; go get 2 bytes (module type)
+                    andb      #LangMask ; just keep language mask
+                    pshs      d         ; preserve ??? & language
+                    ldd       #M$Name   ; get offset to module name
+                    lbsr      L0B02     ; go get 2 bytes (offset)
+                    leax      d,x       ; point X to module name
+                    puls      a         ; restore type/language
+                    lbsr      L068D     ; find module in module directory
+                    puls      a         ; restore a from the stack
+                    bcs       L0497     ; branch if carry is set to L0497
+                    andb      #$0F      ; mask B with #$0F
+                  IFNE    H6309   ; begin conditional assembly for H6309
                     subr      a,b
-                    else
-                    pshs      a
-                    subb      ,s+
-                    endc
-                    blo       L0497               If wrapped, skip ahead
-                    ldb       #E$KwnMod
-                    fcb       $8C                 skip 2 bytes
-L0491               ldb       #E$DirFul
-L0493               orcc      #Carry
-L0495               puls      x,y,pc
+                  ELSE
+                    pshs      a         ; save a on the stack
+                    subb      ,s+       ; subtract ,s+ from B
+                  ENDC
+                    blo       L0497     ; if wrapped, skip ahead
+                    ldb       #E$KwnMod ; load B from #E$KwnMod
+                    fcb       $8C       ; skip 2 bytes
+L0491               ldb       #E$DirFul ; load B from #E$DirFul
+L0493               orcc      #Carry    ; set condition-code bits using #Carry
+L0495               puls      x,y,pc    ; restore x,y,pc from the stack
 
-L0497               ldx       ,s
-                    ifne      H6309
-                    bsr       L0524
-                    else
-                    lbsr      L0524
-                    endc
-                    bcs       L0491
-                    sty       ,u
-                    stx       MD$MPtr,u
-                    ifne      H6309
-                    clrd
-                    else
-                    clra
-                    clrb
-                    endc
-                    std       MD$Link,u
-                    ldd       #M$Size             Get offset to size of module
-                    lbsr      L0B02               get it
-                    ifne      H6309
-                    addr      x,d                 Add it to module ptr
-                    else
-                    pshs      x
-                    addd      ,s++
-                    endc
-                    std       MD$MBSiz,u
-                    ldy       [MD$MPDAT,u]        get pointer to module DAT
-                    ldx       <D.ModDir           get module directory pointer
-                    pshs      u                   save module pointer
-                    fcb       $8C                 skip 2 bytes
+L0497               ldx       ,s        ; load X from ,s
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    bsr       L0524     ; call local routine L0524
+                  ELSE
+                    lbsr      L0524     ; call local routine L0524
+                  ENDC
+                    bcs       L0491     ; branch if carry is set to L0491
+                    sty       ,u        ; store Y at ,u
+                    stx       MD$MPtr,u ; store X at MD$MPtr,u
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; update processor state
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    std       MD$Link,u ; store D at MD$Link,u
+                    ldd       #M$Size   ; get offset to size of module
+                    lbsr      L0B02     ; get it
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      x,d       ; add it to module ptr
+                  ELSE
+                    pshs      x         ; save x on the stack
+                    addd      ,s++      ; add ,s++ to D
+                  ENDC
+                    std       MD$MBSiz,u ; store D at MD$MBSiz,u
+                    ldy       [MD$MPDAT,u] ; get pointer to module DAT
+                    ldx       <D.ModDir ; get module directory pointer
+                    pshs      u         ; save module pointer
+                    fcb       $8C       ; skip 2 bytes
 
-L04BC               leax      MD$ESize,x          move to next entry
-L04BE               cmpx      <D.ModEnd
-                    bcc       L04CD
-                    cmpx      ,s                  match?
-                    beq       L04BC               no, keep looking
-                    cmpy      [MD$MPDAT,x]        DAT match?
-                    bne       L04BC               no, keep looking
-                    bsr       L04F2
+L04BC               leax      MD$ESize,x ; move to next entry
+L04BE               cmpx      <D.ModEnd ; compare X with <D.ModEnd
+                    bcc       L04CD     ; branch if carry is clear to L04CD
+                    cmpx      ,s        ; match?
+                    beq       L04BC     ; no, keep looking
+                    cmpy      [MD$MPDAT,x] ; dAT match?
+                    bne       L04BC     ; no, keep looking
+                    bsr       L04F2     ; call local routine L04F2
 
-L04CD               puls      u
-                    ldx       <D.BlkMap           Get ptr to block map
-                    ldd       MD$MBSiz,u          Get size of module
-                    addd      #$1FFF              Round up to nearest 8K block
-                    lsra                          Divide by 32
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    ldy       MD$MPDAT,u
+L04CD               puls      u         ; restore u from the stack
+                    ldx       <D.BlkMap ; get ptr to block map
+                    ldd       MD$MBSiz,u ; get size of module
+                    addd      #$1FFF    ; round up to nearest 8K block
+                    lsra                ; divide by 32
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    ldy       MD$MPDAT,u ; load Y from MD$MPDAT,u
 
-                    ifne      H6309
-                    tfr       a,e
-L04DE               ldd       ,y++
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       a,e       ; transfer register value a,e
+L04DE               ldd       ,y++      ; load D from ,y++
                     oim       #ModBlock,d,x
-                    dece
-                    else
-L04DE               pshs      a,x                 save block size, blkmap
-                    ldd       ,y++                D = image block #
-                    leax      d,x                 X = blkmap ptr
-                    ldb       ,x                  get block marker
-                    orb       #ModBlock           set module in block
-                    stb       ,x                  marker
-                    puls      x,a
-                    deca                          count--
-                    endc
-                    bne       L04DE               no, keep going
-                    clrb                          clear carry
-                    puls      x,y,pc              return
+                    dece                ; update processor state
+                  ELSE
+L04DE               pshs      a,x       ; save block size, blkmap
+                    ldd       ,y++      ; D = image block #
+                    leax      d,x       ; X = blkmap ptr
+                    ldb       ,x        ; get block marker
+                    orb       #ModBlock ; set module in block
+                    stb       ,x        ; marker
+                    puls      x,a       ; restore x,a from the stack
+                    deca                ; count--
+                  ENDC
+                    bne       L04DE     ; no, keep going
+                    clrb                ; clear carry
+                    puls      x,y,pc    ; return
 
-L04F2               pshs      d,x,y,u
+L04F2               pshs      d,x,y,u   ; save d,x,y,u on the stack
 * LCB - 6809 - this can be slightly sped up by swapping roles
-                    ldx       ,x
-                    ifne      H6309
-                    tfr       x,w                 Dupe to faster index register
-                    clrd
-L04FA               ldy       ,w
-                    beq       L0503
-                    std       ,w++
-                    bra       L04FA
-L0503               ldy       2,s
-                    else
-                    pshs      x
-                    clra                          D=0000
-                    clrb
-L04FA               ldy       ,x                  last entry?
-                    beq       L0503               ..yes
-                    std       ,x++                no, clear
-                    bra       L04FA               and loop
+                    ldx       ,x        ; load X from ,x
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       x,w       ; dupe to faster index register
+                    clrd                ; update processor state
+L04FA               ldy       ,w        ; load Y from ,w
+                    beq       L0503     ; branch if zero is set to L0503
+                    std       ,w++      ; store D at ,w++
+                    bra       L04FA     ; branch unconditionally to L04FA
+L0503               ldy       2,s       ; load Y from 2,s
+                  ELSE
+                    pshs      x         ; save x on the stack
+                    clra                ; D=0000
+                    clrb                ; clear B
+L04FA               ldy       ,x        ; last entry?
+                    beq       L0503     ; ..yes
+                    std       ,x++      ; no, clear
+                    bra       L04FA     ; and loop
 
 * Entry: U=Ptr to current entry in module directory
 *        Y=Ptr to entry in module directory we are comparing to
-L0503               puls      x
-                    ldy       2,s                 Get ptr to module dir entry we are comparing with
-                    endc
+L0503               puls      x         ; restore x from the stack
+                    ldy       2,s       ; get ptr to module dir entry we are comparing with
+                  ENDC
 *
-                    ldu       MD$MPDAT,u          Get DAT img ptr for module
-                    puls      d
-L050C               cmpx      MD$MPDAT,y          Same as DAT img ptr for other module?
-                    bne       L051B               No, check next one
-                    stu       MD$MPDAT,y          Match; save current entry ptr here
-                    cmpd      MD$MBSiz,y          >memory block size already here?
+                    ldu       MD$MPDAT,u ; get DAT img ptr for module
+                    puls      d         ; restore d from the stack
+L050C               cmpx      MD$MPDAT,y ; same as DAT img ptr for other module?
+                    bne       L051B     ; no, check next one
+                    stu       MD$MPDAT,y ; match; save current entry ptr here
+                    cmpd      MD$MBSiz,y ; >memory block size already here?
 * 6809/6309 LCB - couldn't we change next 2 lines to blo L051B
-                    bhs       L0519               Yes, use new one
-                    ldd       MD$MBSiz,y          No, get original and use that size instead
-L0519               std       MD$MBSiz,y
-L051B               leay      MD$ESize,y          Bump ptr to next module dir entry
-                    cmpy      <D.ModEnd           Are we at end of module dir?
-                    bne       L050C               No,keep checking
-                    puls      x,y,u,pc
+                    bhs       L0519     ; yes, use new one
+                    ldd       MD$MBSiz,y ; no, get original and use that size instead
+L0519               std       MD$MBSiz,y ; store D at MD$MBSiz,y
+L051B               leay      MD$ESize,y ; bump ptr to next module dir entry
+                    cmpy      <D.ModEnd ; are we at end of module dir?
+                    bne       L050C     ; no,keep checking
+                    puls      x,y,u,pc  ; restore x,y,u,pc from the stack
 
 * Exit: B=MMU block # of some sort
-L0524               pshs      x,y,u
-                    ldd       #M$Size             Offset to module size
-                    lbsr      L0B02               Go get module size
-                    addd      ,s                  Add to value
-                    addd      #$1FFF              Calc MMU block #
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    tfr       a,b                 Move block # to B
-                    pshs      b                   Save it as well
-                    comb                          one byte shorter than incb;lslb;negb
-                    lslb                          (D=-B is what we are doing)
-                    sex
-                    bsr       L054E
-                    bcc       L054C
-                    os9       F$GCMDir            get rid of empty slots in module directory
-                    IFNE      H6309
-                    tfr       0,u
-                    ELSE
-                    ldu       #$0000
-                    ENDC
-                    stu       $05,s               Save $0000 so U is 0 in puls below
-                    bsr       L054E
-L054C               puls      b,x,y,u,pc
+L0524               pshs      x,y,u     ; save x,y,u on the stack
+                    ldd       #M$Size   ; offset to module size
+                    lbsr      L0B02     ; go get module size
+                    addd      ,s        ; add to value
+                    addd      #$1FFF    ; calc MMU block #
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    tfr       a,b       ; move block # to B
+                    pshs      b         ; save it as well
+                    comb                ; one byte shorter than incb;lslb;negb
+                    lslb                ; (D=-B is what we are doing)
+                    sex                 ; sign-extend B into A
+                    bsr       L054E     ; call local routine L054E
+                    bcc       L054C     ; branch if carry is clear to L054C
+                    os9       F$GCMDir  ; get rid of empty slots in module directory
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,u       ; transfer register value 0,u
+                  ELSE
+                    ldu       #$0000    ; load U from #$0000
+                  ENDC
+                    stu       $05,s     ; save $0000 so U is 0 in puls below
+                    bsr       L054E     ; call local routine L054E
+L054C               puls      b,x,y,u,pc ; restore b,x,y,u,pc from the stack
 
 * Entry: D=negative offset from end of module Dir DAT Img)
-L054E               ldx       <D.ModDAT           get end ptr of Module Dir DAT image
-                    leax      d,x                 Add our negative offset
-                    cmpx      <D.ModEnd           Is that past the end of the module directory?
-                    blo       S.Poll              no, skip ahead
-                    ldu       7,s                 Yes, get U from stack (0 means we compacted mod dir)
-                    bne       L056E               Not compacted, skip ahead
-                    ldy       <D.ModEnd           Get ptr to end of module directory
-                    leay      MD$ESize,y          Bump up by 1 entry
-                    IFNE      H6309
-                    cmpr      x,y                 Offset we did past new entry?
-                    ELSE
-                    pshs      x                   Offset we did past new entry?
-                    cmpy      ,s++
-                    ENDC
-                    bhi       S.Poll              Yes, skip ahead
-                    sty       <D.ModEnd           No, save new module directory end ptr
-                    leay      -MD$ESize,y         Bump ptr back on entry
-                    sty       $07,s               Save that as new U on exit
-L056E               stx       <D.ModDAT           Save new Module Dir DAT image end ptr
-                    IFNE      H6309
-                    ldd       $05,s               Get source ptr
-                    stx       $05,s
+L054E               ldx       <D.ModDAT ; get end ptr of Module Dir DAT image
+                    leax      d,x       ; add our negative offset
+                    cmpx      <D.ModEnd ; is that past the end of the module directory?
+                    blo       S.Poll    ; no, skip ahead
+                    ldu       7,s       ; yes, get U from stack (0 means we compacted mod dir)
+                    bne       L056E     ; not compacted, skip ahead
+                    ldy       <D.ModEnd ; get ptr to end of module directory
+                    leay      MD$ESize,y ; bump up by 1 entry
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    cmpr      x,y       Offset we did past new entry?
+                  ELSE
+                    pshs      x         ; offset we did past new entry?
+                    cmpy      ,s++      ; compare Y with ,s++
+                  ENDC
+                    bhi       S.Poll    ; yes, skip ahead
+                    sty       <D.ModEnd ; no, save new module directory end ptr
+                    leay      -MD$ESize,y ; bump ptr back on entry
+                    sty       $07,s     ; save that as new U on exit
+L056E               stx       <D.ModDAT ; save new Module Dir DAT image end ptr
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldd       $05,s     ; get source ptr
+                    stx       $05,s     ; store X at $05,s
                     ldf       2,s
-                    clre
-                    rolw
+                    clre                ; update processor state
+                    rolw                ; update processor state
                     tfm       d+,x+
-                    stw       ,x                  Save 0
-                    ELSE
-                    ldy       5,s
-                    ldb       2,s                 B=block count
-                    stx       5,s                 return dir datimg ptr
-L0577               ldu       ,y++                copy images
-                    stu       ,x++                to new mod dat entry
-                    decb
-                    bne       L0577
+                    stw       ,x        Save 0
+                  ELSE
+                    ldy       5,s       ; load Y from 5,s
+                    ldb       2,s       ; B=block count
+                    stx       5,s       ; return dir datimg ptr
+L0577               ldu       ,y++      ; copy images
+                    stu       ,x++      ; to new mod dat entry
+                    decb                ; decrement B
+                    bne       L0577     ; branch if zero is clear to L0577
 * 6809/6309 LCB - stb ,x - same size, faster (4 vs 6). Still need CLR
 *  for clr 1,x to make sure carry is cleared
-                    stb       ,x                  zero flag
-                    clr       1,x                 & clear carry
-                    ENDC
-                    rts
+                    stb       ,x        ; zero flag
+                    clr       1,x       ; & clear carry
+                  ENDC
+                    rts                 ; return to caller
 
 * Default interrupt handling routine on first booting OS9p1
-S.Poll              orcc      #Carry
-                    rts
+S.Poll              orcc      #Carry    ; set condition-code bits using #Carry
+                    rts                 ; return to caller
 
 * Check module ID & calculate module header parity & CRC
 * Entry: X=Block offset of module
 *        Y=DAT image pointer of module
-L0586               pshs      x,y                 save block offset & DAT pointer
-                    IFNE      H6309
-                    clrd                          M$ID offset
-                    ELSE
-                    clra                          M$ID offset
-                    clrb
-                    ENDC
-                    lbsr      L0B02               get module ID
-                    cmpd      #M$ID12             legal module?
-                    beq       L0597               yes, calculate header parity
-                    ldb       #E$BMID             get bad module ID error
-                    bra       L05F3               return error
+L0586               pshs      x,y       ; save block offset & DAT pointer
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; m$ID offset
+                  ELSE
+                    clra                ; m$ID offset
+                    clrb                ; clear B
+                  ENDC
+                    lbsr      L0B02     ; get module ID
+                    cmpd      #M$ID12   ; legal module?
+                    beq       L0597     ; yes, calculate header parity
+                    ldb       #E$BMID   ; get bad module ID error
+                    bra       L05F3     ; return error
 * Calculate module header parity
-L0597               leax      2,x                 point to start location of header calc
-                    lbsr      AdjBlk0             adjust it for block 0
-                    IFNE      H6309
-                    ldw       #($4A*256+M$Revs)   Get initial value & count (7 bytes of header)
-L05A2               lbsr      LDAXY               get a byte from module
-                    eorr      a,e                 add it into running parity
-                    decf                          done full header?
-                    bne       L05A2               no, keep going
-                    ince                          valid parity?
-                    ELSE
-                    leas      -1,s                make var
-                    ldd       #($4A*256+M$Revs)   Get initial value & count (7 bytes of header)
-L05A2               sta       ,s                  save crc
-                    lbsr      LDAXY               get next byte
-                    eora      ,s                  do crc
-                    decb                          more?
-                    bne       L05A2               ..loop
-                    leas      1,s                 drop var
-                    inca                          $FF+1 = 00
-                    ENDC
-                    beq       L05B5               yes, skip ahead
-                    ldb       #E$BMHP             get module header parity error
-                    bra       L05F3               return with error
+L0597               leax      2,x       ; point to start location of header calc
+                    lbsr      AdjBlk0   ; adjust it for block 0
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #($4A*256+M$Revs) Get initial value & count (7 bytes of header)
+L05A2               lbsr      LDAXY     ; get a byte from module
+                    eorr      a,e       add it into running parity
+                    decf                ; done full header?
+                    bne       L05A2     ; no, keep going
+                    ince                ; valid parity?
+                  ELSE
+                    leas      -1,s      ; make var
+                    ldd       #($4A*256+M$Revs) ; get initial value & count (7 bytes of header)
+L05A2               sta       ,s        ; save crc
+                    lbsr      LDAXY     ; get next byte
+                    eora      ,s        ; do crc
+                    decb                ; more?
+                    bne       L05A2     ; ..loop
+                    leas      1,s       ; drop var
+                    inca                ; $FF+1 = 00
+                  ENDC
+                    beq       L05B5     ; yes, skip ahead
+                    ldb       #E$BMHP   ; get module header parity error
+                    bra       L05F3     ; return with error
 
-L05B5               puls      x,y                 restore module pointer & DAT pointer
+L05B5               puls      x,y       ; restore module pointer & DAT pointer
 * this checks if the module CRC checking is on or off
-                    lda       <D.CRC              is CRC checking on?
-                    bne       L05BA               yes - go check it
-                    IFNE      H6309
-                    clrd                          no, clear out
-                    ELSE
-                    clra
-                    clrb
-                    ENDC
-                    rts                           and return
+                    lda       <D.CRC    ; is CRC checking on?
+                    bne       L05BA     ; yes - go check it
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; no, clear out
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    rts                 ; and return
 
 * Begin checking Module CRC
 * Entry: X=Module pointer
 *        Y=DAT image pointer of module
-L05BA               ldd       #M$Size             get offset to module size
-                    lbsr      L0B02               get module size
-                    IFNE      H6309
-                    tfr       d,w                 move length to W
-                    pshs      y,x                 preserve [X]=Buffer pointer,[Y]=DAT pointer
-                    ELSE
-                    pshs      y,x,d               preserve [X]=Buffer pointer,[Y]=DAT pointer
-                    ENDC
-                    ldd       #$FFFF              initial CRC value of $FFFFFF
-                    pshs      d                   set up local 24 bit variable
-                    pshs      b
-                    lbsr      AdjBlk0             adjust module pointer into block 0 for mapping
-                    leau      ,s                  point to CRC accumulator
+L05BA               ldd       #M$Size   ; get offset to module size
+                    lbsr      L0B02     ; get module size
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       d,w       ; move length to W
+                    pshs      y,x       ; preserve [X]=Buffer pointer,[Y]=DAT pointer
+                  ELSE
+                    pshs      y,x,d     ; preserve [X]=Buffer pointer,[Y]=DAT pointer
+                  ENDC
+                    ldd       #$FFFF    ; initial CRC value of $FFFFFF
+                    pshs      d         ; set up local 24 bit variable
+                    pshs      b         ; save b on the stack
+                    lbsr      AdjBlk0   ; adjust module pointer into block 0 for mapping
+                    leau      ,s        ; point to CRC accumulator
 * Loop: W=# bytes left to use in CRC calc
-L05CB               equ       *
-                    IFNE      H6309
-                    tstf                          on 256 byte boundary?
-                    ELSE
-                    tstb
-                    ENDC
-                    bne       L05D8               no, keep going
-                    pshs      x                   give up some time to system
-                    ldx       #1
-                    os9       F$Sleep
-                    puls      x                   restore module pointer
-L05D8               lbsr      LDAXY               get a byte from module into A
-                    bsr       CRCCalc             add it to running CRC
-                    IFNE      H6309
-                    decw                          Dec # bytes left to calculate CRC with
-                    ELSE
-                    ldd       3,s
-                    subd      #$0001
-                    std       3,s
-                    ENDC
-                    bne       L05CB               Still more, continue
-                    IFNE      H6309
-                    puls      b,x                 yes, restore CRC
-                    ELSE
-                    puls      b,x,y               yes, restore CRC
-                    ENDC
-                    cmpb      #CRCCon1            CRC MSB match constant?
-                    bne       L05F1               no, exit with error
-                    cmpx      #CRCCon23           LSW match constant?
-                    beq       L05F5               yes, skip ahead
-L05F1               ldb       #E$BMCRC            Bad Module CRC error
-L05F3               orcc      #Carry              Set up for error
-L05F5               puls      x,y,pc              exit
+L05CB               equ       *         ; define assembler symbol
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tstf                ; on 256 byte boundary?
+                  ELSE
+                    tstb                ; test B and update condition codes
+                  ENDC
+                    bne       L05D8     ; no, keep going
+                    pshs      x         ; give up some time to system
+                    ldx       #1        ; load X from #1
+                    os9       F$Sleep   ; call OS-9 service F$Sleep
+                    puls      x         ; restore module pointer
+L05D8               lbsr      LDAXY     ; get a byte from module into A
+                    bsr       CRCCalc   ; add it to running CRC
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; dec # bytes left to calculate CRC with
+                  ELSE
+                    ldd       3,s       ; load D from 3,s
+                    subd      #$0001    ; subtract #$0001 from D
+                    std       3,s       ; store D at 3,s
+                  ENDC
+                    bne       L05CB     ; still more, continue
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    puls      b,x       ; yes, restore CRC
+                  ELSE
+                    puls      b,x,y     ; yes, restore CRC
+                  ENDC
+                    cmpb      #CRCCon1  ; cRC MSB match constant?
+                    bne       L05F1     ; no, exit with error
+                    cmpx      #CRCCon23 ; lSW match constant?
+                    beq       L05F5     ; yes, skip ahead
+L05F1               ldb       #E$BMCRC  ; bad Module CRC error
+L05F3               orcc      #Carry    ; set up for error
+L05F5               puls      x,y,pc    ; exit
 
 * Calculate 24 bit CRC
 * Entry: A=Byte to add to CRC
@@ -578,60 +578,60 @@ L05F5               puls      x,y,pc              exit
 *
 * Future reference note: Do not use W unless preserved, contains module
 *                        byte counts from routines that come here!!
-CRCCalc             eora      ,u
-                    pshs      a
-                    ldd       1,u
-                    std       ,u
-                    clra
-                    ldb       ,s
-                    IFNE      H6309
-                    lsld
-                    ELSE
-                    aslb
-                    rola
-                    ENDC
-                    eora      1,u
-                    std       1,u
-                    clrb
-                    lda       ,s
-                    IFNE      H6309
-                    lsrd
-                    lsrd
+CRCCalc             eora      ,u        ; exclusive-OR A with ,u
+                    pshs      a         ; save a on the stack
+                    ldd       1,u       ; load D from 1,u
+                    std       ,u        ; store D at ,u
+                    clra                ; clear A
+                    ldb       ,s        ; load B from ,s
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lsld                ; shift or rotate and update condition codes
+                  ELSE
+                    aslb                ; update processor state
+                    rola                ; shift or rotate and update condition codes
+                  ENDC
+                    eora      1,u       ; exclusive-OR A with 1,u
+                    std       1,u       ; store D at 1,u
+                    clrb                ; clear B
+                    lda       ,s        ; load A from ,s
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lsrd                ; shift or rotate and update condition codes
+                    lsrd                ; shift or rotate and update condition codes
                     eord      1,u
-                    ELSE
-                    lsra
-                    rorb
-                    lsra
-                    rorb
-                    eora      1,u
-                    eorb      2,u
-                    ENDC
-                    std       1,u
-                    lda       ,s
-                    lsla
-                    eora      ,s
-                    sta       ,s
-                    lsla
-                    lsla
-                    eora      ,s
-                    sta       ,s
-                    lsla
-                    lsla
-                    lsla
-                    lsla
-                    eora      ,s+
-                    bpl       L0635
-                    IFNE      H6309
+                  ELSE
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    eora      1,u       ; exclusive-OR A with 1,u
+                    eorb      2,u       ; exclusive-OR B with 2,u
+                  ENDC
+                    std       1,u       ; store D at 1,u
+                    lda       ,s        ; load A from ,s
+                    lsla                ; shift or rotate and update condition codes
+                    eora      ,s        ; exclusive-OR A with ,s
+                    sta       ,s        ; store A at ,s
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    eora      ,s        ; exclusive-OR A with ,s
+                    sta       ,s        ; store A at ,s
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    eora      ,s+       ; exclusive-OR A with ,s+
+                    bpl       L0635     ; branch if negative is clear to L0635
+                  IFNE    H6309   ; begin conditional assembly for H6309
                     eim       #$80,,u
                     eim       #$21,2,u
-                    ELSE
-                    ldd       #$8021
-                    eora      ,u
-                    sta       ,u
-                    eorb      2,u
-                    stb       2,u
-                    ENDC
-L0635               rts
+                  ELSE
+                    ldd       #$8021    ; load D from #$8021
+                    eora      ,u        ; exclusive-OR A with ,u
+                    sta       ,u        ; store A at ,u
+                    eorb      2,u       ; exclusive-OR B with 2,u
+                    stb       2,u       ; store B at 2,u
+                  ENDC
+L0635               rts                 ; return to caller
 
 **************************************************
 * System Call: F$CRC
@@ -646,42 +646,42 @@ L0635               rts
 *
 * Error:  CC = C bit set; B = error code
 *
-FCRC                ldd       R$Y,u               get # bytes to do
-                    beq       L0677               nothing there, so nothing to do, return
-                    ldx       R$X,u               get caller's buffer pointer
-                    pshs      d,x                 save # bytes & buffer pointer
-                    leas      -3,s                allocate a 3 byte buffer
-                    ldx       <D.Proc             point to current process descriptor
-                    lda       P$Task,x            get its task number
-                    ldb       <D.SysTsk           get the system task number
-                    ldx       R$U,u               point to user's 24 bit CRC accumulator
-                    ldy       #3                  number of bytes to move
-                    leau      ,s                  point to our temp buffer
-                    pshs      d,x,y               save [D]=task #'s,[X]=Buff,[Y]=3
-                    lbsr      L0B2C               move CRC accumulator to temp buffer
-                    ldx       <D.Proc             point to current process descriptor
-                    leay      <P$DATImg,x         point to its DAT image
-                    ldx       11,s                restore the buffer pointer
-                    lbsr      AdjBlk0             make callers buffer visible
-                    IFNE      H6309
-                    ldw       9,s                 get byte count
-                    ENDC
-L065D               lbsr      LDAXY               get byte from callers buffer
-                    bsr       CRCCalc             add it to CRC
-                    IFNE      H6309
-                    decw                          done?
-                    ELSE
-                    ldd       9,s
-                    subd      #$0001
-                    std       9,s
-                    ENDC
-                    bne       L065D               no, keep going
-                    puls      d,x,y               restore pointers
-                    exg       a,b                 swap around the task numbers
-                    exg       x,u                 and the pointers
-                    lbsr      L0B2C               move accumulator back to user
-                    leas      7,s                 clean up stack
-L0677               clrb                          no error
-                    rts
+FCRC                ldd       R$Y,u     ; get # bytes to do
+                    beq       L0677     ; nothing there, so nothing to do, return
+                    ldx       R$X,u     ; get caller's buffer pointer
+                    pshs      d,x       ; save # bytes & buffer pointer
+                    leas      -3,s      ; allocate a 3 byte buffer
+                    ldx       <D.Proc   ; point to current process descriptor
+                    lda       P$Task,x  ; get its task number
+                    ldb       <D.SysTsk ; get the system task number
+                    ldx       R$U,u     ; point to user's 24 bit CRC accumulator
+                    ldy       #3        ; number of bytes to move
+                    leau      ,s        ; point to our temp buffer
+                    pshs      d,x,y     ; save [D]=task #'s,[X]=Buff,[Y]=3
+                    lbsr      L0B2C     ; move CRC accumulator to temp buffer
+                    ldx       <D.Proc   ; point to current process descriptor
+                    leay      <P$DATImg,x ; point to its DAT image
+                    ldx       11,s      ; restore the buffer pointer
+                    lbsr      AdjBlk0   ; make callers buffer visible
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       9,s       get byte count
+                  ENDC
+L065D               lbsr      LDAXY     ; get byte from callers buffer
+                    bsr       CRCCalc   ; add it to CRC
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decw                ; done?
+                  ELSE
+                    ldd       9,s       ; load D from 9,s
+                    subd      #$0001    ; subtract #$0001 from D
+                    std       9,s       ; store D at 9,s
+                  ENDC
+                    bne       L065D     ; no, keep going
+                    puls      d,x,y     ; restore pointers
+                    exg       a,b       ; swap around the task numbers
+                    exg       x,u       ; and the pointers
+                    lbsr      L0B2C     ; move accumulator back to user
+                    leas      7,s       ; clean up stack
+L0677               clrb                ; no error
+                    rts                 ; return to caller
 
-                    endc
+                  ENDC

--- a/level1/modules/kernel/fwait.asm
+++ b/level1/modules/kernel/fwait.asm
@@ -23,45 +23,45 @@
 ;;; A return from F$Wait with the carry bit set indicates failure; otherwise, the call functioned properly and the
 ;;; child's exit status resides in B.
 
-FWait          ldy       <D.Proc             get the current process descriptor
-               ldx       <D.PrcDBT           get the pointer to the process descriptor table
-               lda       P$CID,y             get the child ID of this process
-               bne       findchild@          branch this process has a child
-               comb                          else set the carry
-               ldb       #E$NoChld           and return an error that this process has no children
-               rts                           return to the caller
-findchild@     os9       F$Find64            find the process descriptor for the child
-               lda       P$State,y           get the state value
-               bita      #Dead               has the child terminated?
-               bne       terminated@         branch if so
-               lda       P$SID,y             else check if the child has siblings
-               bne       findchild@          branch if so
-               clr       R$A,u               clear the A register
-               ldx       <D.Proc             get the current process descriptor
-               orcc      #FIRQMask+IRQMask   mask interrupts
-               ldd       <D.WProcQ           get head wait queue pointer
-               std       P$Queue,x           and set the current process' queue pointer to it
-               stx       <D.WProcQ           store current process at the head of the wait queue
-               lbra      SetupReturn
-terminated@    ldx       <D.Proc             get the current process descriptor
-SignalProcess  lda       P$ID,y              get process ID in process descriptor
-               ldb       <P$Signal,y         and signal in process descriptor
-               std       R$A,u               save both to caller's D register
-               pshs      u,y,x,a             save registers
-_stk1A@        set       0
-_stk1X@        set       1
-_stk1Y@        set       3
-_stk1U@        set       5
-               leay      P$PID,x             get parent process ID
-               ldx       <D.PrcDBT           and pointer to process descriptor table
-               bra       looptop@            branch to the top of the search loop
+FWait               ldy       <D.Proc   ; get the current process descriptor
+                    ldx       <D.PrcDBT ; get the pointer to the process descriptor table
+                    lda       P$CID,y   ; get the child ID of this process
+                    bne       findchild@ ; branch this process has a child
+                    comb                ; else set the carry
+                    ldb       #E$NoChld ; and return an error that this process has no children
+                    rts                 ; return to the caller
+findchild@          os9       F$Find64  ; find the process descriptor for the child
+                    lda       P$State,y ; get the state value
+                    bita      #Dead     ; has the child terminated?
+                    bne       terminated@ ; branch if so
+                    lda       P$SID,y   ; else check if the child has siblings
+                    bne       findchild@ ; branch if so
+                    clr       R$A,u     ; clear the A register
+                    ldx       <D.Proc   ; get the current process descriptor
+                    orcc      #FIRQMask+IRQMask ; mask interrupts
+                    ldd       <D.WProcQ ; get head wait queue pointer
+                    std       P$Queue,x ; and set the current process' queue pointer to it
+                    stx       <D.WProcQ ; store current process at the head of the wait queue
+                    lbra      SetupReturn ; branch unconditionally to SetupReturn
+terminated@         ldx       <D.Proc   ; get the current process descriptor
+SignalProcess       lda       P$ID,y    ; get process ID in process descriptor
+                    ldb       <P$Signal,y ; and signal in process descriptor
+                    std       R$A,u     ; save both to caller's D register
+                    pshs      u,y,x,a   ; save registers
+_stk1A@             set       0         ; define assembler symbol
+_stk1X@             set       1         ; define assembler symbol
+_stk1Y@             set       3         ; define assembler symbol
+_stk1U@             set       5         ; define assembler symbol
+                    leay      P$PID,x   ; get parent process ID
+                    ldx       <D.PrcDBT ; and pointer to process descriptor table
+                    bra       looptop@  ; branch to the top of the search loop
 * Find the process
-loop@          os9       F$Find64            find the process descriptor
-looptop@       lda       P$SID,y             get that process' sibling ID
-               cmpa      _stk1A@,s           is it the same as the one we're looking for?
-               bne       loop@               if not, go get the next one
-               ldu       _stk1Y@,s           get process descriptor saved earlier on the stack
-               ldb       P$SID,u             get the sibling ID from the previous process descriptor
-               stb       P$SID,y             save and store it in the next sibling
-               os9       F$Ret64             return the process descriptor to the free pool
-               puls      pc,u,y,x,a          pull all registers and return to the caller
+loop@               os9       F$Find64  ; find the process descriptor
+looptop@            lda       P$SID,y   ; get that process' sibling ID
+                    cmpa      _stk1A@,s ; is it the same as the one we're looking for?
+                    bne       loop@     ; if not, go get the next one
+                    ldu       _stk1Y@,s ; get process descriptor saved earlier on the stack
+                    ldb       P$SID,u   ; get the sibling ID from the previous process descriptor
+                    stb       P$SID,y   ; save and store it in the next sibling
+                    os9       F$Ret64   ; return the process descriptor to the free pool
+                    puls      pc,u,y,x,a ; pull all registers and return to the caller

--- a/level1/modules/kernel/iocall.asm
+++ b/level1/modules/kernel/iocall.asm
@@ -1,20 +1,20 @@
-IOMgr          fcs       /IOMAN/
+IOMgr               fcs       /IOMAN/
 
-IOCall                   
-               pshs      u,y,x,b,a           save off registers
-               ldu       <D.Init             get pointer to the init module
-               bsr       link@               link to IOMan
-               bcc       callit@             jump into IOMan if it exists
-               bsr       LoadBoot            else attempt to load the bootfile
-               bcs       ex@                 problem booting... return w/ error
-               bsr       link@               ok, NOW link to IOMan
-               bcs       ex@                 still a problem...
-callit@        jsr       ,y                  call into IOMan
-               puls      u,y,x,b,a           restore registers
-               ldx       -2,y                get the location to jump
-               jmp       ,x                  and jump
-ex@            puls      pc,u,y,x,b,a        else restore registers and return
-link@          leax      IOMgr,pcr           point to the IO manager module name
-               lda       #Systm+Objct        it should be a system/object module
-               os9       F$Link              link to it
-               rts                           return if there was an error
+IOCall
+                    pshs      u,y,x,b,a ; save off registers
+                    ldu       <D.Init   ; get pointer to the init module
+                    bsr       link@     ; link to IOMan
+                    bcc       callit@   ; jump into IOMan if it exists
+                    bsr       LoadBoot  ; else attempt to load the bootfile
+                    bcs       ex@       ; problem booting... return w/ error
+                    bsr       link@     ; ok, NOW link to IOMan
+                    bcs       ex@       ; still a problem...
+callit@             jsr       ,y        ; call into IOMan
+                    puls      u,y,x,b,a ; restore registers
+                    ldx       -2,y      ; get the location to jump
+                    jmp       ,x        ; and jump
+ex@                 puls      pc,u,y,x,b,a ; else restore registers and return
+link@               leax      IOMgr,pcr ; point to the IO manager module name
+                    lda       #Systm+Objct ; it should be a system/object module
+                    os9       F$Link    ; link to it
+                    rts                 ; return if there was an error

--- a/level1/modules/kernel/krn.asm
+++ b/level1/modules/kernel/krn.asm
@@ -66,19 +66,19 @@
                     nam       krn
                     ttl       NitrOS-9 Level 1 Kernel
 
-                    use       defsfile
+                    use       defsfile  ; include source file defsfile
 
-tylg                set       Systm+Objct
-atrv                set       ReEnt+rev
-rev                 set       $00
-edition             set       16
+tylg                set       Systm+Objct ; define assembler symbol
+atrv                set       ReEnt+rev ; define assembler symbol
+rev                 set       $00       ; define assembler symbol
+edition             set       16        ; define assembler symbol
 
-ModTop              mod       eom,name,tylg,atrv,OS9Cold,size
+ModTop              mod       eom,name,tylg,atrv,OS9Cold,size ; define OS-9 module header
 
-size                equ       .
+size                equ       .         ; define assembler symbol
 
 name                fcs       /Krn/
-                    fcb       edition
+                    fcb       edition   ; define byte value(s) edition
 
 **************************
 * Kernel entry point
@@ -86,11 +86,11 @@ name                fcs       /Krn/
 * Entry (Wildbits Port):
 *     X = The starting address of the bootfile.
 *     Y = The size of the bootfile in bytes.
-OS9Cold             equ       *
-                    orcc      #IntMasks           mask interrupts
-                    lds       #$500               set the system stack
-                    ifne      wildbits
-*>>>>>>>>>> Wildbits port
+OS9Cold             equ       *         ; define assembler symbol
+                    orcc      #IntMasks ; mask interrupts
+                    lds       #$500     ; set the system stack
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+*[[[ Wildbits port
 * In RAM mode, the Wildbits memory map looks like this:
 *    $0000-$1FFF - RAM at $000000-$001FFF
 *    $2000-$3FFF - RAM at $002000-$003FFF
@@ -101,198 +101,198 @@ OS9Cold             equ       *
 *    $C000-$DFFF - RAM at $00C000-$00DFFF
 *    $E000-$FFFF - RAM at $00E000-$00FFFF
 * Wildbits-specific initialization to get the Wildbits to a sane state.
-                    pshs      x,y                 save the bootfile pointer and size
-                    lda       #$FF                A = $FF
-                    sta       INT_MASK_0          mask all set 0 interrupts
-                    sta       INT_MASK_1          mask all set 1 interrupts
-                    sta       INT_PENDING_0       clear any pending set 0 interrupts
-                    sta       INT_PENDING_1       clear any pending set 0 interrupts
-*<<<<<<<<<< Wildbits port
-                    endc
+                    pshs      x,y       ; save the bootfile pointer and size
+                    lda       #$FF      ; A = $FF
+                    sta       INT_MASK_0 ; mask all set 0 interrupts
+                    sta       INT_MASK_1 ; mask all set 1 interrupts
+                    sta       INT_PENDING_0 ; clear any pending set 0 interrupts
+                    sta       INT_PENDING_1 ; clear any pending set 0 interrupts
+*]]] Wildbits port
+                  ENDC
 
 * Clear out system globals from $0000-$0400.
-                    ldx       #$0000              start clearing memory at $0000
-                    ldy       #$0400              get the number of bytes to clear
-                    clra                          clear A
-                    clrb                          clear B (D now $0000)
-                    tfr       b,dp                transfer to DP
-loop@               std       ,x++                save off at X and increment
-                    leay      -2,y                decrement counter
-                    bne       loop@               continue if not zero
+                    ldx       #$0000    ; start clearing memory at $0000
+                    ldy       #$0400    ; get the number of bytes to clear
+                    clra                ; clear A
+                    clrb                ; clear B (D now $0000)
+                    tfr       b,dp      ; transfer to DP
+loop@               std       ,x++      ; save off at X and increment
+                    leay      -2,y      ; decrement counter
+                    bne       loop@     ; continue if not zero
 
 * Set up the system globals area.
-                    inca                          D = $100
-                    inca                          D = $200
-                    std       <D.FMBM             $200 = start of the free memory bitmap
-                    addb      #$20                D = $220
-                    std       <D.FMBM+2           $220 = end of the free memory bitmap
-                    addb      #$02                D = $222
-                    std       <D.SysDis           $222 = address of the system dispatch table
-                    addb      #$70                D = $292
-                    std       <D.UsrDis           $292 = address of the user dispatch table
-                    clrb                          D = $200
-                    inca                          D = $300
-                    std       <D.ModDir           $300 = module directory starting address
-                    stx       <D.ModDir+2         X = $400 = module directory ending address
+                    inca                ; D = $100
+                    inca                ; D = $200
+                    std       <D.FMBM   ; $200 = start of the free memory bitmap
+                    addb      #$20      ; D = $220
+                    std       <D.FMBM+2 ; $220 = end of the free memory bitmap
+                    addb      #$02      ; D = $222
+                    std       <D.SysDis ; $222 = address of the system dispatch table
+                    addb      #$70      ; D = $292
+                    std       <D.UsrDis ; $292 = address of the user dispatch table
+                    clrb                ; D = $200
+                    inca                ; D = $300
+                    std       <D.ModDir ; $300 = module directory starting address
+                    stx       <D.ModDir+2 ; X = $400 = module directory ending address
 
 * This routine checks for RAM by writing a pattern at an address
 * then reading it back for validation. It may not be needed, so it's
 * conditionalized.
-                    ifne      CHECK_FOR_VALID_RAM
-*>>>>>>>>>> CHECK_FOR_VALID_RAM
-                    ifne      wildbits
-*>>>>>>>>>> Wildbits port
-                    ldx       ,s                  get start of bootfile
-*<<<<<<<<<< Wildbits port
-                    else
-*>>>>>>>>>> NOT(Wildbits port)
+                  IFNE    CHECK_FOR_VALID_RAM ; begin conditional assembly for CHECK_FOR_VALID_RAM
+*[[[ CHECK_FOR_VALID_RAM
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+*[[[ Wildbits port
+                    ldx       ,s        ; get start of bootfile
+*]]] Wildbits port
+                  ELSE
+*[[[ NOT(Wildbits port)
 * Check for valid RAM starting at $400
-                    ldx       #Bt.Start           end at bootfile start
-*<<<<<<<<<< NOT(Wildbits port)
-                    endc
-                    pshs      x                   save it on the stack
-ChkRAM              leay      ,x                  point Y to X ($400)
-                    ldd       ,y                  store org contents in D
-                    ldx       #$00FF              set X to pattern to write
-                    stx       ,y                  write pattern to ,Y
-                    cmpx      ,y                  same as what we wrote?
-                    bne       EndOfRAM@           nope, not RAM here!
-                    ldx       #$FF00              try different pattern
-                    stx       ,y                  write it to ,Y
-                    cmpx      ,y                  same as what we wrote?
-                    bne       EndOfRAM@           nope, not RAM here!
-                    std       ,y                  else restore org contents
-                    leax      >$0100,y            check top of next 256 block
-                    cmpx      ,s                  stop short kernel
-                    bcs       ChkRAM              branch if not done
-                    leay      ,x                  point Y to X (end of RAM)
-EndOfRAM@           leax      ,y                  X = end of RAM
-                    leas      2,s
-*<<<<<<<<<< CHECK_FOR_VALID_RAM
-                    else
-*>>>>>>>>>> NOT(CHECK_FOR_VALID_RAM)
-                    ifne      wildbits
-*>>>>>>>>>> Wildbits port
+                    ldx       #Bt.Start ; end at bootfile start
+*]]] NOT(Wildbits port)
+                  ENDC
+                    pshs      x         ; save it on the stack
+ChkRAM              leay      ,x        ; point Y to X ($400)
+                    ldd       ,y        ; store org contents in D
+                    ldx       #$00FF    ; set X to pattern to write
+                    stx       ,y        ; write pattern to ,Y
+                    cmpx      ,y        ; same as what we wrote?
+                    bne       EndOfRAM@ ; nope, not RAM here!
+                    ldx       #$FF00    ; try different pattern
+                    stx       ,y        ; write it to ,Y
+                    cmpx      ,y        ; same as what we wrote?
+                    bne       EndOfRAM@ ; nope, not RAM here!
+                    std       ,y        ; else restore org contents
+                    leax      >$0100,y  ; check top of next 256 block
+                    cmpx      ,s        ; stop short kernel
+                    bcs       ChkRAM    ; branch if not done
+                    leay      ,x        ; point Y to X (end of RAM)
+EndOfRAM@           leax      ,y        ; X = end of RAM
+                    leas      2,s       ; adjust stack pointer by 2,s
+*]]] CHECK_FOR_VALID_RAM
+                  ELSE
+*[[[ NOT(CHECK_FOR_VALID_RAM)
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+*[[[ Wildbits port
 * NOTE: Krn must be the FIRST module in the bootlist.
-                    puls      x                   get bootfile start
-                    tfr       x,d                 transfer it to D
-                    addd      ,s++                add the bootfile length to D
-                    std       <D.BTHI             save as the bootfile high marker
-                    stx       <D.BTLO             and x as the bootfile low marker
-*<<<<<<<<<< Wildbits port
-                    else
-*>>>>>>>>>> NOT(Wildbits port)
+                    puls      x         ; get bootfile start
+                    tfr       x,d       ; transfer it to D
+                    addd      ,s++      ; add the bootfile length to D
+                    std       <D.BTHI   ; save as the bootfile high marker
+                    stx       <D.BTLO   ; and x as the bootfile low marker
+*]]] Wildbits port
+                  ELSE
+*[[[ NOT(Wildbits port)
 * Check for valid RAM starting at $400
-                    ldx       #Bt.Start           end at bootfile start
-*<<<<<<<<<< NOT(Wildbits port)
-*<<<<<<<<<< NOT(CHECK_FOR_VALID_RAM)
-                    endc
-                    endc
-                    stx       <D.MLIM             save off as the memory limit
+                    ldx       #Bt.Start ; end at bootfile start
+*]]] NOT(Wildbits port)
+*]]] NOT(CHECK_FOR_VALID_RAM)
+                  ENDC
+                  ENDC
+                    stx       <D.MLIM   ; save off as the memory limit
 
-                    ifne      wildbits
-*>>>>>>>>>> Wildbits port
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+*[[[ Wildbits port
 * X = top of Krn, so start searching for modules there.
-*<<<<<<<<<< Wildbits port
-                    endc
+*]]] Wildbits port
+                  ENDC
 
 * Copy vector code over to D.XSWI3 ($0100).
-                    pshs      x                   save off X
-                    leax      >VectCode,pcr       point X to vector code
-                    ldy       #D.XSWI3            point Y to vector base in low RAM
-                    ldb       #VectCSz            get size of vector code in B
-loop@               lda       ,x+                 get source byte
-                    sta       ,y+                 save in destination
-                    decb                          decrement counter
-                    bne       loop@               branch if not done
-                    puls      x                   recover the saved RAM upper limit
+                    pshs      x         ; save off X
+                    leax      >VectCode,pcr ; point X to vector code
+                    ldy       #D.XSWI3  ; point Y to vector base in low RAM
+                    ldb       #VectCSz  ; get size of vector code in B
+loop@               lda       ,x+       ; get source byte
+                    sta       ,y+       ; save in destination
+                    decb                ; decrement counter
+                    bne       loop@     ; branch if not done
+                    puls      x         ; recover the saved RAM upper limit
 
 * Atari has bootfile already in memory
-                    ifne      atari
-*>>>>>>>>>> ATARI LIBER809 port
+                  IFNE    atari   ; begin conditional assembly for atari
+*[[[ ATARI LIBER809 port
 * Flag that we've booted and that Boot Low starts appropriately.
-                    ldy       #$D000              Atari: I/O is at $D000-$D7FF
-                    inc       <D.Boot
-                    stx       <D.BTLO
-                    ldx       #$FFFF
-                    stx       <D.BTHI
-*<<<<<<<<<< ATARI LIBER809 port
-                    else
-                    ifne      corsham
-*>>>>>>>>>> CORSHAM port
-                    ldx       #Bt.Start
-                    ldy       #Bt.Start+Bt.Size-1
-*<<<<<<<<<< CORSHAM port
-                    else
-                    ifne      wildbits
-*>>>>>>>>>> Wildbits port
-                    ldy       #MappedIOStart      stop short of I/O area
-*<<<<<<<<<< Wildbits port
-                    else
-*>>>>>>>>>> NOT(ATARI LIBER809 port | CORSHAM port | Wildbits port)
-                    ldy       #Bt.Start+Bt.Size
-*<<<<<<<<<< NOT(ATARI LIBER809 port | CORSHAM port | Wildbits port)
-                    endc
-                    endc
-                    endc
+                    ldy       #$D000    ; atari: I/O is at $D000-$D7FF
+                    inc       <D.Boot   ; increment <D.Boot
+                    stx       <D.BTLO   ; store X at <D.BTLO
+                    ldx       #$FFFF    ; load X from #$FFFF
+                    stx       <D.BTHI   ; store X at <D.BTHI
+*]]] ATARI LIBER809 port
+                  ELSE
+                  IFNE    corsham ; begin conditional assembly for corsham
+*[[[ CORSHAM port
+                    ldx       #Bt.Start ; load X from #Bt.Start
+                    ldy       #Bt.Start+Bt.Size-1 ; load Y from #Bt.Start+Bt.Size-1
+*]]] CORSHAM port
+                  ELSE
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+*[[[ Wildbits port
+                    ldy       #MappedIOStart ; stop short of I/O area
+*]]] Wildbits port
+                  ELSE
+*[[[ NOT(ATARI LIBER809 port | CORSHAM port | Wildbits port)
+                    ldy       #Bt.Start+Bt.Size ; load Y from #Bt.Start+Bt.Size
+*]]] NOT(ATARI LIBER809 port | CORSHAM port | Wildbits port)
+                  ENDC
+                  ENDC
+                  ENDC
 
-                    lbsr      ValMods
+                    lbsr      ValMods   ; call local routine ValMods
 
 * Some platforms don't have contiguous RAM in the 64K address space due to "holes"
 * for areas such as I/O. For these platforms, we have to perform a separate
 * module scan to look for modules after those holes.
-                    ifne      atari
+                  IFNE    atari   ; begin conditional assembly for atari
 * Atari: look for more modules at $D800-$F3FF.
-*>>>>>>>>>> ATARI LIBER809 port
+*[[[ ATARI LIBER809 port
 * The next three lines reset the low memory and boot start areas so that we can use
 * free RAM above $8000. This code works because we just validated modules above and
 * the first module found above $8000 is the start of the bootfile.
-                    ldx       <D.ModDir           get the pointer to the module diretory
-                    ldx       ,x                  get the pointer to the first module entry
-                    stx       <D.MLIM             store its address as the low memory limit
-                    stx       <D.BTLO             and the bootfile low memory start
-                    ldx       #$D800              point to the area past I/O
-                    ldy       #$F400              and up to this
-                    lbsr      ValMods             validate mods here
-*<<<<<<<<<< ATARI LIBER809 port
-                    endc
+                    ldx       <D.ModDir ; get the pointer to the module diretory
+                    ldx       ,x        ; get the pointer to the first module entry
+                    stx       <D.MLIM   ; store its address as the low memory limit
+                    stx       <D.BTLO   ; and the bootfile low memory start
+                    ldx       #$D800    ; point to the area past I/O
+                    ldy       #$F400    ; and up to this
+                    lbsr      ValMods   ; validate mods here
+*]]] ATARI LIBER809 port
+                  ENDC
 
 * Copy vectors to system globals.
-                    leay      >Vectors,pcr        point Y to vectors
-                    leax      >ModTop,pcr         point X to top of the kernel
-                    pshs      x                   save off
-                    ldx       #D.SWI3             point X to vectors in system globals
-copy@               ldd       ,y++                get vector bytes
-                    addd      ,s                  add the kernel's module address
-                    std       ,x++                save off in system globals
-                    cmpx      #D.NMI              at the end?
-                    bls       copy@               branch if not
-                    leas      2,s                 restore stack
+                    leay      >Vectors,pcr ; point Y to vectors
+                    leax      >ModTop,pcr ; point X to top of the kernel
+                    pshs      x         ; save off
+                    ldx       #D.SWI3   ; point X to vectors in system globals
+copy@               ldd       ,y++      ; get vector bytes
+                    addd      ,s        ; add the kernel's module address
+                    std       ,x++      ; save off in system globals
+                    cmpx      #D.NMI    ; at the end?
+                    bls       copy@     ; branch if not
+                    leas      2,s       ; restore stack
 
 * Fill in more system globals.
-                    leax      >URtoSs,pcr         get address of user to system state routine
-                    stx       <D.URtoSs           store it in system globals
-                    leax      >UsrIRQ,pcr         get user state IRQ routine
-                    stx       <D.UsrIRQ           store it in system globals
-                    leax      >UsrSvc,pcr         get the user state service routine
-                    stx       <D.UsrSvc           store it in system globals
-                    leax      >SysIRQ,pcr         get the system state IRQ routine
-                    stx       <D.SysIRQ           store it in system globals
-                    stx       <D.SvcIRQ           and the IRQ sevice vector
-                    leax      >SysSvc,pcr         get the system state service routine
-                    stx       <D.SysSvc           store it in system globals
-                    stx       <D.SWI2             and in the SWI2 vector
-                    leax      DUMMY,pcr           get the DUMMY routine
-                    stx       <D.NMI              store it in the NMI vector
-                    leax      >Poll,pcr           get the default polling routine
-                    stx       <D.Poll             store it in system globals
-                    leax      >Clock,pcr          get the default tick generator routine
-                    stx       <D.Clock            store it in system globals
-                    stx       <D.AltIRQ           and in the alternate IRQ vector
+                    leax      >URtoSs,pcr ; get address of user to system state routine
+                    stx       <D.URtoSs ; store it in system globals
+                    leax      >UsrIRQ,pcr ; get user state IRQ routine
+                    stx       <D.UsrIRQ ; store it in system globals
+                    leax      >UsrSvc,pcr ; get the user state service routine
+                    stx       <D.UsrSvc ; store it in system globals
+                    leax      >SysIRQ,pcr ; get the system state IRQ routine
+                    stx       <D.SysIRQ ; store it in system globals
+                    stx       <D.SvcIRQ ; and the IRQ sevice vector
+                    leax      >SysSvc,pcr ; get the system state service routine
+                    stx       <D.SysSvc ; store it in system globals
+                    stx       <D.SWI2   ; and in the SWI2 vector
+                    leax      DUMMY,pcr ; get the DUMMY routine
+                    stx       <D.NMI    ; store it in the NMI vector
+                    leax      >Poll,pcr ; get the default polling routine
+                    stx       <D.Poll   ; store it in system globals
+                    leax      >Clock,pcr ; get the default tick generator routine
+                    stx       <D.Clock  ; store it in system globals
+                    stx       <D.AltIRQ ; and in the alternate IRQ vector
 
 * Install system calls.
-                    leay      >SysTbl,pcr         get the system call table address
-                    lbsr      InstallSvc          and install it
+                    leay      >SysTbl,pcr ; get the system call table address
+                    lbsr      InstallSvc ; and install it
 
 * Setup the free memory bitmap.
 * This area of the kernel is highly platform-dependent.
@@ -300,342 +300,342 @@ copy@               ldd       ,y++                get vector bytes
 * The free memory bitmap has the following structure:
 *   bit 7 of 0,x corresponds to page 0, bit 6 to page 1 etc.
 *   bit 7 of 1,x corresponds to page 8, bit 6 to page 9 etc.
-                    ldx       <D.FMBM             get free memory bitmap in X
-                    ifne      atari
-*>>>>>>>>>> ATARI LIBER809 port
+                    ldx       <D.FMBM   ; get free memory bitmap in X
+                  IFNE    atari   ; begin conditional assembly for atari
+*[[[ ATARI LIBER809 port
 * Atari needs $0000-$08FF and $D000-$D7FF reserved.
-                    ldb       #%11111111
-                    stb       ,x                  mark $0000-$07FF as allocated
-                    stb       $1A,x               mark $D000-$D7FF I/O area as allocated
-                    ldb       #%10000000
-                    stb       1,x                 mark $0800-$08FF as allocated
-*<<<<<<<<<< ATARI LIBER809 port
-                    else
-                    ifne      corsham
-*>>>>>>>>>> CORSHAM port
+                    ldb       #%11111111 ; load B from #%11111111
+                    stb       ,x        ; mark $0000-$07FF as allocated
+                    stb       $1A,x     ; mark $D000-$D7FF I/O area as allocated
+                    ldb       #%10000000 ; load B from #%10000000
+                    stb       1,x       ; mark $0800-$08FF as allocated
+*]]] ATARI LIBER809 port
+                  ELSE
+                  IFNE    corsham ; begin conditional assembly for corsham
+*[[[ CORSHAM port
 * Corsham needs $0000-$04FF and $E000-$EFFF reserved.
-                    ldb       #%11111000
-                    stb       ,x                  mark $0000-$04FF as allocated
-                    ldb       #%11111111
-                    stb       $1C,x               mark $E000-$E7FF I/O area as allocated
-                    stb       $1D,x               mark $E800-$EFFF I/O area as allocated
-*<<<<<<<<<< CORSHAM port
-                    else
-*>>>>>>>>>> NOT(ATARI LIBER809 port | CORSHAM port)
+                    ldb       #%11111000 ; load B from #%11111000
+                    stb       ,x        ; mark $0000-$04FF as allocated
+                    ldb       #%11111111 ; load B from #%11111111
+                    stb       $1C,x     ; mark $E000-$E7FF I/O area as allocated
+                    stb       $1D,x     ; mark $E800-$EFFF I/O area as allocated
+*]]] CORSHAM port
+                  ELSE
+*[[[ NOT(ATARI LIBER809 port | CORSHAM port)
 * All other ports need $0000-$04FF reserved.
-                    ldb       #%11111000
-                    stb       ,x                  mark $0000-$04FF as allocated
-*<<<<<<<<<< NOT(ATARI LIBER809 port | CORSHAM port)
-                    endc
-                    endc
+                    ldb       #%11111000 ; load B from #%11111000
+                    stb       ,x        ; mark $0000-$04FF as allocated
+*]]] NOT(ATARI LIBER809 port | CORSHAM port)
+                  ENDC
+                  ENDC
 
 * Exclude high memory as defined (earlier) by D.MLIM.
-                    clra                          A = 0
-                    ldb       <D.MLIM             B = upper byte of 16 bit memory limit
-                    negb                          negate B
-                    tfr       d,y                 transfer D to Y (Y = the number of bits to set)
-                    negb                          negate B (D = the number of the first bit to set)
-                    lbsr      AllocBit            call into F$AllBit to allocate bits
+                    clra                ; A = 0
+                    ldb       <D.MLIM   ; B = upper byte of 16 bit memory limit
+                    negb                ; negate B
+                    tfr       d,y       ; transfer D to Y (Y = the number of bits to set)
+                    negb                ; negate B (D = the number of the first bit to set)
+                    lbsr      AllocBit  ; call into F$AllBit to allocate bits
 
 * Link to init module.
-                    lda       #Systm+0            we want a system module
-                    leax      >InitNam,pcr        point to the configuration module name
-                    os9       F$Link              link to it
-                    lbcs      OS9Cold             if error, restart kernel
-                    stu       <D.Init             else store it in system globals
-                    lda       Feature1,u          get feature byte 1
-                    bita      #CRCOn              is CRC checking on?
-                    beq       continue@           branch if not (already cleared earlier)
-                    inc       <D.CRC              else turn on CRC checking
+                    lda       #Systm+0  ; we want a system module
+                    leax      >InitNam,pcr ; point to the configuration module name
+                    os9       F$Link    ; link to it
+                    lbcs      OS9Cold   ; if error, restart kernel
+                    stu       <D.Init   ; else store it in system globals
+                    lda       Feature1,u ; get feature byte 1
+                    bita      #CRCOn    ; is CRC checking on?
+                    beq       continue@ ; branch if not (already cleared earlier)
+                    inc       <D.CRC    ; else turn on CRC checking
 continue@
 
 * Jump into krnp2 here
-                    leax      >P2Nam,pcr          point X to name of kernel part 2 module
-                    lda       #Systm+Objct        it should be System+Object code type/language
-                    os9       F$Link              link to it
-                    lbcs      OS9Cold             branch out if error (catastrophic)
-                    jmp       ,y                  else jump to code entry point in part 2 module
+                    leax      >P2Nam,pcr ; point X to name of kernel part 2 module
+                    lda       #Systm+Objct ; it should be System+Object code type/language
+                    os9       F$Link    ; link to it
+                    lbcs      OS9Cold   ; branch out if error (catastrophic)
+                    jmp       ,y        ; else jump to code entry point in part 2 module
 
-SWI3                pshs      pc,x,b              save off registers
-                    ldb       #P$SWI3             get P$SWI3
-                    bra       FixSWI              save it off in process descriptor
-SWI2                pshs      pc,x,b              save off registers again
-                    ldb       #P$SWI2             get P$SWI2
-                    bra       FixSWI              save it off in process descriptor
-SVCNMI              jmp       [>D.NMI]            jump to address in D.NMI
-DUMMY               rti                           return from interrupt
-SVCIRQ              jmp       [>D.SvcIRQ]         jump to service IRQ address
-SWI                 pshs      pc,x,b              save off registers
-                    ldb       #P$SWI              get P$SWI
-FixSWI              ldx       >D.Proc             get process descriptor
-                    ldx       b,x                 get SWI entry
-                    stx       3,s                 put in PC on stack
-                    puls      pc,x,b              restore registers and return
+SWI3                pshs      pc,x,b    ; save off registers
+                    ldb       #P$SWI3   ; get P$SWI3
+                    bra       FixSWI    ; save it off in process descriptor
+SWI2                pshs      pc,x,b    ; save off registers again
+                    ldb       #P$SWI2   ; get P$SWI2
+                    bra       FixSWI    ; save it off in process descriptor
+SVCNMI              jmp       [>D.NMI]  ; jump to address in D.NMI
+DUMMY               rti                 ; return from interrupt
+SVCIRQ              jmp       [>D.SvcIRQ] ; jump to service IRQ address
+SWI                 pshs      pc,x,b    ; save off registers
+                    ldb       #P$SWI    ; get P$SWI
+FixSWI              ldx       >D.Proc   ; get process descriptor
+                    ldx       b,x       ; get SWI entry
+                    stx       3,s       ; put in PC on stack
+                    puls      pc,x,b    ; restore registers and return
 
 * User state interrupt service routine entry.
-UsrIRQ              leay      <DoIRQPoll,pcr      point to the default IRQ polling routine
+UsrIRQ              leay      <DoIRQPoll,pcr ; point to the default IRQ polling routine
 * Transition from user to system state.
-URtoSs              clra                          clear A
-                    tfr       a,dp                and transfer to the direct page
-                    ldx       <D.Proc             get current process desc
+URtoSs              clra                ; clear A
+                    tfr       a,dp      ; and transfer to the direct page
+                    ldx       <D.Proc   ; get current process desc
 * The system state service routine address moves into the D.SWI2 vector.
 * That way, if a system call is made while we are in system state,
 * D.SWI2 is vectored to the system state service routine.
-                    ldd       <D.SysSvc           get system state system call vector
-                    std       <D.SWI2             store in D.SWI2
+                    ldd       <D.SysSvc ; get system state system call vector
+                    std       <D.SWI2   ; store in D.SWI2
 * The same comment above applies to the IRQ service vector.
-                    ldd       <D.SysIRQ           get system IRQ vector
-                    std       <D.SvcIRQ           store in D.SvcIRQ
-                    leau      ,s                  point U to S
-                    stu       P$SP,x              and save in process P$SP
-                    lda       P$State,x           get state field in proc desc
-                    ora       #SysState           mark process to be in system state
-                    sta       P$State,x           store it
-                    jmp       ,y                  jump to the polling routine
+                    ldd       <D.SysIRQ ; get system IRQ vector
+                    std       <D.SvcIRQ ; store in D.SvcIRQ
+                    leau      ,s        ; point U to S
+                    stu       P$SP,x    ; and save in process P$SP
+                    lda       P$State,x ; get state field in proc desc
+                    ora       #SysState ; mark process to be in system state
+                    sta       P$State,x ; store it
+                    jmp       ,y        ; jump to the polling routine
 
-DoIRQPoll           jsr       [>D.Poll]           call the interrupt polling routine
-                    bcc       go@                 branch if carry clear
-                    ldb       ,s                  get the CC on the stack
-                    orb       #IRQMask            mask IRQs
-                    stb       ,s                  and save it back
-go@                 lbra      ActivateProc        go activate the process
+DoIRQPoll           jsr       [>D.Poll] ; call the interrupt polling routine
+                    bcc       go@       ; branch if carry clear
+                    ldb       ,s        ; get the CC on the stack
+                    orb       #IRQMask  ; mask IRQs
+                    stb       ,s        ; and save it back
+go@                 lbra      ActivateProc ; go activate the process
 
 * System state interrupt service routine entry
-SysIRQ              clra                          clear A
-                    tfr       a,dp                and transfer it to the direct page
-                    jsr       [>D.Poll]           call the vectored IRQ polling routine
-                    bcc       ex@                 branch if carry is clear
-                    ldb       ,s                  get the CC on the stack
-                    orb       #IRQMask            mask IRQs
-                    stb       ,s                  and save it back
-ex@                 rti                           return from interrupt
+SysIRQ              clra                ; clear A
+                    tfr       a,dp      ; and transfer it to the direct page
+                    jsr       [>D.Poll] ; call the vectored IRQ polling routine
+                    bcc       ex@       ; branch if carry is clear
+                    ldb       ,s        ; get the CC on the stack
+                    orb       #IRQMask  ; mask IRQs
+                    stb       ,s        ; and save it back
+ex@                 rti                 ; return from interrupt
 
 * This is the default interrupt polling routine -- it does nothing.
-Poll                comb
-                    rts
+Poll                comb                ; update processor state
+                    rts                 ; return to caller
 
 * Here is the default clock routine which performs process queue management.
-Clock               ldx       <D.SProcQ           get pointer to sleeping proc queue
-                    beq       decslice@           branch if no process sleeping
-                    lda       P$State,x           get state of that process
-                    bita      #TimSleep           timed sleep?
-                    beq       decslice@           branch if clear
-                    ldu       P$SP,x              else get process stack pointer
-                    ldd       R$X,u               get the value of the process X reg
-                    subd      #$0001              subtract one from it
-                    std       R$X,u               and store it back
-                    bne       decslice@           branch if not zero (still will sleep)
-nextqentry@         ldu       P$Queue,x           get process current queue pointer
-                    bsr       SFAProc             activate the process
-                    leax      ,u                  point to the queue
-                    beq       saveit@             branch if empty
-                    lda       P$State,x           get process state byte
-                    bita      #TimSleep           bit set?
-                    beq       saveit@             branch if not
-                    ldu       P$SP,x              get process stack pointer
-                    ldd       R$X,u               then get process X register
-                    beq       nextqentry@         branch if zero
-saveit@             stx       <D.SProcQ           save in the sleep queue
-decslice@           dec       <D.Slice            decrement slice
-                    bne       ex@                 if not 0, exit ISR
-                    lda       <D.TSlice           else get default time slice
-                    sta       <D.Slice            and save it as slice
-                    ldx       <D.Proc             get proc desc of current proc
-                    beq       ex@                 if none, exit ISR
-                    lda       P$State,x           get process state
-                    ora       #TimOut             set timeout bit
-                    sta       P$State,x           and store back
-                    bpl       gosys@              branch if not system state
-ex@                 rti                           return from the interrupt
-gosys@              leay      >ActivateProc,pcr   point Y to activate process routine
-                    bra       URtoSs              go to system state
+Clock               ldx       <D.SProcQ ; get pointer to sleeping proc queue
+                    beq       decslice@ ; branch if no process sleeping
+                    lda       P$State,x ; get state of that process
+                    bita      #TimSleep ; timed sleep?
+                    beq       decslice@ ; branch if clear
+                    ldu       P$SP,x    ; else get process stack pointer
+                    ldd       R$X,u     ; get the value of the process X reg
+                    subd      #$0001    ; subtract one from it
+                    std       R$X,u     ; and store it back
+                    bne       decslice@ ; branch if not zero (still will sleep)
+nextqentry@         ldu       P$Queue,x ; get process current queue pointer
+                    bsr       SFAProc   ; activate the process
+                    leax      ,u        ; point to the queue
+                    beq       saveit@   ; branch if empty
+                    lda       P$State,x ; get process state byte
+                    bita      #TimSleep ; bit set?
+                    beq       saveit@   ; branch if not
+                    ldu       P$SP,x    ; get process stack pointer
+                    ldd       R$X,u     ; then get process X register
+                    beq       nextqentry@ ; branch if zero
+saveit@             stx       <D.SProcQ ; save in the sleep queue
+decslice@           dec       <D.Slice  ; decrement slice
+                    bne       ex@       ; if not 0, exit ISR
+                    lda       <D.TSlice ; else get default time slice
+                    sta       <D.Slice  ; and save it as slice
+                    ldx       <D.Proc   ; get proc desc of current proc
+                    beq       ex@       ; if none, exit ISR
+                    lda       P$State,x ; get process state
+                    ora       #TimOut   ; set timeout bit
+                    sta       P$State,x ; and store back
+                    bpl       gosys@    ; branch if not system state
+ex@                 rti                 ; return from the interrupt
+gosys@              leay      >ActivateProc,pcr ; point Y to activate process routine
+                    bra       URtoSs    ; go to system state
 
-                    use       faproc.asm
+                    use       faproc.asm ; include source file faproc.asm
 
 * User state system call entry point.
 *
 * All system calls made from user state go through this code.
-UsrSvc              leay      <MakeSysCall,pcr    point Y to make system call routine
-                    orcc      #IntMasks           mask interrupts
-                    lbra      URtoSs              go to system state
+UsrSvc              leay      <MakeSysCall,pcr ; point Y to make system call routine
+                    orcc      #IntMasks ; mask interrupts
+                    lbra      URtoSs    ; go to system state
 
-MakeSysCall         andcc     #^IntMasks          unmask interrupts
-                    ldy       <D.UsrDis           get pointer to user system call dispatch table
-                    bsr       DoSysCall           go do the system call
-ActivateProc        ldx       <D.Proc             get current proc desc
-                    beq       FNProc              branch to FNProc if none
-                    orcc      #IntMasks           mask interrupts
-                    ldb       P$State,x           get state value in proc desc
-                    andb      #^SysState          turn off system state flag
-                    stb       P$State,x           save state value
-                    bitb      #TimOut             timeout bit set?
-                    beq       CheckState          branch if not
-                    andb      #^TimOut            else turn off bit
-                    stb       P$State,x           in state value
-                    bsr       SFAProc
-                    bra       FNProc              next process
+MakeSysCall         andcc     #^IntMasks ; unmask interrupts
+                    ldy       <D.UsrDis ; get pointer to user system call dispatch table
+                    bsr       DoSysCall ; go do the system call
+ActivateProc        ldx       <D.Proc   ; get current proc desc
+                    beq       FNProc    ; branch to FNProc if none
+                    orcc      #IntMasks ; mask interrupts
+                    ldb       P$State,x ; get state value in proc desc
+                    andb      #^SysState ; turn off system state flag
+                    stb       P$State,x ; save state value
+                    bitb      #TimOut   ; timeout bit set?
+                    beq       CheckState ; branch if not
+                    andb      #^TimOut  ; else turn off bit
+                    stb       P$State,x ; in state value
+                    bsr       SFAProc   ; call local routine SFAProc
+                    bra       FNProc    ; next process
 
 * System state system call entry point.
 *
 * All system calls made from system state go through this code.
-SysSvc              clra                          A = 0
-                    tfr       a,dp                set direct page to 0
-                    leau      ,s                  point U to SP
-                    ldy       <D.SysDis           get system state dispatch table ptr
-                    bsr       DoSysCall           perform the system call
-                    rti                           return
+SysSvc              clra                ; A = 0
+                    tfr       a,dp      ; set direct page to 0
+                    leau      ,s        ; point U to SP
+                    ldy       <D.SysDis ; get system state dispatch table ptr
+                    bsr       DoSysCall ; perform the system call
+                    rti                 ; return
 
 * This is the common system call entry point for user and system state.
 *
 * Entry: Y = The dispatch table (user or system).
 *        U = The caller's register pointer.
-DoSysCall           pshs      u                   save off caller's register pointer
-                    ldx       R$PC,u              point X to PC
-                    ldb       ,x+                 get func code at X
-                    stx       R$PC,u              restore updated PC
-                    lslb                          high bit set?
-                    bcc       nonio@              branch if not (non I/O call)
-                    rorb                          else restore B (its an I/O call)
-                    ldx       -2,y                grab IOMan vector
-                    beq       callexit@           just exit if IOMan vector is empty
-                    bra       execcall@           make system call
-nonio@              cmpb      #$37*2              non-IO call; are we in safe are?
-                    bcc       callerr@            branch if not (unknown service)
-                    ldx       b,y                 X = address of system call
-                    beq       callerr@            if nil, unknown service
-execcall@           jsr       ,x                  jsr into system call
-callexit@           puls      u                   recover caller's registers
-                    tfr       cc,a                get CC into A
-                    bcc       FixCC               branch if no error
-                    stb       R$B,u               store error code
-FixCC               ldb       R$CC,u              get caller's CC
-                    andb      #^(Negative+Zero+TwosOvfl+Carry) turn off these flags
-                    stb       R$CC,u              save to caller's CC
-                    anda      #Negative+Zero+TwosOvfl+Carry turn off these flags
-                    ora       R$CC,u              OR with caller's CC
-                    sta       R$CC,u              and saved to caller's CC
-                    rts                           return
-callerr@            comb                          set carry for error state
-                    ldb       #E$UnkSvc           unknown service
-                    bra       callexit@           perform exit
+DoSysCall           pshs      u         ; save off caller's register pointer
+                    ldx       R$PC,u    ; point X to PC
+                    ldb       ,x+       ; get func code at X
+                    stx       R$PC,u    ; restore updated PC
+                    lslb                ; high bit set?
+                    bcc       nonio@    ; branch if not (non I/O call)
+                    rorb                ; else restore B (its an I/O call)
+                    ldx       -2,y      ; grab IOMan vector
+                    beq       callexit@ ; just exit if IOMan vector is empty
+                    bra       execcall@ ; make system call
+nonio@              cmpb      #$37*2    ; non-IO call; are we in safe are?
+                    bcc       callerr@  ; branch if not (unknown service)
+                    ldx       b,y       ; X = address of system call
+                    beq       callerr@  ; if nil, unknown service
+execcall@           jsr       ,x        ; jsr into system call
+callexit@           puls      u         ; recover caller's registers
+                    tfr       cc,a      ; get CC into A
+                    bcc       FixCC     ; branch if no error
+                    stb       R$B,u     ; store error code
+FixCC               ldb       R$CC,u    ; get caller's CC
+                    andb      #^(Negative+Zero+TwosOvfl+Carry) ; turn off these flags
+                    stb       R$CC,u    ; save to caller's CC
+                    anda      #Negative+Zero+TwosOvfl+Carry ; turn off these flags
+                    ora       R$CC,u    ; oR with caller's CC
+                    sta       R$CC,u    ; and saved to caller's CC
+                    rts                 ; return
+callerr@            comb                ; set carry for error state
+                    ldb       #E$UnkSvc ; unknown service
+                    bra       callexit@ ; perform exit
 
-                    use       fnproc.asm
-                    use       flink.asm
-                    use       fvmodul.asm
-                    use       fcrc.asm
-                    use       ffork.asm
-                    use       fchain.asm
-                    use       fsrqmem.asm
-                    use       fallbit.asm
-                    use       fprsnam.asm
-                    use       fcmpnam.asm
-                    use       fssvc.asm
+                    use       fnproc.asm ; include source file fnproc.asm
+                    use       flink.asm ; include source file flink.asm
+                    use       fvmodul.asm ; include source file fvmodul.asm
+                    use       fcrc.asm  ; include source file fcrc.asm
+                    use       ffork.asm ; include source file ffork.asm
+                    use       fchain.asm ; include source file fchain.asm
+                    use       fsrqmem.asm ; include source file fsrqmem.asm
+                    use       fallbit.asm ; include source file fallbit.asm
+                    use       fprsnam.asm ; include source file fprsnam.asm
+                    use       fcmpnam.asm ; include source file fcmpnam.asm
+                    use       fssvc.asm ; include source file fssvc.asm
 
 * Validate modules in memory.
 *
 * Entry: X = The address to start searching.
 *        Y = The address to stop (actually stops at Y-1).
-ValMods             pshs      y                   save off Y
-loop@               lbsr      ValMod              go validate module
-                    bcs       ValErr              branch if error
-                    ldd       M$Size,x            get size of module into D
-                    leax      d,x                 point X past module
-                    bra       valcheck            go check if we're at end
-ValErr              cmpb      #E$KwnMod           did the validation check show a known module?
-                    beq       ex@                 branch if so
-                    leax      1,x                 else advance X by one byte
-valcheck            cmpx      ,s                  check if we're at end
-                    bcs       loop@               branch if not
-ex@                 puls      y,pc                restore Y and return
+ValMods             pshs      y         ; save off Y
+loop@               lbsr      ValMod    ; go validate module
+                    bcs       ValErr    ; branch if error
+                    ldd       M$Size,x  ; get size of module into D
+                    leax      d,x       ; point X past module
+                    bra       valcheck  ; go check if we're at end
+ValErr              cmpb      #E$KwnMod ; did the validation check show a known module?
+                    beq       ex@       ; branch if so
+                    leax      1,x       ; else advance X by one byte
+valcheck            cmpx      ,s        ; check if we're at end
+                    bcs       loop@     ; branch if not
+ex@                 puls      y,pc      ; restore Y and return
 
 * This vector code that the kernel copies to low RAM ($0100).
-VectCode            bra       SWI3Jmp             $0100
-                    nop
-                    bra       SWI2Jmp             $0103
-                    nop
-                    bra       SWIJmp              $0106
-                    nop
-                    bra       NMIJmp              $0109
-                    nop
-                    bra       IRQJmp              $010C
-                    nop
-                    bra       FIRQJmp             $010F
-SWI3Jmp             jmp       [>D.SWI3]
-SWI2Jmp             jmp       [>D.SWI2]
-SWIJmp              jmp       [>D.SWI]
-NMIJmp              jmp       [>D.NMI]
-IRQJmp              jmp       [>D.IRQ]
-FIRQJmp             jmp       [>D.FIRQ]
-VectCSz             equ       *-VectCode
+VectCode            bra       SWI3Jmp   ; $0100
+                    nop       ;         no operation placeholder
+                    bra       SWI2Jmp   ; $0103
+                    nop       ;         no operation placeholder
+                    bra       SWIJmp    ; $0106
+                    nop       ;         no operation placeholder
+                    bra       NMIJmp    ; $0109
+                    nop       ;         no operation placeholder
+                    bra       IRQJmp    ; $010C
+                    nop       ;         no operation placeholder
+                    bra       FIRQJmp   ; $010F
+SWI3Jmp             jmp       [>D.SWI3] ; transfer control to [>D.SWI3]
+SWI2Jmp             jmp       [>D.SWI2] ; transfer control to [>D.SWI2]
+SWIJmp              jmp       [>D.SWI]  ; transfer control to [>D.SWI]
+NMIJmp              jmp       [>D.NMI]  ; transfer control to [>D.NMI]
+IRQJmp              jmp       [>D.IRQ]  ; transfer control to [>D.IRQ]
+FIRQJmp             jmp       [>D.FIRQ] ; transfer control to [>D.FIRQ]
+VectCSz             equ       *-VectCode ; define assembler symbol
 
 
 * The system call table.
-SysTbl              fcb       F$Link
-                    fdb       FLink-*-2
-                    fcb       F$Fork
-                    fdb       FFork-*-2
-                    fcb       F$Chain
-                    fdb       FChain-*-2
-                    fcb       F$Chain+SysState
-                    fdb       SFChain-*-2
-                    fcb       F$PrsNam
-                    fdb       FPrsNam-*-2
-                    fcb       F$CmpNam
-                    fdb       FCmpNam-*-2
-                    fcb       F$SchBit
-                    fdb       FSchBit-*-2
-                    fcb       F$AllBit
-                    fdb       FAllBit-*-2
-                    fcb       F$DelBit
-                    fdb       FDelBit-*-2
-                    fcb       F$CRC
-                    fdb       FCRC-*-2
-                    fcb       F$SRqMem+SysState
-                    fdb       FSRqMem-*-2
-                    fcb       F$SRtMem+SysState
-                    fdb       FSRtMem-*-2
-                    fcb       F$AProc+SysState
-                    fdb       FAProc-*-2
-                    fcb       F$NProc+SysState
-                    fdb       FNProc-*-2
-                    fcb       F$VModul+SysState
-                    fdb       FVModul-*-2
-                    fcb       F$SSvc
-                    fdb       FSSvc-*-2
-                    fcb       $80
+SysTbl              fcb       F$Link    ; define byte value(s) F$Link
+                    fdb       FLink-*-2 ; define word value(s) FLink-*-2
+                    fcb       F$Fork    ; define byte value(s) F$Fork
+                    fdb       FFork-*-2 ; define word value(s) FFork-*-2
+                    fcb       F$Chain   ; define byte value(s) F$Chain
+                    fdb       FChain-*-2 ; define word value(s) FChain-*-2
+                    fcb       F$Chain+SysState ; define byte value(s) F$Chain+SysState
+                    fdb       SFChain-*-2 ; define word value(s) SFChain-*-2
+                    fcb       F$PrsNam  ; define byte value(s) F$PrsNam
+                    fdb       FPrsNam-*-2 ; define word value(s) FPrsNam-*-2
+                    fcb       F$CmpNam  ; define byte value(s) F$CmpNam
+                    fdb       FCmpNam-*-2 ; define word value(s) FCmpNam-*-2
+                    fcb       F$SchBit  ; define byte value(s) F$SchBit
+                    fdb       FSchBit-*-2 ; define word value(s) FSchBit-*-2
+                    fcb       F$AllBit  ; define byte value(s) F$AllBit
+                    fdb       FAllBit-*-2 ; define word value(s) FAllBit-*-2
+                    fcb       F$DelBit  ; define byte value(s) F$DelBit
+                    fdb       FDelBit-*-2 ; define word value(s) FDelBit-*-2
+                    fcb       F$CRC     ; define byte value(s) F$CRC
+                    fdb       FCRC-*-2  ; define word value(s) FCRC-*-2
+                    fcb       F$SRqMem+SysState ; define byte value(s) F$SRqMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                    fcb       F$SRtMem+SysState ; define byte value(s) F$SRtMem+SysState
+                    fdb       FSRtMem-*-2 ; define word value(s) FSRtMem-*-2
+                    fcb       F$AProc+SysState ; define byte value(s) F$AProc+SysState
+                    fdb       FAProc-*-2 ; define word value(s) FAProc-*-2
+                    fcb       F$NProc+SysState ; define byte value(s) F$NProc+SysState
+                    fdb       FNProc-*-2 ; define word value(s) FNProc-*-2
+                    fcb       F$VModul+SysState ; define byte value(s) F$VModul+SysState
+                    fdb       FVModul-*-2 ; define word value(s) FVModul-*-2
+                    fcb       F$SSvc    ; define byte value(s) F$SSvc
+                    fdb       FSSvc-*-2 ; define word value(s) FSSvc-*-2
+                    fcb       $80       ; define byte value(s) $80
 
 InitNam             fcs       /Init/
 
 P2Nam               fcs       /krnp2/
 
-EOMTop              equ       *
+EOMTop              equ       *         ; define assembler symbol
 
-                    ifeq      corsham+wildbits
-*>>>>>>>>>> NOT(CORSHAM port | Wildbits port)
+                  IFEQ    corsham+wildbits ; begin conditional assembly for corsham+wildbits
+*[[[ NOT(CORSHAM port | Wildbits port)
                     emod
-eom                 equ       *
-*<<<<<<<<<< NOT(CORSHAM port | Wildbits port)
-                    endc
+eom                 equ       *         ; define assembler symbol
+*]]] NOT(CORSHAM port | Wildbits port)
+                  ENDC
 
-Vectors		        fdb	       SWI3		SWI3
-                    fdb	       SWI2		SWI2
-                    fdb	       DUMMY		FIRQ
-                    fdb	       SVCIRQ		IRQ
-                    fdb	       SWI		SWI
-                    fdb	       SVCNMI		NMI
+Vectors             fdb       SWI3      ; sWI3
+                    fdb       SWI2      ; sWI2
+                    fdb       DUMMY     ; fIRQ
+                    fdb       SVCIRQ    ; iRQ
+                    fdb       SWI       ; sWI
+                    fdb       SVCNMI    ; nMI
 
-                    ifne      atari
-*>>>>>>>>>> ATARI LIBER809 port
-                    fdb       $F3FE-(*-OS9Cold)
-*<<<<<<<<<< ATARI LIBER809 port
-                    endc
-                    
-                    ifne      corsham+wildbits
-*>>>>>>>>>> CORSHAM port | Wildbits port
+                  IFNE    atari   ; begin conditional assembly for atari
+*[[[ ATARI LIBER809 port
+                    fdb       $F3FE-(*-OS9Cold) ; define word value(s) $F3FE-(*-OS9Cold)
+*]]] ATARI LIBER809 port
+                  ENDC
+
+                  IFNE    corsham+wildbits ; begin conditional assembly for corsham+wildbits
+*[[[ CORSHAM port | Wildbits port
                     emod
-eom                 equ       *
-*<<<<<<<<<< CORSHAM port | Wildbits port
-                    endc
-EOMSize             equ       *-EOMTop
+eom                 equ       *         ; define assembler symbol
+*]]] CORSHAM port | Wildbits port
+                  ENDC
+EOMSize             equ       *-EOMTop  ; define assembler symbol
 
                     end

--- a/level1/modules/kernel/krnp2.asm
+++ b/level1/modules/kernel/krnp2.asm
@@ -10,145 +10,145 @@
                     nam       krnp2
                     ttl       NitrOS-9 Level 1 Kernel Part 2
 
-                    use       defsfile
+                    use       defsfile  ; include source file defsfile
 
-tylg                set       Systm+Objct
-atrv                set       ReEnt+rev
-rev                 set       $00
-edition             set       11
+tylg                set       Systm+Objct ; define assembler symbol
+atrv                set       ReEnt+rev ; define assembler symbol
+rev                 set       $00       ; define assembler symbol
+edition             set       11        ; define assembler symbol
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,start,size ; define OS-9 module header
 
-size                equ       .
+size                equ       .         ; define assembler symbol
 
 name                fcs       /KrnP2/
-                    fcb       edition
+                    fcb       edition   ; define byte value(s) edition
 
-SvcTbl              fcb       $7F
-                    fdb       IOCall-*-2
-                    fcb       F$Unlink
-                    fdb       FUnlink-*-2
-                    fcb       F$Wait
-                    fdb       FWait-*-2
-                    fcb       F$Exit
-                    fdb       FExit-*-2
-                    fcb       F$Mem
-                    fdb       FMem-*-2
-                    fcb       F$Send
-                    fdb       FSend-*-2
-                    fcb       F$Sleep
-                    fdb       FSleep-*-2
-                    fcb       F$Icpt
-                    fdb       FIcpt-*-2
-                    fcb       F$ID
-                    fdb       FID-*-2
-                    fcb       F$SPrior
-                    fdb       FSPrior-*-2
-                    fcb       F$SSwi
-                    fdb       FSSwi-*-2
-                    fcb       F$STime
-                    fdb       FSTime-*-2
-                    fcb       F$Find64+$80
-                    fdb       FFind64-*-2
-                    fcb       F$All64+$80
-                    fdb       FAll64-*-2
-                    fcb       F$Ret64+$80
-                    fdb       FRet64-*-2
-                    ifne      UseFDebug
-                    fcb       F$Debug
-                    fdb       FDebug-*-2
-                    endc
+SvcTbl              fcb       $7F       ; define byte value(s) $7F
+                    fdb       IOCall-*-2 ; define word value(s) IOCall-*-2
+                    fcb       F$Unlink  ; define byte value(s) F$Unlink
+                    fdb       FUnlink-*-2 ; define word value(s) FUnlink-*-2
+                    fcb       F$Wait    ; define byte value(s) F$Wait
+                    fdb       FWait-*-2 ; define word value(s) FWait-*-2
+                    fcb       F$Exit    ; define byte value(s) F$Exit
+                    fdb       FExit-*-2 ; define word value(s) FExit-*-2
+                    fcb       F$Mem     ; define byte value(s) F$Mem
+                    fdb       FMem-*-2  ; define word value(s) FMem-*-2
+                    fcb       F$Send    ; define byte value(s) F$Send
+                    fdb       FSend-*-2 ; define word value(s) FSend-*-2
+                    fcb       F$Sleep   ; define byte value(s) F$Sleep
+                    fdb       FSleep-*-2 ; define word value(s) FSleep-*-2
+                    fcb       F$Icpt    ; define byte value(s) F$Icpt
+                    fdb       FIcpt-*-2 ; define word value(s) FIcpt-*-2
+                    fcb       F$ID      ; define byte value(s) F$ID
+                    fdb       FID-*-2   ; define word value(s) FID-*-2
+                    fcb       F$SPrior  ; define byte value(s) F$SPrior
+                    fdb       FSPrior-*-2 ; define word value(s) FSPrior-*-2
+                    fcb       F$SSwi    ; define byte value(s) F$SSwi
+                    fdb       FSSwi-*-2 ; define word value(s) FSSwi-*-2
+                    fcb       F$STime   ; define byte value(s) F$STime
+                    fdb       FSTime-*-2 ; define word value(s) FSTime-*-2
+                    fcb       F$Find64+$80 ; define byte value(s) F$Find64+$80
+                    fdb       FFind64-*-2 ; define word value(s) FFind64-*-2
+                    fcb       F$All64+$80 ; define byte value(s) F$All64+$80
+                    fdb       FAll64-*-2 ; define word value(s) FAll64-*-2
+                    fcb       F$Ret64+$80 ; define byte value(s) F$Ret64+$80
+                    fdb       FRet64-*-2 ; define word value(s) FRet64-*-2
+                  IFNE    UseFDebug ; begin conditional assembly for UseFDebug
+                    fcb       F$Debug   ; define byte value(s) F$Debug
+                    fdb       FDebug-*-2 ; define word value(s) FDebug-*-2
+                  ENDC
 
-                    fcb       $80
+                    fcb       $80       ; define byte value(s) $80
 
-start               equ       *
+start               equ       *         ; define assembler symbol
 * Install system calls.
-                    leay      SvcTbl,pcr          point to the system call table
-                    os9       F$SSvc              install the system calls
+                    leay      SvcTbl,pcr ; point to the system call table
+                    os9       F$SSvc    ; install the system calls
 * Allocate a process descriptor for the initial process.
-                    ldx       <D.PrcDBT           get process descriptor table in X
-                    os9       F$All64             allocate a new 64 byte page
-                    bcs       FatalErr            failed to allocate
-                    stx       <D.PrcDBT           save off
-                    sty       <D.Proc             save off new process descriptor pointer
-                    tfr       s,d                 transfer the stack pointer to D
-                    deca                          set address to 1 minus stack's MSB
-                    ldb       #$01                set page count to 1 (256 bytes)
-                    std       P$ADDR,y            save off in P$ADDR and P$PagCnt
-                    lda       #SysState           get system state flag
-                    sta       P$State,y           set the state in the process descriptor
-                    ldu       <D.Init             get init module address in U
+                    ldx       <D.PrcDBT ; get process descriptor table in X
+                    os9       F$All64   ; allocate a new 64 byte page
+                    bcs       FatalErr  ; failed to allocate
+                    stx       <D.PrcDBT ; save off
+                    sty       <D.Proc   ; save off new process descriptor pointer
+                    tfr       s,d       ; transfer the stack pointer to D
+                    deca                ; set address to 1 minus stack's MSB
+                    ldb       #$01      ; set page count to 1 (256 bytes)
+                    std       P$ADDR,y  ; save off in P$ADDR and P$PagCnt
+                    lda       #SysState ; get system state flag
+                    sta       P$State,y ; set the state in the process descriptor
+                    ldu       <D.Init   ; get init module address in U
 
 * ChdDir should identify system device, result in a call to IOCall which links and
 * initializes IOMan. This could fail if IOMan is not loaded.
-                    bsr       ChdDir              attempt to change directories
-                    bcc       open@               success
+                    bsr       ChdDir    ; attempt to change directories
+                    bcc       open@     ; success
 * Maybe we failed because we didn't have all the modules we needed? Load and
 * validate the boot file and then try again.
-                    lbsr      LoadBoot            else attempt to load bootfile
-                    bsr       ChdDir              then try to change directories again
-open@               bsr       OpenCons            try to open the console
-                    bcc       ChainProg           branch if successful
+                    lbsr      LoadBoot  ; else attempt to load bootfile
+                    bsr       ChdDir    ; then try to change directories again
+open@               bsr       OpenCons  ; try to open the console
+                    bcc       ChainProg ; branch if successful
 
 * Maybe we were able to get this far without needing anything from the boot file, but now
 * we need it for the console device.
-                    lbsr      LoadBoot            else attempt to load bootfile
-                    bsr       OpenCons            try to open the console again
-                    bcc       ChainProg
-forever@            bra       forever@
+                    lbsr      LoadBoot  ; else attempt to load bootfile
+                    bsr       OpenCons  ; try to open the console again
+                    bcc       ChainProg ; branch if carry is clear to ChainProg
+forever@            bra       forever@  ; branch unconditionally to forever@
 
 * Hmm. No check for success. Probably should "bcs fatalerr" here?
 
-ChainProg           ldd       InitStr,u           get the offset to the 'GO' program from the Init module
-                    leax      d,u                 point X to the address of the name
-                    lda       #Objct              object code
-                    clrb                          no optional data area needed
-                    ldy       #$0000              no parameter area needed
-                    os9       F$Chain             chain to it
-FatalErr            jmp       [$FFFE]             jump to the RESET vector
+ChainProg           ldd       InitStr,u ; get the offset to the 'GO' program from the Init module
+                    leax      d,u       ; point X to the address of the name
+                    lda       #Objct    ; object code
+                    clrb                ; no optional data area needed
+                    ldy       #$0000    ; no parameter area needed
+                    os9       F$Chain   ; chain to it
+FatalErr            jmp       [$FFFE]   ; jump to the RESET vector
 
 * Change the directory.
 * Entry: U = The address of the Init module.
-ChdDir              clrb                          clear carry
-                    ldd       <SysStr,u           get system device
-                    beq       ex@                 branch if none - carry still clear
-                    leax      d,u                 address of the path list
-                    lda       #READ.+EXEC.        access mode
-                    os9       I$ChgDir            change directory to it
-ex@                 rts                           carry set -> error
+ChdDir              clrb                ; clear carry
+                    ldd       <SysStr,u ; get system device
+                    beq       ex@       ; branch if none - carry still clear
+                    leax      d,u       ; address of the path list
+                    lda       #READ.+EXEC. ; access mode
+                    os9       I$ChgDir  ; change directory to it
+ex@                 rts                 ; carry set -> error
 
 * Open the console device.
 * Entry: U = The address of the Init module
-OpenCons            clrb                          clear B
-                    ldd       <StdStr,u           get the offset to the console device in the Init module
-                    leax      d,u                 point X to the address of the name
-                    lda       #UPDAT.             open for update
-                    os9       I$Open              open it
-                    bcs       ex@                 branch if error
-                    ldx       <D.Proc             get process descriptor
-                    sta       P$Path+0,x          save path to console to stdin...
-                    os9       I$Dup               duplicate it
-                    sta       P$Path+1,x          ...stdout
-                    os9       I$Dup               duplicate it
-                    sta       P$Path+2,x          ...and stderr
-ex@                 rts                           return to the caller
+OpenCons            clrb                ; clear B
+                    ldd       <StdStr,u ; get the offset to the console device in the Init module
+                    leax      d,u       ; point X to the address of the name
+                    lda       #UPDAT.   ; open for update
+                    os9       I$Open    ; open it
+                    bcs       ex@       ; branch if error
+                    ldx       <D.Proc   ; get process descriptor
+                    sta       P$Path+0,x ; save path to console to stdin...
+                    os9       I$Dup     ; duplicate it
+                    sta       P$Path+1,x ; ...stdout
+                    os9       I$Dup     ; duplicate it
+                    sta       P$Path+2,x ; ...and stderr
+ex@                 rts                 ; return to the caller
 
 
-                    use       funlink.asm
-                    use       fwait.asm
-                    use       fexit.asm
-                    use       fmem.asm
-                    use       fsend.asm
-                    use       fsleep.asm
-                    use       ficpt.asm
-                    use       fsprior.asm
-                    use       fid.asm
-                    use       fsswi.asm
-                    use       fstime.asm
-                    use       ffind64.asm
-                    use       fall64.asm
-                    use       fret64.asm
-                    use       iocall.asm
+                    use       funlink.asm ; include source file funlink.asm
+                    use       fwait.asm ; include source file fwait.asm
+                    use       fexit.asm ; include source file fexit.asm
+                    use       fmem.asm  ; include source file fmem.asm
+                    use       fsend.asm ; include source file fsend.asm
+                    use       fsleep.asm ; include source file fsleep.asm
+                    use       ficpt.asm ; include source file ficpt.asm
+                    use       fsprior.asm ; include source file fsprior.asm
+                    use       fid.asm   ; include source file fid.asm
+                    use       fsswi.asm ; include source file fsswi.asm
+                    use       fstime.asm ; include source file fstime.asm
+                    use       ffind64.asm ; include source file ffind64.asm
+                    use       fall64.asm ; include source file fall64.asm
+                    use       fret64.asm ; include source file fret64.asm
+                    use       iocall.asm ; include source file iocall.asm
 
 
 * Attempt to load bootfile and validate the modules it contains.
@@ -158,43 +158,43 @@ ex@                 rts                           return to the caller
 * Exit:
 *
 * CC Carry set on Error
-LoadBoot            pshs      u                   save off the init module address
-                    comb                          set the carry in anticipation of any errors
-                    tst       <D.Boot             already booted?
-                    bne       JmpBtEr             yep, return to caller...
-                    inc       <D.Boot             else set boot flag
-                    ldd       <BootStr,u          get pointer to boot str
-                    beq       JmpBtEr             if none, return to caller
-                    leax      d,u                 X = ptr to boot mod name
-                    lda       #Systm+Objct        it's a system/object module
-                    os9       F$Link              link
-                    bcs       JmpBtEr             return if error
-                    jsr       ,y                  ...else jsr into boot module
+LoadBoot            pshs      u         ; save off the init module address
+                    comb                ; set the carry in anticipation of any errors
+                    tst       <D.Boot   ; already booted?
+                    bne       JmpBtEr   ; yep, return to caller...
+                    inc       <D.Boot   ; else set boot flag
+                    ldd       <BootStr,u ; get pointer to boot str
+                    beq       JmpBtEr   ; if none, return to caller
+                    leax      d,u       ; X = ptr to boot mod name
+                    lda       #Systm+Objct ; it's a system/object module
+                    os9       F$Link    ; link
+                    bcs       JmpBtEr   ; return if error
+                    jsr       ,y        ; ...else jsr into boot module
 * D = Size of the loaded bootfile.
 * X = Address of the loaded bootfile.
-                    bcs       JmpBtEr             return if error
-                    stx       <D.MLIM             else save off to the memory low limit
-                    stx       <D.BTLO             and the bootfile low address
-                    leau      d,x                 advance 'D' bytes
-                    stu       <D.BTHI             and save the bootfile high address
+                    bcs       JmpBtEr   ; return if error
+                    stx       <D.MLIM   ; else save off to the memory low limit
+                    stx       <D.BTLO   ; and the bootfile low address
+                    leau      d,x       ; advance 'D' bytes
+                    stu       <D.BTHI   ; and save the bootfile high address
 * Search through bootfile and validate modules.
-ValBoot             ldd       ,x                  grab the first two bytes
-                    cmpd      #M$ID12             are they the module sync bytes?
-                    bne       ValBoot1            branch if not
-                    os9       F$VModul            else validate the module
-                    bcs       ValBoot1            and branch if error
-                    ldd       M$Size,x            get module size
-                    leax      d,x                 move X to next module
-                    bra       ValBoot2            verify that we're not in the kernel area
-ValBoot1            leax      1,x                 advance one byte
-ValBoot2            cmpx      <D.BTHI             are we less that the high mark of the bootfile?
-                    bcs       ValBoot             branch if we are
-JmpBtEr             puls      pc,u                retore register and return to caller
+ValBoot             ldd       ,x        ; grab the first two bytes
+                    cmpd      #M$ID12   ; are they the module sync bytes?
+                    bne       ValBoot1  ; branch if not
+                    os9       F$VModul  ; else validate the module
+                    bcs       ValBoot1  ; and branch if error
+                    ldd       M$Size,x  ; get module size
+                    leax      d,x       ; move X to next module
+                    bra       ValBoot2  ; verify that we're not in the kernel area
+ValBoot1            leax      1,x       ; advance one byte
+ValBoot2            cmpx      <D.BTHI   ; are we less that the high mark of the bootfile?
+                    bcs       ValBoot   ; branch if we are
+JmpBtEr             puls      pc,u      ; retore register and return to caller
 
 
-                    ifne      UseFDebug
-                    use       fdebug.asm
-                    endc
+                  IFNE    UseFDebug ; begin conditional assembly for UseFDebug
+                    use       fdebug.asm ; include source file fdebug.asm
+                  ENDC
 
                     emod
-eom                 equ       *
+eom                 equ       *         ; define assembler symbol

--- a/level2/modules/kernel/ccbfnproc.asm
+++ b/level2/modules/kernel/ccbfnproc.asm
@@ -20,30 +20,30 @@ FNProc
                   ENDC
                     fcb       $8C       ; skip the next 2 bytes
 
-FNprocReEnableIrqsWait cwai      #^IntMasks ; re-enable IRQ's and wait for one
-FNprocShutOffInterruptsAgain orcc      #IntMasks ; shut off interrupts again
+FNprocReEnblIrqs    cwai      #^IntMasks ; re-enable IRQ's and wait for one
+FNprocShutOffInts   orcc      #IntMasks ; shut off interrupts again
                     lda       #Suspend  ; get suspend suspend state flag
                     ldx       #D.AProcQ-P$Queue ; for start of loop, setup to point to current process
 
 * Loop to find next active process that is not Suspended
-FNprocPreviousLinkProcessDesc leay      ,x        ; point y to previous link (process dsc. ptr)
+FNprocPrvsLinkProc  leay      ,x        ; point y to previous link (process dsc. ptr)
                     ldx       P$Queue,y ; get process dsc. ptr for next active process
-                    beq       FNprocReEnableIrqsWait ; none, allow any pending IRQ thru & try again
+                    beq       FNprocReEnblIrqs ; none, allow any pending IRQ thru & try again
                     bita      P$State,x ; there is one, is it Suspended?
-                    bne       FNprocPreviousLinkProcessDesc ; yes, skip it & try next one
+                    bne       FNprocPrvsLinkProc ; yes, skip it & try next one
 
 * Found a process in line ready to be started
                     ldd       P$Queue,x ; get next process dsc. ptr in line after found one
                     std       P$Queue,y ; save the next one in line in previous' next ptr
                     stx       <D.Proc   ; make new process dsc. the current one
-                    lbsr      FAlltskAlreadyHaveTask ; go check or make a task # for the found process
+                    lbsr      FAlltskHasHaveTask ; go check or make a task # for the found process
                     bcs       KrnActivateProcess ; couldn't get one, go to next process in line
                     lda       <D.TSlice ; reload # ticks this process can run
                     sta       <D.Slice  ; save as new tick counter for process
                     ldu       P$SP,x    ; get the process stack pointer
                     lda       P$State,x ; get it's state
-                    lbmi      KrnForceSystemTaskSystem ; if in System State, switch to system task (0)
-FNprocCondemnedByDeadlySignal bita      #Condem   ; was it condemned by a deadly signal?
+                    lbmi      KrnFrcSysTask ; if in System State, switch to system task (0)
+FNprocCndmnByDdly   bita      #Condem   ; was it condemned by a deadly signal?
                     bne       FNprocJoin2 ; yes, go exit with Error=the signal code #
                     lbsr      TstImg    ; do a F$SetTsk if the ImgChg flag is set
 FNprocSignals       ldb       <P$Signal,x ; any signals?
@@ -52,7 +52,7 @@ FNprocSignals       ldb       <P$Signal,x ; any signals?
                     beq       FNprocSignal ; yes, go wake it up
                     leas      -R$Size,s ; make a register buffer on stack
                     leau      ,s        ; point to it
-                    lbsr      CopyUserStackToSystem ; copy the stack from process to our copy of it
+                    lbsr      CpUsrStkTo ; copy the stack from process to our copy of it
                     lda       <P$Signal,x ; get last signal
                     sta       R$B,u     ; save it to process' B
 
@@ -64,7 +64,7 @@ FNprocSignals       ldb       <P$Signal,x ; any signals?
                     ldd       P$SP,x    ; get it's stack pointer
                     subd      #R$Size   ; take off register stack
                     std       P$SP,x    ; save updated SP
-                    lbsr      CopySystemStackToUser ; copy modified stack back overtop process' stack
+                    lbsr      CpSysStkTo ; copy modified stack back overtop process' stack
                     leas      R$Size,s  ; purge temporary stack
 FNprocSignal        clr       <P$Signal,x ; clear the signal
 
@@ -78,7 +78,7 @@ FNprocJoin          equ       *         ; define assembler symbol FNprocJoin
                     stb       <D.Quick  ; store B at <D.Quick
                   ENDC
 BackTo1             equ       *         ; define assembler symbol BackTo1
-FNprocUsersSystemCallService ldu       <D.UsrSvc ; get current User's system call service routine ptr
+FNprocUsrsSysCall   ldu       <D.UsrSvc ; get current User's system call service routine ptr
                     stu       <D.XSWI2  ; save as SWI2 service routine ptr
                     ldu       <D.UsrIRQ ; get IRQ entry point for user state
                     stu       <D.XIRQ   ; save as IRQ service routine ptr
@@ -86,7 +86,7 @@ FNprocUsersSystemCallService ldu       <D.UsrSvc ; get current User's system cal
                     ldb       P$Task,x  ; get task number
                     lslb                ; 2 bytes per entry in D.TskIpt
                     ldy       P$SP,x    ; get stack pointer
-                    lbsr      KrnWeGoingBackSameTask ; re-map the DAT image, if necessary
+                    lbsr      KrnWeGngBack ; re-map the DAT image, if necessary
 
                     ldb       <D.Quick  ; get quick return flag
                     lbra      KrnJoin2  ; go switch GIME over to new process & run

--- a/level2/modules/kernel/ccbfnproc.asm
+++ b/level2/modules/kernel/ccbfnproc.asm
@@ -7,103 +7,103 @@
 *
 * Output: Control does not return to the caller
 *
-FNProc                   
-               ifgt      Level-1
-               ldx       <D.SysPrc           get system process descriptor
-               stx       <D.Proc             save it as current
-               lds       <D.SysStk           get system stack pointer
-               andcc     #^IntMasks          re-enable IRQ's (to allow pending one through)
-               else      
-               clra      
-               clrb      
-               std       <D.Proc
-               endc      
-               fcb       $8C                 skip the next 2 bytes
+FNProc
+                  IFGT    Level-1 ; begin conditional assembly for Level-1
+                    ldx       <D.SysPrc ; get system process descriptor
+                    stx       <D.Proc   ; save it as current
+                    lds       <D.SysStk ; get system stack pointer
+                    andcc     #^IntMasks ; re-enable IRQ's (to allow pending one through)
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                    std       <D.Proc   ; store D at <D.Proc
+                  ENDC
+                    fcb       $8C       ; skip the next 2 bytes
 
-L0D91          cwai      #^IntMasks          re-enable IRQ's and wait for one
-L0D93          orcc      #IntMasks           Shut off interrupts again
-               lda       #Suspend            get suspend suspend state flag
-               ldx       #D.AProcQ-P$Queue   For start of loop, setup to point to current process
+L0D91               cwai      #^IntMasks ; re-enable IRQ's and wait for one
+L0D93               orcc      #IntMasks ; shut off interrupts again
+                    lda       #Suspend  ; get suspend suspend state flag
+                    ldx       #D.AProcQ-P$Queue ; for start of loop, setup to point to current process
 
 * Loop to find next active process that is not Suspended
-L0D9A          leay      ,x                  Point y to previous link (process dsc. ptr)
-               ldx       P$Queue,y           Get process dsc. ptr for next active process
-               beq       L0D91               None, allow any pending IRQ thru & try again
-               bita      P$State,x           There is one, is it Suspended?
-               bne       L0D9A               Yes, skip it & try next one
+L0D9A               leay      ,x        ; point y to previous link (process dsc. ptr)
+                    ldx       P$Queue,y ; get process dsc. ptr for next active process
+                    beq       L0D91     ; none, allow any pending IRQ thru & try again
+                    bita      P$State,x ; there is one, is it Suspended?
+                    bne       L0D9A     ; yes, skip it & try next one
 
 * Found a process in line ready to be started
-               ldd       P$Queue,x           Get next process dsc. ptr in line after found one
-               std       P$Queue,y           Save the next one in line in previous' next ptr
-               stx       <D.Proc             Make new process dsc. the current one
-               lbsr      L0C58               Go check or make a task # for the found process
-               bcs       L0D83               Couldn't get one, go to next process in line
-               lda       <D.TSlice           Reload # ticks this process can run
-               sta       <D.Slice            Save as new tick counter for process
-               ldu       P$SP,x              get the process stack pointer
-               lda       P$State,x           get it's state
-               lbmi      L0E29               If in System State, switch to system task (0)
-L0DB9          bita      #Condem             Was it condemned by a deadly signal?
-               bne       L0DFD               Yes, go exit with Error=the signal code #
-               lbsr      TstImg              do a F$SetTsk if the ImgChg flag is set
-L0DBD          ldb       <P$Signal,x         any signals?
-               beq       L0DF7               no, go on
-               decb                          is it a wake up signal?
-               beq       L0DEF               yes, go wake it up
-               leas      -R$Size,s           make a register buffer on stack
-               leau      ,s                  point to it
-               lbsr      L02CB               copy the stack from process to our copy of it
-               lda       <P$Signal,x         get last signal
-               sta       R$B,u               save it to process' B
+                    ldd       P$Queue,x ; get next process dsc. ptr in line after found one
+                    std       P$Queue,y ; save the next one in line in previous' next ptr
+                    stx       <D.Proc   ; make new process dsc. the current one
+                    lbsr      L0C58     ; go check or make a task # for the found process
+                    bcs       L0D83     ; couldn't get one, go to next process in line
+                    lda       <D.TSlice ; reload # ticks this process can run
+                    sta       <D.Slice  ; save as new tick counter for process
+                    ldu       P$SP,x    ; get the process stack pointer
+                    lda       P$State,x ; get it's state
+                    lbmi      L0E29     ; if in System State, switch to system task (0)
+L0DB9               bita      #Condem   ; was it condemned by a deadly signal?
+                    bne       L0DFD     ; yes, go exit with Error=the signal code #
+                    lbsr      TstImg    ; do a F$SetTsk if the ImgChg flag is set
+L0DBD               ldb       <P$Signal,x ; any signals?
+                    beq       L0DF7     ; no, go on
+                    decb                ; is it a wake up signal?
+                    beq       L0DEF     ; yes, go wake it up
+                    leas      -R$Size,s ; make a register buffer on stack
+                    leau      ,s        ; point to it
+                    lbsr      L02CB     ; copy the stack from process to our copy of it
+                    lda       <P$Signal,x ; get last signal
+                    sta       R$B,u     ; save it to process' B
 
-               ldd       <P$SigVec,x         any intercept trap?
-               beq       L0DFD               no, go force the process to F$Exit
-               std       R$PC,u              save vector to it's PC
-               ldd       <P$SigDat,x         get pointer to intercept data area
-               std       R$U,u               save it to it's U
-               ldd       P$SP,x              get it's stack pointer
-               subd      #R$Size             take off register stack
-               std       P$SP,x              save updated SP
-               lbsr      L02DA               Copy modified stack back overtop process' stack
-               leas      R$Size,s            purge temporary stack
-L0DEF          clr       <P$Signal,x         clear the signal
+                    ldd       <P$SigVec,x ; any intercept trap?
+                    beq       L0DFD     ; no, go force the process to F$Exit
+                    std       R$PC,u    ; save vector to it's PC
+                    ldd       <P$SigDat,x ; get pointer to intercept data area
+                    std       R$U,u     ; save it to it's U
+                    ldd       P$SP,x    ; get it's stack pointer
+                    subd      #R$Size   ; take off register stack
+                    std       P$SP,x    ; save updated SP
+                    lbsr      L02DA     ; copy modified stack back overtop process' stack
+                    leas      R$Size,s  ; purge temporary stack
+L0DEF               clr       <P$Signal,x ; clear the signal
 
 * No signals go here
-L0DF7          equ       *
-               ifne      H6309
-               oim       #$01,<D.Quick
-               else      
-               ldb       <D.Quick
-               orb       #$01
-               stb       <D.Quick
-               endc      
-BackTo1        equ       *
-L0DF2          ldu       <D.UsrSvc           Get current User's system call service routine ptr
-               stu       <D.XSWI2            Save as SWI2 service routine ptr
-               ldu       <D.UsrIRQ           Get IRQ entry point for user state
-               stu       <D.XIRQ             Save as IRQ service routine ptr
+L0DF7               equ       *         ; define assembler symbol L0DF7
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.Quick ; apply immediate bit operation #$01,<D.Quick
+                  ELSE
+                    ldb       <D.Quick  ; load B from <D.Quick
+                    orb       #$01      ; merge #$01 into B
+                    stb       <D.Quick  ; store B at <D.Quick
+                  ENDC
+BackTo1             equ       *         ; define assembler symbol BackTo1
+L0DF2               ldu       <D.UsrSvc ; get current User's system call service routine ptr
+                    stu       <D.XSWI2  ; save as SWI2 service routine ptr
+                    ldu       <D.UsrIRQ ; get IRQ entry point for user state
+                    stu       <D.XIRQ   ; save as IRQ service routine ptr
 
-               ldb       P$Task,x            get task number
-               lslb                          2 bytes per entry in D.TskIpt
-               ldy       P$SP,x              get stack pointer
-               lbsr      L0E8D               re-map the DAT image, if necessary
+                    ldb       P$Task,x  ; get task number
+                    lslb                ; 2 bytes per entry in D.TskIpt
+                    ldy       P$SP,x    ; get stack pointer
+                    lbsr      L0E8D     ; re-map the DAT image, if necessary
 
-               ldb       <D.Quick            get quick return flag
-               lbra      L0E4C               Go switch GIME over to new process & run
+                    ldb       <D.Quick  ; get quick return flag
+                    lbra      L0E4C     ; go switch GIME over to new process & run
 
 * Process a signal (process had no signal trap)
-L0DFD          equ       *
-               ifne      H6309
-               oim       #SysState,P$State,x Put process into system state
-               else      
-               ldb       P$State,x
-               orb       #SysState
-               stb       P$State,x
-               endc      
-               leas      >P$Stack,x          Point SP to process' stack
-               andcc     #^IntMasks          Turn interrupts on
-               ldb       <P$Signal,x         Get signal that process received
-               clr       <P$Signal,x         Clear out the one in process dsc.
-               os9       F$Exit              Exit with signal # being error code
+L0DFD               equ       *         ; define assembler symbol L0DFD
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #SysState,P$State,x ; put process into system state
+                  ELSE
+                    ldb       P$State,x ; load B from P$State,x
+                    orb       #SysState ; merge #SysState into B
+                    stb       P$State,x ; store B at P$State,x
+                  ENDC
+                    leas      >P$Stack,x ; point SP to process' stack
+                    andcc     #^IntMasks ; turn interrupts on
+                    ldb       <P$Signal,x ; get signal that process received
+                    clr       <P$Signal,x ; clear out the one in process dsc.
+                    os9       F$Exit    ; exit with signal # being error code
 
-S.SvcIRQ       jmp       [>D.Poll]           Call IOMAN for IRQ polling
+S.SvcIRQ            jmp       [>D.Poll] ; call IOMAN for IRQ polling

--- a/level2/modules/kernel/ccbfnproc.asm
+++ b/level2/modules/kernel/ccbfnproc.asm
@@ -20,56 +20,56 @@ FNProc
                   ENDC
                     fcb       $8C       ; skip the next 2 bytes
 
-L0D91               cwai      #^IntMasks ; re-enable IRQ's and wait for one
-L0D93               orcc      #IntMasks ; shut off interrupts again
+FNprocReEnableIrqsWait cwai      #^IntMasks ; re-enable IRQ's and wait for one
+FNprocShutOffInterruptsAgain orcc      #IntMasks ; shut off interrupts again
                     lda       #Suspend  ; get suspend suspend state flag
                     ldx       #D.AProcQ-P$Queue ; for start of loop, setup to point to current process
 
 * Loop to find next active process that is not Suspended
-L0D9A               leay      ,x        ; point y to previous link (process dsc. ptr)
+FNprocPreviousLinkProcessDesc leay      ,x        ; point y to previous link (process dsc. ptr)
                     ldx       P$Queue,y ; get process dsc. ptr for next active process
-                    beq       L0D91     ; none, allow any pending IRQ thru & try again
+                    beq       FNprocReEnableIrqsWait ; none, allow any pending IRQ thru & try again
                     bita      P$State,x ; there is one, is it Suspended?
-                    bne       L0D9A     ; yes, skip it & try next one
+                    bne       FNprocPreviousLinkProcessDesc ; yes, skip it & try next one
 
 * Found a process in line ready to be started
                     ldd       P$Queue,x ; get next process dsc. ptr in line after found one
                     std       P$Queue,y ; save the next one in line in previous' next ptr
                     stx       <D.Proc   ; make new process dsc. the current one
-                    lbsr      L0C58     ; go check or make a task # for the found process
-                    bcs       L0D83     ; couldn't get one, go to next process in line
+                    lbsr      FAlltskAlreadyHaveTask ; go check or make a task # for the found process
+                    bcs       KrnActivateProcess ; couldn't get one, go to next process in line
                     lda       <D.TSlice ; reload # ticks this process can run
                     sta       <D.Slice  ; save as new tick counter for process
                     ldu       P$SP,x    ; get the process stack pointer
                     lda       P$State,x ; get it's state
-                    lbmi      L0E29     ; if in System State, switch to system task (0)
-L0DB9               bita      #Condem   ; was it condemned by a deadly signal?
-                    bne       L0DFD     ; yes, go exit with Error=the signal code #
+                    lbmi      KrnForceSystemTaskSystem ; if in System State, switch to system task (0)
+FNprocCondemnedByDeadlySignal bita      #Condem   ; was it condemned by a deadly signal?
+                    bne       FNprocJoin2 ; yes, go exit with Error=the signal code #
                     lbsr      TstImg    ; do a F$SetTsk if the ImgChg flag is set
-L0DBD               ldb       <P$Signal,x ; any signals?
-                    beq       L0DF7     ; no, go on
+FNprocSignals       ldb       <P$Signal,x ; any signals?
+                    beq       FNprocJoin ; no, go on
                     decb                ; is it a wake up signal?
-                    beq       L0DEF     ; yes, go wake it up
+                    beq       FNprocSignal ; yes, go wake it up
                     leas      -R$Size,s ; make a register buffer on stack
                     leau      ,s        ; point to it
-                    lbsr      L02CB     ; copy the stack from process to our copy of it
+                    lbsr      CopyUserStackToSystem ; copy the stack from process to our copy of it
                     lda       <P$Signal,x ; get last signal
                     sta       R$B,u     ; save it to process' B
 
                     ldd       <P$SigVec,x ; any intercept trap?
-                    beq       L0DFD     ; no, go force the process to F$Exit
+                    beq       FNprocJoin2 ; no, go force the process to F$Exit
                     std       R$PC,u    ; save vector to it's PC
                     ldd       <P$SigDat,x ; get pointer to intercept data area
                     std       R$U,u     ; save it to it's U
                     ldd       P$SP,x    ; get it's stack pointer
                     subd      #R$Size   ; take off register stack
                     std       P$SP,x    ; save updated SP
-                    lbsr      L02DA     ; copy modified stack back overtop process' stack
+                    lbsr      CopySystemStackToUser ; copy modified stack back overtop process' stack
                     leas      R$Size,s  ; purge temporary stack
-L0DEF               clr       <P$Signal,x ; clear the signal
+FNprocSignal        clr       <P$Signal,x ; clear the signal
 
 * No signals go here
-L0DF7               equ       *         ; define assembler symbol L0DF7
+FNprocJoin          equ       *         ; define assembler symbol FNprocJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.Quick ; apply immediate bit operation #$01,<D.Quick
                   ELSE
@@ -78,7 +78,7 @@ L0DF7               equ       *         ; define assembler symbol L0DF7
                     stb       <D.Quick  ; store B at <D.Quick
                   ENDC
 BackTo1             equ       *         ; define assembler symbol BackTo1
-L0DF2               ldu       <D.UsrSvc ; get current User's system call service routine ptr
+FNprocUsersSystemCallService ldu       <D.UsrSvc ; get current User's system call service routine ptr
                     stu       <D.XSWI2  ; save as SWI2 service routine ptr
                     ldu       <D.UsrIRQ ; get IRQ entry point for user state
                     stu       <D.XIRQ   ; save as IRQ service routine ptr
@@ -86,13 +86,13 @@ L0DF2               ldu       <D.UsrSvc ; get current User's system call service
                     ldb       P$Task,x  ; get task number
                     lslb                ; 2 bytes per entry in D.TskIpt
                     ldy       P$SP,x    ; get stack pointer
-                    lbsr      L0E8D     ; re-map the DAT image, if necessary
+                    lbsr      KrnWeGoingBackSameTask ; re-map the DAT image, if necessary
 
                     ldb       <D.Quick  ; get quick return flag
-                    lbra      L0E4C     ; go switch GIME over to new process & run
+                    lbra      KrnJoin2  ; go switch GIME over to new process & run
 
 * Process a signal (process had no signal trap)
-L0DFD               equ       *         ; define assembler symbol L0DFD
+FNprocJoin2         equ       *         ; define assembler symbol FNprocJoin2
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #SysState,P$State,x ; put process into system state
                   ELSE

--- a/level2/modules/kernel/ccbfsrqmem.asm
+++ b/level2/modules/kernel/ccbfsrqmem.asm
@@ -22,15 +22,15 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FSRqMem        ldd       R$D,u               get memory allocation size requested
-               addd      #$00FF              round it up to nearest 256 byte page (e.g. $1FF = $2FE)
-               clrb                          just keep # of pages (and start 8K block #, e.g. $2FE = $200)
-               std       R$D,u               save rounded version back to user
+FSRqMem             ldd       R$D,u     ; get memory allocation size requested
+                    addd      #$00FF    ; round it up to nearest 256 byte page (e.g. $1FF = $2FE)
+                    clrb                ; just keep # of pages (and start 8K block #, e.g. $2FE = $200)
+                    std       R$D,u     ; save rounded version back to user
 *         leay  Bt.Start/256,y
 *         leay  $20,y        skip Block 0 (always reserved for system)
 * Change to pshs a,b:use 1,s for block # to check, and ,s for TFM spot
 *         incb               skip block 0 (always reserved for system)
-               pshs      d                   reserve a byte & put 0 byte on stack
+                    pshs      d         ; reserve a byte & put 0 byte on stack
 
 
 * IMPORTANT!!!
@@ -39,38 +39,38 @@ FSRqMem        ldd       R$D,u               get memory allocation size requeste
 * memory map based upon the state of the system DAT image.
 * This code really slows down F$SRqMem and since that system call is used quite often in the system,
 * I am commenting it out in the hopes that I can remember what the hell I put it in for. -- Boisy
-               ifeq      1
-               ldy       <D.SysMem           get ptr to SMAP table
+                  IFEQ    1       ; begin conditional assembly for 1
+                    ldy       <D.SysMem ; get ptr to SMAP table
 * This loop updates the SMAP table if anything can be marked as unused
-L082F          ldx       <D.SysDAT           get pointer to system DAT block list
-               lslb                          adjust block offset for 2 bytes/entry
-               ldd       b,x                 get block type/# from system DAT
-               cmpd      #DAT.Free           Unused block?
-               beq       L0847               yes, mark it free in SMAP table
-               ldx       <D.BlkMap           No, get ptr to MMAP table
-               lda       d,x                 Get block marker for 2 meg mem map
-               cmpa      #RAMinUse           Is it in use (not free, ROM or used by module)?
-               bne       L0848               No, mark it as type it is in SMAP table
-               leay      32,y                Yes, move to next block in pages
-               bra       L084F               move to next block & try again
+L082F               ldx       <D.SysDAT ; get pointer to system DAT block list
+                    lslb                ; adjust block offset for 2 bytes/entry
+                    ldd       b,x       ; get block type/# from system DAT
+                    cmpd      #DAT.Free ; unused block?
+                    beq       L0847     ; yes, mark it free in SMAP table
+                    ldx       <D.BlkMap ; no, get ptr to MMAP table
+                    lda       d,x       ; get block marker for 2 meg mem map
+                    cmpa      #RAMinUse ; is it in use (not free, ROM or used by module)?
+                    bne       L0848     ; no, mark it as type it is in SMAP table
+                    leay      32,y      ; yes, move to next block in pages
+                    bra       L084F     ; move to next block & try again
 * Free RAM:
-L0847          clra                          Byte to fill system page map with (0=Not in use)
+L0847               clra                ; byte to fill system page map with (0=Not in use)
 * NOT! RAMinUse:
-               ifne      H6309
-L0848          sta       ,s                  Put it on stack
-               ldw       #$0020              Get size of 8K block in pages
-               tfm       s,y+                Mark entire block's worth of pages with A
-               else      
-L0848          ldb       #32                 count = 32 pages
-L084A          sta       ,y+                 mark the RAM
-               decb      
-               bne       L084A
-               endc      
-L084F          inc       1,s                 Bump up to next block to check
-               ldb       1,s                 Get it
-               cmpb      #DAT.BlCt           Done whole 64k system space?
-               blo       L082F               no, keep checking
-               endc      
+                  IFNE    H6309   ; begin conditional assembly for H6309
+L0848               sta       ,s        ; put it on stack
+                    ldw       #$0020    ; get size of 8K block in pages
+                    tfm       s,y+      ; mark entire block's worth of pages with A
+                  ELSE
+L0848               ldb       #32       ; count = 32 pages
+L084A               sta       ,y+       ; mark the RAM
+                    decb                ; decrement B
+                    bne       L084A     ; branch if zero is clear to L084A
+                  ENDC
+L084F               inc       1,s       ; bump up to next block to check
+                    ldb       1,s       ; get it
+                    cmpb      #DAT.BlCt ; done whole 64k system space?
+                    blo       L082F     ; no, keep checking
+                  ENDC
 
 
 * Now we can actually attempt to allocate the system RAM requested
@@ -78,61 +78,61 @@ L084F          inc       1,s                 Bump up to next block to check
 * they are: Kernel (REL/BOOT/KRN - 17 pages), vector RAM & I/O (2 pages)
 * (Already permanently marked @ L01D2)
 * At the start, Y is pointing to the end of the SMAP table+1
-               ldx       <D.SysMem           Get start of table ptr
-         * CCB change - start scanning from f000 down, rather than ec00
- *        leay  Bt.Start/256,x
-               leay      $ff00/256,x
-         * end of CCB change
-               ldb       #32                 skip block 0: it's always full
-               abx                           same size, but faster than leax $20,x
+                    ldx       <D.SysMem ; get start of table ptr
+                    *         CCB       change - start scanning from f000 down, rather than ec00
+                    *         leay      Bt.Start/256,x
+                    leay      $ff00/256,x ; compute $ff00/256,x into Y
+                    *         end       of CCB change
+                    ldb       #32       ; skip block 0: it's always full
+                    abx                 ; same size, but faster than leax $20,x
 *         leay  -(256-(Bt.Start>>8)),y  skip Kernel, Vector RAM & I/O (Can't be free)
-L0857          ldb       R$A,u               Get # 256 byte pages requested
+L0857               ldb       R$A,u     ; get # 256 byte pages requested
 * Loop (from end of system mem map) to look for # continuous pages requested
-L0859          equ       *
-               ifne      H6309
-               cmpr      x,y                 We still have any system RAM left to try?
-               else      
-               pshs      x
-               cmpy      ,s++
-               endc      
-               bhi       L0863               Yes, continue
-               comb                          Exit with No System RAM Error
-               ldb       #E$NoRAM
-               bra       L0894               Eat stack & exit
+L0859               equ       *         ; define assembler symbol L0859
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    cmpr      x,y       ; we still have any system RAM left to try?
+                  ELSE
+                    pshs      x         ; save x on the stack
+                    cmpy      ,s++      ; compare Y with ,s++
+                  ENDC
+                    bhi       L0863     ; yes, continue
+                    comb                ; exit with No System RAM Error
+                    ldb       #E$NoRAM  ; load B from #E$NoRAM
+                    bra       L0894     ; eat stack & exit
 
-L0863          lda       ,-y                 Get page marker (starting @ end of SMAP)
-               bne       L0857               Used, try next lower page
-               decb                          Found 1 page, dec # pages we need to allocate
-               bne       L0859               Still more pages needed, check if we can get more
-               sty       ,s                  Found free contiguous pages, save SMAP entry ptr
-               lda       1,s                 Get LSB of ptr
-               lsra                          Divide by 32 (Calculate start 8K block #)
-               lsra      
-               lsra      
-               lsra      
-               lsra      
-               ldb       1,s                 Get LSB of ptr again
-               andb      #%00011111          Keep only within 8K block offset
-               addb      R$A,u               Add # pages requested
-               addb      #$1F                Round up to nearest 8K block
-               lsrb                          Divide by 32 (Calculate end 8K block #)
-               lsrb      
-               lsrb      
-               lsrb      
-               lsrb      
-               ldx       <D.SysPrc           Get ptr to system proc. dsc.
-               lbsr      L09BE               Allocate an image with our start/end block #'s
-               bcs       L0894               Couldn't, exit with error
-               ldb       R$A,u               Get # pages requested
+L0863               lda       ,-y       ; get page marker (starting @ end of SMAP)
+                    bne       L0857     ; used, try next lower page
+                    decb                ; found 1 page, dec # pages we need to allocate
+                    bne       L0859     ; still more pages needed, check if we can get more
+                    sty       ,s        ; found free contiguous pages, save SMAP entry ptr
+                    lda       1,s       ; get LSB of ptr
+                    lsra                ; divide by 32 (Calculate start 8K block #)
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    ldb       1,s       ; get LSB of ptr again
+                    andb      #%00011111 ; keep only within 8K block offset
+                    addb      R$A,u     ; add # pages requested
+                    addb      #$1F      ; round up to nearest 8K block
+                    lsrb                ; divide by 32 (Calculate end 8K block #)
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    lsrb                ; shift or rotate and update condition codes
+                    ldx       <D.SysPrc ; get ptr to system proc. dsc.
+                    lbsr      L09BE     ; allocate an image with our start/end block #'s
+                    bcs       L0894     ; couldn't, exit with error
+                    ldb       R$A,u     ; get # pages requested
 *         lda   #RAMinUse    Get SMAP in use flag
 *L088A    sta   ,y+          Mark all the pages requested as In Use
-L088A          inc       ,y+                 Since RAMinUse is 1, we can save space by INC'ing from 0->1
-               decb      
-               bne       L088A
-               lda       1,s                 Get MSB of ptr to start of newly allocated Sys RAM
-               std       R$U,u               Save for caller
-               clrb                          No error
-L0894          puls      u,pc                Eat stack (U is changed after it exits) & return
+L088A               inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
+                    decb                ; decrement B
+                    bne       L088A     ; branch if zero is clear to L088A
+                    lda       1,s       ; get MSB of ptr to start of newly allocated Sys RAM
+                    std       R$U,u     ; save for caller
+                    clrb                ; no error
+L0894               puls      u,pc      ; eat stack (U is changed after it exits) & return
 
 
 **************************************************
@@ -147,85 +147,85 @@ L0894          puls      u,pc                Eat stack (U is changed after it ex
 *
 * Error:  CC = C bit set; B = error code
 *
-FSRtMem        ldd       R$D,u               get # pages to free up
-               beq       L08F2               nothing to free, return without error
-               addd      #$00FF              round it up to nearest page
-               ldb       R$U+1,u             get LSB of address
-               beq       L08A6               it's a even page, skip ahead
-               comb                          set carry
-               ldb       #E$BPAddr           get error code
-               rts                           return
+FSRtMem             ldd       R$D,u     ; get # pages to free up
+                    beq       L08F2     ; nothing to free, return without error
+                    addd      #$00FF    ; round it up to nearest page
+                    ldb       R$U+1,u   ; get LSB of address
+                    beq       L08A6     ; it's a even page, skip ahead
+                    comb                ; set carry
+                    ldb       #E$BPAddr ; get error code
+                    rts                 ; return
 
-L08A6          ldb       R$U,u               get MSB of page address
-               beq       L08F2               not a legal page, return without error
-               ldx       <D.SysMem           get pointer to system memory map
-               abx                           set pointer into map
-L08AD          equ       *
-               ifne      H6309
-               aim       #^RAMinUse,,x+
-               else      
-               ldb       ,x
-               andb      #^RAMinUse
-               stb       ,x+
-               endc      
-               deca      
-               bne       L08AD
+L08A6               ldb       R$U,u     ; get MSB of page address
+                    beq       L08F2     ; not a legal page, return without error
+                    ldx       <D.SysMem ; get pointer to system memory map
+                    abx                 ; set pointer into map
+L08AD               equ       *         ; define assembler symbol L08AD
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^RAMinUse,,x+ ; apply immediate bit operation #^RAMinUse,,x+
+                  ELSE
+                    ldb       ,x        ; load B from ,x
+                    andb      #^RAMinUse ; mask B with #^RAMinUse
+                    stb       ,x+       ; store B at ,x+
+                  ENDC
+                    deca                ; decrement A
+                    bne       L08AD     ; branch if zero is clear to L08AD
 * Scan DAT image to find memory blocks to free up
-               ldx       <D.SysDAT           get pointer to system DAT image
-               ifne      H6309
-               lde       #DAT.BlCt           get # blocks to check
-               else      
-               ldy       #DAT.BlCt
-               endc      
-L08BC          ldd       ,x                  get block image
-               cmpd      #DAT.Free           is it already free?
-               beq       L08EC               yes, skip to next one
-               ldu       <D.BlkMap           get pointer to MMU block map
-               lda       d,u                 get allocation flag for this block: 16-bit offset
-               cmpa      #RAMinUse           being used?
-               bne       L08EC               no, move to next block
-               tfr       x,d
-               subd      <D.SysDAT
-               lslb      
-               lslb      
-               lslb      
-               lslb      
-               ldu       <D.SysMem           get pointer to system map
-               ifne      H6309
-               addr      d,u
+                    ldx       <D.SysDAT ; get pointer to system DAT image
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lde       #DAT.BlCt ; get # blocks to check
+                  ELSE
+                    ldy       #DAT.BlCt ; load Y from #DAT.BlCt
+                  ENDC
+L08BC               ldd       ,x        ; get block image
+                    cmpd      #DAT.Free ; is it already free?
+                    beq       L08EC     ; yes, skip to next one
+                    ldu       <D.BlkMap ; get pointer to MMU block map
+                    lda       d,u       ; get allocation flag for this block: 16-bit offset
+                    cmpa      #RAMinUse ; being used?
+                    bne       L08EC     ; no, move to next block
+                    tfr       x,d       ; transfer register value x,d
+                    subd      <D.SysDAT ; subtract <D.SysDAT from D
+                    lslb                ; shift or rotate and update condition codes
+                    lslb                ; shift or rotate and update condition codes
+                    lslb                ; shift or rotate and update condition codes
+                    lslb                ; shift or rotate and update condition codes
+                    ldu       <D.SysMem ; get pointer to system map
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,u       ; add d,u to destination register
 * Check if we can remove the entire memory block from system map
-               ldf       #16                 get # pages per block/2
-L08DA          ldd       ,u++                Either of these 2 pages allocated?
-               else      
-               leau      d,u
-               ldb       #32
-L08DA          lda       ,u+                 Either of these 2 pages allocated?
-               endc      
-               bne       L08EC               yes, can't free block, skip to next one
-               ifne      H6309
-               decf                          checked all pages?
-               else      
-               decb      
-               endc      
-               bne       L08DA               no, keep looking
-               ldd       ,x                  get block # into B: could be >$80
-               ldu       <D.BlkMap           point to allocation table
-               ifne      H6309
-               sta       d,u                 clear the block using 16-bit offset
-               else      
-               clr       d,u
-               endc      
-               ldd       #DAT.Free           get free block marker
-               std       ,x                  save it into DAT image
-L08EC          leax      2,x                 move to next DAT block
-               ifne      H6309
-               dece                          done?
-               else      
-               leay      -1,y
-               endc      
-               bne       L08BC               no, keep checking
-L08F2          clrb                          clear errors
-L08F3          rts                           return
+                    ldf       #16       ; get # pages per block/2
+L08DA               ldd       ,u++      ; either of these 2 pages allocated?
+                  ELSE
+                    leau      d,u       ; compute d,u into U
+                    ldb       #32       ; load B from #32
+L08DA               lda       ,u+       ; either of these 2 pages allocated?
+                  ENDC
+                    bne       L08EC     ; yes, can't free block, skip to next one
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decf                ; checked all pages?
+                  ELSE
+                    decb                ; decrement B
+                  ENDC
+                    bne       L08DA     ; no, keep looking
+                    ldd       ,x        ; get block # into B: could be >$80
+                    ldu       <D.BlkMap ; point to allocation table
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    sta       d,u       ; clear the block using 16-bit offset
+                  ELSE
+                    clr       d,u       ; clear d,u
+                  ENDC
+                    ldd       #DAT.Free ; get free block marker
+                    std       ,x        ; save it into DAT image
+L08EC               leax      2,x       ; move to next DAT block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    dece                ; done?
+                  ELSE
+                    leay      -1,y      ; compute -1,y into Y
+                  ENDC
+                    bne       L08BC     ; no, keep checking
+L08F2               clrb                ; clear errors
+L08F3               rts                 ; return
 
 
 **************************************************
@@ -241,56 +241,56 @@ L08F3          rts                           return
 *
 * Error:  CC = C bit set; B = error code
 *
-FBoot                    
-        ** CCB change: just panic
-               lda       #'t                 tried to boot
-               jsr       <D.BtBug
-               jmp       <D.Crash
-        **
-               coma                          Set boot flag
-               lda       <D.Boot             we booted once before?
-               bne       L08F3               Yes, return
-               inc       <D.Boot             Set boot flag
-               ldx       <D.Init             Get ptr to init module if it exists
-               beq       L0908               it doesn't, point to boot name
-               ldd       <BootStr,x          Get offset to text
-               beq       L0908               Doesn't exist, get hard coded text
-               leax      d,x                 Adjust X to point to boot module
-               bra       L090C               Try & link to module
+FBoot
+                    **        CCB       change: just panic
+                    lda       #'t       ; tried to boot
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    jmp       <D.Crash  ; transfer control to <D.Crash
+                    **
+                    coma                ; set boot flag
+                    lda       <D.Boot   ; we booted once before?
+                    bne       L08F3     ; yes, return
+                    inc       <D.Boot   ; set boot flag
+                    ldx       <D.Init   ; get ptr to init module if it exists
+                    beq       L0908     ; it doesn't, point to boot name
+                    ldd       <BootStr,x ; get offset to text
+                    beq       L0908     ; doesn't exist, get hard coded text
+                    leax      d,x       ; adjust X to point to boot module
+                    bra       L090C     ; try & link to module
 
-boot           fcs       /Boot/
+boot                fcs       /Boot/
 
-L0908          leax      <boot,pcr
+L0908               leax      <boot,pcr ; compute <boot,pcr into X
 * Link to module and execute
-L090C          lda       #Systm+Objct
-               os9       F$Link
-               bcs       L08F3
-               lda       #'b                 calling boot
-               jsr       <D.BtBug
-               jsr       ,y                  load boot file
-               bcs       L08F3
-               std       <D.BtSz             save boot file size
-               stx       <D.BtPtr            save start pointer of bootfile
-               lda       #'b                 boot returns OK
-               jsr       <D.BtBug
+L090C               lda       #Systm+Objct ; load A from #Systm+Objct
+                    os9       F$Link    ; call OS-9 service F$Link
+                    bcs       L08F3     ; branch if carry is set to L08F3
+                    lda       #'b       ; calling boot
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    jsr       ,y        ; load boot file
+                    bcs       L08F3     ; branch if carry is set to L08F3
+                    std       <D.BtSz   ; save boot file size
+                    stx       <D.BtPtr  ; save start pointer of bootfile
+                    lda       #'b       ; boot returns OK
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
 
 * added for IOMan system memory extentions
-               ifne      H6309
-               ldd       M$Name,x            grab the name offset
-               ldd       d,x                 find the first 2 bytes of the first module
-               cmpd      #$4E69              'Ni' ? (NitrOS9 module?)
-               bne       not.ext             no, not system memory extensions
-               ldd       M$Exec,x            grab the execution ptr
-               jmp       d,x                 and go execute the system memory extension module
-               endc      
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldd       M$Name,x  ; grab the name offset
+                    ldd       d,x       ; find the first 2 bytes of the first module
+                    cmpd      #$4E69    ; 'Ni' ? (NitrOS9 module?)
+                    bne       not.ext   ; no, not system memory extensions
+                    ldd       M$Exec,x  ; grab the execution ptr
+                    jmp       d,x       ; and go execute the system memory extension module
+                  ENDC
 
-not.ext        ldd       <D.BtSz
-               bsr       I.VBlock            internal verify block routine
-               ldx       <D.SysDAT           get system DAT pointer
-               ldb       $0D,x               get highest allocated block number
-               incb                          allocate block 0, too
-               ldx       <D.BlkMap           point to the memory block map
-               lbra      L01DF               and go mark the blocks as used.
+not.ext             ldd       <D.BtSz   ; load D from <D.BtSz
+                    bsr       I.VBlock  ; internal verify block routine
+                    ldx       <D.SysDAT ; get system DAT pointer
+                    ldb       $0D,x     ; get highest allocated block number
+                    incb                ; allocate block 0, too
+                    ldx       <D.BlkMap ; point to the memory block map
+                    lbra      L01DF     ; and go mark the blocks as used.
 
 
 **************************************************
@@ -305,63 +305,63 @@ not.ext        ldd       <D.BtSz
 *
 * Error:  CC = C bit set; B = error code
 *
-FVBlock        ldd       R$D,u               size of block to verify
-               ldx       R$X,u               start address to verify
+FVBlock             ldd       R$D,u     ; size of block to verify
+                    ldx       R$X,u     ; start address to verify
 
-I.VBlock       leau      d,x                 point to end of bootfile
-               tfr       x,d                 transfer start of block to D
-               anda      #$E0
-               clrb                          D is now block number
-               pshs      d,u                 save starting block and end of block
-               lsra      
-               lsra      
-               lsra      
-               lsra                          A is now logical block * 2
-               ldy       <D.SysDAT           get pointer to system DAT
-               leay      a,y                 y is pointer of sys block map of start of block
-L092D          ldd       M$ID,x              get module ID
-               cmpd      #M$ID12             legal ID?
-               bne       L0954               no, keep looking
+I.VBlock            leau      d,x       ; point to end of bootfile
+                    tfr       x,d       ; transfer start of block to D
+                    anda      #$E0      ; mask A with #$E0
+                    clrb                ; D is now block number
+                    pshs      d,u       ; save starting block and end of block
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; A is now logical block * 2
+                    ldy       <D.SysDAT ; get pointer to system DAT
+                    leay      a,y       ; y is pointer of sys block map of start of block
+L092D               ldd       M$ID,x    ; get module ID
+                    cmpd      #M$ID12   ; legal ID?
+                    bne       L0954     ; no, keep looking
 
-               ldd       M$Name,x            find name offset pointer
-               pshs      x
-               leax      d,x
-name.prt       lda       ,x+                 get first character of the name
-               jsr       <D.BtBug            print it out
-               bpl       name.prt
-               lda       #C$SPAC             a space
-               jsr       <D.BtBug
-               puls      x
+                    ldd       M$Name,x  ; find name offset pointer
+                    pshs      x         ; save x on the stack
+                    leax      d,x       ; compute d,x into X
+name.prt            lda       ,x+       ; get first character of the name
+                    jsr       <D.BtBug  ; print it out
+                    bpl       name.prt  ; branch if negative is clear to name.prt
+                    lda       #C$SPAC   ; a space
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    puls      x         ; restore x from the stack
 
-               ifne      H6309
-               ldd       ,s                  offset into block
-               subr      d,x                 make X=offset into block
-               else      
-               tfr       x,d
-               subd      ,s
-               tfr       d,x
-               endc      
-               tfr       y,d
-               os9       F$VModul
-               ifne      H6309
-               ldw       ,s
-               leax      w,x
-               else      
-               pshs      b
-               ldd       1,s
-               leax      d,x
-               puls      b
-               endc      
-               bcc       L094E
-               cmpb      #E$KwnMod
-               bne       L0954
-L094E          ldd       M$Size,x
-               leax      d,x
-               fcb       $8C                 skip 2 bytes
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldd       ,s        ; offset into block
+                    subr      d,x       ; make X=offset into block
+                  ELSE
+                    tfr       x,d       ; transfer register value x,d
+                    subd      ,s        ; subtract ,s from D
+                    tfr       d,x       ; transfer register value d,x
+                  ENDC
+                    tfr       y,d       ; transfer register value y,d
+                    os9       F$VModul  ; call OS-9 service F$VModul
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       ,s        ; load W from ,s
+                    leax      w,x       ; compute w,x into X
+                  ELSE
+                    pshs      b         ; save b on the stack
+                    ldd       1,s       ; load D from 1,s
+                    leax      d,x       ; compute d,x into X
+                    puls      b         ; restore b from the stack
+                  ENDC
+                    bcc       L094E     ; branch if carry is clear to L094E
+                    cmpb      #E$KwnMod ; compare B with #E$KwnMod
+                    bne       L0954     ; branch if zero is clear to L0954
+L094E               ldd       M$Size,x  ; load D from M$Size,x
+                    leax      d,x       ; compute d,x into X
+                    fcb       $8C       ; skip 2 bytes
 
-L0954          leax      1,x                 move to next byte
-L0956          cmpx      2,s                 gone thru whole bootfile?
-               bcs       L092D               no, keep looking
-               leas      4,s                 purge stack
-               clrb      
-               rts       
+L0954               leax      1,x       ; move to next byte
+L0956               cmpx      2,s       ; gone thru whole bootfile?
+                    bcs       L092D     ; no, keep looking
+                    leas      4,s       ; purge stack
+                    clrb                ; clear B
+                    rts                 ; return to caller

--- a/level2/modules/kernel/ccbfsrqmem.asm
+++ b/level2/modules/kernel/ccbfsrqmem.asm
@@ -42,34 +42,34 @@ FSRqMem             ldd       R$D,u     ; get memory allocation size requested
                   IFEQ    1       ; begin conditional assembly for 1
                     ldy       <D.SysMem ; get ptr to SMAP table
 * This loop updates the SMAP table if anything can be marked as unused
-L082F               ldx       <D.SysDAT ; get pointer to system DAT block list
+FSrqmemSystemDATBlockList ldx       <D.SysDAT ; get pointer to system DAT block list
                     lslb                ; adjust block offset for 2 bytes/entry
                     ldd       b,x       ; get block type/# from system DAT
                     cmpd      #DAT.Free ; unused block?
-                    beq       L0847     ; yes, mark it free in SMAP table
+                    beq       FSrqmemFillSystemPageMapNot ; yes, mark it free in SMAP table
                     ldx       <D.BlkMap ; no, get ptr to MMAP table
                     lda       d,x       ; get block marker for 2 meg mem map
                     cmpa      #RAMinUse ; is it in use (not free, ROM or used by module)?
-                    bne       L0848     ; no, mark it as type it is in SMAP table
+                    bne       FSrqmemPut ; no, mark it as type it is in SMAP table
                     leay      32,y      ; yes, move to next block in pages
-                    bra       L084F     ; move to next block & try again
+                    bra       FSrqmemBumpUpBlockCheck ; move to next block & try again
 * Free RAM:
-L0847               clra                ; byte to fill system page map with (0=Not in use)
+FSrqmemFillSystemPageMapNot clra                ; byte to fill system page map with (0=Not in use)
 * NOT! RAMinUse:
                   IFNE    H6309   ; begin conditional assembly for H6309
-L0848               sta       ,s        ; put it on stack
+FSrqmemPut          sta       ,s        ; put it on stack
                     ldw       #$0020    ; get size of 8K block in pages
                     tfm       s,y+      ; mark entire block's worth of pages with A
                   ELSE
-L0848               ldb       #32       ; count = 32 pages
-L084A               sta       ,y+       ; mark the RAM
+FSrqmemPut          ldb       #32       ; count = 32 pages
+FSrqmemMarkRAM      sta       ,y+       ; mark the RAM
                     decb                ; decrement B
-                    bne       L084A     ; branch if zero is clear to L084A
+                    bne       FSrqmemMarkRAM ; branch if zero is clear to FSrqmemMarkRAM
                   ENDC
-L084F               inc       1,s       ; bump up to next block to check
+FSrqmemBumpUpBlockCheck inc       1,s       ; bump up to next block to check
                     ldb       1,s       ; get it
                     cmpb      #DAT.BlCt ; done whole 64k system space?
-                    blo       L082F     ; no, keep checking
+                    blo       FSrqmemSystemDATBlockList ; no, keep checking
                   ENDC
 
 
@@ -86,24 +86,24 @@ L084F               inc       1,s       ; bump up to next block to check
                     ldb       #32       ; skip block 0: it's always full
                     abx                 ; same size, but faster than leax $20,x
 *         leay  -(256-(Bt.Start>>8)),y  skip Kernel, Vector RAM & I/O (Can't be free)
-L0857               ldb       R$A,u     ; get # 256 byte pages requested
+FSrqmemNumberPagesRequested ldb       R$A,u     ; get # 256 byte pages requested
 * Loop (from end of system mem map) to look for # continuous pages requested
-L0859               equ       *         ; define assembler symbol L0859
+FSrqmemJoin         equ       *         ; define assembler symbol FSrqmemJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
                     cmpr      x,y       ; we still have any system RAM left to try?
                   ELSE
                     pshs      x         ; save x on the stack
                     cmpy      ,s++      ; compare Y with ,s++
                   ENDC
-                    bhi       L0863     ; yes, continue
+                    bhi       FSrqmemPageMarkerStartingEndSystem ; yes, continue
                     comb                ; exit with No System RAM Error
                     ldb       #E$NoRAM  ; load B from #E$NoRAM
-                    bra       L0894     ; eat stack & exit
+                    bra       FSrqmemExit ; eat stack & exit
 
-L0863               lda       ,-y       ; get page marker (starting @ end of SMAP)
-                    bne       L0857     ; used, try next lower page
+FSrqmemPageMarkerStartingEndSystem lda       ,-y       ; get page marker (starting @ end of SMAP)
+                    bne       FSrqmemNumberPagesRequested ; used, try next lower page
                     decb                ; found 1 page, dec # pages we need to allocate
-                    bne       L0859     ; still more pages needed, check if we can get more
+                    bne       FSrqmemJoin ; still more pages needed, check if we can get more
                     sty       ,s        ; found free contiguous pages, save SMAP entry ptr
                     lda       1,s       ; get LSB of ptr
                     lsra                ; divide by 32 (Calculate start 8K block #)
@@ -121,18 +121,18 @@ L0863               lda       ,-y       ; get page marker (starting @ end of SMA
                     lsrb                ; shift or rotate and update condition codes
                     lsrb                ; shift or rotate and update condition codes
                     ldx       <D.SysPrc ; get ptr to system proc. dsc.
-                    lbsr      L09BE     ; allocate an image with our start/end block #'s
-                    bcs       L0894     ; couldn't, exit with error
+                    lbsr      FAllimgTarget ; allocate an image with our start/end block #'s
+                    bcs       FSrqmemExit ; couldn't, exit with error
                     ldb       R$A,u     ; get # pages requested
 *         lda   #RAMinUse    Get SMAP in use flag
 *L088A    sta   ,y+          Mark all the pages requested as In Use
-L088A               inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
+FSrqmemSinceRaminuseWeCanSpace inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
                     decb                ; decrement B
-                    bne       L088A     ; branch if zero is clear to L088A
+                    bne       FSrqmemSinceRaminuseWeCanSpace ; branch if zero is clear to FSrqmemSinceRaminuseWeCanSpace
                     lda       1,s       ; get MSB of ptr to start of newly allocated Sys RAM
                     std       R$U,u     ; save for caller
                     clrb                ; no error
-L0894               puls      u,pc      ; eat stack (U is changed after it exits) & return
+FSrqmemExit         puls      u,pc      ; eat stack (U is changed after it exits) & return
 
 
 **************************************************
@@ -148,19 +148,19 @@ L0894               puls      u,pc      ; eat stack (U is changed after it exits
 * Error:  CC = C bit set; B = error code
 *
 FSRtMem             ldd       R$D,u     ; get # pages to free up
-                    beq       L08F2     ; nothing to free, return without error
+                    beq       FSrqmemErrorCarry ; nothing to free, return without error
                     addd      #$00FF    ; round it up to nearest page
                     ldb       R$U+1,u   ; get LSB of address
-                    beq       L08A6     ; it's a even page, skip ahead
+                    beq       FSrqmemMsbPage ; it's a even page, skip ahead
                     comb                ; set carry
                     ldb       #E$BPAddr ; get error code
                     rts                 ; return
 
-L08A6               ldb       R$U,u     ; get MSB of page address
-                    beq       L08F2     ; not a legal page, return without error
+FSrqmemMsbPage      ldb       R$U,u     ; get MSB of page address
+                    beq       FSrqmemErrorCarry ; not a legal page, return without error
                     ldx       <D.SysMem ; get pointer to system memory map
                     abx                 ; set pointer into map
-L08AD               equ       *         ; define assembler symbol L08AD
+FSrqmemJoin2        equ       *         ; define assembler symbol FSrqmemJoin2
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^RAMinUse,,x+ ; apply immediate bit operation #^RAMinUse,,x+
                   ELSE
@@ -169,7 +169,7 @@ L08AD               equ       *         ; define assembler symbol L08AD
                     stb       ,x+       ; store B at ,x+
                   ENDC
                     deca                ; decrement A
-                    bne       L08AD     ; branch if zero is clear to L08AD
+                    bne       FSrqmemJoin2 ; branch if zero is clear to FSrqmemJoin2
 * Scan DAT image to find memory blocks to free up
                     ldx       <D.SysDAT ; get pointer to system DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -177,13 +177,13 @@ L08AD               equ       *         ; define assembler symbol L08AD
                   ELSE
                     ldy       #DAT.BlCt ; load Y from #DAT.BlCt
                   ENDC
-L08BC               ldd       ,x        ; get block image
+FSrqmemBlockImage   ldd       ,x        ; get block image
                     cmpd      #DAT.Free ; is it already free?
-                    beq       L08EC     ; yes, skip to next one
+                    beq       FSrqmemDATBlock ; yes, skip to next one
                     ldu       <D.BlkMap ; get pointer to MMU block map
                     lda       d,u       ; get allocation flag for this block: 16-bit offset
                     cmpa      #RAMinUse ; being used?
-                    bne       L08EC     ; no, move to next block
+                    bne       FSrqmemDATBlock ; no, move to next block
                     tfr       x,d       ; transfer register value x,d
                     subd      <D.SysDAT ; subtract <D.SysDAT from D
                     lslb                ; shift or rotate and update condition codes
@@ -195,19 +195,19 @@ L08BC               ldd       ,x        ; get block image
                     addr      d,u       ; add d,u to destination register
 * Check if we can remove the entire memory block from system map
                     ldf       #16       ; get # pages per block/2
-L08DA               ldd       ,u++      ; either of these 2 pages allocated?
+FSrqmemEitherThesePagesAllocated ldd       ,u++      ; either of these 2 pages allocated?
                   ELSE
                     leau      d,u       ; compute d,u into U
                     ldb       #32       ; load B from #32
-L08DA               lda       ,u+       ; either of these 2 pages allocated?
+FSrqmemEitherThesePagesAllocated lda       ,u+       ; either of these 2 pages allocated?
                   ENDC
-                    bne       L08EC     ; yes, can't free block, skip to next one
+                    bne       FSrqmemDATBlock ; yes, can't free block, skip to next one
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decf                ; checked all pages?
                   ELSE
                     decb                ; decrement B
                   ENDC
-                    bne       L08DA     ; no, keep looking
+                    bne       FSrqmemEitherThesePagesAllocated ; no, keep looking
                     ldd       ,x        ; get block # into B: could be >$80
                     ldu       <D.BlkMap ; point to allocation table
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -217,15 +217,15 @@ L08DA               lda       ,u+       ; either of these 2 pages allocated?
                   ENDC
                     ldd       #DAT.Free ; get free block marker
                     std       ,x        ; save it into DAT image
-L08EC               leax      2,x       ; move to next DAT block
+FSrqmemDATBlock     leax      2,x       ; move to next DAT block
                   IFNE    H6309   ; begin conditional assembly for H6309
                     dece                ; done?
                   ELSE
                     leay      -1,y      ; compute -1,y into Y
                   ENDC
-                    bne       L08BC     ; no, keep checking
-L08F2               clrb                ; clear errors
-L08F3               rts                 ; return
+                    bne       FSrqmemBlockImage ; no, keep checking
+FSrqmemErrorCarry   clrb                ; clear errors
+FSrqmemReturn       rts                 ; return
 
 
 **************************************************
@@ -249,26 +249,26 @@ FBoot
                     **
                     coma                ; set boot flag
                     lda       <D.Boot   ; we booted once before?
-                    bne       L08F3     ; yes, return
+                    bne       FSrqmemReturn ; yes, return
                     inc       <D.Boot   ; set boot flag
                     ldx       <D.Init   ; get ptr to init module if it exists
-                    beq       L0908     ; it doesn't, point to boot name
+                    beq       FSrqmemBootPcr ; it doesn't, point to boot name
                     ldd       <BootStr,x ; get offset to text
-                    beq       L0908     ; doesn't exist, get hard coded text
+                    beq       FSrqmemBootPcr ; doesn't exist, get hard coded text
                     leax      d,x       ; adjust X to point to boot module
-                    bra       L090C     ; try & link to module
+                    bra       FSrqmemSystmObjct ; try & link to module
 
 boot                fcs       /Boot/
 
-L0908               leax      <boot,pcr ; compute <boot,pcr into X
+FSrqmemBootPcr      leax      <boot,pcr ; compute <boot,pcr into X
 * Link to module and execute
-L090C               lda       #Systm+Objct ; load A from #Systm+Objct
+FSrqmemSystmObjct   lda       #Systm+Objct ; load A from #Systm+Objct
                     os9       F$Link    ; call OS-9 service F$Link
-                    bcs       L08F3     ; branch if carry is set to L08F3
+                    bcs       FSrqmemReturn ; branch if carry is set to FSrqmemReturn
                     lda       #'b       ; calling boot
                     jsr       <D.BtBug  ; call routine at <D.BtBug
                     jsr       ,y        ; load boot file
-                    bcs       L08F3     ; branch if carry is set to L08F3
+                    bcs       FSrqmemReturn ; branch if carry is set to FSrqmemReturn
                     std       <D.BtSz   ; save boot file size
                     stx       <D.BtPtr  ; save start pointer of bootfile
                     lda       #'b       ; boot returns OK
@@ -290,7 +290,7 @@ not.ext             ldd       <D.BtSz   ; load D from <D.BtSz
                     ldb       $0D,x     ; get highest allocated block number
                     incb                ; allocate block 0, too
                     ldx       <D.BlkMap ; point to the memory block map
-                    lbra      L01DF     ; and go mark the blocks as used.
+                    lbra      KrnRAMUseFlag ; and go mark the blocks as used.
 
 
 **************************************************
@@ -319,9 +319,9 @@ I.VBlock            leau      d,x       ; point to end of bootfile
                     lsra                ; A is now logical block * 2
                     ldy       <D.SysDAT ; get pointer to system DAT
                     leay      a,y       ; y is pointer of sys block map of start of block
-L092D               ldd       M$ID,x    ; get module ID
+FSrqmemModuleIDSignature ldd       M$ID,x    ; get module ID
                     cmpd      #M$ID12   ; legal ID?
-                    bne       L0954     ; no, keep looking
+                    bne       FSrqmemTarget ; no, keep looking
 
                     ldd       M$Name,x  ; find name offset pointer
                     pshs      x         ; save x on the stack
@@ -352,16 +352,16 @@ name.prt            lda       ,x+       ; get first character of the name
                     leax      d,x       ; compute d,x into X
                     puls      b         ; restore b from the stack
                   ENDC
-                    bcc       L094E     ; branch if carry is clear to L094E
+                    bcc       FSrqmemModuleSize ; branch if carry is clear to FSrqmemModuleSize
                     cmpb      #E$KwnMod ; compare B with #E$KwnMod
-                    bne       L0954     ; branch if zero is clear to L0954
-L094E               ldd       M$Size,x  ; load D from M$Size,x
+                    bne       FSrqmemTarget ; branch if zero is clear to FSrqmemTarget
+FSrqmemModuleSize   ldd       M$Size,x  ; load D from M$Size,x
                     leax      d,x       ; compute d,x into X
                     fcb       $8C       ; skip 2 bytes
 
-L0954               leax      1,x       ; move to next byte
-L0956               cmpx      2,s       ; gone thru whole bootfile?
-                    bcs       L092D     ; no, keep looking
+FSrqmemTarget       leax      1,x       ; move to next byte
+FSrqmemHaveWeGoneThroughBootfile cmpx      2,s       ; gone thru whole bootfile?
+                    bcs       FSrqmemModuleIDSignature ; no, keep looking
                     leas      4,s       ; purge stack
                     clrb                ; clear B
                     rts                 ; return to caller

--- a/level2/modules/kernel/ccbfsrqmem.asm
+++ b/level2/modules/kernel/ccbfsrqmem.asm
@@ -42,19 +42,19 @@ FSRqMem             ldd       R$D,u     ; get memory allocation size requested
                   IFEQ    1       ; begin conditional assembly for 1
                     ldy       <D.SysMem ; get ptr to SMAP table
 * This loop updates the SMAP table if anything can be marked as unused
-FSrqmemSystemDATBlockList ldx       <D.SysDAT ; get pointer to system DAT block list
+FSrqmemSysDATBlk    ldx       <D.SysDAT ; get pointer to system DAT block list
                     lslb                ; adjust block offset for 2 bytes/entry
                     ldd       b,x       ; get block type/# from system DAT
                     cmpd      #DAT.Free ; unused block?
-                    beq       FSrqmemFillSystemPageMapNot ; yes, mark it free in SMAP table
+                    beq       FSrqmemFillSysPg ; yes, mark it free in SMAP table
                     ldx       <D.BlkMap ; no, get ptr to MMAP table
                     lda       d,x       ; get block marker for 2 meg mem map
                     cmpa      #RAMinUse ; is it in use (not free, ROM or used by module)?
                     bne       FSrqmemPut ; no, mark it as type it is in SMAP table
                     leay      32,y      ; yes, move to next block in pages
-                    bra       FSrqmemBumpUpBlockCheck ; move to next block & try again
+                    bra       FSrqmemBumpUpBlk ; move to next block & try again
 * Free RAM:
-FSrqmemFillSystemPageMapNot clra                ; byte to fill system page map with (0=Not in use)
+FSrqmemFillSysPg    clra                ; byte to fill system page map with (0=Not in use)
 * NOT! RAMinUse:
                   IFNE    H6309   ; begin conditional assembly for H6309
 FSrqmemPut          sta       ,s        ; put it on stack
@@ -66,10 +66,10 @@ FSrqmemMarkRAM      sta       ,y+       ; mark the RAM
                     decb                ; decrement B
                     bne       FSrqmemMarkRAM ; branch if zero is clear to FSrqmemMarkRAM
                   ENDC
-FSrqmemBumpUpBlockCheck inc       1,s       ; bump up to next block to check
+FSrqmemBumpUpBlk    inc       1,s       ; bump up to next block to check
                     ldb       1,s       ; get it
                     cmpb      #DAT.BlCt ; done whole 64k system space?
-                    blo       FSrqmemSystemDATBlockList ; no, keep checking
+                    blo       FSrqmemSysDATBlk ; no, keep checking
                   ENDC
 
 
@@ -86,7 +86,7 @@ FSrqmemBumpUpBlockCheck inc       1,s       ; bump up to next block to check
                     ldb       #32       ; skip block 0: it's always full
                     abx                 ; same size, but faster than leax $20,x
 *         leay  -(256-(Bt.Start>>8)),y  skip Kernel, Vector RAM & I/O (Can't be free)
-FSrqmemNumberPagesRequested ldb       R$A,u     ; get # 256 byte pages requested
+FSrqmemNumPgsReq    ldb       R$A,u     ; get # 256 byte pages requested
 * Loop (from end of system mem map) to look for # continuous pages requested
 FSrqmemJoin         equ       *         ; define assembler symbol FSrqmemJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -95,13 +95,13 @@ FSrqmemJoin         equ       *         ; define assembler symbol FSrqmemJoin
                     pshs      x         ; save x on the stack
                     cmpy      ,s++      ; compare Y with ,s++
                   ENDC
-                    bhi       FSrqmemPageMarkerStartingEndSystem ; yes, continue
+                    bhi       FSrqmemPgMrkrStrtn ; yes, continue
                     comb                ; exit with No System RAM Error
                     ldb       #E$NoRAM  ; load B from #E$NoRAM
                     bra       FSrqmemExit ; eat stack & exit
 
-FSrqmemPageMarkerStartingEndSystem lda       ,-y       ; get page marker (starting @ end of SMAP)
-                    bne       FSrqmemNumberPagesRequested ; used, try next lower page
+FSrqmemPgMrkrStrtn  lda       ,-y       ; get page marker (starting @ end of SMAP)
+                    bne       FSrqmemNumPgsReq ; used, try next lower page
                     decb                ; found 1 page, dec # pages we need to allocate
                     bne       FSrqmemJoin ; still more pages needed, check if we can get more
                     sty       ,s        ; found free contiguous pages, save SMAP entry ptr
@@ -126,9 +126,9 @@ FSrqmemPageMarkerStartingEndSystem lda       ,-y       ; get page marker (starti
                     ldb       R$A,u     ; get # pages requested
 *         lda   #RAMinUse    Get SMAP in use flag
 *L088A    sta   ,y+          Mark all the pages requested as In Use
-FSrqmemSinceRaminuseWeCanSpace inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
+FSrqmemSncRamUseWe  inc       ,y+       ; since RAMinUse is 1, we can save space by INC'ing from 0->1
                     decb                ; decrement B
-                    bne       FSrqmemSinceRaminuseWeCanSpace ; branch if zero is clear to FSrqmemSinceRaminuseWeCanSpace
+                    bne       FSrqmemSncRamUseWe ; branch if zero is clear to FSrqmemSncRamUseWe
                     lda       1,s       ; get MSB of ptr to start of newly allocated Sys RAM
                     std       R$U,u     ; save for caller
                     clrb                ; no error
@@ -195,11 +195,11 @@ FSrqmemBlockImage   ldd       ,x        ; get block image
                     addr      d,u       ; add d,u to destination register
 * Check if we can remove the entire memory block from system map
                     ldf       #16       ; get # pages per block/2
-FSrqmemEitherThesePagesAllocated ldd       ,u++      ; either of these 2 pages allocated?
+FSrqmemEthrThsPgs   ldd       ,u++      ; either of these 2 pages allocated?
                   ELSE
                     leau      d,u       ; compute d,u into U
                     ldb       #32       ; load B from #32
-FSrqmemEitherThesePagesAllocated lda       ,u+       ; either of these 2 pages allocated?
+FSrqmemEthrThsPgs   lda       ,u+       ; either of these 2 pages allocated?
                   ENDC
                     bne       FSrqmemDATBlock ; yes, can't free block, skip to next one
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -207,7 +207,7 @@ FSrqmemEitherThesePagesAllocated lda       ,u+       ; either of these 2 pages a
                   ELSE
                     decb                ; decrement B
                   ENDC
-                    bne       FSrqmemEitherThesePagesAllocated ; no, keep looking
+                    bne       FSrqmemEthrThsPgs ; no, keep looking
                     ldd       ,x        ; get block # into B: could be >$80
                     ldu       <D.BlkMap ; point to allocation table
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -319,7 +319,7 @@ I.VBlock            leau      d,x       ; point to end of bootfile
                     lsra                ; A is now logical block * 2
                     ldy       <D.SysDAT ; get pointer to system DAT
                     leay      a,y       ; y is pointer of sys block map of start of block
-FSrqmemModuleIDSignature ldd       M$ID,x    ; get module ID
+FSrqmemModIDSgntr   ldd       M$ID,x    ; get module ID
                     cmpd      #M$ID12   ; legal ID?
                     bne       FSrqmemTarget ; no, keep looking
 
@@ -360,8 +360,8 @@ FSrqmemModuleSize   ldd       M$Size,x  ; load D from M$Size,x
                     fcb       $8C       ; skip 2 bytes
 
 FSrqmemTarget       leax      1,x       ; move to next byte
-FSrqmemHaveWeGoneThroughBootfile cmpx      2,s       ; gone thru whole bootfile?
-                    bcs       FSrqmemModuleIDSignature ; no, keep looking
+FSrqmemHaveWeGone   cmpx      2,s       ; gone thru whole bootfile?
+                    bcs       FSrqmemModIDSgntr ; no, keep looking
                     leas      4,s       ; purge stack
                     clrb                ; clear B
                     rts                 ; return to caller

--- a/level2/modules/kernel/ccbkrn.asm
+++ b/level2/modules/kernel/ccbkrn.asm
@@ -25,23 +25,23 @@
                     nam       krn
                     ttl       NitrOS-9 Level 2 Kernel
 
-                    use       defsfile
+                    use       defsfile  ; include source file defsfile
 
 * defines for customizations
-Revision            set       9                   module revision
-Edition             set       19                  module Edition
-Where               equ       $F000               absolute address of where Kernel starts in memory
+Revision            set       9         ; module revision
+Edition             set       19        ; module Edition
+Where               equ       $F000     ; absolute address of where Kernel starts in memory
 
-                    mod       eom,MName,Systm,ReEnt+Revision,entry,0
+                    mod       eom,MName,Systm,ReEnt+Revision,entry,0 ; define OS-9 module header
 
-                    *         CCB                 Change: module name changes to CCBKrn
+                    *         CCB       Change: module name changes to CCBKrn
 MName               fcs       /CCBKrn/
-                    fcb       Edition
+                    fcb       Edition   ; define byte value(s) Edition
 
-                    *         CCB                 Change: added a automagic "fill" directive
-                    *         between             the end of the kernel module, proper, and the fe page code
-                    *         see                 way down. Manually refilling the empty space after each
-                    *         code                change was a pain and error prone.  BG
+                    *         CCB       Change: added a automagic "fill" directive
+                    *         between   the end of the kernel module, proper, and the fe page code
+                    *         see       way down. Manually refilling the empty space after each
+                    *         code      change was a pain and error prone.  BG
 
 * FILL - all unused bytes are now here
 *       fcc     /www.nitros9.org /
@@ -60,295 +60,295 @@ MName               fcs       /CCBKrn/
 
 * Might as well have this here as just past the end of Kernel...
 DisTable
-                    fdb       L0CD2+Where         D.Clock absolute address at the start
-                    fdb       XSWI3+Where         D.XSWI3
-                    fdb       XSWI2+Where         D.XSWI2
-                    fdb       D.Crash             D.XFIRQ crash on an FIRQ
-                    fdb       XIRQ+Where          D.XIRQ
-                    fdb       XSWI+Where          D.XSWI
-                    fdb       D.Crash             D.XNMI crash on an NMI
-                    fdb       $0055               D.ErrRst ??? Not used as far as I can tell
-                    fdb       Sys.Vec+Where       Initial Kernel system call vector
-DisSize             equ       *-DisTable
+                    fdb       L0CD2+Where ; d.Clock absolute address at the start
+                    fdb       XSWI3+Where ; d.XSWI3
+                    fdb       XSWI2+Where ; d.XSWI2
+                    fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
+                    fdb       XIRQ+Where ; d.XIRQ
+                    fdb       XSWI+Where ; d.XSWI
+                    fdb       D.Crash   ; d.XNMI crash on an NMI
+                    fdb       $0055     ; d.ErrRst ??? Not used as far as I can tell
+                    fdb       Sys.Vec+Where ; initial Kernel system call vector
+DisSize             equ       *-DisTable ; define assembler symbol DisSize
 * DO NOT ADD ANYTHING BETWEEN THESE 2 TABLES: see code using 'SubSiz', below
-LowSub              equ       $0160               start of low memory subroutines
-SubStrt             equ       *
+LowSub              equ       $0160     ; start of low memory subroutines
+SubStrt             equ       *         ; define assembler symbol SubStrt
 * D.Flip0 - switch to system task 0
-R.Flip0             equ       *
-                    ifne      H6309
-                    aim       #$FE,<D.TINIT       map type 0
-                    lde       <D.TINIT            another 2 bytes saved if GRFDRV does: tfr cc,e
-                    ste       >DAT.Task           and we can use A here, instead of E
-                    else
-                    pshs      a
-                    lda       <D.TINIT
-                    anda      #$FE                force TR=0
-                    sta       <D.TINIT
-                    sta       >DAT.Task
-                    puls      a
-                    endc
-                    clr       <D.SSTskN
-                    tfr       x,s
-                    tfr       a,cc
-                    rts
-SubSiz              equ       *-SubStrt
+R.Flip0             equ       *         ; define assembler symbol R.Flip0
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #$FE,<D.TINIT ; map type 0
+                    lde       <D.TINIT  ; another 2 bytes saved if GRFDRV does: tfr cc,e
+                    ste       >DAT.Task ; and we can use A here, instead of E
+                  ELSE
+                    pshs      a         ; save a on the stack
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    anda      #$FE      ; force TR=0
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                    sta       >DAT.Task ; store A at >DAT.Task
+                    puls      a         ; restore a from the stack
+                  ENDC
+                    clr       <D.SSTskN ; clear <D.SSTskN
+                    tfr       x,s       ; transfer register value x,s
+                    tfr       a,cc      ; transfer register value a,cc
+                    rts                 ; return to caller
+SubSiz              equ       *-SubStrt ; define assembler symbol SubSiz
 * Don't add any code here: See L0065, below.
 * Interrupt service routine
-Vectors             jmp       [<-(D.SWI3-D.XSWI3),x] (-$10) (Jmp to 2ndary vector)
+Vectors             jmp       [<-(D.SWI3-D.XSWI3),x] ; (-$10) (Jmp to 2ndary vector)
 
 * Let's start by initializing system page
-entry               equ       *
-                    *         CCB                 Addition - save stacked OS9Boot size and make a dummy kernel printer
-                    pulu      d                   pull boot file size from CoCoBoot and
-                    std       <D.BtSz             save to direct page for later use
-                    inc       <D.Boot             mark boot attempted flag
-                    inc       <D.Speed            mark high speed
-                    lds       #$1fff              reset system stack (s/b 0x2000 ?!?!)
-                    lda       #$7e                put code in DP so rest of kernel can
-                    sta       <D.BtBug            call kernel printing routine
-                    leax      BtDebug,pc
-                    stx       <D.BtBug+1
-                    sta       <D.Crash            and do the same with the kernel crash
-                    leax      Crash,pc            code
-                    stx       <D.Crash+1
-                    bra       CCBEND              jump over new kprint & crash routines
+entry               equ       *         ; define assembler symbol entry
+                    *         CCB       Addition - save stacked OS9Boot size and make a dummy kernel printer
+                    pulu      d         ; pull boot file size from CoCoBoot and
+                    std       <D.BtSz   ; save to direct page for later use
+                    inc       <D.Boot   ; mark boot attempted flag
+                    inc       <D.Speed  ; mark high speed
+                    lds       #$1fff    ; reset system stack (s/b 0x2000 ?!?!)
+                    lda       #$7e      ; put code in DP so rest of kernel can
+                    sta       <D.BtBug  ; call kernel printing routine
+                    leax      BtDebug,pc ; compute BtDebug,pc into X
+                    stx       <D.BtBug+1 ; store X at <D.BtBug+1
+                    sta       <D.Crash  ; and do the same with the kernel crash
+                    leax      Crash,pc  ; code
+                    stx       <D.Crash+1 ; store X at <D.Crash+1
+                    bra       CCBEND    ; jump over new kprint & crash routines
 
-                    *         This                is a kernel print routine
-                    *         This                is added to replace the same routine found in "rel.asm"
-                    *         so                  we get debug output.
-                    *         Takes               A - charactor to print
-                    *         modifies            - nothing
-BtDebug             pshs      cc,d,x              save the register
-                    orcc      #IntMasks           turn IRQ's off
-                    ldb       #$3b                block to map in
-                    stb       >DAT.Regs           map the boot screen into block 0
-                    ldx       >$0002              where to put the bytes
-                    sta       ,x+                 put the character on-screen
-                    stx       >$0002              save updated address
-                    clr       >DAT.Regs           map block 0 in again
-                    puls      cc,d,x,pc           restore and return
-                    *         This                routine just prints "!" and loops forever
-Crash               lda       #'!                 print a "!"
-                    jsr       <D.BtBug
-e                   bra       e                   loop forever
+                    *         This      is a kernel print routine
+                    *         This      is added to replace the same routine found in "rel.asm"
+                    *         so        we get debug output.
+                    *         Takes     A - charactor to print
+                    *         modifies  - nothing
+BtDebug             pshs      cc,d,x    ; save the register
+                    orcc      #IntMasks ; turn IRQ's off
+                    ldb       #$3b      ; block to map in
+                    stb       >DAT.Regs ; map the boot screen into block 0
+                    ldx       >$0002    ; where to put the bytes
+                    sta       ,x+       ; put the character on-screen
+                    stx       >$0002    ; save updated address
+                    clr       >DAT.Regs ; map block 0 in again
+                    puls      cc,d,x,pc ; restore and return
+                    *         This      routine just prints "!" and loops forever
+Crash               lda       #'!       ; print a "!"
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+e                   bra       e         ; loop forever
 CCBEND
-                    *         end                 of CCB Addition
+                    *         end       of CCB Addition
 
-                    *         This                code clears the rest of the low block
-                    *         rel.asm/cocoboot    has cleared the DP already.
-                    ifne      H6309
-                    ldq       #$01001f00          start address to clear & # bytes to clear
-                    leay      <entry+2,pc         point to a 0
-                    tfm       y,d+
-                    std       <D.CCStk            set pointer to top of global memory to $2000
-                    lda       #$01                set task user table to $0100
-                    else
-                    ldx       #$100
-                    ldy       #$2000-$100
-                    clra
-                    clrb
-L001C               std       ,x++
-                    leay      -2,y
-                    bne       L001C
-                    stx       <D.CCStk            Set pointer to top of global memory to $2000
-                    inca                          D = $0100
-                    endc
+                    *         This      code clears the rest of the low block
+                    *         rel.asm/cocoboot has cleared the DP already.
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$01001f00 ; start address to clear & # bytes to clear
+                    leay      <entry+2,pc ; point to a 0
+                    tfm       y,d+      ; transfer memory block using y,d+
+                    std       <D.CCStk  ; set pointer to top of global memory to $2000
+                    lda       #$01      ; set task user table to $0100
+                  ELSE
+                    ldx       #$100     ; load X from #$100
+                    ldy       #$2000-$100 ; load Y from #$2000-$100
+                    clra                ; clear A
+                    clrb                ; clear B
+L001C               std       ,x++      ; store D at ,x++
+                    leay      -2,y      ; compute -2,y into Y
+                    bne       L001C     ; branch if zero is clear to L001C
+                    stx       <D.CCStk  ; set pointer to top of global memory to $2000
+                    inca                ; D = $0100
+                  ENDC
 
 * Setup system direct page variables
-                    std       <D.Tasks            set Task Structure pointer to 0x100
-                    addb      #$20                set Task image table pointer to $0120
-                    std       <D.TskIPt
-                    clrb                          set memory block map pointer to $0200
-                    inca
-                    std       <D.BlkMap
-                    addb      #$40                set second block map pointer to $0240
-                    std       <D.BlkMap+2
-                    clrb                          set system service dispatch table
-                    inca                          pointer to 0x300
-                    std       <D.SysDis
-                    inca                          set user dispatch table pointer to $0400
-                    std       <D.UsrDis
-                    inca                          set process descriptor block pointer to $0500
-                    std       <D.PrcDBT
-                    inca                          set system process descriptor pointer to $0600
-                    std       <D.SysPrc
-                    std       <D.Proc             set user process descriptor pointer to $0600
-                    adda      #$02                set stack pointer to $0800
-                    tfr       d,s
-                    inca                          set system stack base pointer to $0900
-                    std       <D.SysStk
-                    std       <D.SysMem           set system memory map ptr $0900
-                    inca                          set module directory start ptr to $0a00
-                    std       <D.ModDir
-                    std       <D.ModEnd           set module directory end ptr to $0a00
-                    adda      #$06                set secondary module directory start to $1000
-                    std       <D.ModDir+2
-                    std       <D.ModDAT           set module directory DAT pointer to $1000
-                    std       <D.CCMem            set pointer to beginning of global memory to $1000
+                    std       <D.Tasks  ; set Task Structure pointer to 0x100
+                    addb      #$20      ; set Task image table pointer to $0120
+                    std       <D.TskIPt ; store D at <D.TskIPt
+                    clrb                ; set memory block map pointer to $0200
+                    inca                ; increment A
+                    std       <D.BlkMap ; store D at <D.BlkMap
+                    addb      #$40      ; set second block map pointer to $0240
+                    std       <D.BlkMap+2 ; store D at <D.BlkMap+2
+                    clrb                ; set system service dispatch table
+                    inca                ; pointer to 0x300
+                    std       <D.SysDis ; store D at <D.SysDis
+                    inca                ; set user dispatch table pointer to $0400
+                    std       <D.UsrDis ; store D at <D.UsrDis
+                    inca                ; set process descriptor block pointer to $0500
+                    std       <D.PrcDBT ; store D at <D.PrcDBT
+                    inca                ; set system process descriptor pointer to $0600
+                    std       <D.SysPrc ; store D at <D.SysPrc
+                    std       <D.Proc   ; set user process descriptor pointer to $0600
+                    adda      #$02      ; set stack pointer to $0800
+                    tfr       d,s       ; transfer register value d,s
+                    inca                ; set system stack base pointer to $0900
+                    std       <D.SysStk ; store D at <D.SysStk
+                    std       <D.SysMem ; set system memory map ptr $0900
+                    inca                ; set module directory start ptr to $0a00
+                    std       <D.ModDir ; store D at <D.ModDir
+                    std       <D.ModEnd ; set module directory end ptr to $0a00
+                    adda      #$06      ; set secondary module directory start to $1000
+                    std       <D.ModDir+2 ; store D at <D.ModDir+2
+                    std       <D.ModDAT ; set module directory DAT pointer to $1000
+                    std       <D.CCMem  ; set pointer to beginning of global memory to $1000
 * In following line, CRC=ON if it is STA <D.CRC, CRC=OFF if it is a STB <D.CRC
-                    stb       <D.CRC              set CRC checking flag to off
+                    stb       <D.CRC    ; set CRC checking flag to off
 
 * Initialize interrupt vector tables, move pointer data down to DP
 * CCB Change:
 * this line was an error?
 *       leay    <DisTable,pcr
-                    leay      DisTable,pcr        point to table of absolute vector addresses
+                    leay      DisTable,pcr ; point to table of absolute vector addresses
 *
 *
-                    ldx       #D.Clock            where to put it in memory
-                    ifne      H6309
-                    ldf       #DisSize            size of the table - E=0 from TFM, above
-                    tfm       y+,x+               move it over
-                    else
-                    ldb       #DisSize
+                    ldx       #D.Clock  ; where to put it in memory
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #DisSize  ; size of the table - E=0 from TFM, above
+                    tfm       y+,x+     ; move it over
+                  ELSE
+                    ldb       #DisSize  ; load B from #DisSize
 l@
-                    lda       ,y+                 load a byte from source
-                    sta       ,x+                 store a byte to dest
-                    decb                          bump counter
-                    bne       l@                  loop if we're not done
-                    endc
+                    lda       ,y+       ; load a byte from source
+                    sta       ,x+       ; store a byte to dest
+                    decb                ; bump counter
+                    bne       l@        ; loop if we're not done
+                  ENDC
 
 * initialize D.Flip0 routine in low memory, move function down to low
 * memory.
 * Y=ptr to R.Flip0 already
 *         leay  >R.Flip0,pc
-                    ldu       #LowSub             move to 0x160
-                    stu       <D.Flip0            store fuction pointer to DP area
-                    ifne      H6309
-                    ldf       #SubSiz             size of it
-                    tfm       y+,u+               copy it over
-                    else
-                    ldb       #SubSiz
-Loop2               lda       ,y+                 load a byte from source
-                    sta       ,u+                 and save to destination
-                    decb                          bump counter
-                    bne       Loop2               loop if not done
-                    endc
+                    ldu       #LowSub   ; move to 0x160
+                    stu       <D.Flip0  ; store fuction pointer to DP area
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #SubSiz   ; size of it
+                    tfm       y+,u+     ; copy it over
+                  ELSE
+                    ldb       #SubSiz   ; load B from #SubSiz
+Loop2               lda       ,y+       ; load a byte from source
+                    sta       ,u+       ; and save to destination
+                    decb                ; bump counter
+                    bne       Loop2     ; loop if not done
+                  ENDC
 
 *         leau   <Vectors,pc   point to vector
 * fill in the secondard interrupt vectors to all point to
-                    tfr       y,u                 move the pointer to a faster register
-L0065               stu       ,x++                Set all IRQ vectors to go to Vectors for now
-                    cmpx      #D.NMI
-                    bls       L0065
+                    tfr       y,u       ; move the pointer to a faster register
+L0065               stu       ,x++      ; set all IRQ vectors to go to Vectors for now
+                    cmpx      #D.NMI    ; compare X with #D.NMI
+                    bls       L0065     ; branch if unsigned result is lower or same to L0065
 
 * Initialize user interupt vectors
-                    ldx       <D.XSWI2            Get SWI2 (os9 command) service routine pointer
-                    stx       <D.UsrSvc           Save it as user service routine pointer
-                    ldx       <D.XIRQ             Get IRQ service routine pointer
-                    stx       <D.UsrIRQ           Save it as user IRQ routine pointer
+                    ldx       <D.XSWI2  ; get SWI2 (os9 command) service routine pointer
+                    stx       <D.UsrSvc ; save it as user service routine pointer
+                    ldx       <D.XIRQ   ; get IRQ service routine pointer
+                    stx       <D.UsrIRQ ; save it as user IRQ routine pointer
 
-                    leax      >SysCall,pc         Setup System service routine entry vector
-                    stx       <D.SysSvc
-                    stx       <D.XSWI2
+                    leax      >SysCall,pc ; setup System service routine entry vector
+                    stx       <D.SysSvc ; store X at <D.SysSvc
+                    stx       <D.XSWI2  ; store X at <D.XSWI2
 
-                    leax      >S.SysIRQ,pc        Setup system IRQ service vector
-                    stx       <D.SysIRQ
-                    stx       <D.XIRQ
+                    leax      >S.SysIRQ,pc ; setup system IRQ service vector
+                    stx       <D.SysIRQ ; store X at <D.SysIRQ
+                    stx       <D.XIRQ   ; store X at <D.XIRQ
 
-                    leax      >S.SvcIRQ,pc        Setup in system IRQ service vector
-                    stx       <D.SvcIRQ
-                    leax      >S.Poll,pc          Setup interrupt polling vector
-                    stx       <D.Poll             ORCC #$01;RTS
-                    leax      >S.AltIRQ,pc        Setup alternate IRQ vector: pts to an RTS
-                    stx       <D.AltIRQ
+                    leax      >S.SvcIRQ,pc ; setup in system IRQ service vector
+                    stx       <D.SvcIRQ ; store X at <D.SvcIRQ
+                    leax      >S.Poll,pc ; setup interrupt polling vector
+                    stx       <D.Poll   ; oRCC #$01;RTS
+                    leax      >S.AltIRQ,pc ; setup alternate IRQ vector: pts to an RTS
+                    stx       <D.AltIRQ ; store X at <D.AltIRQ
 
-                    lda       #'K                 --- in Kernel
-                    jsr       <D.BtBug            ---
+                    lda       #'K       ; --- in Kernel
+                    jsr       <D.BtBug  ; ---
 
-                    leax      >S.Flip1,pc         Setup change to task 1 vector
-                    stx       <D.Flip1
+                    leax      >S.Flip1,pc ; setup change to task 1 vector
+                    stx       <D.Flip1  ; store X at <D.Flip1
 
 * Setup System calls
-                    leay      >SysCalls,pc        load y with address of table, below
-                    lbsr      InstallSvc          copy table below into dispatch table
+                    leay      >SysCalls,pc ; load y with address of table, below
+                    lbsr      InstallSvc ; copy table below into dispatch table
 
 * Initialize system process descriptor
-                    ldu       <D.PrcDBT           get process table pointer
-                    ldx       <D.SysPrc           get system process pointer
+                    ldu       <D.PrcDBT ; get process table pointer
+                    ldx       <D.SysPrc ; get system process pointer
 
 * These overlap because it is quicker than trying to strip hi byte from X
-                    stx       ,u                  save it as first process in table
-                    stx       1,u                 save it as the second as well
-                    ifne      H6309
-                    oim       #$01,P$ID,x         Set process ID to 1 (inited to 0)
-                    oim       #SysState,P$State,x Set to system state (inited to 0)
-                    else
-                    ldd       #$01*256+SysState
-                    sta       P$ID,x              set PID to 1
-                    stb       P$State,x           set state to system (*NOT* zero )
-                    endc
-                    clra                          set System task as task #0
-                    sta       <D.SysTsk
-                    sta       P$Task,x
-                    coma                          Setup its priority & age ($FF)
-                    sta       P$Prior,x
-                    sta       P$Age,x
-                    leax      <P$DATImg,x         point to DAT image
-                    stx       <D.SysDAT           save it as a pointer in DP
+                    stx       ,u        ; save it as first process in table
+                    stx       1,u       ; save it as the second as well
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,P$ID,x ; set process ID to 1 (inited to 0)
+                    oim       #SysState,P$State,x ; set to system state (inited to 0)
+                  ELSE
+                    ldd       #$01*256+SysState ; load D from #$01*256+SysState
+                    sta       P$ID,x    ; set PID to 1
+                    stb       P$State,x ; set state to system (*NOT* zero )
+                  ENDC
+                    clra                ; set System task as task #0
+                    sta       <D.SysTsk ; store A at <D.SysTsk
+                    sta       P$Task,x  ; store A at P$Task,x
+                    coma                ; setup its priority & age ($FF)
+                    sta       P$Prior,x ; store A at P$Prior,x
+                    sta       P$Age,x   ; store A at P$Age,x
+                    leax      <P$DATImg,x ; point to DAT image
+                    stx       <D.SysDAT ; save it as a pointer in DP
 * actually, since block 0 is tfm'd to be zero, we can skip the next 2 lines
-                    ifne      H6309
-                    clrd
-                    else
-                    clra
-                    clrb
-                    endc
-                    std       ,x++                initialize 1st block to 0 (for this DP)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; clear D
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    std       ,x++      ; initialize 1st block to 0 (for this DP)
 
 * Dat.BlCt-ROMCount-RAMCount
-                    lda       #$06                initialize the rest of the blocks to be free
-                    ldu       #DAT.Free
-L00EF               stu       ,x++                store free "flag"
-                    deca                          bump counter
-                    bne       L00EF               loop if not done
+                    lda       #$06      ; initialize the rest of the blocks to be free
+                    ldu       #DAT.Free ; load U from #DAT.Free
+L00EF               stu       ,x++      ; store free "flag"
+                    deca                ; bump counter
+                    bne       L00EF     ; loop if not done
 
-                    ldu       #KrnBlk             Block where the kernel will live
-                    stu       ,x
+                    ldu       #KrnBlk   ; block where the kernel will live
+                    stu       ,x        ; store U at ,x
 
-                    ldx       <D.Tasks            Point to task user table
-                    inc       ,x                  mark first 2 in use (system & GrfDrv)
-                    inc       1,x
+                    ldx       <D.Tasks  ; point to task user table
+                    inc       ,x        ; mark first 2 in use (system & GrfDrv)
+                    inc       1,x       ; increment 1,x
 
 * Setup system memory map
-                    ldx       <D.SysMem           Get system memory map pointer
-                    ldb       <D.CCStk            Get MSB of top of CC memory
-L0104               inc       ,x+                 Mark it as used
-                    decb                          Done?
-                    bne       L0104               No, go back till done
+                    ldx       <D.SysMem ; get system memory map pointer
+                    ldb       <D.CCStk  ; get MSB of top of CC memory
+L0104               inc       ,x+       ; mark it as used
+                    decb                ; done?
+                    bne       L0104     ; no, go back till done
 
 * Calculate memory size
-                    *         CCB                 Comment:
-                    *         This                code only modifies 2 bytes in the x0 blocks (x=doesn't cares)
-                    *         which               at worst will be our DP. Should not effect CCB's prior load of
-                    *         OS9Boot             it can only be loaded into block x1 through x6 and 3f so
-                    *         we                  should be safe.
-                    ldx       <D.BlkMap           get ptr to 8k block map
-                    inc       <KrnBlk,x           mark block holding kernel as used
-                    ifne      H6309
-                    ldq       #$00080100          e=Marker, D=Block # to check
-L0111               asld                          get next block #
-                    stb       >DAT.Regs+5         Map block into block 6 of my task
-                    ste       >-$6000,x           save marker to that block
-                    cmpe      ,x                  did it ghost to block 0?
-                    bne       L0111               No, keep going till ghost is found
-                    stb       <D.MemSz            Save # 8k mem blocks that exist
-                    addr      x,d                 add number of blocks to block map start
-                    else
-                    ldd       #$0008
-L0111               aslb
-                    rola
-                    stb       >DAT.Regs+5
-                    pshs      a
-                    lda       #$01
-                    sta       >-$6000,x
-                    cmpa      ,x
-                    puls      a
-                    bne       L0111
-                    stb       <D.MemSz
-                    pshs      x
-                    addd      ,s++
-                    endc
-                    std       <D.BlkMap+2         save block map end pointer
+                    *         CCB       Comment:
+                    *         This      code only modifies 2 bytes in the x0 blocks (x=doesn't cares)
+                    *         which     at worst will be our DP. Should not effect CCB's prior load of
+                    *         OS9Boot   it can only be loaded into block x1 through x6 and 3f so
+                    *         we        should be safe.
+                    ldx       <D.BlkMap ; get ptr to 8k block map
+                    inc       <KrnBlk,x ; mark block holding kernel as used
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$00080100 ; e=Marker, D=Block # to check
+L0111               asld                ; get next block #
+                    stb       >DAT.Regs+5 ; map block into block 6 of my task
+                    ste       >-$6000,x ; save marker to that block
+                    cmpe      ,x        ; did it ghost to block 0?
+                    bne       L0111     ; no, keep going till ghost is found
+                    stb       <D.MemSz  ; save # 8k mem blocks that exist
+                    addr      x,d       ; add number of blocks to block map start
+                  ELSE
+                    ldd       #$0008    ; load D from #$0008
+L0111               aslb                ; update processor state
+                    rola                ; shift or rotate and update condition codes
+                    stb       >DAT.Regs+5 ; store B at >DAT.Regs+5
+                    pshs      a         ; save a on the stack
+                    lda       #$01      ; load A from #$01
+                    sta       >-$6000,x ; store A at >-$6000,x
+                    cmpa      ,x        ; compare A with ,x
+                    puls      a         ; restore a from the stack
+                    bne       L0111     ; branch if zero is clear to L0111
+                    stb       <D.MemSz  ; store B at <D.MemSz
+                    pshs      x         ; save x on the stack
+                    addd      ,s++      ; add ,s++ to D
+                  ENDC
+                    std       <D.BlkMap+2 ; save block map end pointer
 
 * [D] at this point will contain 1 of the following:
 * $0210 - 128k
@@ -356,18 +356,18 @@ L0111               aslb
 * $0240 - 512k
 * $0280 - 1024k
 * $0300 - 2048k
-                    bitb      #%00110000          block above 128K-256K?
-                    beq       L0170               yes, no need to mark block map
-                    tstb                          2 meg?
-                    beq       L0170               yes, skip this
+                    bitb      #%00110000 ; block above 128K-256K?
+                    beq       L0170     ; yes, no need to mark block map
+                    tstb                ; 2 meg?
+                    beq       L0170     ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
-                    abx                           add maximum block number to block map start
-                    leax      -1,x                Skip good blocks that are RAM
-                    lda       #NotRAM             Not RAM flag
-                    subb      #$3F                Calculate # blocks to mark as not RAM
-L0127               sta       ,x+                 Mark them all
-                    decb
-                    bne       L0127
+                    abx                 ; add maximum block number to block map start
+                    leax      -1,x      ; skip good blocks that are RAM
+                    lda       #NotRAM   ; not RAM flag
+                    subb      #$3F      ; calculate # blocks to mark as not RAM
+L0127               sta       ,x+       ; mark them all
+                    decb                ; decrement B
+                    bne       L0127     ; branch if zero is clear to L0127
 
 L0170
 * CCB - Commented out next two line. we don't have REL or BOOT, so the verify will be only
@@ -381,63 +381,63 @@ L0170
 *       lbsr    I.VBlock        go verify it
 *       bsr     L01D2           go mark system map
 * CCB Change - I'm commenting out this whole section, and replacing it
-                    ifeq      1
+                  IFEQ    1       ; begin conditional assembly for 1
 * See if init module is in memory already
-L01B0               leax      <init,pc            point to 'Init' module name
-                    bsr       link                try & link it
-                    bcc       L01BF               no error, go on
-L01B8               os9       F$Boot              error linking init, try & load boot file
-                    bcc       L01B0               got it, try init again
-                    bra       L01CE               error, re-booting do D.Crash
-L01BF               stu       <D.Init             Save init module pointer
-                    lda       Feature1,u          Get feature byte #1 from init module
-                    bita      #CRCOn              CRC feature on?
-                    beq       ShowI               if not, continue
-                    inc       <D.CRC              else inc. CRC flag
-ShowI               lda       #'i                 found init module
-                    jsr       <D.BtBug
+L01B0               leax      <init,pc  ; point to 'Init' module name
+                    bsr       link      ; try & link it
+                    bcc       L01BF     ; no error, go on
+L01B8               os9       F$Boot    ; error linking init, try & load boot file
+                    bcc       L01B0     ; got it, try init again
+                    bra       L01CE     ; error, re-booting do D.Crash
+L01BF               stu       <D.Init   ; save init module pointer
+                    lda       Feature1,u ; get feature byte #1 from init module
+                    bita      #CRCOn    ; cRC feature on?
+                    beq       ShowI     ; if not, continue
+                    inc       <D.CRC    ; else inc. CRC flag
+ShowI               lda       #'i       ; found init module
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
 
-L01C1               leax      <krnp2,pc           Point to it's name
-                    bsr       link                Try to link it
-                    bcc       L01D0               It worked, execute it
-                    os9       F$Boot              It doesn't exist try re-booting
-                    bcc       L01C1               No error's, let's try to link it again
-L01CE               jmp       <D.Crash            obviously can't do it, crash machine
-L01D0               jmp       ,y                  execute krnp2
-                    endc
+L01C1               leax      <krnp2,pc ; point to it's name
+                    bsr       link      ; try to link it
+                    bcc       L01D0     ; it worked, execute it
+                    os9       F$Boot    ; it doesn't exist try re-booting
+                    bcc       L01C1     ; no error's, let's try to link it again
+L01CE               jmp       <D.Crash  ; obviously can't do it, crash machine
+L01D0               jmp       ,y        ; execute krnp2
+                  ENDC
 
 * CCB we'll replace above with this:
-                    ldd       <D.BtSz             get the size of OS9Boot file
-                    addd      #$fff               add size of krn and round to higher size
-                    clrb
-                    pshs      d                   save on stack
-                    os9       F$SRqMem            get memory - U is our starting address
-                    stu       <D.BtPtr            save this just incase something uses it
-                    tfr       u,x                 setup x for vblock
-                    puls      d                   setup d for vblock with stacked size
-                    lbsr      I.VBlock            verify OS9Boot
-                    *         this                was copied from f$boot
-                    *         I                   dont know why we need to do this.  Wouldn't
-                    *         f$srqmem            do this for us?!?!  But the system won't boot without.
-                    ldx       <D.SysDAT           get system DAT pointer
-                    ldb       $0D,x               get highest allocated block number
-                    incb                          allocate block 0, too
-                    ldx       <D.BlkMap           point to the memory block map
-                    bsr       L01DF               and go mark the blocks as used
-                    *         end                 of copy from f$boot
-                    leax      <init,pc            point to 'Init' module name
-                    bsr       link                try & link it
-L01BF               stu       <D.Init             Save init module pointer
-                    lda       Feature1,u          Get feature byte #1 from init module
-                    bita      #CRCOn              CRC feature on?
+                    ldd       <D.BtSz   ; get the size of OS9Boot file
+                    addd      #$fff     ; add size of krn and round to higher size
+                    clrb                ; clear B
+                    pshs      d         ; save on stack
+                    os9       F$SRqMem  ; get memory - U is our starting address
+                    stu       <D.BtPtr  ; save this just incase something uses it
+                    tfr       u,x       ; setup x for vblock
+                    puls      d         ; setup d for vblock with stacked size
+                    lbsr      I.VBlock  ; verify OS9Boot
+                    *         this      was copied from f$boot
+                    *         I         dont know why we need to do this.  Wouldn't
+                    *         f$srqmem  do this for us?!?!  But the system won't boot without.
+                    ldx       <D.SysDAT ; get system DAT pointer
+                    ldb       $0D,x     ; get highest allocated block number
+                    incb                ; allocate block 0, too
+                    ldx       <D.BlkMap ; point to the memory block map
+                    bsr       L01DF     ; and go mark the blocks as used
+                    *         end       of copy from f$boot
+                    leax      <init,pc  ; point to 'Init' module name
+                    bsr       link      ; try & link it
+L01BF               stu       <D.Init   ; save init module pointer
+                    lda       Feature1,u ; get feature byte #1 from init module
+                    bita      #CRCOn    ; cRC feature on?
 *       beq     ShowI           if not, continue
-                    inc       <D.CRC              else inc. CRC flag
-ShowI               lda       #'i                 found init module
-                    jsr       <D.BtBug
-L01C1               leax      <krnp2,pc           Point to it's name
-                    bsr       link                Try to link it
+                    inc       <D.CRC    ; else inc. CRC flag
+ShowI               lda       #'i       ; found init module
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+L01C1               leax      <krnp2,pc ; point to it's name
+                    bsr       link      ; try to link it
 *e      bra     e
-L01D0               jmp       ,y                  execute krnp2
+L01D0               jmp       ,y        ; execute krnp2
 
 
 * CCB - End of change
@@ -448,7 +448,7 @@ L01D0               jmp       ,y                  execute krnp2
 *       * CCB Change - only mark KRN as used (BOOT and REL don't exist)
 *       ldd     #NotRAM*256+(Bt.Start/256)      B = MSB of start of the boot
 *       ldd     #NotRam*256+(Where/256)         B = MSB of start of REL
-                    *         CCB                 Change end
+                    *         CCB       Change end
 *       abx                     point to Bt.Start - start of boot track
 *       comb                    we have $FF-$ED pages to mark as used
 *       sta     b,x             Mark I/O as not RAM
@@ -456,398 +456,398 @@ L01D0               jmp       ,y                  execute krnp2
 * Mark kernel and boot file in system memory as used - there is no
 * reason this is a routine anymore - only one place calls it, but
 * some speghetti is here... one of the IRQ routines "borrows" this rts.
-L01DF               lda       #RAMinUse           get in use flag
-L01E1               sta       ,x+                 save it
-                    decb                          done?
-                    bne       L01E1               no, keep going
-                    ldx       <D.BlkMap           get pointer to start of block map
-                    sta       <KrnBlk,x           mark kernel block as RAMinUse, instead of ModInBlk
-S.AltIRQ            rts                           return
+L01DF               lda       #RAMinUse ; get in use flag
+L01E1               sta       ,x+       ; save it
+                    decb                ; done?
+                    bne       L01E1     ; no, keep going
+                    ldx       <D.BlkMap ; get pointer to start of block map
+                    sta       <KrnBlk,x ; mark kernel block as RAMinUse, instead of ModInBlk
+S.AltIRQ            rts                 ; return
 
 * Link module pointed to by X
-link                lda       #Systm              Attempt to link system module
-                    os9       F$Link
-                    rts
+link                lda       #Systm    ; attempt to link system module
+                    os9       F$Link    ; call OS-9 service F$Link
+                    rts                 ; return to caller
 
 init                fcs       'Init'
 krnp2               fcs       'krnp2'
 
 * Service vector call pointers
-SysCalls            fcb       F$Link
-                    fdb       FLink-*-2
-                    fcb       F$PrsNam
-                    fdb       FPrsNam-*-2
-                    fcb       F$CmpNam
-                    fdb       FCmpNam-*-2
-                    fcb       F$CmpNam+SysState
-                    fdb       FSCmpNam-*-2
-                    fcb       F$CRC
-                    fdb       FCRC-*-2
-                    fcb       F$SRqMem+SysState
-                    fdb       FSRqMem-*-2
-                    fcb       F$SRtMem+SysState
-                    fdb       FSRtMem-*-2
-                    fcb       F$AProc+SysState
-                    fdb       FAProc-*-2
-                    fcb       F$NProc+SysState
-                    fdb       FNProc-*-2
-                    fcb       F$VModul+SysState
-                    fdb       FVModul-*-2
-                    fcb       F$SSvc+SysState
-                    fdb       FSSvc-*-2
-                    fcb       F$SLink+SysState
-                    fdb       FSLink-*-2
-                    fcb       F$Boot+SysState
-                    fdb       FBoot-*-2
-                    fcb       F$BtMem+SysState
-                    fdb       FSRqMem-*-2
-                    ifne      H6309
-                    fcb       F$CpyMem
-                    fdb       FCpyMem-*-2
-                    endc
-                    fcb       F$Move+SysState
-                    fdb       FMove-*-2
-                    fcb       F$AllImg+SysState
-                    fdb       FAllImg-*-2
-                    fcb       F$SetImg+SysState
-                    fdb       FSetImg-*-2
-                    fcb       F$FreeLB+SysState
-                    fdb       FSFreeLB-*-2
-                    fcb       F$FreeHB+SysState
-                    fdb       FFreeHB-*-2
-                    fcb       F$AllTsk+SysState
-                    fdb       FAllTsk-*-2
-                    fcb       F$DelTsk+SysState
-                    fdb       FDelTsk-*-2
-                    fcb       F$SetTsk+SysState
-                    fdb       FSetTsk-*-2
-                    fcb       F$ResTsk+SysState
-                    fdb       FResTsk-*-2
-                    fcb       F$RelTsk+SysState
-                    fdb       FRelTsk-*-2
-                    fcb       F$DATLog+SysState
-                    fdb       FDATLog-*-2
-                    fcb       F$LDAXY+SysState
-                    fdb       FLDAXY-*-2
-                    fcb       F$LDDDXY+SysState
-                    fdb       FLDDDXY-*-2
-                    fcb       F$LDABX+SysState
-                    fdb       FLDABX-*-2
-                    fcb       F$STABX+SysState
-                    fdb       FSTABX-*-2
-                    fcb       F$ELink+SysState
-                    fdb       FELink-*-2
-                    fcb       F$FModul+SysState
-                    fdb       FFModul-*-2
-                    fcb       F$VBlock+SysState
-                    fdb       FVBlock-*-2
-                    ifne      H6309
-                    fcb       F$DelRAM
-                    fdb       FDelRAM-*-2
-                    endc
-                    fcb       $80
+SysCalls            fcb       F$Link    ; define byte value(s) F$Link
+                    fdb       FLink-*-2 ; define word value(s) FLink-*-2
+                    fcb       F$PrsNam  ; define byte value(s) F$PrsNam
+                    fdb       FPrsNam-*-2 ; define word value(s) FPrsNam-*-2
+                    fcb       F$CmpNam  ; define byte value(s) F$CmpNam
+                    fdb       FCmpNam-*-2 ; define word value(s) FCmpNam-*-2
+                    fcb       F$CmpNam+SysState ; define byte value(s) F$CmpNam+SysState
+                    fdb       FSCmpNam-*-2 ; define word value(s) FSCmpNam-*-2
+                    fcb       F$CRC     ; define byte value(s) F$CRC
+                    fdb       FCRC-*-2  ; define word value(s) FCRC-*-2
+                    fcb       F$SRqMem+SysState ; define byte value(s) F$SRqMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                    fcb       F$SRtMem+SysState ; define byte value(s) F$SRtMem+SysState
+                    fdb       FSRtMem-*-2 ; define word value(s) FSRtMem-*-2
+                    fcb       F$AProc+SysState ; define byte value(s) F$AProc+SysState
+                    fdb       FAProc-*-2 ; define word value(s) FAProc-*-2
+                    fcb       F$NProc+SysState ; define byte value(s) F$NProc+SysState
+                    fdb       FNProc-*-2 ; define word value(s) FNProc-*-2
+                    fcb       F$VModul+SysState ; define byte value(s) F$VModul+SysState
+                    fdb       FVModul-*-2 ; define word value(s) FVModul-*-2
+                    fcb       F$SSvc+SysState ; define byte value(s) F$SSvc+SysState
+                    fdb       FSSvc-*-2 ; define word value(s) FSSvc-*-2
+                    fcb       F$SLink+SysState ; define byte value(s) F$SLink+SysState
+                    fdb       FSLink-*-2 ; define word value(s) FSLink-*-2
+                    fcb       F$Boot+SysState ; define byte value(s) F$Boot+SysState
+                    fdb       FBoot-*-2 ; define word value(s) FBoot-*-2
+                    fcb       F$BtMem+SysState ; define byte value(s) F$BtMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    fcb       F$CpyMem  ; define byte value(s) F$CpyMem
+                    fdb       FCpyMem-*-2 ; define word value(s) FCpyMem-*-2
+                  ENDC
+                    fcb       F$Move+SysState ; define byte value(s) F$Move+SysState
+                    fdb       FMove-*-2 ; define word value(s) FMove-*-2
+                    fcb       F$AllImg+SysState ; define byte value(s) F$AllImg+SysState
+                    fdb       FAllImg-*-2 ; define word value(s) FAllImg-*-2
+                    fcb       F$SetImg+SysState ; define byte value(s) F$SetImg+SysState
+                    fdb       FSetImg-*-2 ; define word value(s) FSetImg-*-2
+                    fcb       F$FreeLB+SysState ; define byte value(s) F$FreeLB+SysState
+                    fdb       FSFreeLB-*-2 ; define word value(s) FSFreeLB-*-2
+                    fcb       F$FreeHB+SysState ; define byte value(s) F$FreeHB+SysState
+                    fdb       FFreeHB-*-2 ; define word value(s) FFreeHB-*-2
+                    fcb       F$AllTsk+SysState ; define byte value(s) F$AllTsk+SysState
+                    fdb       FAllTsk-*-2 ; define word value(s) FAllTsk-*-2
+                    fcb       F$DelTsk+SysState ; define byte value(s) F$DelTsk+SysState
+                    fdb       FDelTsk-*-2 ; define word value(s) FDelTsk-*-2
+                    fcb       F$SetTsk+SysState ; define byte value(s) F$SetTsk+SysState
+                    fdb       FSetTsk-*-2 ; define word value(s) FSetTsk-*-2
+                    fcb       F$ResTsk+SysState ; define byte value(s) F$ResTsk+SysState
+                    fdb       FResTsk-*-2 ; define word value(s) FResTsk-*-2
+                    fcb       F$RelTsk+SysState ; define byte value(s) F$RelTsk+SysState
+                    fdb       FRelTsk-*-2 ; define word value(s) FRelTsk-*-2
+                    fcb       F$DATLog+SysState ; define byte value(s) F$DATLog+SysState
+                    fdb       FDATLog-*-2 ; define word value(s) FDATLog-*-2
+                    fcb       F$LDAXY+SysState ; define byte value(s) F$LDAXY+SysState
+                    fdb       FLDAXY-*-2 ; define word value(s) FLDAXY-*-2
+                    fcb       F$LDDDXY+SysState ; define byte value(s) F$LDDDXY+SysState
+                    fdb       FLDDDXY-*-2 ; define word value(s) FLDDDXY-*-2
+                    fcb       F$LDABX+SysState ; define byte value(s) F$LDABX+SysState
+                    fdb       FLDABX-*-2 ; define word value(s) FLDABX-*-2
+                    fcb       F$STABX+SysState ; define byte value(s) F$STABX+SysState
+                    fdb       FSTABX-*-2 ; define word value(s) FSTABX-*-2
+                    fcb       F$ELink+SysState ; define byte value(s) F$ELink+SysState
+                    fdb       FELink-*-2 ; define word value(s) FELink-*-2
+                    fcb       F$FModul+SysState ; define byte value(s) F$FModul+SysState
+                    fdb       FFModul-*-2 ; define word value(s) FFModul-*-2
+                    fcb       F$VBlock+SysState ; define byte value(s) F$VBlock+SysState
+                    fdb       FVBlock-*-2 ; define word value(s) FVBlock-*-2
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    fcb       F$DelRAM  ; define byte value(s) F$DelRAM
+                    fdb       FDelRAM-*-2 ; define word value(s) FDelRAM-*-2
+                  ENDC
+                    fcb       $80       ; define byte value(s) $80
 
 * SWI3 vector entry
-XSWI3               lda       #P$SWI3             point to SWI3 vector
-                    fcb       $8C                 skip 2 bytes
+XSWI3               lda       #P$SWI3   ; point to SWI3 vector
+                    fcb       $8C       ; skip 2 bytes
 
 * SWI vector entry
-XSWI                lda       #P$SWI              point to SWI vector
-                    ldx       <D.Proc             get process pointer
-                    ldu       a,x                 user defined SWI[x]?
-                    beq       L028E               no, go get option byte
-GoUser              lbra      L0E5E               Yes, go call users's routine
+XSWI                lda       #P$SWI    ; point to SWI vector
+                    ldx       <D.Proc   ; get process pointer
+                    ldu       a,x       ; user defined SWI[x]?
+                    beq       L028E     ; no, go get option byte
+GoUser              lbra      L0E5E     ; yes, go call users's routine
 
 * SWI2 vector entry
-XSWI2               ldx       <D.Proc             get current process descriptor
-                    ldu       P$SWI2,x            any SWI vector?
-                    bne       GoUser              yes, go execute it
+XSWI2               ldx       <D.Proc   ; get current process descriptor
+                    ldu       P$SWI2,x  ; any SWI vector?
+                    bne       GoUser    ; yes, go execute it
 
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-L028E               ldu       <D.SysSvc           set system call processor to system side
-                    stu       <D.XSWI2
-                    ldu       <D.SysIRQ           do the same thing for IRQ's
-                    stu       <D.XIRQ
-                    ifne      H6309
-                    oim       #SysState,P$State,x mark process as in system state
-                    else
-                    lda       P$State,x
-                    ora       #SysState
-                    sta       P$State,x
-                    endc
+L028E               ldu       <D.SysSvc ; set system call processor to system side
+                    stu       <D.XSWI2  ; store U at <D.XSWI2
+                    ldu       <D.SysIRQ ; do the same thing for IRQ's
+                    stu       <D.XIRQ   ; store U at <D.XIRQ
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #SysState,P$State,x ; mark process as in system state
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    ora       #SysState ; merge #SysState into A
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
 * copy register stack to process descriptor
-                    sts       P$SP,x              save stack pointer
-                    leas      (P$Stack-R$Size),x  point S to register stack destination
+                    sts       P$SP,x    ; save stack pointer
+                    leas      (P$Stack-R$Size),x ; point S to register stack destination
 
-                    ifne      H6309
-                    leau      R$Size-1,s          point to last byte of destination register stack
-                    leay      -1,y                point to caller's register stack in $FEE1
-                    ldw       #R$Size             size of the register stack
-                    tfm       y-,u-
-                    leau      ,s                  needed because the TFM is u-, not -u (post, not pre)
-                    else
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leau      R$Size-1,s ; point to last byte of destination register stack
+                    leay      -1,y      ; point to caller's register stack in $FEE1
+                    ldw       #R$Size   ; size of the register stack
+                    tfm       y-,u-     ; transfer memory block using y-,u-
+                    leau      ,s        ; needed because the TFM is u-, not -u (post, not pre)
+                  ELSE
 * Note!  R$Size MUST BE an EVEN number of bytes for this to work!
-                    leau      R$Size,s            point to last byte of destination register stack
-                    lda       #R$Size/2
-Loop3               ldx       ,--y
-                    stx       ,--u
-                    deca
-                    bne       Loop3
-                    endc
-                    andcc     #^IntMasks
+                    leau      R$Size,s  ; point to last byte of destination register stack
+                    lda       #R$Size/2 ; load A from #R$Size/2
+Loop3               ldx       ,--y      ; load X from ,--y
+                    stx       ,--u      ; store X at ,--u
+                    deca                ; decrement A
+                    bne       Loop3     ; branch if zero is clear to Loop3
+                  ENDC
+                    andcc     #^IntMasks ; clear condition-code bits using #^IntMasks
 * B=function code already from calling process: DON'T USE IT!
-                    ldx       R$PC,u              get where PC was from process
-                    leax      1,x                 move PC past option
-                    stx       R$PC,u              save updated PC to process
+                    ldx       R$PC,u    ; get where PC was from process
+                    leax      1,x       ; move PC past option
+                    stx       R$PC,u    ; save updated PC to process
 * execute function call
-                    ldy       <D.UsrDis           get user dispatch table pointer
-                    lbsr      L033B               go execute option
-                    ifne      H6309
-                    aim       #^IntMasks,R$CC,u   Clear interrupt flags in caller's CC
-                    else
-                    lda       R$CC,u
-                    anda      #^IntMasks
-                    sta       R$CC,u
-                    endc
-                    ldx       <D.Proc             get current process ptr
-                    ifne      H6309
-                    aim       #^(SysState+TimOut),P$State,x Clear system & timeout flags
-                    else
-                    lda       P$State,x
-                    anda      #^(SysState+TimOut)
-                    sta       P$State,x
-                    endc
+                    ldy       <D.UsrDis ; get user dispatch table pointer
+                    lbsr      L033B     ; go execute option
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^IntMasks,R$CC,u ; clear interrupt flags in caller's CC
+                  ELSE
+                    lda       R$CC,u    ; load A from R$CC,u
+                    anda      #^IntMasks ; mask A with #^IntMasks
+                    sta       R$CC,u    ; store A at R$CC,u
+                  ENDC
+                    ldx       <D.Proc   ; get current process ptr
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^(SysState+TimOut),P$State,x ; clear system & timeout flags
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    anda      #^(SysState+TimOut) ; mask A with #^(SysState+TimOut)
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
 
 * Check for image change now, which lets stuff like F$MapBlk and F$ClrBlk
 * do the short-circuit thing, too.  Adds about 20 cycles to each system call.
-                    lbsr      TstImg              it doesn't hurt to call this twice
-                    lda       P$State,x           get current state of the process
-                    ora       <P$Signal,x         is there a pending signal?
-                    sta       <D.Quick            save quick return flag
-                    beq       AllClr              if nothing's have changed, do full checks
+                    lbsr      TstImg    ; it doesn't hurt to call this twice
+                    lda       P$State,x ; get current state of the process
+                    ora       <P$Signal,x ; is there a pending signal?
+                    sta       <D.Quick  ; save quick return flag
+                    beq       AllClr    ; if nothing's have changed, do full checks
 
-DoFull              bsr       L02DA               move the stack frame back to user state
-                    lbra      L0D80               go back to the process
+DoFull              bsr       L02DA     ; move the stack frame back to user state
+                    lbra      L0D80     ; go back to the process
 
 * add ldu P$SP,x, etc...
-AllClr              equ       *
-                    ifne      H6309
-                    inc       <D.QCnt
-                    aim       #$1F,<D.QCnt
-                    beq       DoFull              every 32 system calls, do the full check
-                    ldw       #R$Size             --- size of the register stack
-                    ldy       #Where+SWIStack     --- to stack at top of memory
-                    orcc      #IntMasks
-                    tfm       u+,y+               --- move the stack to the top of memory
-                    else
-                    lda       <D.QCnt
-                    inca
-                    anda      #$1F
-                    sta       <D.QCnt
-                    beq       DoFull
-                    ldb       #R$Size
-                    ldy       #Where+SWIStack
-                    orcc      #IntMasks
-Loop4               lda       ,u+
-                    sta       ,y+
-                    decb
-                    bne       Loop4
-                    endc
-                    lbra      BackTo1             otherwise simply return to the user
+AllClr              equ       *         ; define assembler symbol AllClr
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    inc       <D.QCnt   ; increment <D.QCnt
+                    aim       #$1F,<D.QCnt ; apply immediate bit operation #$1F,<D.QCnt
+                    beq       DoFull    ; every 32 system calls, do the full check
+                    ldw       #R$Size   ; --- size of the register stack
+                    ldy       #Where+SWIStack ; --- to stack at top of memory
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+                    tfm       u+,y+     ; --- move the stack to the top of memory
+                  ELSE
+                    lda       <D.QCnt   ; load A from <D.QCnt
+                    inca                ; increment A
+                    anda      #$1F      ; mask A with #$1F
+                    sta       <D.QCnt   ; store A at <D.QCnt
+                    beq       DoFull    ; branch if zero is set to DoFull
+                    ldb       #R$Size   ; load B from #R$Size
+                    ldy       #Where+SWIStack ; load Y from #Where+SWIStack
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+Loop4               lda       ,u+       ; load A from ,u+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Loop4     ; branch if zero is clear to Loop4
+                  ENDC
+                    lbra      BackTo1   ; otherwise simply return to the user
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-L02CB               pshs      cc,x,y,u            preserve registers
-                    ldb       P$Task,x            get task #
-                    ldx       P$SP,x              get stack pointer
-                    lbsr      L0BF3               calculate block offset (only affects A&X)
-                    leax      -$6000,x            adjust pointer to where memory map will be
-                    bra       L02E9               go copy it
+L02CB               pshs      cc,x,y,u  ; preserve registers
+                    ldb       P$Task,x  ; get task #
+                    ldx       P$SP,x    ; get stack pointer
+                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    leax      -$6000,x  ; adjust pointer to where memory map will be
+                    bra       L02E9     ; go copy it
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-L02DA               pshs      cc,x,y,u            preserve registers
-                    ldb       P$Task,x            get task # of destination
-                    ldx       P$SP,x              get stack pointer
-                    lbsr      L0BF3               calculate block offset (only affects A&X)
-                    leax      -$6000,x            adjust pointer to where memory map will be
-                    exg       x,y                 swap pointers & copy
+L02DA               pshs      cc,x,y,u  ; preserve registers
+                    ldb       P$Task,x  ; get task # of destination
+                    ldx       P$SP,x    ; get stack pointer
+                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    leax      -$6000,x  ; adjust pointer to where memory map will be
+                    exg       x,y       ; swap pointers & copy
 * Copy a register stack
 * Entry: X=Source
 *        Y=Destination
 *        A=Offset into DAT image of stack
 *        B=Task #
-L02E9               leau      a,u                 point to block # of where stack is
-                    lda       1,u                 get first block
-                    ldb       3,u                 get a second just in case of overlap
-                    orcc      #IntMasks           shutdown interupts while we do this
-                    std       >DAT.Regs+5         map blocks in
-                    ifne      H6309
-                    ldw       #R$Size             get size of register stack
-                    tfm       x+,y+               copy it
-                    else
-                    ldb       #R$Size
-Loop5               lda       ,x+
-                    sta       ,y+
-                    decb
-                    bne       Loop5
-                    endc
-                    ldx       <D.SysDAT           remap the blocks we took out
-                    lda       $0B,x
-                    ldb       $0D,x
-                    std       >DAT.Regs+5
-                    puls      cc,x,y,u,pc         restore & return
+L02E9               leau      a,u       ; point to block # of where stack is
+                    lda       1,u       ; get first block
+                    ldb       3,u       ; get a second just in case of overlap
+                    orcc      #IntMasks ; shutdown interupts while we do this
+                    std       >DAT.Regs+5 ; map blocks in
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get size of register stack
+                    tfm       x+,y+     ; copy it
+                  ELSE
+                    ldb       #R$Size   ; load B from #R$Size
+Loop5               lda       ,x+       ; load A from ,x+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Loop5     ; branch if zero is clear to Loop5
+                  ENDC
+                    ldx       <D.SysDAT ; remap the blocks we took out
+                    lda       $0B,x     ; load A from $0B,x
+                    ldb       $0D,x     ; load B from $0D,x
+                    std       >DAT.Regs+5 ; store D at >DAT.Regs+5
+                    puls      cc,x,y,u,pc ; restore & return
 
 * Process software interupts from system state
 * Entry: U=Register stack pointer
-SysCall             leau      ,s                  get pointer to register stack
-                    lda       <D.SSTskN           Get system task # (0=SYSTEM, 1=GRFDRV)
-                    clr       <D.SSTskN           Force to System Process
-                    pshs      a                   Save the system task number
-                    lda       ,u                  Restore callers CC register (R$CC=$00)
-                    tfr       a,cc                make it current
-                    ldx       R$PC,u              Get my caller's PC register
-                    leax      1,x                 move PC to next position
-                    stx       R$PC,u              Save my caller's updated PC register
-                    ldy       <D.SysDis           get system dispatch table pointer
-                    bsr       L033B               execute system call
-                    puls      a                   restore system state task number
-                    lbra      L0E2B               return to process
+SysCall             leau      ,s        ; get pointer to register stack
+                    lda       <D.SSTskN ; get system task # (0=SYSTEM, 1=GRFDRV)
+                    clr       <D.SSTskN ; force to System Process
+                    pshs      a         ; save the system task number
+                    lda       ,u        ; restore callers CC register (R$CC=$00)
+                    tfr       a,cc      ; make it current
+                    ldx       R$PC,u    ; get my caller's PC register
+                    leax      1,x       ; move PC to next position
+                    stx       R$PC,u    ; save my caller's updated PC register
+                    ldy       <D.SysDis ; get system dispatch table pointer
+                    bsr       L033B     ; execute system call
+                    puls      a         ; restore system state task number
+                    lbra      L0E2B     ; return to process
 
 * Entry: X = system call vector to jump to
-Sys.Vec             jmp       ,x                  execute service call
+Sys.Vec             jmp       ,x        ; execute service call
 
 * Execute system call
 * Entry: B=Function call #
 *        Y=Function dispatch table pointer (D.SysDis or D.UsrDis)
 L033B
-                    lslb                          is it a I/O call? (Also multiplys by 2 for offset)
-                    bcc       L0345               no, go get normal vector
+                    lslb                ; is it a I/O call? (Also multiplys by 2 for offset)
+                    bcc       L0345     ; no, go get normal vector
 * Execute I/O system calls
-                    ldx       IOEntry,y           get IOMan vector
+                    ldx       IOEntry,y ; get IOMan vector
 * Execute the system call
-L034F               pshs      u                   preserve register stack pointer
-                    jsr       [D.SysVec]          perform a vectored system call
-                    puls      u                   restore pointer
-L0355               tfr       cc,a                move CC to A for stack update
-                    bcc       L035B               go update it if no error from call
-                    stb       R$B,u               save error code to caller's B
-L035B               ldb       R$CC,u              get callers CC, R$CC=$00
-                    ifne      H6309
-                    andd      #$2FD0              [A]=H,N,Z,V,C [B]=E,F,I
-                    orr       b,a                 merge them together
-                    else
-                    anda      #$2F                [A]=H,N,Z,V,C
-                    andb      #$D0                [B]=E,F,I
-                    pshs      b
-                    ora       ,s+
-                    endc
-                    sta       R$CC,u              return it to caller, R$CC=$00
-                    rts
+L034F               pshs      u         ; preserve register stack pointer
+                    jsr       [D.SysVec] ; perform a vectored system call
+                    puls      u         ; restore pointer
+L0355               tfr       cc,a      ; move CC to A for stack update
+                    bcc       L035B     ; go update it if no error from call
+                    stb       R$B,u     ; save error code to caller's B
+L035B               ldb       R$CC,u    ; get callers CC, R$CC=$00
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
+                    orr       b,a       merge them together
+                  ELSE
+                    anda      #$2F      ; [A]=H,N,Z,V,C
+                    andb      #$D0      ; [B]=E,F,I
+                    pshs      b         ; save b on the stack
+                    ora       ,s+       ; merge ,s+ into A
+                  ENDC
+                    sta       R$CC,u    ; return it to caller, R$CC=$00
+                    rts                 ; return to caller
 
 * Execute regular system calls
 L0345
-                    clra                          clear MSB of offset
-                    ldx       d,y                 get vector to call
-                    bne       L034F               it's initialized, go execute it
-                    comb                          set carry for error
-                    ldb       #E$UnkSvc           get error code
-                    bra       L0355               return with it
+                    clra                ; clear MSB of offset
+                    ldx       d,y       ; get vector to call
+                    bne       L034F     ; it's initialized, go execute it
+                    comb                ; set carry for error
+                    ldb       #E$UnkSvc ; get error code
+                    bra       L0355     ; return with it
 
-                    use       fssvc.asm
+                    use       fssvc.asm ; include source file fssvc.asm
 
-                    use       flink.asm
+                    use       flink.asm ; include source file flink.asm
 
-                    use       fvmodul.asm
+                    use       fvmodul.asm ; include source file fvmodul.asm
 
-                    use       ffmodul.asm
+                    use       ffmodul.asm ; include source file ffmodul.asm
 
-                    use       fprsnam.asm
+                    use       fprsnam.asm ; include source file fprsnam.asm
 
-                    use       fcmpnam.asm
+                    use       fcmpnam.asm ; include source file fcmpnam.asm
 
-                    use       ccbfsrqmem.asm
+                    use       ccbfsrqmem.asm ; include source file ccbfsrqmem.asm
 
 *         use   fallram.asm
 
 
-                    ifne      H6309
-                    use       fdelram.asm
-                    endc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    use       fdelram.asm ; include source file fdelram.asm
+                  ENDC
 
-                    use       fallimg.asm
+                    use       fallimg.asm ; include source file fallimg.asm
 
-                    use       ffreehb.asm
+                    use       ffreehb.asm ; include source file ffreehb.asm
 
-                    use       fdatlog.asm
+                    use       fdatlog.asm ; include source file fdatlog.asm
 
-                    use       fld.asm
+                    use       fld.asm   ; include source file fld.asm
 
-                    ifne      H6309
-                    use       fcpymem.asm
-                    endc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    use       fcpymem.asm ; include source file fcpymem.asm
+                  ENDC
 
-                    use       fmove.asm
+                    use       fmove.asm ; include source file fmove.asm
 
-                    use       fldabx.asm
+                    use       fldabx.asm ; include source file fldabx.asm
 
-                    use       falltsk.asm
+                    use       falltsk.asm ; include source file falltsk.asm
 
-                    use       faproc.asm
+                    use       faproc.asm ; include source file faproc.asm
 
 * System IRQ service routine
-XIRQ                ldx       <D.Proc             get current process pointer
-                    sts       P$SP,x              save the stack pointer
-                    lds       <D.SysStk           get system stack pointer
-                    ldd       <D.SysSvc           set system service routine to current
-                    std       <D.XSWI2
-                    ldd       <D.SysIRQ           set system IRQ routine to current
-                    std       <D.XIRQ
-                    jsr       [>D.SvcIRQ]         execute irq service
-                    bcc       L0D5B
+XIRQ                ldx       <D.Proc   ; get current process pointer
+                    sts       P$SP,x    ; save the stack pointer
+                    lds       <D.SysStk ; get system stack pointer
+                    ldd       <D.SysSvc ; set system service routine to current
+                    std       <D.XSWI2  ; store D at <D.XSWI2
+                    ldd       <D.SysIRQ ; set system IRQ routine to current
+                    std       <D.XIRQ   ; store D at <D.XIRQ
+                    jsr       [>D.SvcIRQ] ; execute irq service
+                    bcc       L0D5B     ; branch if carry is clear to L0D5B
 
-                    ldx       <D.Proc             get current process pointer
-                    ldb       P$Task,x
-                    ldx       P$SP,x              get it's stack pointer
+                    ldx       <D.Proc   ; get current process pointer
+                    ldb       P$Task,x  ; load B from P$Task,x
+                    ldx       P$SP,x    ; get it's stack pointer
 
-                    pshs      u,d,cc              save some registers
-                    leau      ,s                  point to a 'caller register stack'
-                    lbsr      L0C40               do a LDB 0,X in task B
-                    puls      u,d,cc              and now A ( R$A,U ) = the CC we want
+                    pshs      u,d,cc    ; save some registers
+                    leau      ,s        ; point to a 'caller register stack'
+                    lbsr      L0C40     ; do a LDB 0,X in task B
+                    puls      u,d,cc    ; and now A ( R$A,U ) = the CC we want
 
-                    ora       #IntMasks           disable it's IRQ's
-                    lbsr      L0C28               save it back
-L0D5B               orcc      #IntMasks           shut down IRQ's
-                    ldx       <D.Proc             get current process pointer
-                    tst       <D.QIRQ             was it a clock IRQ?
-                    lbne      L0DF7               if not, do a quick return
+                    ora       #IntMasks ; disable it's IRQ's
+                    lbsr      L0C28     ; save it back
+L0D5B               orcc      #IntMasks ; shut down IRQ's
+                    ldx       <D.Proc   ; get current process pointer
+                    tst       <D.QIRQ   ; was it a clock IRQ?
+                    lbne      L0DF7     ; if not, do a quick return
 
-                    lda       P$State,x           Get it's state
-                    bita      #TimOut             Is it timed out?
-                    bne       L0D7C               yes, wake it up
+                    lda       P$State,x ; get it's state
+                    bita      #TimOut   ; is it timed out?
+                    bne       L0D7C     ; yes, wake it up
 * Update active process queue
-                    ldu       #(D.AProcQ-P$Queue) point to active process queue
-                    ldb       #Suspend            get suspend flag
-L0D6A               ldu       P$Queue,u           get a active process pointer
-                    beq       L0D78
-                    bitb      P$State,u           is it suspended?
-                    bne       L0D6A               yes, go to next one in chain
-                    ldb       P$Prior,x           get current process priority
-                    cmpb      P$Prior,u           do we bump this one?
-                    blo       L0D7C
+                    ldu       #(D.AProcQ-P$Queue) ; point to active process queue
+                    ldb       #Suspend  ; get suspend flag
+L0D6A               ldu       P$Queue,u ; get a active process pointer
+                    beq       L0D78     ; branch if zero is set to L0D78
+                    bitb      P$State,u ; is it suspended?
+                    bne       L0D6A     ; yes, go to next one in chain
+                    ldb       P$Prior,x ; get current process priority
+                    cmpb      P$Prior,u ; do we bump this one?
+                    blo       L0D7C     ; branch if unsigned result is lower to L0D7C
 
-L0D78               ldu       P$SP,x
-                    bra       L0DB9
+L0D78               ldu       P$SP,x    ; load U from P$SP,x
+                    bra       L0DB9     ; branch unconditionally to L0DB9
 
-L0D7C               anda      #^TimOut
-                    sta       P$State,x
+L0D7C               anda      #^TimOut  ; mask A with #^TimOut
+                    sta       P$State,x ; store A at P$State,x
 
-L0D80               equ       *
-L0D83               bsr       L0D11               activate next process
+L0D80               equ       *         ; define assembler symbol L0D80
+L0D83               bsr       L0D11     ; activate next process
 
-                    use       ccbfnproc.asm
+                    use       ccbfnproc.asm ; include source file ccbfnproc.asm
 
 * The following routines must appear no earlier than $E00 when assembled, as
 * they have to always be in the vector RAM page ($FE00-$FEFF)
@@ -855,185 +855,185 @@ L0D83               bsr       L0D11               activate next process
 * CCB: this code (after pad) start assembling *before* 0xfe00, it's too big to
 * fit into the memory as stated above!!!!
 
-PAD                 fill      $00,($0df1-*)       fill memory to ensure the above happens
+PAD                 fill      $00,($0df1-*) ; fill memory to ensure the above happens
 * Default routine for D.SysIRQ
 S.SysIRQ
-                    lda       <D.SSTskN           Get current task's GIME task # (0 or 1)
-                    beq       FastIRQ             Use super-fast version for system state
-                    clr       <D.SSTskN           Clear out memory copy (task 0)
-                    jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
-                    inc       <D.SSTskN           Save task # for system state
-                    lda       #1                  Task 1
-                    ora       <D.TINIT            Merge task bit's into Shadow version
-                    sta       <D.TINIT            Update shadow
-                    sta       >DAT.Task           Save to GIME as well & return
-                    bra       DoneIRQ             Check for error and exit
+                    lda       <D.SSTskN ; get current task's GIME task # (0 or 1)
+                    beq       FastIRQ   ; use super-fast version for system state
+                    clr       <D.SSTskN ; clear out memory copy (task 0)
+                    jsr       [>D.SvcIRQ] ; (Normally routine in Clock calling D.Poll)
+                    inc       <D.SSTskN ; save task # for system state
+                    lda       #1        ; task 1
+                    ora       <D.TINIT  ; merge task bit's into Shadow version
+                    sta       <D.TINIT  ; update shadow
+                    sta       >DAT.Task ; save to GIME as well & return
+                    bra       DoneIRQ   ; check for error and exit
 
-FastIRQ             jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
-DoneIRQ             bcc       L0E28               No error on IRQ, exit
-                    ifne      H6309
-                    oim       #IntMasks,0,s       Setup RTI to shut interrupts off again
-                    else
-                    lda       ,s
-                    ora       #IntMasks
-                    sta       ,s
-                    endc
-L0E28               rti
+FastIRQ             jsr       [>D.SvcIRQ] ; (Normally routine in Clock calling D.Poll)
+DoneIRQ             bcc       L0E28     ; no error on IRQ, exit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #IntMasks,0,s ; setup RTI to shut interrupts off again
+                  ELSE
+                    lda       ,s        ; load A from ,s
+                    ora       #IntMasks ; merge #IntMasks into A
+                    sta       ,s        ; store A at ,s
+                  ENDC
+L0E28               rti                 ; return from interrupt
 
 * return from a system call
-L0E29               clra                          Force System task # to 0 (non-GRDRV)
-L0E2B               ldx       <D.SysPrc           Get system process dsc. ptr
-                    lbsr      TstImg              check image, and F$SetTsk (PRESERVES A)
-                    orcc      #IntMasks           Shut interrupts off
-                    sta       <D.SSTskN           Save task # for system state
-                    beq       Fst2                If task 0, skip subroutine
-                    ora       <D.TINIT            Merge task bit's into Shadow version
-                    sta       <D.TINIT            Update shadow
-                    sta       >DAT.Task           Save to GIME as well & return
-Fst2                leas      ,u                  Stack ptr=U & return
-                    rti
+L0E29               clra                ; force System task # to 0 (non-GRDRV)
+L0E2B               ldx       <D.SysPrc ; get system process dsc. ptr
+                    lbsr      TstImg    ; check image, and F$SetTsk (PRESERVES A)
+                    orcc      #IntMasks ; shut interrupts off
+                    sta       <D.SSTskN ; save task # for system state
+                    beq       Fst2      ; if task 0, skip subroutine
+                    ora       <D.TINIT  ; merge task bit's into Shadow version
+                    sta       <D.TINIT  ; update shadow
+                    sta       >DAT.Task ; save to GIME as well & return
+Fst2                leas      ,u        ; stack ptr=U & return
+                    rti                 ; return from interrupt
 
 * Switch to new process, X=Process descriptor pointer, U=Stack pointer
-L0E4C               equ       *
-                    ifne      H6309
-                    oim       #$01,<D.TINIT       switch GIME shadow to user state
-                    lda       <D.TINIT
-                    else
-                    lda       <D.TINIT
-                    ora       #$01
-                    sta       <D.TINIT
-                    endc
-                    sta       >DAT.Task           save it to GIME
-                    leas      ,y                  point to new stack
-                    tstb                          is the stack at SWISTACK?
-                    bne       MyRTI               no, we're doing a system-state rti
+L0E4C               equ       *         ; define assembler symbol L0E4C
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch GIME shadow to user state
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                  ELSE
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    ora       #$01      ; merge #$01 into A
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                  ENDC
+                    sta       >DAT.Task ; save it to GIME
+                    leas      ,y        ; point to new stack
+                    tstb                ; is the stack at SWISTACK?
+                    bne       MyRTI     ; no, we're doing a system-state rti
 
-                    ifne      H6309
-                    ldf       #R$Size             E=0 from call to L0E8D before
-                    ldu       #Where+SWIStack     point to the stack
-                    tfm       u+,y+               move the stack from top of memory to user memory
-                    else
-                    ldb       #R$Size
-                    ldu       #Where+SWIStack     point to the stack
-RtiLoop             lda       ,u+
-                    sta       ,y+
-                    decb
-                    bne       RtiLoop
-                    endc
-MyRTI               rti                           return from IRQ
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #R$Size   ; e=0 from call to L0E8D before
+                    ldu       #Where+SWIStack ; point to the stack
+                    tfm       u+,y+     ; move the stack from top of memory to user memory
+                  ELSE
+                    ldb       #R$Size   ; load B from #R$Size
+                    ldu       #Where+SWIStack ; point to the stack
+RtiLoop             lda       ,u+       ; load A from ,u+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       RtiLoop   ; branch if zero is clear to RtiLoop
+                  ENDC
+MyRTI               rti                 ; return from IRQ
 
 
 * Execute routine in task 1 pointed to by U
 * comes from user requested SWI vectors
-L0E5E               equ       *
-                    ifne      H6309
-                    oim       #$01,<D.TINIT       switch GIME shadow to user state
-                    ldb       <D.TINIT
-                    else
-                    ldb       <D.TINIT
-                    orb       #$01
-                    stb       <D.TINIT
-                    endc
-                    stb       >DAT.Task
-                    jmp       ,u
+L0E5E               equ       *         ; define assembler symbol L0E5E
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch GIME shadow to user state
+                    ldb       <D.TINIT  ; load B from <D.TINIT
+                  ELSE
+                    ldb       <D.TINIT  ; load B from <D.TINIT
+                    orb       #$01      ; merge #$01 into B
+                    stb       <D.TINIT  ; store B at <D.TINIT
+                  ENDC
+                    stb       >DAT.Task ; store B at >DAT.Task
+                    jmp       ,u        ; transfer control to ,u
 
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
-S.Flip1             ldb       #2                  get Task image entry numberx2 for Grfdrv (task 1)
-                    bsr       L0E8D               copy over the DAT image
-                    ifne      H6309
-                    oim       #$01,<D.TINIT
-                    lda       <D.TINIT            get copy of GIME Task side
-                    else
-                    lda       <D.TINIT
-                    ora       #$01
-                    sta       <D.TINIT
-                    endc
-                    sta       >DAT.Task           save it to GIME register
-                    inc       <D.SSTskN           increment system state task number
-                    rti                           return
+S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfdrv (task 1)
+                    bsr       L0E8D     ; copy over the DAT image
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; apply immediate bit operation #$01,<D.TINIT
+                    lda       <D.TINIT  ; get copy of GIME Task side
+                  ELSE
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    ora       #$01      ; merge #$01 into A
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                  ENDC
+                    sta       >DAT.Task ; save it to GIME register
+                    inc       <D.SSTskN ; increment system state task number
+                    rti                 ; return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-L0E8D               cmpb      <D.Task1N           are we going back to the same task
-                    beq       L0EA3               without the DAT image changing?
-                    stb       <D.Task1N           nope, save current task in map type 1
-                    ldx       #DAT.Regs+8         get MMU start register for process's
-                    ldu       <D.TskIPt           get task image pointer table
-                    ldu       b,u                 get address of DAT image
-L0E93               leau      1,u                 point to actual MMU block
-                    ifne      H6309
-                    lde       #4                  get # banks/2 for task
-                    else
-                    lda       #4
-                    pshs      a
-                    endc
-L0E9B               lda       ,u++                get a bank
-                    ldb       ,u++                and next one
-                    std       ,x++                Save it to MMU
-                    ifne      H6309
-                    dece                          done?
-                    else
-                    dec       ,s
-                    endc
-                    bne       L0E9B               no, keep going
-                    ifeq      H6309
-                    leas      1,s
-                    endc
-L0EA3               rts                           return
+L0E8D               cmpb      <D.Task1N ; are we going back to the same task
+                    beq       L0EA3     ; without the DAT image changing?
+                    stb       <D.Task1N ; nope, save current task in map type 1
+                    ldx       #DAT.Regs+8 ; get MMU start register for process's
+                    ldu       <D.TskIPt ; get task image pointer table
+                    ldu       b,u       ; get address of DAT image
+L0E93               leau      1,u       ; point to actual MMU block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lde       #4        ; get # banks/2 for task
+                  ELSE
+                    lda       #4        ; load A from #4
+                    pshs      a         ; save a on the stack
+                  ENDC
+L0E9B               lda       ,u++      ; get a bank
+                    ldb       ,u++      ; and next one
+                    std       ,x++      ; save it to MMU
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    dece                ; done?
+                  ELSE
+                    dec       ,s        ; decrement ,s
+                  ENDC
+                    bne       L0E9B     ; no, keep going
+                  IFEQ    H6309   ; begin conditional assembly for H6309
+                    leas      1,s       ; adjust stack pointer by 1,s
+                  ENDC
+L0EA3               rts                 ; return
 
 * Execute FIRQ vector (called from $FEF4)
-FIRQVCT             ldx       #D.FIRQ             get DP offset of vector
-                    bra       L0EB8               go execute it
+FIRQVCT             ldx       #D.FIRQ   ; get DP offset of vector
+                    bra       L0EB8     ; go execute it
 
 * Execute IRQ vector (called from $FEF7)
-IRQVCT              orcc      #IntMasks           disasble IRQ's
-                    ldx       #D.IRQ              get DP offset of vector
+IRQVCT              orcc      #IntMasks ; disasble IRQ's
+                    ldx       #D.IRQ    ; get DP offset of vector
 
 * Execute interrupt vector, B=DP Vector offset
-L0EB8               clra                          (faster than CLR >$xxxx)
-                    sta       >DAT.Task           Force to Task 0 (system state)
-                    ifne      H6309
-                    tfr       0,dp                setup DP
-                    else
-                    tfr       a,dp
-                    endc
-MapGrf              equ       *
-                    ifne      H6309
-                    aim       #$FE,<D.TINIT       switch GIME shadow to system state
-                    lda       <D.TINIT            set GIME again just in case timer is used
-                    else
-                    lda       <D.TINIT
-                    anda      #$FE
-                    sta       <D.TINIT
-                    endc
-MapT0               sta       >DAT.Task
-                    jmp       [,x]                execute it
+L0EB8               clra                ; (faster than CLR >$xxxx)
+                    sta       >DAT.Task ; force to Task 0 (system state)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,dp      ; setup DP
+                  ELSE
+                    tfr       a,dp      ; transfer register value a,dp
+                  ENDC
+MapGrf              equ       *         ; define assembler symbol MapGrf
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #$FE,<D.TINIT ; switch GIME shadow to system state
+                    lda       <D.TINIT  ; set GIME again just in case timer is used
+                  ELSE
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    anda      #$FE      ; mask A with #$FE
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                  ENDC
+MapT0               sta       >DAT.Task ; store A at >DAT.Task
+                    jmp       [,x]      ; execute it
 
 * Execute SWI3 vector (called from $FEEE)
-SWI3VCT             orcc      #IntMasks           disable IRQ's
-                    ldx       #D.SWI3             get DP offset of vector
-                    bra       SWICall             go execute it
+SWI3VCT             orcc      #IntMasks ; disable IRQ's
+                    ldx       #D.SWI3   ; get DP offset of vector
+                    bra       SWICall   ; go execute it
 
 * Execute SWI2 vector (called from $FEF1)
-SWI2VCT             orcc      #IntMasks           disasble IRQ's
-                    ldx       #D.SWI2             get DP offset of vector
+SWI2VCT             orcc      #IntMasks ; disasble IRQ's
+                    ldx       #D.SWI2   ; get DP offset of vector
 
 * This routine is called from an SWI, SWI2, or SWI3
 * saves 1 cycle on system-system calls
 * saves about 200 cycles (calls to I.LDABX and L029E) on grfdrv-system,
 *  or user-system calls.
-SWICall             ldb       [R$PC,s]            get callcode of the system call
+SWICall             ldb       [R$PC,s]  ; get callcode of the system call
 * NOTE: Alan DeKok claims that this is BAD.  It crashed Colin McKay's
 * CoCo 3.  Instead, we should do a clra/sta >DAT.Task.
 *         clr   >DAT.Task       go to map type 1
-                    clra
-                    sta       >DAT.Task
+                    clra                ; clear A
+                    sta       >DAT.Task ; store A at >DAT.Task
 * set DP to zero
-                    ifne      H6309
-                    tfr       0,dp
-                    else
-                    tfr       a,dp
-                    endc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,dp      ; transfer register value 0,dp
+                  ELSE
+                    tfr       a,dp      ; transfer register value a,dp
+                  ENDC
 
 * These lines add a total of 81 addition cycles to each SWI(2,3) call,
 * and 36 bytes+12 for R$Size in the constant page at $FExx
@@ -1042,47 +1042,47 @@ SWICall             ldb       [R$PC,s]            get callcode of the system cal
 * For processes that re-vector SWI, SWI3, it adds 81 cycles.  BUT SWI(3)
 * CANNOT be vectored to L0EBF cause the user SWI service routine has been
 * changed
-                    lda       <D.TINIT            get map type flag
-                    bita      #$01                check it without changing it
+                    lda       <D.TINIT  ; get map type flag
+                    bita      #$01      ; check it without changing it
 
 * Change to LBEQ R.SysSvc to avoid JMP [,X]
 * and add R.SysSvc STA >DAT.Task ???
-                    beq       MapT0               in map 0: restore hardware and do system service
-                    tst       <D.SSTskN           get system state 0,1
-                    bne       MapGrf              if in grfdrv, go to map 0 and do system service
+                    beq       MapT0     ; in map 0: restore hardware and do system service
+                    tst       <D.SSTskN ; get system state 0,1
+                    bne       MapGrf    ; if in grfdrv, go to map 0 and do system service
 
 * the preceding few lines are necessary, as all SWI's still pass thru
 * here before being vectored to the system service routine... which
 * doesn't copy the stack from user state.
-                    sta       >DAT.Task           go to map type X again to get user's stack
+                    sta       >DAT.Task ; go to map type X again to get user's stack
 * a byte less, a cycle more than ldy #$FEED-R$Size, or ldy #$F000+SWIStack
-                    leay      <SWIStack,pc        where to put the register stack: to $FEDF
-                    tfr       s,u                 get a copy of where the stack is
-                    ifne      H6309
-                    ldw       #R$Size             get the size of the stack
-                    tfm       u+,y+               move the stack to the top of memory
-                    else
-                    pshs      b
-                    ldb       #R$Size
-Looper              lda       ,u+
-                    sta       ,y+
-                    decb
-                    bne       Looper
-                    puls      b
-                    endc
-                    bra       L0EB8               and go from map type 1 to map type 0
+                    leay      <SWIStack,pc ; where to put the register stack: to $FEDF
+                    tfr       s,u       ; get a copy of where the stack is
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get the size of the stack
+                    tfm       u+,y+     ; move the stack to the top of memory
+                  ELSE
+                    pshs      b         ; save b on the stack
+                    ldb       #R$Size   ; load B from #R$Size
+Looper              lda       ,u+       ; load A from ,u+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Looper    ; branch if zero is clear to Looper
+                    puls      b         ; restore b from the stack
+                  ENDC
+                    bra       L0EB8     ; and go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
-SWIVCT              ldx       #D.SWI              get DP offset of vector
-                    bra       SWICall             go execute it
+SWIVCT              ldx       #D.SWI    ; get DP offset of vector
+                    bra       SWICall   ; go execute it
 
 * Execute NMI vector (called from $FEFD)
-NMIVCT              ldx       #D.NMI              get DP offset of vector
-                    bra       L0EB8               go execute it
+NMIVCT              ldx       #D.NMI    ; get DP offset of vector
+                    bra       L0EB8     ; go execute it
 
 * The end of the kernel module is here
                     emod
-eom                 equ       *
+eom                 equ       *         ; define assembler symbol eom
 
 * What follows after the kernel module is the register stack, starting
 * at $FEDD (6309) or $FEDF (6809).  This register stack area is used by
@@ -1091,27 +1091,27 @@ eom                 equ       *
 * MMU registers.
 SWIStack
                     fcc       /REGISTER STACK/    same # bytes as R$Size for 6809
-                    ifne      H6309
+                  IFNE    H6309   ; begin conditional assembly for H6309
                     fcc       /63/                if 6309, add two more spaces
-                    endc
+                  ENDC
 
-                    fcb       $55                 D.ErrRst
+                    fcb       $55       ; d.ErrRst
 
 * This list of addresses ends up at $FEEE after the kernel track is loaded
 * into memory.  All interrupts come through the 6809 vectors at $FFF0-$FFFE
 * and get directed to here.  From here, the BRA takes CPU control to the
 * various handlers in the kernel.
-                    bra       SWI3VCT             SWI3 vector comes here
-                    nop
-                    bra       SWI2VCT             SWI2 vector comes here
-                    nop
-                    bra       FIRQVCT             FIRQ vector comes here
-                    nop
-                    bra       IRQVCT              IRQ vector comes here
-                    nop
-                    bra       SWIVCT              SWI vector comes here
-                    nop
-                    bra       NMIVCT              NMI vector comes here
-                    nop
+                    bra       SWI3VCT   ; sWI3 vector comes here
+                    nop       ; no operation placeholder
+                    bra       SWI2VCT   ; sWI2 vector comes here
+                    nop       ; no operation placeholder
+                    bra       FIRQVCT   ; fIRQ vector comes here
+                    nop       ; no operation placeholder
+                    bra       IRQVCT    ; iRQ vector comes here
+                    nop       ; no operation placeholder
+                    bra       SWIVCT    ; sWI vector comes here
+                    nop       ; no operation placeholder
+                    bra       NMIVCT    ; nMI vector comes here
+                    nop       ; no operation placeholder
 
                     end

--- a/level2/modules/kernel/ccbkrn.asm
+++ b/level2/modules/kernel/ccbkrn.asm
@@ -60,7 +60,7 @@ MName               fcs       /CCBKrn/
 
 * Might as well have this here as just past the end of Kernel...
 DisTable
-                    fdb       L0CD2+Where ; d.Clock absolute address at the start
+                    fdb       FAlltskSleepingProcessQueue+Where ; d.Clock absolute address at the start
                     fdb       XSWI3+Where ; d.XSWI3
                     fdb       XSWI2+Where ; d.XSWI2
                     fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
@@ -147,9 +147,9 @@ CCBEND
                     ldy       #$2000-$100 ; load Y from #$2000-$100
                     clra                ; clear A
                     clrb                ; clear B
-L001C               std       ,x++      ; store D at ,x++
+CcbkrnTarget        std       ,x++      ; store D at ,x++
                     leay      -2,y      ; compute -2,y into Y
-                    bne       L001C     ; branch if zero is clear to L001C
+                    bne       CcbkrnTarget ; branch if zero is clear to CcbkrnTarget
                     stx       <D.CCStk  ; set pointer to top of global memory to $2000
                     inca                ; D = $0100
                   ENDC
@@ -228,9 +228,9 @@ Loop2               lda       ,y+       ; load a byte from source
 *         leau   <Vectors,pc   point to vector
 * fill in the secondard interrupt vectors to all point to
                     tfr       y,u       ; move the pointer to a faster register
-L0065               stu       ,x++      ; set all IRQ vectors to go to Vectors for now
+CcbkrnIRQVectorsVectorsNow stu       ,x++      ; set all IRQ vectors to go to Vectors for now
                     cmpx      #D.NMI    ; compare X with #D.NMI
-                    bls       L0065     ; branch if unsigned result is lower or same to L0065
+                    bls       CcbkrnIRQVectorsVectorsNow ; branch if unsigned result is lower or same to CcbkrnIRQVectorsVectorsNow
 
 * Initialize user interupt vectors
                     ldx       <D.XSWI2  ; get SWI2 (os9 command) service routine pointer
@@ -298,9 +298,9 @@ L0065               stu       ,x++      ; set all IRQ vectors to go to Vectors f
 * Dat.BlCt-ROMCount-RAMCount
                     lda       #$06      ; initialize the rest of the blocks to be free
                     ldu       #DAT.Free ; load U from #DAT.Free
-L00EF               stu       ,x++      ; store free "flag"
+CcbkrnFreeFlag      stu       ,x++      ; store free "flag"
                     deca                ; bump counter
-                    bne       L00EF     ; loop if not done
+                    bne       CcbkrnFreeFlag ; loop if not done
 
                     ldu       #KrnBlk   ; block where the kernel will live
                     stu       ,x        ; store U at ,x
@@ -312,9 +312,9 @@ L00EF               stu       ,x++      ; store free "flag"
 * Setup system memory map
                     ldx       <D.SysMem ; get system memory map pointer
                     ldb       <D.CCStk  ; get MSB of top of CC memory
-L0104               inc       ,x+       ; mark it as used
+KrnMarkUsed         inc       ,x+       ; mark it as used
                     decb                ; done?
-                    bne       L0104     ; no, go back till done
+                    bne       KrnMarkUsed ; no, go back till done
 
 * Calculate memory size
                     *         CCB       Comment:
@@ -326,16 +326,16 @@ L0104               inc       ,x+       ; mark it as used
                     inc       <KrnBlk,x ; mark block holding kernel as used
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldq       #$00080100 ; e=Marker, D=Block # to check
-L0111               asld                ; get next block #
+KrnBlock            asld                ; get next block #
                     stb       >DAT.Regs+5 ; map block into block 6 of my task
                     ste       >-$6000,x ; save marker to that block
                     cmpe      ,x        ; did it ghost to block 0?
-                    bne       L0111     ; no, keep going till ghost is found
+                    bne       KrnBlock  ; no, keep going till ghost is found
                     stb       <D.MemSz  ; save # 8k mem blocks that exist
                     addr      x,d       ; add number of blocks to block map start
                   ELSE
                     ldd       #$0008    ; load D from #$0008
-L0111               aslb                ; update processor state
+KrnBlock            aslb                ; update processor state
                     rola                ; shift or rotate and update condition codes
                     stb       >DAT.Regs+5 ; store B at >DAT.Regs+5
                     pshs      a         ; save a on the stack
@@ -343,7 +343,7 @@ L0111               aslb                ; update processor state
                     sta       >-$6000,x ; store A at >-$6000,x
                     cmpa      ,x        ; compare A with ,x
                     puls      a         ; restore a from the stack
-                    bne       L0111     ; branch if zero is clear to L0111
+                    bne       KrnBlock  ; branch if zero is clear to KrnBlock
                     stb       <D.MemSz  ; store B at <D.MemSz
                     pshs      x         ; save x on the stack
                     addd      ,s++      ; add ,s++ to D
@@ -357,19 +357,19 @@ L0111               aslb                ; update processor state
 * $0280 - 1024k
 * $0300 - 2048k
                     bitb      #%00110000 ; block above 128K-256K?
-                    beq       L0170     ; yes, no need to mark block map
+                    beq       Mc09KrnStartBootTrackMemory ; yes, no need to mark block map
                     tstb                ; 2 meg?
-                    beq       L0170     ; yes, skip this
+                    beq       Mc09KrnStartBootTrackMemory ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
                     abx                 ; add maximum block number to block map start
                     leax      -1,x      ; skip good blocks that are RAM
                     lda       #NotRAM   ; not RAM flag
                     subb      #$3F      ; calculate # blocks to mark as not RAM
-L0127               sta       ,x+       ; mark them all
+CcbkrnMarkThem      sta       ,x+       ; mark them all
                     decb                ; decrement B
-                    bne       L0127     ; branch if zero is clear to L0127
+                    bne       CcbkrnMarkThem ; branch if zero is clear to CcbkrnMarkThem
 
-L0170
+Mc09KrnStartBootTrackMemory
 * CCB - Commented out next two line. we don't have REL or BOOT, so the verify will be only
 * for the memory taken by KRN itself... f000 to ff00
 *       ldx     #Bt.Start       start address of the boot track in memory
@@ -383,13 +383,13 @@ L0170
 * CCB Change - I'm commenting out this whole section, and replacing it
                   IFEQ    1       ; begin conditional assembly for 1
 * See if init module is in memory already
-L01B0               leax      <init,pc  ; point to 'Init' module name
+CcbkrnInitModuleName leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
-                    bcc       L01BF     ; no error, go on
-L01B8               os9       F$Boot    ; error linking init, try & load boot file
-                    bcc       L01B0     ; got it, try init again
-                    bra       L01CE     ; error, re-booting do D.Crash
-L01BF               stu       <D.Init   ; save init module pointer
+                    bcc       KrnInitModule ; no error, go on
+CcbkrnErrorLinkingInitTryBoot os9       F$Boot    ; error linking init, try & load boot file
+                    bcc       CcbkrnInitModuleName ; got it, try init again
+                    bra       KrnObviouslyCantCrashMachine ; error, re-booting do D.Crash
+KrnInitModule       stu       <D.Init   ; save init module pointer
                     lda       Feature1,u ; get feature byte #1 from init module
                     bita      #CRCOn    ; cRC feature on?
                     beq       ShowI     ; if not, continue
@@ -397,13 +397,13 @@ L01BF               stu       <D.Init   ; save init module pointer
 ShowI               lda       #'i       ; found init module
                     jsr       <D.BtBug  ; call routine at <D.BtBug
 
-L01C1               leax      <krnp2,pc ; point to it's name
+KrnKrnp2sName       leax      <krnp2,pc ; point to it's name
                     bsr       link      ; try to link it
-                    bcc       L01D0     ; it worked, execute it
+                    bcc       KrnJumpKrnp2 ; it worked, execute it
                     os9       F$Boot    ; it doesn't exist try re-booting
-                    bcc       L01C1     ; no error's, let's try to link it again
-L01CE               jmp       <D.Crash  ; obviously can't do it, crash machine
-L01D0               jmp       ,y        ; execute krnp2
+                    bcc       KrnKrnp2sName ; no error's, let's try to link it again
+KrnObviouslyCantCrashMachine jmp       <D.Crash  ; obviously can't do it, crash machine
+KrnJumpKrnp2        jmp       ,y        ; execute krnp2
                   ENDC
 
 * CCB we'll replace above with this:
@@ -423,21 +423,21 @@ L01D0               jmp       ,y        ; execute krnp2
                     ldb       $0D,x     ; get highest allocated block number
                     incb                ; allocate block 0, too
                     ldx       <D.BlkMap ; point to the memory block map
-                    bsr       L01DF     ; and go mark the blocks as used
+                    bsr       KrnRAMUseFlag ; and go mark the blocks as used
                     *         end       of copy from f$boot
                     leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
-L01BF               stu       <D.Init   ; save init module pointer
+KrnInitModule       stu       <D.Init   ; save init module pointer
                     lda       Feature1,u ; get feature byte #1 from init module
                     bita      #CRCOn    ; cRC feature on?
 *       beq     ShowI           if not, continue
                     inc       <D.CRC    ; else inc. CRC flag
 ShowI               lda       #'i       ; found init module
                     jsr       <D.BtBug  ; call routine at <D.BtBug
-L01C1               leax      <krnp2,pc ; point to it's name
+KrnKrnp2sName       leax      <krnp2,pc ; point to it's name
                     bsr       link      ; try to link it
 *e      bra     e
-L01D0               jmp       ,y        ; execute krnp2
+KrnJumpKrnp2        jmp       ,y        ; execute krnp2
 
 
 * CCB - End of change
@@ -456,10 +456,10 @@ L01D0               jmp       ,y        ; execute krnp2
 * Mark kernel and boot file in system memory as used - there is no
 * reason this is a routine anymore - only one place calls it, but
 * some speghetti is here... one of the IRQ routines "borrows" this rts.
-L01DF               lda       #RAMinUse ; get in use flag
-L01E1               sta       ,x+       ; save it
+KrnRAMUseFlag       lda       #RAMinUse ; get in use flag
+KrnMarkPage         sta       ,x+       ; save it
                     decb                ; done?
-                    bne       L01E1     ; no, keep going
+                    bne       KrnMarkPage ; no, keep going
                     ldx       <D.BlkMap ; get pointer to start of block map
                     sta       <KrnBlk,x ; mark kernel block as RAMinUse, instead of ModInBlk
 S.AltIRQ            rts                 ; return
@@ -555,8 +555,8 @@ XSWI3               lda       #P$SWI3   ; point to SWI3 vector
 XSWI                lda       #P$SWI    ; point to SWI vector
                     ldx       <D.Proc   ; get process pointer
                     ldu       a,x       ; user defined SWI[x]?
-                    beq       L028E     ; no, go get option byte
-GoUser              lbra      L0E5E     ; yes, go call users's routine
+                    beq       KrnSystemCallServiceVector ; no, go get option byte
+GoUser              lbra      KrnJoin3  ; yes, go call users's routine
 
 * SWI2 vector entry
 XSWI2               ldx       <D.Proc   ; get current process descriptor
@@ -566,7 +566,7 @@ XSWI2               ldx       <D.Proc   ; get current process descriptor
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-L028E               ldu       <D.SysSvc ; set system call processor to system side
+KrnSystemCallServiceVector ldu       <D.SysSvc ; set system call processor to system side
                     stu       <D.XSWI2  ; store U at <D.XSWI2
                     ldu       <D.SysIRQ ; do the same thing for IRQ's
                     stu       <D.XIRQ   ; store U at <D.XIRQ
@@ -603,7 +603,7 @@ Loop3               ldx       ,--y      ; load X from ,--y
                     stx       R$PC,u    ; save updated PC to process
 * execute function call
                     ldy       <D.UsrDis ; get user dispatch table pointer
-                    lbsr      L033B     ; go execute option
+                    lbsr      ExecSvcCall ; go execute option
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^IntMasks,R$CC,u ; clear interrupt flags in caller's CC
                   ELSE
@@ -628,8 +628,8 @@ Loop3               ldx       ,--y      ; load X from ,--y
                     sta       <D.Quick  ; save quick return flag
                     beq       AllClr    ; if nothing's have changed, do full checks
 
-DoFull              bsr       L02DA     ; move the stack frame back to user state
-                    lbra      L0D80     ; go back to the process
+DoFull              bsr       CopySystemStackToUser ; move the stack frame back to user state
+                    lbra      KrnJoin   ; go back to the process
 
 * add ldu P$SP,x, etc...
 AllClr              equ       *         ; define assembler symbol AllClr
@@ -659,19 +659,19 @@ Loop4               lda       ,u+       ; load A from ,u+
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-L02CB               pshs      cc,x,y,u  ; preserve registers
+CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task #
                     ldx       P$SP,x    ; get stack pointer
-                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    lbsr      FMoveLater ; calculate block offset (only affects A&X)
                     leax      -$6000,x  ; adjust pointer to where memory map will be
-                    bra       L02E9     ; go copy it
+                    bra       KrnBlockNumberWhere ; go copy it
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-L02DA               pshs      cc,x,y,u  ; preserve registers
+CopySystemStackToUser          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task # of destination
                     ldx       P$SP,x    ; get stack pointer
-                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    lbsr      FMoveLater ; calculate block offset (only affects A&X)
                     leax      -$6000,x  ; adjust pointer to where memory map will be
                     exg       x,y       ; swap pointers & copy
 * Copy a register stack
@@ -679,7 +679,7 @@ L02DA               pshs      cc,x,y,u  ; preserve registers
 *        Y=Destination
 *        A=Offset into DAT image of stack
 *        B=Task #
-L02E9               leau      a,u       ; point to block # of where stack is
+KrnBlockNumberWhere leau      a,u       ; point to block # of where stack is
                     lda       1,u       ; get first block
                     ldb       3,u       ; get a second just in case of overlap
                     orcc      #IntMasks ; shutdown interupts while we do this
@@ -712,9 +712,9 @@ SysCall             leau      ,s        ; get pointer to register stack
                     leax      1,x       ; move PC to next position
                     stx       R$PC,u    ; save my caller's updated PC register
                     ldy       <D.SysDis ; get system dispatch table pointer
-                    bsr       L033B     ; execute system call
+                    bsr       ExecSvcCall ; execute system call
                     puls      a         ; restore system state task number
-                    lbra      L0E2B     ; return to process
+                    lbra      KrnSystemProcessDescriptor ; return to process
 
 * Entry: X = system call vector to jump to
 Sys.Vec             jmp       ,x        ; execute service call
@@ -722,19 +722,19 @@ Sys.Vec             jmp       ,x        ; execute service call
 * Execute system call
 * Entry: B=Function call #
 *        Y=Function dispatch table pointer (D.SysDis or D.UsrDis)
-L033B
+ExecSvcCall
                     lslb                ; is it a I/O call? (Also multiplys by 2 for offset)
-                    bcc       L0345     ; no, go get normal vector
+                    bcc       GetSvcVector ; no, go get normal vector
 * Execute I/O system calls
                     ldx       IOEntry,y ; get IOMan vector
 * Execute the system call
-L034F               pshs      u         ; preserve register stack pointer
+CallSvcVector          pshs      u         ; preserve register stack pointer
                     jsr       [D.SysVec] ; perform a vectored system call
                     puls      u         ; restore pointer
-L0355               tfr       cc,a      ; move CC to A for stack update
-                    bcc       L035B     ; go update it if no error from call
+UpdateCallerCC          tfr       cc,a      ; move CC to A for stack update
+                    bcc       MergeCallerCC    ; go update it if no error from call
                     stb       R$B,u     ; save error code to caller's B
-L035B               ldb       R$CC,u    ; get callers CC, R$CC=$00
+MergeCallerCC              ldb       R$CC,u    ; get callers CC, R$CC=$00
                   IFNE    H6309   ; begin conditional assembly for H6309
                     andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
                     orr       b,a       merge them together
@@ -748,13 +748,13 @@ L035B               ldb       R$CC,u    ; get callers CC, R$CC=$00
                     rts                 ; return to caller
 
 * Execute regular system calls
-L0345
+GetSvcVector
                     clra                ; clear MSB of offset
                     ldx       d,y       ; get vector to call
-                    bne       L034F     ; it's initialized, go execute it
+                    bne       CallSvcVector ; it's initialized, go execute it
                     comb                ; set carry for error
                     ldb       #E$UnkSvc ; get error code
-                    bra       L0355     ; return with it
+                    bra       UpdateCallerCC ; return with it
 
                     use       fssvc.asm ; include source file fssvc.asm
 
@@ -806,7 +806,7 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
                     ldd       <D.SysIRQ ; set system IRQ routine to current
                     std       <D.XIRQ   ; store D at <D.XIRQ
                     jsr       [>D.SvcIRQ] ; execute irq service
-                    bcc       L0D5B     ; branch if carry is clear to L0D5B
+                    bcc       KrnShutDownInterrupts ; branch if carry is clear to KrnShutDownInterrupts
 
                     ldx       <D.Proc   ; get current process pointer
                     ldb       P$Task,x  ; load B from P$Task,x
@@ -814,38 +814,38 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
 
                     pshs      u,d,cc    ; save some registers
                     leau      ,s        ; point to a 'caller register stack'
-                    lbsr      L0C40     ; do a LDB 0,X in task B
+                    lbsr      FLdabxTarget ; do a LDB 0,X in task B
                     puls      u,d,cc    ; and now A ( R$A,U ) = the CC we want
 
                     ora       #IntMasks ; disable it's IRQ's
-                    lbsr      L0C28     ; save it back
-L0D5B               orcc      #IntMasks ; shut down IRQ's
+                    lbsr      FLdabxCarry ; save it back
+KrnShutDownInterrupts orcc      #IntMasks ; shut down IRQ's
                     ldx       <D.Proc   ; get current process pointer
                     tst       <D.QIRQ   ; was it a clock IRQ?
-                    lbne      L0DF7     ; if not, do a quick return
+                    lbne      FNprocJoin ; if not, do a quick return
 
                     lda       P$State,x ; get it's state
                     bita      #TimOut   ; is it timed out?
-                    bne       L0D7C     ; yes, wake it up
+                    bne       KrnTimeoutFlag ; yes, wake it up
 * Update active process queue
                     ldu       #(D.AProcQ-P$Queue) ; point to active process queue
                     ldb       #Suspend  ; get suspend flag
-L0D6A               ldu       P$Queue,u ; get a active process pointer
-                    beq       L0D78     ; branch if zero is set to L0D78
+KrnActiveProcess    ldu       P$Queue,u ; get a active process pointer
+                    beq       UseProcessStack ; branch if zero is set to UseProcessStack
                     bitb      P$State,u ; is it suspended?
-                    bne       L0D6A     ; yes, go to next one in chain
+                    bne       KrnActiveProcess ; yes, go to next one in chain
                     ldb       P$Prior,x ; get current process priority
                     cmpb      P$Prior,u ; do we bump this one?
-                    blo       L0D7C     ; branch if unsigned result is lower to L0D7C
+                    blo       KrnTimeoutFlag ; branch if unsigned result is lower to KrnTimeoutFlag
 
-L0D78               ldu       P$SP,x    ; load U from P$SP,x
-                    bra       L0DB9     ; branch unconditionally to L0DB9
+UseProcessStack          ldu       P$SP,x    ; load U from P$SP,x
+                    bra       FNprocCondemnedByDeadlySignal ; branch unconditionally to FNprocCondemnedByDeadlySignal
 
-L0D7C               anda      #^TimOut  ; mask A with #^TimOut
+KrnTimeoutFlag      anda      #^TimOut  ; mask A with #^TimOut
                     sta       P$State,x ; store A at P$State,x
 
-L0D80               equ       *         ; define assembler symbol L0D80
-L0D83               bsr       L0D11     ; activate next process
+KrnJoin             equ       *         ; define assembler symbol KrnJoin
+KrnActivateProcess  bsr       FAprocTarget ; activate next process
 
                     use       ccbfnproc.asm ; include source file ccbfnproc.asm
 
@@ -870,7 +870,7 @@ S.SysIRQ
                     bra       DoneIRQ   ; check for error and exit
 
 FastIRQ             jsr       [>D.SvcIRQ] ; (Normally routine in Clock calling D.Poll)
-DoneIRQ             bcc       L0E28     ; no error on IRQ, exit
+DoneIRQ             bcc       KrnReturn ; no error on IRQ, exit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #IntMasks,0,s ; setup RTI to shut interrupts off again
                   ELSE
@@ -878,11 +878,11 @@ DoneIRQ             bcc       L0E28     ; no error on IRQ, exit
                     ora       #IntMasks ; merge #IntMasks into A
                     sta       ,s        ; store A at ,s
                   ENDC
-L0E28               rti                 ; return from interrupt
+KrnReturn           rti                 ; return from interrupt
 
 * return from a system call
-L0E29               clra                ; force System task # to 0 (non-GRDRV)
-L0E2B               ldx       <D.SysPrc ; get system process dsc. ptr
+KrnForceSystemTaskSystem clra                ; force System task # to 0 (non-GRDRV)
+KrnSystemProcessDescriptor ldx       <D.SysPrc ; get system process dsc. ptr
                     lbsr      TstImg    ; check image, and F$SetTsk (PRESERVES A)
                     orcc      #IntMasks ; shut interrupts off
                     sta       <D.SSTskN ; save task # for system state
@@ -894,7 +894,7 @@ Fst2                leas      ,u        ; stack ptr=U & return
                     rti                 ; return from interrupt
 
 * Switch to new process, X=Process descriptor pointer, U=Stack pointer
-L0E4C               equ       *         ; define assembler symbol L0E4C
+KrnJoin2            equ       *         ; define assembler symbol KrnJoin2
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch GIME shadow to user state
                     lda       <D.TINIT  ; load A from <D.TINIT
@@ -909,7 +909,7 @@ L0E4C               equ       *         ; define assembler symbol L0E4C
                     bne       MyRTI     ; no, we're doing a system-state rti
 
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    ldf       #R$Size   ; e=0 from call to L0E8D before
+                    ldf       #R$Size   ; e=0 from call to KrnWeGoingBackSameTask before
                     ldu       #Where+SWIStack ; point to the stack
                     tfm       u+,y+     ; move the stack from top of memory to user memory
                   ELSE
@@ -925,7 +925,7 @@ MyRTI               rti                 ; return from IRQ
 
 * Execute routine in task 1 pointed to by U
 * comes from user requested SWI vectors
-L0E5E               equ       *         ; define assembler symbol L0E5E
+KrnJoin3            equ       *         ; define assembler symbol KrnJoin3
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch GIME shadow to user state
                     ldb       <D.TINIT  ; load B from <D.TINIT
@@ -940,7 +940,7 @@ L0E5E               equ       *         ; define assembler symbol L0E5E
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
 S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfdrv (task 1)
-                    bsr       L0E8D     ; copy over the DAT image
+                    bsr       KrnWeGoingBackSameTask ; copy over the DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; apply immediate bit operation #$01,<D.TINIT
                     lda       <D.TINIT  ; get copy of GIME Task side
@@ -954,20 +954,20 @@ S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfd
                     rti                 ; return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-L0E8D               cmpb      <D.Task1N ; are we going back to the same task
-                    beq       L0EA3     ; without the DAT image changing?
+KrnWeGoingBackSameTask cmpb      <D.Task1N ; are we going back to the same task
+                    beq       KrnReturn2 ; without the DAT image changing?
                     stb       <D.Task1N ; nope, save current task in map type 1
                     ldx       #DAT.Regs+8 ; get MMU start register for process's
                     ldu       <D.TskIPt ; get task image pointer table
                     ldu       b,u       ; get address of DAT image
-L0E93               leau      1,u       ; point to actual MMU block
+KrnActualMMUBlock   leau      1,u       ; point to actual MMU block
                   IFNE    H6309   ; begin conditional assembly for H6309
                     lde       #4        ; get # banks/2 for task
                   ELSE
                     lda       #4        ; load A from #4
                     pshs      a         ; save a on the stack
                   ENDC
-L0E9B               lda       ,u++      ; get a bank
+KrnBank             lda       ,u++      ; get a bank
                     ldb       ,u++      ; and next one
                     std       ,x++      ; save it to MMU
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -975,22 +975,22 @@ L0E9B               lda       ,u++      ; get a bank
                   ELSE
                     dec       ,s        ; decrement ,s
                   ENDC
-                    bne       L0E9B     ; no, keep going
+                    bne       KrnBank   ; no, keep going
                   IFEQ    H6309   ; begin conditional assembly for H6309
                     leas      1,s       ; adjust stack pointer by 1,s
                   ENDC
-L0EA3               rts                 ; return
+KrnReturn2          rts                 ; return
 
 * Execute FIRQ vector (called from $FEF4)
 FIRQVCT             ldx       #D.FIRQ   ; get DP offset of vector
-                    bra       L0EB8     ; go execute it
+                    bra       KrnFasterClrXxxx ; go execute it
 
 * Execute IRQ vector (called from $FEF7)
 IRQVCT              orcc      #IntMasks ; disasble IRQ's
                     ldx       #D.IRQ    ; get DP offset of vector
 
 * Execute interrupt vector, B=DP Vector offset
-L0EB8               clra                ; (faster than CLR >$xxxx)
+KrnFasterClrXxxx    clra                ; (faster than CLR >$xxxx)
                     sta       >DAT.Task ; force to Task 0 (system state)
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       0,dp      ; setup DP
@@ -1070,7 +1070,7 @@ Looper              lda       ,u+       ; load A from ,u+
                     bne       Looper    ; branch if zero is clear to Looper
                     puls      b         ; restore b from the stack
                   ENDC
-                    bra       L0EB8     ; and go from map type 1 to map type 0
+                    bra       KrnFasterClrXxxx ; and go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
 SWIVCT              ldx       #D.SWI    ; get DP offset of vector
@@ -1078,7 +1078,7 @@ SWIVCT              ldx       #D.SWI    ; get DP offset of vector
 
 * Execute NMI vector (called from $FEFD)
 NMIVCT              ldx       #D.NMI    ; get DP offset of vector
-                    bra       L0EB8     ; go execute it
+                    bra       KrnFasterClrXxxx ; go execute it
 
 * The end of the kernel module is here
                     emod
@@ -1102,16 +1102,16 @@ SWIStack
 * and get directed to here.  From here, the BRA takes CPU control to the
 * various handlers in the kernel.
                     bra       SWI3VCT   ; sWI3 vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       SWI2VCT   ; sWI2 vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       FIRQVCT   ; fIRQ vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       IRQVCT    ; iRQ vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       SWIVCT    ; sWI vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       NMIVCT    ; nMI vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
 
                     end

--- a/level2/modules/kernel/ccbkrn.asm
+++ b/level2/modules/kernel/ccbkrn.asm
@@ -60,7 +60,7 @@ MName               fcs       /CCBKrn/
 
 * Might as well have this here as just past the end of Kernel...
 DisTable
-                    fdb       FAlltskSleepingProcessQueue+Where ; d.Clock absolute address at the start
+                    fdb       FAlltskSleepProcQ+Where ; d.Clock absolute address at the start
                     fdb       XSWI3+Where ; d.XSWI3
                     fdb       XSWI2+Where ; d.XSWI2
                     fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
@@ -228,9 +228,9 @@ Loop2               lda       ,y+       ; load a byte from source
 *         leau   <Vectors,pc   point to vector
 * fill in the secondard interrupt vectors to all point to
                     tfr       y,u       ; move the pointer to a faster register
-CcbkrnIRQVectorsVectorsNow stu       ,x++      ; set all IRQ vectors to go to Vectors for now
+CcbkrnIRQVctrsVctrs stu       ,x++      ; set all IRQ vectors to go to Vectors for now
                     cmpx      #D.NMI    ; compare X with #D.NMI
-                    bls       CcbkrnIRQVectorsVectorsNow ; branch if unsigned result is lower or same to CcbkrnIRQVectorsVectorsNow
+                    bls       CcbkrnIRQVctrsVctrs ; branch if unsigned result is lower or same to CcbkrnIRQVctrsVctrs
 
 * Initialize user interupt vectors
                     ldx       <D.XSWI2  ; get SWI2 (os9 command) service routine pointer
@@ -357,9 +357,9 @@ KrnBlock            aslb                ; update processor state
 * $0280 - 1024k
 * $0300 - 2048k
                     bitb      #%00110000 ; block above 128K-256K?
-                    beq       Mc09KrnStartBootTrackMemory ; yes, no need to mark block map
+                    beq       Mc09KrnStart ; yes, no need to mark block map
                     tstb                ; 2 meg?
-                    beq       Mc09KrnStartBootTrackMemory ; yes, skip this
+                    beq       Mc09KrnStart ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
                     abx                 ; add maximum block number to block map start
                     leax      -1,x      ; skip good blocks that are RAM
@@ -369,7 +369,7 @@ CcbkrnMarkThem      sta       ,x+       ; mark them all
                     decb                ; decrement B
                     bne       CcbkrnMarkThem ; branch if zero is clear to CcbkrnMarkThem
 
-Mc09KrnStartBootTrackMemory
+Mc09KrnStart
 * CCB - Commented out next two line. we don't have REL or BOOT, so the verify will be only
 * for the memory taken by KRN itself... f000 to ff00
 *       ldx     #Bt.Start       start address of the boot track in memory
@@ -383,12 +383,12 @@ Mc09KrnStartBootTrackMemory
 * CCB Change - I'm commenting out this whole section, and replacing it
                   IFEQ    1       ; begin conditional assembly for 1
 * See if init module is in memory already
-CcbkrnInitModuleName leax      <init,pc  ; point to 'Init' module name
+CcbkrnInitModName   leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
                     bcc       KrnInitModule ; no error, go on
-CcbkrnErrorLinkingInitTryBoot os9       F$Boot    ; error linking init, try & load boot file
-                    bcc       CcbkrnInitModuleName ; got it, try init again
-                    bra       KrnObviouslyCantCrashMachine ; error, re-booting do D.Crash
+CcbkrnErrLnkngInit  os9       F$Boot    ; error linking init, try & load boot file
+                    bcc       CcbkrnInitModName ; got it, try init again
+                    bra       KrnBadCantCrsh ; error, re-booting do D.Crash
 KrnInitModule       stu       <D.Init   ; save init module pointer
                     lda       Feature1,u ; get feature byte #1 from init module
                     bita      #CRCOn    ; cRC feature on?
@@ -402,7 +402,7 @@ KrnKrnp2sName       leax      <krnp2,pc ; point to it's name
                     bcc       KrnJumpKrnp2 ; it worked, execute it
                     os9       F$Boot    ; it doesn't exist try re-booting
                     bcc       KrnKrnp2sName ; no error's, let's try to link it again
-KrnObviouslyCantCrashMachine jmp       <D.Crash  ; obviously can't do it, crash machine
+KrnBadCantCrsh      jmp       <D.Crash  ; obviously can't do it, crash machine
 KrnJumpKrnp2        jmp       ,y        ; execute krnp2
                   ENDC
 
@@ -555,7 +555,7 @@ XSWI3               lda       #P$SWI3   ; point to SWI3 vector
 XSWI                lda       #P$SWI    ; point to SWI vector
                     ldx       <D.Proc   ; get process pointer
                     ldu       a,x       ; user defined SWI[x]?
-                    beq       KrnSystemCallServiceVector ; no, go get option byte
+                    beq       KrnSysCallSvc ; no, go get option byte
 GoUser              lbra      KrnJoin3  ; yes, go call users's routine
 
 * SWI2 vector entry
@@ -566,7 +566,7 @@ XSWI2               ldx       <D.Proc   ; get current process descriptor
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-KrnSystemCallServiceVector ldu       <D.SysSvc ; set system call processor to system side
+KrnSysCallSvc       ldu       <D.SysSvc ; set system call processor to system side
                     stu       <D.XSWI2  ; store U at <D.XSWI2
                     ldu       <D.SysIRQ ; do the same thing for IRQ's
                     stu       <D.XIRQ   ; store U at <D.XIRQ
@@ -628,7 +628,7 @@ Loop3               ldx       ,--y      ; load X from ,--y
                     sta       <D.Quick  ; save quick return flag
                     beq       AllClr    ; if nothing's have changed, do full checks
 
-DoFull              bsr       CopySystemStackToUser ; move the stack frame back to user state
+DoFull              bsr       CpSysStkTo ; move the stack frame back to user state
                     lbra      KrnJoin   ; go back to the process
 
 * add ldu P$SP,x, etc...
@@ -659,7 +659,7 @@ Loop4               lda       ,u+       ; load A from ,u+
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
+CpUsrStkTo          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task #
                     ldx       P$SP,x    ; get stack pointer
                     lbsr      FMoveLater ; calculate block offset (only affects A&X)
@@ -668,7 +668,7 @@ CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-CopySystemStackToUser          pshs      cc,x,y,u  ; preserve registers
+CpSysStkTo          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task # of destination
                     ldx       P$SP,x    ; get stack pointer
                     lbsr      FMoveLater ; calculate block offset (only affects A&X)
@@ -714,7 +714,7 @@ SysCall             leau      ,s        ; get pointer to register stack
                     ldy       <D.SysDis ; get system dispatch table pointer
                     bsr       ExecSvcCall ; execute system call
                     puls      a         ; restore system state task number
-                    lbra      KrnSystemProcessDescriptor ; return to process
+                    lbra      KrnSysProcDesc ; return to process
 
 * Entry: X = system call vector to jump to
 Sys.Vec             jmp       ,x        ; execute service call
@@ -728,13 +728,13 @@ ExecSvcCall
 * Execute I/O system calls
                     ldx       IOEntry,y ; get IOMan vector
 * Execute the system call
-CallSvcVector          pshs      u         ; preserve register stack pointer
+CallSvcVector       pshs      u         ; preserve register stack pointer
                     jsr       [D.SysVec] ; perform a vectored system call
                     puls      u         ; restore pointer
-UpdateCallerCC          tfr       cc,a      ; move CC to A for stack update
-                    bcc       MergeCallerCC    ; go update it if no error from call
+UpdateCallerCC      tfr       cc,a      ; move CC to A for stack update
+                    bcc       MergeCallerCC ; go update it if no error from call
                     stb       R$B,u     ; save error code to caller's B
-MergeCallerCC              ldb       R$CC,u    ; get callers CC, R$CC=$00
+MergeCallerCC       ldb       R$CC,u    ; get callers CC, R$CC=$00
                   IFNE    H6309   ; begin conditional assembly for H6309
                     andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
                     orr       b,a       merge them together
@@ -806,7 +806,7 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
                     ldd       <D.SysIRQ ; set system IRQ routine to current
                     std       <D.XIRQ   ; store D at <D.XIRQ
                     jsr       [>D.SvcIRQ] ; execute irq service
-                    bcc       KrnShutDownInterrupts ; branch if carry is clear to KrnShutDownInterrupts
+                    bcc       KrnShutDownInts ; branch if carry is clear to KrnShutDownInts
 
                     ldx       <D.Proc   ; get current process pointer
                     ldb       P$Task,x  ; load B from P$Task,x
@@ -819,7 +819,7 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
 
                     ora       #IntMasks ; disable it's IRQ's
                     lbsr      FLdabxCarry ; save it back
-KrnShutDownInterrupts orcc      #IntMasks ; shut down IRQ's
+KrnShutDownInts     orcc      #IntMasks ; shut down IRQ's
                     ldx       <D.Proc   ; get current process pointer
                     tst       <D.QIRQ   ; was it a clock IRQ?
                     lbne      FNprocJoin ; if not, do a quick return
@@ -838,8 +838,8 @@ KrnActiveProcess    ldu       P$Queue,u ; get a active process pointer
                     cmpb      P$Prior,u ; do we bump this one?
                     blo       KrnTimeoutFlag ; branch if unsigned result is lower to KrnTimeoutFlag
 
-UseProcessStack          ldu       P$SP,x    ; load U from P$SP,x
-                    bra       FNprocCondemnedByDeadlySignal ; branch unconditionally to FNprocCondemnedByDeadlySignal
+UseProcessStack     ldu       P$SP,x    ; load U from P$SP,x
+                    bra       FNprocCndmnByDdly ; branch unconditionally to FNprocCndmnByDdly
 
 KrnTimeoutFlag      anda      #^TimOut  ; mask A with #^TimOut
                     sta       P$State,x ; store A at P$State,x
@@ -881,8 +881,8 @@ DoneIRQ             bcc       KrnReturn ; no error on IRQ, exit
 KrnReturn           rti                 ; return from interrupt
 
 * return from a system call
-KrnForceSystemTaskSystem clra                ; force System task # to 0 (non-GRDRV)
-KrnSystemProcessDescriptor ldx       <D.SysPrc ; get system process dsc. ptr
+KrnFrcSysTask       clra                ; force System task # to 0 (non-GRDRV)
+KrnSysProcDesc      ldx       <D.SysPrc ; get system process dsc. ptr
                     lbsr      TstImg    ; check image, and F$SetTsk (PRESERVES A)
                     orcc      #IntMasks ; shut interrupts off
                     sta       <D.SSTskN ; save task # for system state
@@ -909,7 +909,7 @@ KrnJoin2            equ       *         ; define assembler symbol KrnJoin2
                     bne       MyRTI     ; no, we're doing a system-state rti
 
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    ldf       #R$Size   ; e=0 from call to KrnWeGoingBackSameTask before
+                    ldf       #R$Size   ; e=0 from call to KrnWeGngBack before
                     ldu       #Where+SWIStack ; point to the stack
                     tfm       u+,y+     ; move the stack from top of memory to user memory
                   ELSE
@@ -940,7 +940,7 @@ KrnJoin3            equ       *         ; define assembler symbol KrnJoin3
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
 S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfdrv (task 1)
-                    bsr       KrnWeGoingBackSameTask ; copy over the DAT image
+                    bsr       KrnWeGngBack ; copy over the DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; apply immediate bit operation #$01,<D.TINIT
                     lda       <D.TINIT  ; get copy of GIME Task side
@@ -954,7 +954,7 @@ S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfd
                     rti                 ; return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-KrnWeGoingBackSameTask cmpb      <D.Task1N ; are we going back to the same task
+KrnWeGngBack        cmpb      <D.Task1N ; are we going back to the same task
                     beq       KrnReturn2 ; without the DAT image changing?
                     stb       <D.Task1N ; nope, save current task in map type 1
                     ldx       #DAT.Regs+8 ; get MMU start register for process's

--- a/level2/modules/kernel/fallimg.asm
+++ b/level2/modules/kernel/fallimg.asm
@@ -26,28 +26,28 @@ FAllimgTarget       pshs      d,x,y,u   ; save d,x,y,u on the stack
                     pshs      d,x,y,u   ; save regs
 FAllimgDATBlock     ldd       ,y++      ; get DAT for current block
                     cmpd      #DAT.Free ; is it free?
-                    beq       FAllimgDropTotalBlocksNeeded ; yes, skip ahead
+                    beq       FAllimgDropTtlBlks ; yes, skip ahead
                     lda       d,u       ; no, get the memory block block type
                     cmpa      #RAMinUse ; rAM already in use?
                     puls      d         ; get # of blocks to allocate back
-                    bne       FAllimgWeCouldntAllocateMemoryFull ; not RAM in use, skip ahead
+                    bne       FAllimgWeNoAlloc ; not RAM in use, skip ahead
                   IFNE    H6309   ; begin conditional assembly for H6309
                     decd      ;         drop                # of blocks needed
                   ELSE
                     subd      #$0001    ; drop # of blocks needed
                   ENDC
                     pshs      d         ; save as new # of blocks still needed
-FAllimgDropTotalBlocksNeeded leax      -1,x      ; drop total # of blocks needed
+FAllimgDropTtlBlks  leax      -1,x      ; drop total # of blocks needed
                     bne       FAllimgDATBlock ; still more, keep checking
                     ldx       ,s++      ; get # of blocks still needed
                     beq       FAllimgSome ; none, skip ahead
-FAllimgFlagMMUBlockFullMemory lda       ,u+       ; get flag byte for next MMU block in full memory map
-                    bne       FAllimgHaveWeHitEndFull ; not free, skip ahead
+FAllimgFlagMMUBlk   lda       ,u+       ; get flag byte for next MMU block in full memory map
+                    bne       FAllimgHaveWeHit ; not free, skip ahead
                     leax      -1,x      ; free, drop total # of blocks needed
                     beq       FAllimgSome ; no more left, skip ahead
-FAllimgHaveWeHitEndFull cmpu      <D.BlkMap+2 ; have we hit the end of the full memory map?
-                    blo       FAllimgFlagMMUBlockFullMemory ; no, keep checking
-FAllimgWeCouldntAllocateMemoryFull ldb       #E$MemFul ; yes, we couldn't allocate, mem full error
+FAllimgHaveWeHit    cmpu      <D.BlkMap+2 ; have we hit the end of the full memory map?
+                    blo       FAllimgFlagMMUBlk ; no, keep checking
+FAllimgWeNoAlloc    ldb       #E$MemFul ; yes, we couldn't allocate, mem full error
                     leas      6,s       ; eat stack
                     stb       1,s       ; save error # on stack to pull off as B
                     comb                ; update processor state
@@ -55,17 +55,17 @@ FAllimgWeCouldntAllocateMemoryFull ldb       #E$MemFul ; yes, we couldn't alloca
 
 * Found enough RAM for allocation request
 FAllimgSome         puls      x,y,u     ; restore some regs
-FAllimgDATImageBlock ldd       ,y++      ; get DAT image for current 8K block
+FAllimgDATImgBlk    ldd       ,y++      ; get DAT image for current 8K block
                     cmpd      #DAT.Free ; is it marked as free?
-                    bne       FAllimgDecBlocksLeftAssign ; no, skip ahead
-FAllimgMemoryMapFlagMMUBlock lda       ,u+       ; yes, get memory map flag for MMU block
-                    bne       FAllimgMemoryMapFlagMMUBlock ; already allocated in some way, look for free one
+                    bne       FAllimgDecBlksLeft ; no, skip ahead
+FAllimgMemMapFlag   lda       ,u+       ; yes, get memory map flag for MMU block
+                    bne       FAllimgMemMapFlag ; already allocated in some way, look for free one
                     inc       ,-u       ; was unused; set to RAMinUse
                     tfr       u,d       ; move ptr to just allocated block to D
                     subd      <D.BlkMap ; subtract start of main memory map ptr
                     std       -2,y      ; save MMU block # into DAT block
-FAllimgDecBlocksLeftAssign leax      -1,x      ; dec # blocks left to assign
-                    bne       FAllimgDATImageBlock ; keep going until all are allocated
+FAllimgDecBlksLeft  leax      -1,x      ; dec # blocks left to assign
+                    bne       FAllimgDATImgBlk ; keep going until all are allocated
                     ldx       2,s       ; get process descriptor ptr back
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #ImgChg,P$State,x ; flag DAT IMG change for system

--- a/level2/modules/kernel/fallimg.asm
+++ b/level2/modules/kernel/fallimg.asm
@@ -11,68 +11,68 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FAllImg             ldd       R$D,u               get starting block # & # of blocks
-                    ldx       R$X,u               get process descriptor pointer
+FAllImg             ldd       R$D,u     ; get starting block # & # of blocks
+                    ldx       R$X,u     ; get process descriptor pointer
 * 6309 NOTE: IF W IS USED HERE, TRY TO PRESERVE IT AS F$SRQMEM WILL
 *   PROBABLY END UP USING IT
 * Entry point from F$SRqMem
-L09BE               pshs      d,x,y,u
-                    lsla                          Start MMU block #*2 (2 bytes/DAT entry)
-                    leay      P$DATImg,x          Point to DAT img in process descriptor
-                    leay      a,y                 Point to specific block # we want
-                    clra
-                    tfr       d,x                 X=# of blocks
-                    ldu       <D.BlkMap           Get memory block map ptr
-                    pshs      d,x,y,u             Save regs
-L09CD               ldd       ,y++                Get DAT for current block
-                    cmpd      #DAT.Free           Is it free?
-                    beq       L09E2               Yes, skip ahead
-                    lda       d,u                 No, get the memory block block type
-                    cmpa      #RAMinUse           RAM already in use?
-                    puls      d                   Get # of blocks to allocate back
-                    bne       L09F7               not RAM in use, skip ahead
-                    IFNE      H6309
-                    decd      Drop                # of blocks needed
-                    ELSE
-                    subd      #$0001              Drop # of blocks needed
-                    ENDC
-                    pshs      d                   Save as new # of blocks still needed
-L09E2               leax      -1,x                Drop total # of blocks needed
-                    bne       L09CD               Still more, keep checking
-                    ldx       ,s++                Get # of blocks still needed
-                    beq       L0A00               None, skip ahead
-L09EA               lda       ,u+                 Get flag byte for next MMU block in full memory map
-                    bne       L09F2               Not free, skip ahead
-                    leax      -1,x                Free, drop total # of blocks needed
-                    beq       L0A00               No more left, skip ahead
-L09F2               cmpu      <D.BlkMap+2         Have we hit the end of the full memory map?
-                    blo       L09EA               No, keep checking
-L09F7               ldb       #E$MemFul           Yes, we couldn't allocate, mem full error
-                    leas      6,s                 Eat stack
-                    stb       1,s                 Save error # on stack to pull off as B
-                    comb
-                    puls      d,x,y,u,pc          Restore regs, exit with mem full error
+L09BE               pshs      d,x,y,u   ; save d,x,y,u on the stack
+                    lsla                ; start MMU block #*2 (2 bytes/DAT entry)
+                    leay      P$DATImg,x ; point to DAT img in process descriptor
+                    leay      a,y       ; point to specific block # we want
+                    clra                ; clear A
+                    tfr       d,x       ; X=# of blocks
+                    ldu       <D.BlkMap ; get memory block map ptr
+                    pshs      d,x,y,u   ; save regs
+L09CD               ldd       ,y++      ; get DAT for current block
+                    cmpd      #DAT.Free ; is it free?
+                    beq       L09E2     ; yes, skip ahead
+                    lda       d,u       ; no, get the memory block block type
+                    cmpa      #RAMinUse ; rAM already in use?
+                    puls      d         ; get # of blocks to allocate back
+                    bne       L09F7     ; not RAM in use, skip ahead
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decd      ; drop                # of blocks needed
+                  ELSE
+                    subd      #$0001    ; drop # of blocks needed
+                  ENDC
+                    pshs      d         ; save as new # of blocks still needed
+L09E2               leax      -1,x      ; drop total # of blocks needed
+                    bne       L09CD     ; still more, keep checking
+                    ldx       ,s++      ; get # of blocks still needed
+                    beq       L0A00     ; none, skip ahead
+L09EA               lda       ,u+       ; get flag byte for next MMU block in full memory map
+                    bne       L09F2     ; not free, skip ahead
+                    leax      -1,x      ; free, drop total # of blocks needed
+                    beq       L0A00     ; no more left, skip ahead
+L09F2               cmpu      <D.BlkMap+2 ; have we hit the end of the full memory map?
+                    blo       L09EA     ; no, keep checking
+L09F7               ldb       #E$MemFul ; yes, we couldn't allocate, mem full error
+                    leas      6,s       ; eat stack
+                    stb       1,s       ; save error # on stack to pull off as B
+                    comb                ; update processor state
+                    puls      d,x,y,u,pc ; restore regs, exit with mem full error
 
 * Found enough RAM for allocation request
-L0A00               puls      x,y,u               Restore some regs
-L0A02               ldd       ,y++                Get DAT image for current 8K block
-                    cmpd      #DAT.Free           Is it marked as free?
-                    bne       L0A16               No, skip ahead
-L0A0A               lda       ,u+                 Yes, get memory map flag for MMU block
-                    bne       L0A0A               Already allocated in some way, look for free one
-                    inc       ,-u                 Was unused; set to RAMinUse
-                    tfr       u,d                 Move ptr to just allocated block to D
-                    subd      <D.BlkMap           Subtract start of main memory map ptr
-                    std       -2,y                Save MMU block # into DAT block
-L0A16               leax      -1,x                Dec # blocks left to assign
-                    bne       L0A02               Keep going until all are allocated
-                    ldx       2,s                 Get process descriptor ptr back
-                    IFNE      H6309
-                    oim       #ImgChg,P$State,x   flag DAT IMG change for system
-                    ELSE
-                    lda       P$State,x           flag DAT IMG change for system
-                    ora       #ImgChg
-                    sta       P$State,x
-                    ENDC
-                    clrb                          No error, restore regs & return
-                    puls      d,x,y,u,pc
+L0A00               puls      x,y,u     ; restore some regs
+L0A02               ldd       ,y++      ; get DAT image for current 8K block
+                    cmpd      #DAT.Free ; is it marked as free?
+                    bne       L0A16     ; no, skip ahead
+L0A0A               lda       ,u+       ; yes, get memory map flag for MMU block
+                    bne       L0A0A     ; already allocated in some way, look for free one
+                    inc       ,-u       ; was unused; set to RAMinUse
+                    tfr       u,d       ; move ptr to just allocated block to D
+                    subd      <D.BlkMap ; subtract start of main memory map ptr
+                    std       -2,y      ; save MMU block # into DAT block
+L0A16               leax      -1,x      ; dec # blocks left to assign
+                    bne       L0A02     ; keep going until all are allocated
+                    ldx       2,s       ; get process descriptor ptr back
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #ImgChg,P$State,x ; flag DAT IMG change for system
+                  ELSE
+                    lda       P$State,x ; flag DAT IMG change for system
+                    ora       #ImgChg   ; merge #ImgChg into A
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+                    clrb                ; no error, restore regs & return
+                    puls      d,x,y,u,pc ; restore d,x,y,u,pc from the stack

--- a/level2/modules/kernel/fallimg.asm
+++ b/level2/modules/kernel/fallimg.asm
@@ -16,7 +16,7 @@ FAllImg             ldd       R$D,u     ; get starting block # & # of blocks
 * 6309 NOTE: IF W IS USED HERE, TRY TO PRESERVE IT AS F$SRQMEM WILL
 *   PROBABLY END UP USING IT
 * Entry point from F$SRqMem
-L09BE               pshs      d,x,y,u   ; save d,x,y,u on the stack
+FAllimgTarget       pshs      d,x,y,u   ; save d,x,y,u on the stack
                     lsla                ; start MMU block #*2 (2 bytes/DAT entry)
                     leay      P$DATImg,x ; point to DAT img in process descriptor
                     leay      a,y       ; point to specific block # we want
@@ -24,48 +24,48 @@ L09BE               pshs      d,x,y,u   ; save d,x,y,u on the stack
                     tfr       d,x       ; X=# of blocks
                     ldu       <D.BlkMap ; get memory block map ptr
                     pshs      d,x,y,u   ; save regs
-L09CD               ldd       ,y++      ; get DAT for current block
+FAllimgDATBlock     ldd       ,y++      ; get DAT for current block
                     cmpd      #DAT.Free ; is it free?
-                    beq       L09E2     ; yes, skip ahead
+                    beq       FAllimgDropTotalBlocksNeeded ; yes, skip ahead
                     lda       d,u       ; no, get the memory block block type
                     cmpa      #RAMinUse ; rAM already in use?
                     puls      d         ; get # of blocks to allocate back
-                    bne       L09F7     ; not RAM in use, skip ahead
+                    bne       FAllimgWeCouldntAllocateMemoryFull ; not RAM in use, skip ahead
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    decd      ; drop                # of blocks needed
+                    decd      ;         drop                # of blocks needed
                   ELSE
                     subd      #$0001    ; drop # of blocks needed
                   ENDC
                     pshs      d         ; save as new # of blocks still needed
-L09E2               leax      -1,x      ; drop total # of blocks needed
-                    bne       L09CD     ; still more, keep checking
+FAllimgDropTotalBlocksNeeded leax      -1,x      ; drop total # of blocks needed
+                    bne       FAllimgDATBlock ; still more, keep checking
                     ldx       ,s++      ; get # of blocks still needed
-                    beq       L0A00     ; none, skip ahead
-L09EA               lda       ,u+       ; get flag byte for next MMU block in full memory map
-                    bne       L09F2     ; not free, skip ahead
+                    beq       FAllimgSome ; none, skip ahead
+FAllimgFlagMMUBlockFullMemory lda       ,u+       ; get flag byte for next MMU block in full memory map
+                    bne       FAllimgHaveWeHitEndFull ; not free, skip ahead
                     leax      -1,x      ; free, drop total # of blocks needed
-                    beq       L0A00     ; no more left, skip ahead
-L09F2               cmpu      <D.BlkMap+2 ; have we hit the end of the full memory map?
-                    blo       L09EA     ; no, keep checking
-L09F7               ldb       #E$MemFul ; yes, we couldn't allocate, mem full error
+                    beq       FAllimgSome ; no more left, skip ahead
+FAllimgHaveWeHitEndFull cmpu      <D.BlkMap+2 ; have we hit the end of the full memory map?
+                    blo       FAllimgFlagMMUBlockFullMemory ; no, keep checking
+FAllimgWeCouldntAllocateMemoryFull ldb       #E$MemFul ; yes, we couldn't allocate, mem full error
                     leas      6,s       ; eat stack
                     stb       1,s       ; save error # on stack to pull off as B
                     comb                ; update processor state
                     puls      d,x,y,u,pc ; restore regs, exit with mem full error
 
 * Found enough RAM for allocation request
-L0A00               puls      x,y,u     ; restore some regs
-L0A02               ldd       ,y++      ; get DAT image for current 8K block
+FAllimgSome         puls      x,y,u     ; restore some regs
+FAllimgDATImageBlock ldd       ,y++      ; get DAT image for current 8K block
                     cmpd      #DAT.Free ; is it marked as free?
-                    bne       L0A16     ; no, skip ahead
-L0A0A               lda       ,u+       ; yes, get memory map flag for MMU block
-                    bne       L0A0A     ; already allocated in some way, look for free one
+                    bne       FAllimgDecBlocksLeftAssign ; no, skip ahead
+FAllimgMemoryMapFlagMMUBlock lda       ,u+       ; yes, get memory map flag for MMU block
+                    bne       FAllimgMemoryMapFlagMMUBlock ; already allocated in some way, look for free one
                     inc       ,-u       ; was unused; set to RAMinUse
                     tfr       u,d       ; move ptr to just allocated block to D
                     subd      <D.BlkMap ; subtract start of main memory map ptr
                     std       -2,y      ; save MMU block # into DAT block
-L0A16               leax      -1,x      ; dec # blocks left to assign
-                    bne       L0A02     ; keep going until all are allocated
+FAllimgDecBlocksLeftAssign leax      -1,x      ; dec # blocks left to assign
+                    bne       FAllimgDATImageBlock ; keep going until all are allocated
                     ldx       2,s       ; get process descriptor ptr back
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #ImgChg,P$State,x ; flag DAT IMG change for system

--- a/level2/modules/kernel/fallprc.asm
+++ b/level2/modules/kernel/fallprc.asm
@@ -11,29 +11,29 @@
 *
 FAllPrc             pshs      u         ; preserve register stack pointer
                     bsr       AllPrc    ; try & allocate descriptor
-                    bcs       L02E8     ; can't do, return
+                    bcs       FAllprcReturn ; can't do, return
                     ldx       ,s        ; get register stack pointer
                     stu       R$U,x     ; save pointer to new descriptor
-L02E8               puls      u,pc      ; restore & return
+FAllprcReturn       puls      u,pc      ; restore & return
 * Allocate a process desciptor
 * Entry: None
 AllPrc              ldx       <D.PrcDBT ; get pointer to process descriptor block table
-L02EC               lda       ,x+       ; get a process block #
-                    bne       L02EC     ; used, keep looking
+FAllprcProcessBlock lda       ,x+       ; get a process block #
+                    bne       FAllprcProcessBlock ; used, keep looking
                     leax      -1,x      ; point to it again
                     tfr       x,d       ; move it to D
                     subd      <D.PrcDBT ; subtract pointer to table (gives actual prc. ID)
                     tsta                ; id valid?
-                    beq       L02FE     ; yes, go on
+                    beq       FAllprcProcess ; yes, go on
                     comb                ; set carry
                     ldb       #E$PrcFul ; get error code
                     rts                 ; return with error
 
-L02FE               pshs      b         ; save process #
+FAllprcProcess      pshs      b         ; save process #
                     ldd       #P$Size   ; get size of descriptor
                     os9       F$SRqMem  ; request the memory for it
                     puls      a         ; restore process #
-                    bcs       L032F     ; exit if error from mem call
+                    bcs       FAllprcReturn2 ; exit if error from mem call
                     sta       P$ID,u    ; save ID to descriptor
                     tfr       u,d       ; transfer register value u,d
                     sta       ,x        ; save ID to process descriptor table
@@ -79,11 +79,11 @@ LChinese            stx       ,y++      ; 8 \                Clear 2 bytes
                     ldb       #DAT.BlCt ; # of double byte writes
                     ldx       #DAT.Free ; empty block marker
                     leay      P$DATImg,u ; compute P$DATImg,u into Y
-L0329               stx       ,y++      ; store X at ,y++
+FAllprcTarget       stx       ,y++      ; store X at ,y++
                     decb                ; done?
-                    bne       L0329     ; no, keep going
+                    bne       FAllprcTarget ; no, keep going
                     clrb                ; clear carry
-L032F               rts                 ; return
+FAllprcReturn2      rts                 ; return
 
 **************************************************
 * System Call: F$DelPrc
@@ -93,7 +93,7 @@ L032F               rts                 ; return
 * Error:  CC = C bit set; B = error code
 *
 FDelPrc             lda       R$A,u     ; get process #
-                    bra       L0386     ; delete it
+                    bra       FAllprcTarget2 ; delete it
 
 
 **************************************************
@@ -117,62 +117,62 @@ FDelPrc             lda       R$A,u     ; get process #
 *
 FWait               ldx       <D.Proc   ; get current process
                     lda       P$CID,x   ; any children?
-                    beq       L0368     ; no, exit with error
-L033A               lbsr      L0B2E     ; get pointer to child process dsc. into Y
+                    beq       FAllprcErrorExit ; no, exit with error
+FAllprcChildProcessDesc lbsr      FGprocpTarget ; get pointer to child process dsc. into Y
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #Dead,P$State,y ; is child dead?
                   ELSE
                     lda       P$State,y ; load A from P$State,y
                     bita      #Dead     ; test bits in A against #Dead
                   ENDC
-                    bne       L036C     ; yes, send message to parent
+                    bne       FAllprcProcessIDDeadChild ; yes, send message to parent
                     lda       P$SID,y   ; no, check for another child (thru sibling list)
-                    bne       L033A     ; yes there is another child, go see if it is dead
+                    bne       FAllprcChildProcessDesc ; yes there is another child, go see if it is dead
 * NOTE: MAY WANT TO ADD IN CLRB, CHANGE TO STD R$A,u
                     sta       R$A,u     ; no child has died, clear out process # & status
                     sta       R$B,u     ; code in caller's A&B regs
                     pshs      cc        ; preserve CC
                     orcc      #IntMasks ; shut off interrupts
                     lda       <P$Signal,x ; any signals pending?
-                    beq       L035D     ; no, skip ahead
+                    beq       FAllprcHeadWaitingProcessLine ; no, skip ahead
 * No Child died, but received signal
                     deca                ; yes, is it a wakeup signal?
-                    bne       L035A     ; no, wake it up with proper signal
+                    bne       FAllprcWakeUpSignalWillSent ; no, wake it up with proper signal
                     sta       <P$Signal,x ; clear out signal code
-L035A               lbra      L071B     ; go wake it up (no signal will be sent)
+FAllprcWakeUpSignalWillSent lbra      FSleepTarget ; go wake it up (no signal will be sent)
 
 * No dead child & no signal...execute next F$Waiting process in line
-L035D               ldd       <D.WProcQ ; get ptr to head of waiting process line
+FAllprcHeadWaitingProcessLine ldd       <D.WProcQ ; get ptr to head of waiting process line
                     std       P$Queue,x ; save as next process in line from current one
                     stx       <D.WProcQ ; save curr. process as new head of waiting process line
                     puls      cc        ; restore interupts
-                    lbra      L0780     ; go activate next process in line
+                    lbra      FSleepTarget4 ; go activate next process in line
 
-L0368               comb                ; exit with No Children error
+FAllprcErrorExit    comb                ; exit with No Children error
                     ldb       #E$NoChld ; load B from #E$NoChld
                     rts                 ; return to caller
 
 * Child has died
 * Entry: Y=Ptr to child process that died
 *        U=Ptr to caller's register stack
-L036C               lda       P$ID,y    ; get process ID of dead child
+FAllprcProcessIDDeadChild lda       P$ID,y    ; get process ID of dead child
                     ldb       <P$Signal,y ; get signal code that child received (if any)
                     std       R$D,u     ; save in caller's D
                     leau      ,y        ; point U to child process dsc.
                     leay      P$CID-P$SID,x ; bump Y up by 1 for 1st loop so P$SID below
 *                             actually references P$CID
-                    bra       L037C     ; skip ahead
+                    bra       FAllprcSiblingIDChildIDSt ; skip ahead
 
 * Update linked list of sibling processes to exclude dead child
-L0379               lbsr      L0B2E     ; get pointer to process
-L037C               lda       P$SID,y   ; get Sibling ID (or Child ID on 1st run)
+FAllprcProcess2     lbsr      FGprocpTarget ; get pointer to process
+FAllprcSiblingIDChildIDSt lda       P$SID,y   ; get Sibling ID (or Child ID on 1st run)
                     cmpa      P$ID,u    ; same as Dying process ID?
-                    bne       L0379     ; no, go get ptr to Sibling process & do again
+                    bne       FAllprcProcess2 ; no, go get ptr to Sibling process & do again
                     ldb       P$SID,u   ; yes, wrapped to our own, get Sibling ID from child
                     stb       P$SID,y   ; save as sibling process id # in other sibling
-L0386               pshs      d,x,u     ; preserve regs
+FAllprcTarget2      pshs      d,x,u     ; preserve regs
                     cmpa      WGlobal+G.AlPID ; does dying process have an alarm set up?
-                    bne       L0393     ; no, go on
+                    bne       FAllprcDyingProcessBack ; no, go on
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; faster than 2 memory clears
                   ELSE
@@ -180,11 +180,11 @@ L0386               pshs      d,x,u     ; preserve regs
                     clrb                ; clear B
                   ENDC
                     std       WGlobal+G.AlPID ; clear alarm ID & signal
-L0393               ldb       ,s        ; get dying process # back
+FAllprcDyingProcessBack ldb       ,s        ; get dying process # back
                     ldx       <D.PrcDBT ; get ptr to process descriptor block table
                     abx                 ; offset into table
                     lda       ,x        ; get MSB of process dsc. ptr
-                    beq       L03AC     ; if gone already, exit
+                    beq       FAllprcReturn3 ; if gone already, exit
                     clrb                ; clear B
                     stb       ,x        ; clear out entry in block table
                     tfr       d,x       ; move process dsc. ptr to X
@@ -192,4 +192,4 @@ L0393               ldb       ,s        ; get dying process # back
                     leau      ,x        ; point U to start of Dead process dsc.
                     ldd       #P$Size   ; size of a process dsc.
                     os9       F$SRtMem  ; deallocate process dsc. from system memory pool
-L03AC               puls      d,x,u,pc  ; restore regs & return
+FAllprcReturn3      puls      d,x,u,pc  ; restore regs & return

--- a/level2/modules/kernel/fallprc.asm
+++ b/level2/modules/kernel/fallprc.asm
@@ -118,31 +118,31 @@ FDelPrc             lda       R$A,u     ; get process #
 FWait               ldx       <D.Proc   ; get current process
                     lda       P$CID,x   ; any children?
                     beq       FAllprcErrorExit ; no, exit with error
-FAllprcChildProcessDesc lbsr      FGprocpTarget ; get pointer to child process dsc. into Y
+FAllprcKidProcDesc  lbsr      FGprocpTarget ; get pointer to child process dsc. into Y
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #Dead,P$State,y ; is child dead?
                   ELSE
                     lda       P$State,y ; load A from P$State,y
                     bita      #Dead     ; test bits in A against #Dead
                   ENDC
-                    bne       FAllprcProcessIDDeadChild ; yes, send message to parent
+                    bne       FAllprcProcIDDead ; yes, send message to parent
                     lda       P$SID,y   ; no, check for another child (thru sibling list)
-                    bne       FAllprcChildProcessDesc ; yes there is another child, go see if it is dead
+                    bne       FAllprcKidProcDesc ; yes there is another child, go see if it is dead
 * NOTE: MAY WANT TO ADD IN CLRB, CHANGE TO STD R$A,u
                     sta       R$A,u     ; no child has died, clear out process # & status
                     sta       R$B,u     ; code in caller's A&B regs
                     pshs      cc        ; preserve CC
                     orcc      #IntMasks ; shut off interrupts
                     lda       <P$Signal,x ; any signals pending?
-                    beq       FAllprcHeadWaitingProcessLine ; no, skip ahead
+                    beq       FAllprcHeadWaitProc ; no, skip ahead
 * No Child died, but received signal
                     deca                ; yes, is it a wakeup signal?
-                    bne       FAllprcWakeUpSignalWillSent ; no, wake it up with proper signal
+                    bne       FAllprcWakeUpSig ; no, wake it up with proper signal
                     sta       <P$Signal,x ; clear out signal code
-FAllprcWakeUpSignalWillSent lbra      FSleepTarget ; go wake it up (no signal will be sent)
+FAllprcWakeUpSig    lbra      FSleepTarget ; go wake it up (no signal will be sent)
 
 * No dead child & no signal...execute next F$Waiting process in line
-FAllprcHeadWaitingProcessLine ldd       <D.WProcQ ; get ptr to head of waiting process line
+FAllprcHeadWaitProc ldd       <D.WProcQ ; get ptr to head of waiting process line
                     std       P$Queue,x ; save as next process in line from current one
                     stx       <D.WProcQ ; save curr. process as new head of waiting process line
                     puls      cc        ; restore interupts
@@ -155,24 +155,24 @@ FAllprcErrorExit    comb                ; exit with No Children error
 * Child has died
 * Entry: Y=Ptr to child process that died
 *        U=Ptr to caller's register stack
-FAllprcProcessIDDeadChild lda       P$ID,y    ; get process ID of dead child
+FAllprcProcIDDead   lda       P$ID,y    ; get process ID of dead child
                     ldb       <P$Signal,y ; get signal code that child received (if any)
                     std       R$D,u     ; save in caller's D
                     leau      ,y        ; point U to child process dsc.
                     leay      P$CID-P$SID,x ; bump Y up by 1 for 1st loop so P$SID below
 *                             actually references P$CID
-                    bra       FAllprcSiblingIDChildIDSt ; skip ahead
+                    bra       FAllprcSibIDKid ; skip ahead
 
 * Update linked list of sibling processes to exclude dead child
 FAllprcProcess2     lbsr      FGprocpTarget ; get pointer to process
-FAllprcSiblingIDChildIDSt lda       P$SID,y   ; get Sibling ID (or Child ID on 1st run)
+FAllprcSibIDKid     lda       P$SID,y   ; get Sibling ID (or Child ID on 1st run)
                     cmpa      P$ID,u    ; same as Dying process ID?
                     bne       FAllprcProcess2 ; no, go get ptr to Sibling process & do again
                     ldb       P$SID,u   ; yes, wrapped to our own, get Sibling ID from child
                     stb       P$SID,y   ; save as sibling process id # in other sibling
 FAllprcTarget2      pshs      d,x,u     ; preserve regs
                     cmpa      WGlobal+G.AlPID ; does dying process have an alarm set up?
-                    bne       FAllprcDyingProcessBack ; no, go on
+                    bne       FAllprcDyngProcBack ; no, go on
                   IFNE    H6309   ; begin conditional assembly for H6309
                     clrd                ; faster than 2 memory clears
                   ELSE
@@ -180,7 +180,7 @@ FAllprcTarget2      pshs      d,x,u     ; preserve regs
                     clrb                ; clear B
                   ENDC
                     std       WGlobal+G.AlPID ; clear alarm ID & signal
-FAllprcDyingProcessBack ldb       ,s        ; get dying process # back
+FAllprcDyngProcBack ldb       ,s        ; get dying process # back
                     ldx       <D.PrcDBT ; get ptr to process descriptor block table
                     abx                 ; offset into table
                     lda       ,x        ; get MSB of process dsc. ptr

--- a/level2/modules/kernel/fallprc.asm
+++ b/level2/modules/kernel/fallprc.asm
@@ -9,49 +9,49 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FAllPrc             pshs      u                   preserve register stack pointer
-                    bsr       AllPrc              try & allocate descriptor
-                    bcs       L02E8               can't do, return
-                    ldx       ,s                  get register stack pointer
-                    stu       R$U,x               save pointer to new descriptor
-L02E8               puls      u,pc                restore & return
+FAllPrc             pshs      u         ; preserve register stack pointer
+                    bsr       AllPrc    ; try & allocate descriptor
+                    bcs       L02E8     ; can't do, return
+                    ldx       ,s        ; get register stack pointer
+                    stu       R$U,x     ; save pointer to new descriptor
+L02E8               puls      u,pc      ; restore & return
 * Allocate a process desciptor
 * Entry: None
-AllPrc              ldx       <D.PrcDBT           get pointer to process descriptor block table
-L02EC               lda       ,x+                 get a process block #
-                    bne       L02EC               used, keep looking
-                    leax      -1,x                point to it again
-                    tfr       x,d                 move it to D
-                    subd      <D.PrcDBT           subtract pointer to table (gives actual prc. ID)
-                    tsta                          id valid?
-                    beq       L02FE               yes, go on
-                    comb                          set carry
-                    ldb       #E$PrcFul           get error code
-                    rts                           Return with error
+AllPrc              ldx       <D.PrcDBT ; get pointer to process descriptor block table
+L02EC               lda       ,x+       ; get a process block #
+                    bne       L02EC     ; used, keep looking
+                    leax      -1,x      ; point to it again
+                    tfr       x,d       ; move it to D
+                    subd      <D.PrcDBT ; subtract pointer to table (gives actual prc. ID)
+                    tsta                ; id valid?
+                    beq       L02FE     ; yes, go on
+                    comb                ; set carry
+                    ldb       #E$PrcFul ; get error code
+                    rts                 ; return with error
 
-L02FE               pshs      b                   save process #
-                    ldd       #P$Size             get size of descriptor
-                    os9       F$SRqMem            request the memory for it
-                    puls      a                   restore process #
-                    bcs       L032F               exit if error from mem call
-                    sta       P$ID,u              save ID to descriptor
-                    tfr       u,d
-                    sta       ,x                  save ID to process descriptor table
+L02FE               pshs      b         ; save process #
+                    ldd       #P$Size   ; get size of descriptor
+                    os9       F$SRqMem  ; request the memory for it
+                    puls      a         ; restore process #
+                    bcs       L032F     ; exit if error from mem call
+                    sta       P$ID,u    ; save ID to descriptor
+                    tfr       u,d       ; transfer register value u,d
+                    sta       ,x        ; save ID to process descriptor table
 * Clear out process descriptor through till stack
-                    IFNE      H6309
-                    leay      <Null3,pc           Point to 0 byte
-                    leax      P$PID,u             Point to start of part to clear
-                    ldw       #$0100              256 bytes to clear
-Null3               equ       *-1
-                    tfm       y,x+
-                    ELSE
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leay      <Null3,pc ; point to 0 byte
+                    leax      P$PID,u   ; point to start of part to clear
+                    ldw       #$0100    ; 256 bytes to clear
+Null3               equ       *-1       ; define assembler symbol Null3
+                    tfm       y,x+      ; transfer memory block using y,x+
+                  ELSE
 * LCB - 6809 optimization- ldd #$80 / ldx #$0000
-                    leay      P$PID,u             5 Point to start of process descriptor
-                    ldb       #$80                2 # of 2 byte sets to clear
-                    ldx       #$0000              3 Value to clear with
-LChinese            stx       ,y++                8 \                Clear 2 bytes
-                    decb                          2  > 1664 cycles   dec ctr
-                    bne       LChinese            3 /                Keep going until done
+                    leay      P$PID,u   ; 5 Point to start of process descriptor
+                    ldb       #$80      ; 2 # of 2 byte sets to clear
+                    ldx       #$0000    ; 3 Value to clear with
+LChinese            stx       ,y++      ; 8 \                Clear 2 bytes
+                    decb                ; 2  > 1664 cycles   dec ctr
+                    bne       LChinese  ; 3 /                Keep going until done
 
 * original code:
 *         clra               2
@@ -61,7 +61,7 @@ LChinese            stx       ,y++                8 \                Clear 2 byt
 *LChinese std    ,x++        8 \
 *         leay   -1,y        5  > 2048 cycles
 *         bne   LChinese     3 /
-                    ENDC
+                  ENDC
 
 ***************************************************************************
 * OS-9 L2 Upgrade Enhancement: Stamp current date/time for start of process
@@ -73,17 +73,17 @@ LChinese            stx       ,y++                8 \                Clear 2 byt
 *         sty    <D.Proc        restore current proc desc address
 ***************************************************************************
 
-                    lda       #SysState           set process to system state
-                    sta       P$State,u
+                    lda       #SysState ; set process to system state
+                    sta       P$State,u ; store A at P$State,u
 * Empty out DAT image
-                    ldb       #DAT.BlCt           # of double byte writes
-                    ldx       #DAT.Free           Empty block marker
-                    leay      P$DATImg,u
-L0329               stx       ,y++
-                    decb                          done?
-                    bne       L0329               no, keep going
-                    clrb                          clear carry
-L032F               rts                           return
+                    ldb       #DAT.BlCt ; # of double byte writes
+                    ldx       #DAT.Free ; empty block marker
+                    leay      P$DATImg,u ; compute P$DATImg,u into Y
+L0329               stx       ,y++      ; store X at ,y++
+                    decb                ; done?
+                    bne       L0329     ; no, keep going
+                    clrb                ; clear carry
+L032F               rts                 ; return
 
 **************************************************
 * System Call: F$DelPrc
@@ -92,8 +92,8 @@ L032F               rts                           return
 * Output: None
 * Error:  CC = C bit set; B = error code
 *
-FDelPrc             lda       R$A,u               get process #
-                    bra       L0386               delete it
+FDelPrc             lda       R$A,u     ; get process #
+                    bra       L0386     ; delete it
 
 
 **************************************************
@@ -115,81 +115,81 @@ FDelPrc             lda       R$A,u               get process #
 *
 * Error:  CC = C bit set; B = error code
 *
-FWait               ldx       <D.Proc             get current process
-                    lda       P$CID,x             any children?
-                    beq       L0368               no, exit with error
-L033A               lbsr      L0B2E               get pointer to child process dsc. into Y
-                    IFNE      H6309
-                    tim       #Dead,P$State,y     Is child dead?
-                    ELSE
-                    lda       P$State,y
-                    bita      #Dead
-                    ENDC
-                    bne       L036C               Yes, send message to parent
-                    lda       P$SID,y             No, check for another child (thru sibling list)
-                    bne       L033A               Yes there is another child, go see if it is dead
+FWait               ldx       <D.Proc   ; get current process
+                    lda       P$CID,x   ; any children?
+                    beq       L0368     ; no, exit with error
+L033A               lbsr      L0B2E     ; get pointer to child process dsc. into Y
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #Dead,P$State,y ; is child dead?
+                  ELSE
+                    lda       P$State,y ; load A from P$State,y
+                    bita      #Dead     ; test bits in A against #Dead
+                  ENDC
+                    bne       L036C     ; yes, send message to parent
+                    lda       P$SID,y   ; no, check for another child (thru sibling list)
+                    bne       L033A     ; yes there is another child, go see if it is dead
 * NOTE: MAY WANT TO ADD IN CLRB, CHANGE TO STD R$A,u
-                    sta       R$A,u               No child has died, clear out process # & status
-                    sta       R$B,u               code in caller's A&B regs
-                    pshs      cc                  Preserve CC
-                    orcc      #IntMasks           Shut off interrupts
-                    lda       <P$Signal,x         Any signals pending?
-                    beq       L035D               No, skip ahead
+                    sta       R$A,u     ; no child has died, clear out process # & status
+                    sta       R$B,u     ; code in caller's A&B regs
+                    pshs      cc        ; preserve CC
+                    orcc      #IntMasks ; shut off interrupts
+                    lda       <P$Signal,x ; any signals pending?
+                    beq       L035D     ; no, skip ahead
 * No Child died, but received signal
-                    deca                          Yes, is it a wakeup signal?
-                    bne       L035A               no, wake it up with proper signal
-                    sta       <P$Signal,x         Clear out signal code
-L035A               lbra      L071B               go wake it up (no signal will be sent)
+                    deca                ; yes, is it a wakeup signal?
+                    bne       L035A     ; no, wake it up with proper signal
+                    sta       <P$Signal,x ; clear out signal code
+L035A               lbra      L071B     ; go wake it up (no signal will be sent)
 
 * No dead child & no signal...execute next F$Waiting process in line
-L035D               ldd       <D.WProcQ           get ptr to head of waiting process line
-                    std       P$Queue,x           save as next process in line from current one
-                    stx       <D.WProcQ           save curr. process as new head of waiting process line
-                    puls      cc                  restore interupts
-                    lbra      L0780               go activate next process in line
+L035D               ldd       <D.WProcQ ; get ptr to head of waiting process line
+                    std       P$Queue,x ; save as next process in line from current one
+                    stx       <D.WProcQ ; save curr. process as new head of waiting process line
+                    puls      cc        ; restore interupts
+                    lbra      L0780     ; go activate next process in line
 
-L0368               comb                          Exit with No Children error
-                    ldb       #E$NoChld
-                    rts
+L0368               comb                ; exit with No Children error
+                    ldb       #E$NoChld ; load B from #E$NoChld
+                    rts                 ; return to caller
 
 * Child has died
 * Entry: Y=Ptr to child process that died
 *        U=Ptr to caller's register stack
-L036C               lda       P$ID,y              Get process ID of dead child
-                    ldb       <P$Signal,y         Get signal code that child received (if any)
-                    std       R$D,u               Save in caller's D
-                    leau      ,y                  Point U to child process dsc.
-                    leay      P$CID-P$SID,x       Bump Y up by 1 for 1st loop so P$SID below
+L036C               lda       P$ID,y    ; get process ID of dead child
+                    ldb       <P$Signal,y ; get signal code that child received (if any)
+                    std       R$D,u     ; save in caller's D
+                    leau      ,y        ; point U to child process dsc.
+                    leay      P$CID-P$SID,x ; bump Y up by 1 for 1st loop so P$SID below
 *                             actually references P$CID
-                    bra       L037C               skip ahead
+                    bra       L037C     ; skip ahead
 
 * Update linked list of sibling processes to exclude dead child
-L0379               lbsr      L0B2E               get pointer to process
-L037C               lda       P$SID,y             Get Sibling ID (or Child ID on 1st run)
-                    cmpa      P$ID,u              Same as Dying process ID?
-                    bne       L0379               No, go get ptr to Sibling process & do again
-                    ldb       P$SID,u             Yes, wrapped to our own, get Sibling ID from child
-                    stb       P$SID,y             Save as sibling process id # in other sibling
-L0386               pshs      d,x,u               preserve regs
-                    cmpa      WGlobal+G.AlPID     Does dying process have an alarm set up?
-                    bne       L0393               no, go on
-                    IFNE      H6309
-                    clrd                          Faster than 2 memory clears
-                    ELSE
-                    clra
-                    clrb
-                    ENDC
-                    std       WGlobal+G.AlPID     clear alarm ID & signal
-L0393               ldb       ,s                  get dying process # back
-                    ldx       <D.PrcDBT           get ptr to process descriptor block table
-                    abx                           offset into table
-                    lda       ,x                  Get MSB of process dsc. ptr
-                    beq       L03AC               If gone already, exit
-                    clrb
-                    stb       ,x                  Clear out entry in block table
-                    tfr       d,x                 Move process dsc. ptr to X
-                    os9       F$DelTsk            Remove task # for this process
-                    leau      ,x                  Point U to start of Dead process dsc.
-                    ldd       #P$Size             Size of a process dsc.
-                    os9       F$SRtMem            Deallocate process dsc. from system memory pool
-L03AC               puls      d,x,u,pc            Restore regs & return
+L0379               lbsr      L0B2E     ; get pointer to process
+L037C               lda       P$SID,y   ; get Sibling ID (or Child ID on 1st run)
+                    cmpa      P$ID,u    ; same as Dying process ID?
+                    bne       L0379     ; no, go get ptr to Sibling process & do again
+                    ldb       P$SID,u   ; yes, wrapped to our own, get Sibling ID from child
+                    stb       P$SID,y   ; save as sibling process id # in other sibling
+L0386               pshs      d,x,u     ; preserve regs
+                    cmpa      WGlobal+G.AlPID ; does dying process have an alarm set up?
+                    bne       L0393     ; no, go on
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; faster than 2 memory clears
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    std       WGlobal+G.AlPID ; clear alarm ID & signal
+L0393               ldb       ,s        ; get dying process # back
+                    ldx       <D.PrcDBT ; get ptr to process descriptor block table
+                    abx                 ; offset into table
+                    lda       ,x        ; get MSB of process dsc. ptr
+                    beq       L03AC     ; if gone already, exit
+                    clrb                ; clear B
+                    stb       ,x        ; clear out entry in block table
+                    tfr       d,x       ; move process dsc. ptr to X
+                    os9       F$DelTsk  ; remove task # for this process
+                    leau      ,x        ; point U to start of Dead process dsc.
+                    ldd       #P$Size   ; size of a process dsc.
+                    os9       F$SRtMem  ; deallocate process dsc. from system memory pool
+L03AC               puls      d,x,u,pc  ; restore regs & return

--- a/level2/modules/kernel/fallram.asm
+++ b/level2/modules/kernel/fallram.asm
@@ -9,35 +9,35 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FAllRAM             ldb       R$B,u               get the number blocks requested
-                    pshs      b,x,y               save registers
-                    ldx       <D.BlkMap           get pointer to the start of the block map
-L0974               leay      ,x                  point Y to the current block
-                    ldb       ,s                  get the number of blocks requested
-srchblk             cmpx      <D.BlkMap+2         hit end of map yet?
-                    bhs       L0995               yes, exit with No RAM error
-                    lda       ,x+                 get the block marker
-                    bne       L0974               already used, start over with the next block up
-                    decb                          decrement the number blocks still needed
-                    bne       srchblk             still more, keep checking
+FAllRAM             ldb       R$B,u     ; get the number blocks requested
+                    pshs      b,x,y     ; save registers
+                    ldx       <D.BlkMap ; get pointer to the start of the block map
+L0974               leay      ,x        ; point Y to the current block
+                    ldb       ,s        ; get the number of blocks requested
+srchblk             cmpx      <D.BlkMap+2 ; hit end of map yet?
+                    bhs       L0995     ; yes, exit with No RAM error
+                    lda       ,x+       ; get the block marker
+                    bne       L0974     ; already used, start over with the next block up
+                    decb                ; decrement the number blocks still needed
+                    bne       srchblk   ; still more, keep checking
 * Entry: Y=pointer to start of memory found
 * Note: Due to fact that block map always starts @ $200 (up to $2FF), we
 *       don't need to calculate A
-L0983               tfr       y,d                 copy the start of the requested block memory pointer to D (B)
-                    lda       ,s                  get the number blocks requested
-                    stb       ,s                  save the starting block number
-L098D               inc       ,y+                 flag the blocks as used
-                    deca                          (for all blocks allocated)
-                    bne       L098D               do this until done
-                    puls      b                   get the starting block number
-                    clra                          (allow for D as per original calls)
-                    std       R$D,u               save for the caller
-                    puls      x,y,pc              restore the registers and return
+L0983               tfr       y,d       ; copy the start of the requested block memory pointer to D (B)
+                    lda       ,s        ; get the number blocks requested
+                    stb       ,s        ; save the starting block number
+L098D               inc       ,y+       ; flag the blocks as used
+                    deca                ; (for all blocks allocated)
+                    bne       L098D     ; do this until done
+                    puls      b         ; get the starting block number
+                    clra                ; (allow for D as per original calls)
+                    std       R$D,u     ; save for the caller
+                    puls      x,y,pc    ; restore the registers and return
 
-L0995               comb                          set the carry
-                    ldb       #E$NoRAM            exit with No RAM error
-                    stb       ,s                  save B on the stack for the caller
-                    puls      b,x,y,pc            restore the registers and return
+L0995               comb                ; set the carry
+                    ldb       #E$NoRAM  ; exit with No RAM error
+                    stb       ,s        ; save B on the stack for the caller
+                    puls      b,x,y,pc  ; restore the registers and return
 
 
 **************************************************
@@ -51,15 +51,15 @@ L0995               comb                          set the carry
 *
 * Error:  CC = C bit set; B = error code
 *
-FAlHRAM             ldb       R$B,u               get the number blocks to allocate
-                    pshs      b,x,y               preserve registers
-                    ldx       <D.BlkMap+2         get the pointer to the end of block map
-L09A9               ldb       ,s                  get the number blocks requested
-L09AB               cmpx      <D.BlkMap           are we at the beginning of RAM yet?
-                    bls       L0995               yes, exit with No RAM error
-                    lda       ,-x                 get the RAM block marker
-                    bne       L09A9               if not free, start checking the next one down
-                    decb                          free block; decrement the number blocks left to find the count
-                    bne       L09AB               still more needed, so keep checking
-                    tfr       x,y                 found enough contiguous blocks, so move the pointer to Y
-                    bra       L0983               go mark then blocks as used and return the information to caller
+FAlHRAM             ldb       R$B,u     ; get the number blocks to allocate
+                    pshs      b,x,y     ; preserve registers
+                    ldx       <D.BlkMap+2 ; get the pointer to the end of block map
+L09A9               ldb       ,s        ; get the number blocks requested
+L09AB               cmpx      <D.BlkMap ; are we at the beginning of RAM yet?
+                    bls       L0995     ; yes, exit with No RAM error
+                    lda       ,-x       ; get the RAM block marker
+                    bne       L09A9     ; if not free, start checking the next one down
+                    decb                ; free block; decrement the number blocks left to find the count
+                    bne       L09AB     ; still more needed, so keep checking
+                    tfr       x,y       ; found enough contiguous blocks, so move the pointer to Y
+                    bra       L0983     ; go mark then blocks as used and return the information to caller

--- a/level2/modules/kernel/fallram.asm
+++ b/level2/modules/kernel/fallram.asm
@@ -12,29 +12,29 @@
 FAllRAM             ldb       R$B,u     ; get the number blocks requested
                     pshs      b,x,y     ; save registers
                     ldx       <D.BlkMap ; get pointer to the start of the block map
-L0974               leay      ,x        ; point Y to the current block
+FAllramBlock        leay      ,x        ; point Y to the current block
                     ldb       ,s        ; get the number of blocks requested
 srchblk             cmpx      <D.BlkMap+2 ; hit end of map yet?
-                    bhs       L0995     ; yes, exit with No RAM error
+                    bhs       FAllramCarry ; yes, exit with No RAM error
                     lda       ,x+       ; get the block marker
-                    bne       L0974     ; already used, start over with the next block up
+                    bne       FAllramBlock ; already used, start over with the next block up
                     decb                ; decrement the number blocks still needed
                     bne       srchblk   ; still more, keep checking
 * Entry: Y=pointer to start of memory found
 * Note: Due to fact that block map always starts @ $200 (up to $2FF), we
 *       don't need to calculate A
-L0983               tfr       y,d       ; copy the start of the requested block memory pointer to D (B)
+FAllramStartRequestedBlockMemory tfr       y,d       ; copy the start of the requested block memory pointer to D (B)
                     lda       ,s        ; get the number blocks requested
                     stb       ,s        ; save the starting block number
-L098D               inc       ,y+       ; flag the blocks as used
+FAllramFlagBlocksUsed inc       ,y+       ; flag the blocks as used
                     deca                ; (for all blocks allocated)
-                    bne       L098D     ; do this until done
+                    bne       FAllramFlagBlocksUsed ; do this until done
                     puls      b         ; get the starting block number
                     clra                ; (allow for D as per original calls)
                     std       R$D,u     ; save for the caller
                     puls      x,y,pc    ; restore the registers and return
 
-L0995               comb                ; set the carry
+FAllramCarry        comb                ; set the carry
                     ldb       #E$NoRAM  ; exit with No RAM error
                     stb       ,s        ; save B on the stack for the caller
                     puls      b,x,y,pc  ; restore the registers and return
@@ -54,12 +54,12 @@ L0995               comb                ; set the carry
 FAlHRAM             ldb       R$B,u     ; get the number blocks to allocate
                     pshs      b,x,y     ; preserve registers
                     ldx       <D.BlkMap+2 ; get the pointer to the end of block map
-L09A9               ldb       ,s        ; get the number blocks requested
-L09AB               cmpx      <D.BlkMap ; are we at the beginning of RAM yet?
-                    bls       L0995     ; yes, exit with No RAM error
+FAllramNumberBlocksRequested ldb       ,s        ; get the number blocks requested
+FAllramWeBeginningRAMYet cmpx      <D.BlkMap ; are we at the beginning of RAM yet?
+                    bls       FAllramCarry ; yes, exit with No RAM error
                     lda       ,-x       ; get the RAM block marker
-                    bne       L09A9     ; if not free, start checking the next one down
+                    bne       FAllramNumberBlocksRequested ; if not free, start checking the next one down
                     decb                ; free block; decrement the number blocks left to find the count
-                    bne       L09AB     ; still more needed, so keep checking
+                    bne       FAllramWeBeginningRAMYet ; still more needed, so keep checking
                     tfr       x,y       ; found enough contiguous blocks, so move the pointer to Y
-                    bra       L0983     ; go mark then blocks as used and return the information to caller
+                    bra       FAllramStartRequestedBlockMemory ; go mark then blocks as used and return the information to caller

--- a/level2/modules/kernel/fallram.asm
+++ b/level2/modules/kernel/fallram.asm
@@ -23,12 +23,12 @@ srchblk             cmpx      <D.BlkMap+2 ; hit end of map yet?
 * Entry: Y=pointer to start of memory found
 * Note: Due to fact that block map always starts @ $200 (up to $2FF), we
 *       don't need to calculate A
-FAllramStartRequestedBlockMemory tfr       y,d       ; copy the start of the requested block memory pointer to D (B)
+FAllramStartReqBlk  tfr       y,d       ; copy the start of the requested block memory pointer to D (B)
                     lda       ,s        ; get the number blocks requested
                     stb       ,s        ; save the starting block number
-FAllramFlagBlocksUsed inc       ,y+       ; flag the blocks as used
+FAllramFlagBlksUsed inc       ,y+       ; flag the blocks as used
                     deca                ; (for all blocks allocated)
-                    bne       FAllramFlagBlocksUsed ; do this until done
+                    bne       FAllramFlagBlksUsed ; do this until done
                     puls      b         ; get the starting block number
                     clra                ; (allow for D as per original calls)
                     std       R$D,u     ; save for the caller
@@ -54,12 +54,12 @@ FAllramCarry        comb                ; set the carry
 FAlHRAM             ldb       R$B,u     ; get the number blocks to allocate
                     pshs      b,x,y     ; preserve registers
                     ldx       <D.BlkMap+2 ; get the pointer to the end of block map
-FAllramNumberBlocksRequested ldb       ,s        ; get the number blocks requested
-FAllramWeBeginningRAMYet cmpx      <D.BlkMap ; are we at the beginning of RAM yet?
+FAllramNumBlksReq   ldb       ,s        ; get the number blocks requested
+FAllramWeBegRAM     cmpx      <D.BlkMap ; are we at the beginning of RAM yet?
                     bls       FAllramCarry ; yes, exit with No RAM error
                     lda       ,-x       ; get the RAM block marker
-                    bne       FAllramNumberBlocksRequested ; if not free, start checking the next one down
+                    bne       FAllramNumBlksReq ; if not free, start checking the next one down
                     decb                ; free block; decrement the number blocks left to find the count
-                    bne       FAllramWeBeginningRAMYet ; still more needed, so keep checking
+                    bne       FAllramWeBegRAM ; still more needed, so keep checking
                     tfr       x,y       ; found enough contiguous blocks, so move the pointer to Y
-                    bra       FAllramStartRequestedBlockMemory ; go mark then blocks as used and return the information to caller
+                    bra       FAllramStartReqBlk ; go mark then blocks as used and return the information to caller

--- a/level2/modules/kernel/falltsk.asm
+++ b/level2/modules/kernel/falltsk.asm
@@ -9,15 +9,15 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FAllTsk             ldx       R$X,u               get pointer to process descriptor
-L0C58               ldb       P$Task,x            already have a task #?
-                    bne       L0C64               yes, return
-                    bsr       L0CA6               find a free task
-                    bcs       L0C65               error, couldn't get one, return
-                    stb       P$Task,x            save task #
-                    bsr       L0C79               load MMU with task
-L0C64               clrb                          clear errors
-L0C65               rts                           return
+FAllTsk             ldx       R$X,u     ; get pointer to process descriptor
+L0C58               ldb       P$Task,x  ; already have a task #?
+                    bne       L0C64     ; yes, return
+                    bsr       L0CA6     ; find a free task
+                    bcs       L0C65     ; error, couldn't get one, return
+                    stb       P$Task,x  ; save task #
+                    bsr       L0C79     ; load MMU with task
+L0C64               clrb                ; clear errors
+L0C65               rts                 ; return
 
 **************************************************
 * System Call: F$DelTsk
@@ -30,21 +30,21 @@ L0C65               rts                           return
 *
 * Error:  CC = C bit set; B = error code
 *
-FDelTsk             ldx       R$X,u
-L0C68               ldb       P$Task,x            grab the current task number
-                    beq       L0C64               if system (or released), exit
-                    clr       P$Task,x            force the task number to be zero
-                    bra       L0CC3               do a F$RelTsk
+FDelTsk             ldx       R$X,u     ; load X from R$X,u
+L0C68               ldb       P$Task,x  ; grab the current task number
+                    beq       L0C64     ; if system (or released), exit
+                    clr       P$Task,x  ; force the task number to be zero
+                    bra       L0CC3     ; do a F$RelTsk
 
-TstImg              equ       *
-                    IFNE      H6309
-                    tim       #ImgChg,P$State,x   DAT image change flagged in process desc?
-                    ELSE
-                    ldb       P$State,x           DAT image change flagged in process desc?
-                    bitb      #ImgChg
-                    ENDC
-                    beq       L0C65               if not, exit now: (clear carry not needed)
-                    fcb       $8C                 skip LDX, below
+TstImg              equ       *         ; define assembler symbol TstImg
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #ImgChg,P$State,x ; dAT image change flagged in process desc?
+                  ELSE
+                    ldb       P$State,x ; dAT image change flagged in process desc?
+                    bitb      #ImgChg   ; test bits in B against #ImgChg
+                  ENDC
+                    beq       L0C65     ; if not, exit now: (clear carry not needed)
+                    fcb       $8C       ; skip LDX, below
 **************************************************
 * System Call: F$SetTsk
 *
@@ -56,28 +56,28 @@ TstImg              equ       *
 *
 * Error:  CC = C bit set; B = error code
 *
-FSetTsk             ldx       R$X,u               get process descriptor pointer
-L0C79               equ       *
-                    IFNE      H6309
-                    aim       #^ImgChg,P$State,x  flag DAT image change in process descriptor
-                    ELSE
-                    ldb       P$State,x           flag DAT image change in process descriptor
-                    andb      #^ImgChg
-                    stb       P$State,x
-                    ENDC
-                    clr       <D.Task1N           task 1 DAT image has changed
-                    andcc     #^Carry             clear carry
-                    pshs      cc,d,x,u            preserve everything
-                    ldb       P$Task,x            get task #
-                    leau      <P$DATImg,x         point to DAT image
-                    ldx       <D.TskIPt           get task image table pointer
-                    lslb                          account for 2 bytes/entry
-                    stu       b,x                 save DAT image pointer in task table
-                    cmpb      #2                  is it either system or GrfDrv?
-                    bhi       L0C9F               no, return
-                    ldx       #DAT.Regs           update system DAT image
-                    lbsr      L0E93               go bash the hardware
-L0C9F               puls      cc,d,x,u,pc
+FSetTsk             ldx       R$X,u     ; get process descriptor pointer
+L0C79               equ       *         ; define assembler symbol L0C79
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^ImgChg,P$State,x ; flag DAT image change in process descriptor
+                  ELSE
+                    ldb       P$State,x ; flag DAT image change in process descriptor
+                    andb      #^ImgChg  ; mask B with #^ImgChg
+                    stb       P$State,x ; store B at P$State,x
+                  ENDC
+                    clr       <D.Task1N ; task 1 DAT image has changed
+                    andcc     #^Carry   ; clear carry
+                    pshs      cc,d,x,u  ; preserve everything
+                    ldb       P$Task,x  ; get task #
+                    leau      <P$DATImg,x ; point to DAT image
+                    ldx       <D.TskIPt ; get task image table pointer
+                    lslb                ; account for 2 bytes/entry
+                    stu       b,x       ; save DAT image pointer in task table
+                    cmpb      #2        ; is it either system or GrfDrv?
+                    bhi       L0C9F     ; no, return
+                    ldx       #DAT.Regs ; update system DAT image
+                    lbsr      L0E93     ; go bash the hardware
+L0C9F               puls      cc,d,x,u,pc ; restore cc,d,x,u,pc from the stack
 
 **************************************************
 * System Call: F$ResTsk
@@ -90,29 +90,29 @@ L0C9F               puls      cc,d,x,u,pc
 *
 * Error:  CC = C bit set; B = error code
 *
-FResTsk             bsr       L0CA6
-                    stb       R$B,u
-L0CA5               rts
+FResTsk             bsr       L0CA6     ; call local routine L0CA6
+                    stb       R$B,u     ; store B at R$B,u
+L0CA5               rts                 ; return to caller
 
 
 * Find a free task in task map
 * Entry: None
 * Exit : B=Task #
-L0CA6               pshs      x                   preserve X
-                    ldb       #$02                get starting task # (skip System/Grfdrv)
-                    ldx       <D.Tasks            get task table pointer
-L0CAC               lda       b,x                 task allocated?
-                    beq       L0CBA               no, allocate it & return
-                    incb                          move to next task
-                    cmpb      #$20                end of task list?
-                    bne       L0CAC               no, keep looking
-                    comb                          set carry for error
-                    ldb       #E$NoTask           get error code
-                    puls      x,pc
+L0CA6               pshs      x         ; preserve X
+                    ldb       #$02      ; get starting task # (skip System/Grfdrv)
+                    ldx       <D.Tasks  ; get task table pointer
+L0CAC               lda       b,x       ; task allocated?
+                    beq       L0CBA     ; no, allocate it & return
+                    incb                ; move to next task
+                    cmpb      #$20      ; end of task list?
+                    bne       L0CAC     ; no, keep looking
+                    comb                ; set carry for error
+                    ldb       #E$NoTask ; get error code
+                    puls      x,pc      ; restore x,pc from the stack
 
-L0CBA               stb       b,x                 flag task used (1 cycle faster than inc)
-                    clra                          clear carry
-L0CBF               puls      x,pc                restore & return
+L0CBA               stb       b,x       ; flag task used (1 cycle faster than inc)
+                    clra                ; clear carry
+L0CBF               puls      x,pc      ; restore & return
 
 
 **************************************************
@@ -126,13 +126,13 @@ L0CBF               puls      x,pc                restore & return
 *
 * Error:  CC = C bit set; B = error code
 *
-FRelTsk             ldb       R$B,u               Get task # to release
-L0CC3               pshs      b,x                 Preserve it & X
-                    tstb                          check out B
-                    beq       L0CD0               If system task, don't bother deleting the task
-                    ldx       <D.Tasks            Get task table ptr
-                    clr       b,x                 Clear out the task
-L0CD0               puls      b,x,pc              Restore regs & return
+FRelTsk             ldb       R$B,u     ; get task # to release
+L0CC3               pshs      b,x       ; preserve it & X
+                    tstb                ; check out B
+                    beq       L0CD0     ; if system task, don't bother deleting the task
+                    ldx       <D.Tasks  ; get task table ptr
+                    clr       b,x       ; clear out the task
+L0CD0               puls      b,x,pc    ; restore regs & return
 
 * Sleeping process update (Gets executed from clock)
 * Could move this code into Clock, but what about the call to F$AProc (L0D11)?
@@ -140,51 +140,51 @@ L0CD0               puls      b,x,pc              Restore regs & return
 *   Possible, move ALL software-clock code into OS9p2, and therefore
 * have it auto-initialize?  All hardware clocks would then be called
 * just once a minute.
-L0CD2               ldx       <D.SProcQ           Get sleeping process Queue ptr
-                    beq       L0CFD               None (no one sleeping), so exit
-                    IFNE      H6309
-                    tim       #TimSleep,P$State,x Is it a timed sleep?
-                    ELSE
-                    ldb       P$State,x           Is it a timed sleep?
-                    bitb      #TimSleep
-                    ENDC
-                    beq       L0CFD               No, exit: waiting for signal/interrupt
-                    ldu       P$SP,x              Yes, get his stack pointer
-                    ldd       R$X,u               Get his sleep tick count
-                    IFNE      H6309
-                    decd      decrement           sleep count
-                    ELSE
-                    subd      #$0001
-                    ENDC
-                    std       R$X,u               Save it back
-                    bne       L0CFD               Still more ticks to go, so exit
+L0CD2               ldx       <D.SProcQ ; get sleeping process Queue ptr
+                    beq       L0CFD     ; none (no one sleeping), so exit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #TimSleep,P$State,x ; is it a timed sleep?
+                  ELSE
+                    ldb       P$State,x ; is it a timed sleep?
+                    bitb      #TimSleep ; test bits in B against #TimSleep
+                  ENDC
+                    beq       L0CFD     ; no, exit: waiting for signal/interrupt
+                    ldu       P$SP,x    ; yes, get his stack pointer
+                    ldd       R$X,u     ; get his sleep tick count
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    decd      ; decrement           sleep count
+                  ELSE
+                    subd      #$0001    ; subtract #$0001 from D
+                  ENDC
+                    std       R$X,u     ; save it back
+                    bne       L0CFD     ; still more ticks to go, so exit
 * Process needs to wake up, update queue pointers
-L0CE7               ldu       P$Queue,x           Get next process in Queue
-                    bsr       L0D11               activate it
-                    leax      ,u                  point to new process
-                    beq       L0CFB               don't exist, go on
-                    IFNE      H6309
-                    tim       #TimSleep,P$State,x is it in a timed sleep?
-                    ELSE
-                    ldb       P$State,x           Is it a timed sleep?
-                    bitb      #TimSleep
-                    ENDC
-                    beq       L0CFB               no, go update process table
-                    ldu       P$SP,x              get it's stack pointer
-                    ldd       R$X,u               any sleep time left?
-                    beq       L0CE7               no, go activate next process in queue
-L0CFB               stx       <D.SProcQ           Store new sleeping process pointer
-L0CFD               dec       <D.Slice            Any time remaining on process?
-                    bne       L0D0D               Yes, exit
-                    inc       <D.Slice            reset slice count
-                    ldx       <D.Proc             Get current process pointer
-                    beq       L0D0D               none, return
-                    IFNE      H6309
-                    oim       #TimOut,P$State,x   put him in a timeout state
-                    ELSE
-                    ldb       P$State,x           put him in a timeout state
-                    orb       #TimOut
-                    stb       P$State,x
-                    ENDC
-L0D0D               clrb
-                    rts
+L0CE7               ldu       P$Queue,x ; get next process in Queue
+                    bsr       L0D11     ; activate it
+                    leax      ,u        ; point to new process
+                    beq       L0CFB     ; don't exist, go on
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tim       #TimSleep,P$State,x ; is it in a timed sleep?
+                  ELSE
+                    ldb       P$State,x ; is it a timed sleep?
+                    bitb      #TimSleep ; test bits in B against #TimSleep
+                  ENDC
+                    beq       L0CFB     ; no, go update process table
+                    ldu       P$SP,x    ; get it's stack pointer
+                    ldd       R$X,u     ; any sleep time left?
+                    beq       L0CE7     ; no, go activate next process in queue
+L0CFB               stx       <D.SProcQ ; store new sleeping process pointer
+L0CFD               dec       <D.Slice  ; any time remaining on process?
+                    bne       L0D0D     ; yes, exit
+                    inc       <D.Slice  ; reset slice count
+                    ldx       <D.Proc   ; get current process pointer
+                    beq       L0D0D     ; none, return
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #TimOut,P$State,x ; put him in a timeout state
+                  ELSE
+                    ldb       P$State,x ; put him in a timeout state
+                    orb       #TimOut   ; merge #TimOut into B
+                    stb       P$State,x ; store B at P$State,x
+                  ENDC
+L0D0D               clrb                ; clear B
+                    rts                 ; return to caller

--- a/level2/modules/kernel/falltsk.asm
+++ b/level2/modules/kernel/falltsk.asm
@@ -10,14 +10,14 @@
 * Error:  CC = C bit set; B = error code
 *
 FAllTsk             ldx       R$X,u     ; get pointer to process descriptor
-L0C58               ldb       P$Task,x  ; already have a task #?
-                    bne       L0C64     ; yes, return
-                    bsr       L0CA6     ; find a free task
-                    bcs       L0C65     ; error, couldn't get one, return
+FAlltskAlreadyHaveTask ldb       P$Task,x  ; already have a task #?
+                    bne       FAlltskErrors ; yes, return
+                    bsr       FAlltskTarget2 ; find a free task
+                    bcs       FAlltskReturn ; error, couldn't get one, return
                     stb       P$Task,x  ; save task #
-                    bsr       L0C79     ; load MMU with task
-L0C64               clrb                ; clear errors
-L0C65               rts                 ; return
+                    bsr       FAlltskJoin ; load MMU with task
+FAlltskErrors       clrb                ; clear errors
+FAlltskReturn       rts                 ; return
 
 **************************************************
 * System Call: F$DelTsk
@@ -31,10 +31,10 @@ L0C65               rts                 ; return
 * Error:  CC = C bit set; B = error code
 *
 FDelTsk             ldx       R$X,u     ; load X from R$X,u
-L0C68               ldb       P$Task,x  ; grab the current task number
-                    beq       L0C64     ; if system (or released), exit
+FAlltskGrabTaskNumber ldb       P$Task,x  ; grab the current task number
+                    beq       FAlltskErrors ; if system (or released), exit
                     clr       P$Task,x  ; force the task number to be zero
-                    bra       L0CC3     ; do a F$RelTsk
+                    bra       FAlltskTarget3 ; do a F$RelTsk
 
 TstImg              equ       *         ; define assembler symbol TstImg
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -43,7 +43,7 @@ TstImg              equ       *         ; define assembler symbol TstImg
                     ldb       P$State,x ; dAT image change flagged in process desc?
                     bitb      #ImgChg   ; test bits in B against #ImgChg
                   ENDC
-                    beq       L0C65     ; if not, exit now: (clear carry not needed)
+                    beq       FAlltskReturn ; if not, exit now: (clear carry not needed)
                     fcb       $8C       ; skip LDX, below
 **************************************************
 * System Call: F$SetTsk
@@ -57,7 +57,7 @@ TstImg              equ       *         ; define assembler symbol TstImg
 * Error:  CC = C bit set; B = error code
 *
 FSetTsk             ldx       R$X,u     ; get process descriptor pointer
-L0C79               equ       *         ; define assembler symbol L0C79
+FAlltskJoin         equ       *         ; define assembler symbol FAlltskJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^ImgChg,P$State,x ; flag DAT image change in process descriptor
                   ELSE
@@ -74,10 +74,10 @@ L0C79               equ       *         ; define assembler symbol L0C79
                     lslb                ; account for 2 bytes/entry
                     stu       b,x       ; save DAT image pointer in task table
                     cmpb      #2        ; is it either system or GrfDrv?
-                    bhi       L0C9F     ; no, return
+                    bhi       FAlltskTarget ; no, return
                     ldx       #DAT.Regs ; update system DAT image
-                    lbsr      L0E93     ; go bash the hardware
-L0C9F               puls      cc,d,x,u,pc ; restore cc,d,x,u,pc from the stack
+                    lbsr      KrnActualMMUBlock ; go bash the hardware
+FAlltskTarget       puls      cc,d,x,u,pc ; restore cc,d,x,u,pc from the stack
 
 **************************************************
 * System Call: F$ResTsk
@@ -90,29 +90,29 @@ L0C9F               puls      cc,d,x,u,pc ; restore cc,d,x,u,pc from the stack
 *
 * Error:  CC = C bit set; B = error code
 *
-FResTsk             bsr       L0CA6     ; call local routine L0CA6
+FResTsk             bsr       FAlltskTarget2 ; call local routine FAlltskTarget2
                     stb       R$B,u     ; store B at R$B,u
-L0CA5               rts                 ; return to caller
+FAlltskReturn2      rts                 ; return to caller
 
 
 * Find a free task in task map
 * Entry: None
 * Exit : B=Task #
-L0CA6               pshs      x         ; preserve X
+FAlltskTarget2      pshs      x         ; preserve X
                     ldb       #$02      ; get starting task # (skip System/Grfdrv)
                     ldx       <D.Tasks  ; get task table pointer
-L0CAC               lda       b,x       ; task allocated?
-                    beq       L0CBA     ; no, allocate it & return
+FAlltskTaskAllocated lda       b,x       ; task allocated?
+                    beq       FAlltskFlagTaskUsedCycleFaster ; no, allocate it & return
                     incb                ; move to next task
                     cmpb      #$20      ; end of task list?
-                    bne       L0CAC     ; no, keep looking
+                    bne       FAlltskTaskAllocated ; no, keep looking
                     comb                ; set carry for error
                     ldb       #E$NoTask ; get error code
                     puls      x,pc      ; restore x,pc from the stack
 
-L0CBA               stb       b,x       ; flag task used (1 cycle faster than inc)
+FAlltskFlagTaskUsedCycleFaster stb       b,x       ; flag task used (1 cycle faster than inc)
                     clra                ; clear carry
-L0CBF               puls      x,pc      ; restore & return
+FAlltskReturn3      puls      x,pc      ; restore & return
 
 
 **************************************************
@@ -127,12 +127,12 @@ L0CBF               puls      x,pc      ; restore & return
 * Error:  CC = C bit set; B = error code
 *
 FRelTsk             ldb       R$B,u     ; get task # to release
-L0CC3               pshs      b,x       ; preserve it & X
+FAlltskTarget3      pshs      b,x       ; preserve it & X
                     tstb                ; check out B
-                    beq       L0CD0     ; if system task, don't bother deleting the task
+                    beq       FAlltskReturn4 ; if system task, don't bother deleting the task
                     ldx       <D.Tasks  ; get task table ptr
                     clr       b,x       ; clear out the task
-L0CD0               puls      b,x,pc    ; restore regs & return
+FAlltskReturn4      puls      b,x,pc    ; restore regs & return
 
 * Sleeping process update (Gets executed from clock)
 * Could move this code into Clock, but what about the call to F$AProc (L0D11)?
@@ -140,45 +140,45 @@ L0CD0               puls      b,x,pc    ; restore regs & return
 *   Possible, move ALL software-clock code into OS9p2, and therefore
 * have it auto-initialize?  All hardware clocks would then be called
 * just once a minute.
-L0CD2               ldx       <D.SProcQ ; get sleeping process Queue ptr
-                    beq       L0CFD     ; none (no one sleeping), so exit
+FAlltskSleepingProcessQueue ldx       <D.SProcQ ; get sleeping process Queue ptr
+                    beq       FAlltskTimeRemainingProcess ; none (no one sleeping), so exit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,x ; is it a timed sleep?
                   ELSE
                     ldb       P$State,x ; is it a timed sleep?
                     bitb      #TimSleep ; test bits in B against #TimSleep
                   ENDC
-                    beq       L0CFD     ; no, exit: waiting for signal/interrupt
+                    beq       FAlltskTimeRemainingProcess ; no, exit: waiting for signal/interrupt
                     ldu       P$SP,x    ; yes, get his stack pointer
                     ldd       R$X,u     ; get his sleep tick count
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    decd      ; decrement           sleep count
+                    decd      ;         decrement           sleep count
                   ELSE
                     subd      #$0001    ; subtract #$0001 from D
                   ENDC
                     std       R$X,u     ; save it back
-                    bne       L0CFD     ; still more ticks to go, so exit
+                    bne       FAlltskTimeRemainingProcess ; still more ticks to go, so exit
 * Process needs to wake up, update queue pointers
-L0CE7               ldu       P$Queue,x ; get next process in Queue
-                    bsr       L0D11     ; activate it
+FAlltskProcessQueue ldu       P$Queue,x ; get next process in Queue
+                    bsr       FAprocTarget ; activate it
                     leax      ,u        ; point to new process
-                    beq       L0CFB     ; don't exist, go on
+                    beq       FAlltskNewSleepingProcess ; don't exist, go on
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,x ; is it in a timed sleep?
                   ELSE
                     ldb       P$State,x ; is it a timed sleep?
                     bitb      #TimSleep ; test bits in B against #TimSleep
                   ENDC
-                    beq       L0CFB     ; no, go update process table
+                    beq       FAlltskNewSleepingProcess ; no, go update process table
                     ldu       P$SP,x    ; get it's stack pointer
                     ldd       R$X,u     ; any sleep time left?
-                    beq       L0CE7     ; no, go activate next process in queue
-L0CFB               stx       <D.SProcQ ; store new sleeping process pointer
-L0CFD               dec       <D.Slice  ; any time remaining on process?
-                    bne       L0D0D     ; yes, exit
+                    beq       FAlltskProcessQueue ; no, go activate next process in queue
+FAlltskNewSleepingProcess stx       <D.SProcQ ; store new sleeping process pointer
+FAlltskTimeRemainingProcess dec       <D.Slice  ; any time remaining on process?
+                    bne       FAlltskTarget4 ; yes, exit
                     inc       <D.Slice  ; reset slice count
                     ldx       <D.Proc   ; get current process pointer
-                    beq       L0D0D     ; none, return
+                    beq       FAlltskTarget4 ; none, return
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #TimOut,P$State,x ; put him in a timeout state
                   ELSE
@@ -186,5 +186,5 @@ L0CFD               dec       <D.Slice  ; any time remaining on process?
                     orb       #TimOut   ; merge #TimOut into B
                     stb       P$State,x ; store B at P$State,x
                   ENDC
-L0D0D               clrb                ; clear B
+FAlltskTarget4      clrb                ; clear B
                     rts                 ; return to caller

--- a/level2/modules/kernel/falltsk.asm
+++ b/level2/modules/kernel/falltsk.asm
@@ -10,7 +10,7 @@
 * Error:  CC = C bit set; B = error code
 *
 FAllTsk             ldx       R$X,u     ; get pointer to process descriptor
-FAlltskAlreadyHaveTask ldb       P$Task,x  ; already have a task #?
+FAlltskHasHaveTask  ldb       P$Task,x  ; already have a task #?
                     bne       FAlltskErrors ; yes, return
                     bsr       FAlltskTarget2 ; find a free task
                     bcs       FAlltskReturn ; error, couldn't get one, return
@@ -31,7 +31,7 @@ FAlltskReturn       rts                 ; return
 * Error:  CC = C bit set; B = error code
 *
 FDelTsk             ldx       R$X,u     ; load X from R$X,u
-FAlltskGrabTaskNumber ldb       P$Task,x  ; grab the current task number
+FAlltskGrabTaskNum  ldb       P$Task,x  ; grab the current task number
                     beq       FAlltskErrors ; if system (or released), exit
                     clr       P$Task,x  ; force the task number to be zero
                     bra       FAlltskTarget3 ; do a F$RelTsk
@@ -101,16 +101,16 @@ FAlltskReturn2      rts                 ; return to caller
 FAlltskTarget2      pshs      x         ; preserve X
                     ldb       #$02      ; get starting task # (skip System/Grfdrv)
                     ldx       <D.Tasks  ; get task table pointer
-FAlltskTaskAllocated lda       b,x       ; task allocated?
-                    beq       FAlltskFlagTaskUsedCycleFaster ; no, allocate it & return
+FAlltskTaskAlloc    lda       b,x       ; task allocated?
+                    beq       FAlltskFlagTaskUsed ; no, allocate it & return
                     incb                ; move to next task
                     cmpb      #$20      ; end of task list?
-                    bne       FAlltskTaskAllocated ; no, keep looking
+                    bne       FAlltskTaskAlloc ; no, keep looking
                     comb                ; set carry for error
                     ldb       #E$NoTask ; get error code
                     puls      x,pc      ; restore x,pc from the stack
 
-FAlltskFlagTaskUsedCycleFaster stb       b,x       ; flag task used (1 cycle faster than inc)
+FAlltskFlagTaskUsed stb       b,x       ; flag task used (1 cycle faster than inc)
                     clra                ; clear carry
 FAlltskReturn3      puls      x,pc      ; restore & return
 
@@ -140,15 +140,15 @@ FAlltskReturn4      puls      b,x,pc    ; restore regs & return
 *   Possible, move ALL software-clock code into OS9p2, and therefore
 * have it auto-initialize?  All hardware clocks would then be called
 * just once a minute.
-FAlltskSleepingProcessQueue ldx       <D.SProcQ ; get sleeping process Queue ptr
-                    beq       FAlltskTimeRemainingProcess ; none (no one sleeping), so exit
+FAlltskSleepProcQ   ldx       <D.SProcQ ; get sleeping process Queue ptr
+                    beq       FAlltskTimeRmnng ; none (no one sleeping), so exit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,x ; is it a timed sleep?
                   ELSE
                     ldb       P$State,x ; is it a timed sleep?
                     bitb      #TimSleep ; test bits in B against #TimSleep
                   ENDC
-                    beq       FAlltskTimeRemainingProcess ; no, exit: waiting for signal/interrupt
+                    beq       FAlltskTimeRmnng ; no, exit: waiting for signal/interrupt
                     ldu       P$SP,x    ; yes, get his stack pointer
                     ldd       R$X,u     ; get his sleep tick count
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -157,24 +157,24 @@ FAlltskSleepingProcessQueue ldx       <D.SProcQ ; get sleeping process Queue ptr
                     subd      #$0001    ; subtract #$0001 from D
                   ENDC
                     std       R$X,u     ; save it back
-                    bne       FAlltskTimeRemainingProcess ; still more ticks to go, so exit
+                    bne       FAlltskTimeRmnng ; still more ticks to go, so exit
 * Process needs to wake up, update queue pointers
 FAlltskProcessQueue ldu       P$Queue,x ; get next process in Queue
                     bsr       FAprocTarget ; activate it
                     leax      ,u        ; point to new process
-                    beq       FAlltskNewSleepingProcess ; don't exist, go on
+                    beq       FAlltskNewSleepProc ; don't exist, go on
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tim       #TimSleep,P$State,x ; is it in a timed sleep?
                   ELSE
                     ldb       P$State,x ; is it a timed sleep?
                     bitb      #TimSleep ; test bits in B against #TimSleep
                   ENDC
-                    beq       FAlltskNewSleepingProcess ; no, go update process table
+                    beq       FAlltskNewSleepProc ; no, go update process table
                     ldu       P$SP,x    ; get it's stack pointer
                     ldd       R$X,u     ; any sleep time left?
                     beq       FAlltskProcessQueue ; no, go activate next process in queue
-FAlltskNewSleepingProcess stx       <D.SProcQ ; store new sleeping process pointer
-FAlltskTimeRemainingProcess dec       <D.Slice  ; any time remaining on process?
+FAlltskNewSleepProc stx       <D.SProcQ ; store new sleeping process pointer
+FAlltskTimeRmnng    dec       <D.Slice  ; any time remaining on process?
                     bne       FAlltskTarget4 ; yes, exit
                     inc       <D.Slice  ; reset slice count
                     ldx       <D.Proc   ; get current process pointer

--- a/level2/modules/kernel/fclrblk.asm
+++ b/level2/modules/kernel/fclrblk.asm
@@ -10,44 +10,44 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FClrBlk             ldb       R$B,u
-                    beq       L0BE9
-                    ldd       R$U,u
-                    tstb
-                    bne       IllBlkErr
-                    bita      #$1F
-                    bne       IllBlkErr
-                    ldx       <D.Proc
-                    lda       P$SP,x
-                    anda      #$E0
-                    suba      R$U,u
-                    bcs       L0BCE
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    cmpa      R$B,u
-                    bcs       IllBlkErr
+FClrBlk             ldb       R$B,u     ; load B from R$B,u
+                    beq       L0BE9     ; branch if zero is set to L0BE9
+                    ldd       R$U,u     ; load D from R$U,u
+                    tstb                ; test B and update condition codes
+                    bne       IllBlkErr ; branch if zero is clear to IllBlkErr
+                    bita      #$1F      ; test bits in A against #$1F
+                    bne       IllBlkErr ; branch if zero is clear to IllBlkErr
+                    ldx       <D.Proc   ; load X from <D.Proc
+                    lda       P$SP,x    ; load A from P$SP,x
+                    anda      #$E0      ; mask A with #$E0
+                    suba      R$U,u     ; subtract R$U,u from A
+                    bcs       L0BCE     ; branch if carry is set to L0BCE
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    cmpa      R$B,u     ; compare A with R$B,u
+                    bcs       IllBlkErr ; branch if carry is set to IllBlkErr
 L0BCE
-                    ifne      H6309
-                    oim       #ImgChg,P$State,x
-                    else
-                    lda       P$State,x
-                    ora       #ImgChg
-                    sta       P$State,x
-                    endc
-                    lda       R$U,u
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    leay      P$DATImg,x
-                    leay      a,y
-                    ldb       R$B,u
-                    ldx       #DAT.Free
-L0BE4               stx       ,y++
-                    decb
-                    bne       L0BE4
-L0BE9               clrb
-                    rts
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #ImgChg,P$State,x ; apply immediate bit operation #ImgChg,P$State,x
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    ora       #ImgChg   ; merge #ImgChg into A
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+                    lda       R$U,u     ; load A from R$U,u
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    leay      P$DATImg,x ; compute P$DATImg,x into Y
+                    leay      a,y       ; compute a,y into Y
+                    ldb       R$B,u     ; load B from R$B,u
+                    ldx       #DAT.Free ; load X from #DAT.Free
+L0BE4               stx       ,y++      ; store X at ,y++
+                    decb                ; decrement B
+                    bne       L0BE4     ; branch if zero is clear to L0BE4
+L0BE9               clrb                ; clear B
+                    rts                 ; return to caller

--- a/level2/modules/kernel/fclrblk.asm
+++ b/level2/modules/kernel/fclrblk.asm
@@ -11,7 +11,7 @@
 * Error:  CC = C bit set; B = error code
 *
 FClrBlk             ldb       R$B,u     ; load B from R$B,u
-                    beq       L0BE9     ; branch if zero is set to L0BE9
+                    beq       FClrblkTarget2 ; branch if zero is set to FClrblkTarget2
                     ldd       R$U,u     ; load D from R$U,u
                     tstb                ; test B and update condition codes
                     bne       IllBlkErr ; branch if zero is clear to IllBlkErr
@@ -21,7 +21,7 @@ FClrBlk             ldb       R$B,u     ; load B from R$B,u
                     lda       P$SP,x    ; load A from P$SP,x
                     anda      #$E0      ; mask A with #$E0
                     suba      R$U,u     ; subtract R$U,u from A
-                    bcs       L0BCE     ; branch if carry is set to L0BCE
+                    bcs       MarkImageChanged ; branch if the block range is inside the process stack
                     lsra                ; shift or rotate and update condition codes
                     lsra                ; shift or rotate and update condition codes
                     lsra                ; shift or rotate and update condition codes
@@ -29,7 +29,7 @@ FClrBlk             ldb       R$B,u     ; load B from R$B,u
                     lsra                ; shift or rotate and update condition codes
                     cmpa      R$B,u     ; compare A with R$B,u
                     bcs       IllBlkErr ; branch if carry is set to IllBlkErr
-L0BCE
+MarkImageChanged
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #ImgChg,P$State,x ; apply immediate bit operation #ImgChg,P$State,x
                   ELSE
@@ -46,8 +46,8 @@ L0BCE
                     leay      a,y       ; compute a,y into Y
                     ldb       R$B,u     ; load B from R$B,u
                     ldx       #DAT.Free ; load X from #DAT.Free
-L0BE4               stx       ,y++      ; store X at ,y++
+FClrblkTarget       stx       ,y++      ; store X at ,y++
                     decb                ; decrement B
-                    bne       L0BE4     ; branch if zero is clear to L0BE4
-L0BE9               clrb                ; clear B
+                    bne       FClrblkTarget ; branch if zero is clear to FClrblkTarget
+FClrblkTarget2      clrb                ; clear B
                     rts                 ; return to caller

--- a/level2/modules/kernel/fcpymem.asm
+++ b/level2/modules/kernel/fcpymem.asm
@@ -48,7 +48,7 @@ FCpymemJoin         equ       *         ; define assembler symbol FCpymemJoin
 
                     ldu       2,s       ; get back register stack pointer
                     lbsr      FAlltskTarget2 ; short cut OS9 F$ResTsk
-                    bcs       FCpymemPurgeOurBuffer ; if error, deallocate our stack & exit with error
+                    bcs       FCpymemPrgOurBffr ; if error, deallocate our stack & exit with error
                     tfr       b,e       ; new temp task # into E
                     lslb                ; multiply by 2 for 2 byte entries
                     ldx       <D.TskIPt ; get ptr to task image table
@@ -67,7 +67,7 @@ FCpymemJoin         equ       *         ; define assembler symbol FCpymemJoin
 *         bcs   L09FB        If error, purge stack & return with error code
                     puls      b         ; get back new task #
                     lbsr      FAlltskTarget3 ; short cut OS9 F$RelTsk
-FCpymemPurgeOurBuffer leas      <$14,s    ; purge our stack buffer & return
+FCpymemPrgOurBffr   leas      <$14,s    ; purge our stack buffer & return
                     rts                 ; return to caller
 
 FCpymemErrorExit    clrb                ; no error & exit
@@ -103,7 +103,7 @@ FCpymemJoin         clra                ; set offset to offset to 0
                     bne       FCpymemJoin ; branch if zero is clear to FCpymemJoin
                     ldu       4,s       ; get callers register stack pr back
                     lbsr      FAlltskTarget2 ; short cut os9 F$ResTsk (returns in B, destroys A)
-                    bcs       FCpymemPurgeOurBuffer ; if error, deallocate our stack & exit with error
+                    bcs       FCpymemPrgOurBffr ; if error, deallocate our stack & exit with error
                     stb       ,s        ; save copy of new temp task # (overtop temp ctr)
 * 0,s   =new temp task #
 * 1,s   =task # of caller
@@ -126,7 +126,7 @@ FCpymemJoin         clra                ; set offset to offset to 0
                     puls      b         ; get back temp task #
                     lbsr      FAlltskTarget3 ; shortcut OS9 F$RelTsk
                     leas      -2,s      ; adjust stack for fall thru
-FCpymemPurgeOurBuffer leas      $16,s     ; purge our stack buffer ptr & return
+FCpymemPrgOurBffr   leas      $16,s     ; purge our stack buffer ptr & return
                     rts                 ; return to caller
 
 FCpymemErrorExit    clrb                ; clear B

--- a/level2/modules/kernel/fcpymem.asm
+++ b/level2/modules/kernel/fcpymem.asm
@@ -12,7 +12,7 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-                    ifne      H6309
+                  IFNE    H6309   ; begin conditional assembly for H6309
 * F$CpyMem for NitrOS-9 Level Two
 * Notes:
 * We currently check to see if the end of the buffer we are
@@ -21,114 +21,114 @@
 * data area of a process, or at least into Vector page RAM
 * and I/O ($FE00-$FFFF)???
 *
-FCpyMem             ldd       R$Y,u               get byte count
-                    beq       L0A01               nothing there so nothing to move, return
-                    addd      R$U,u               add it caller's buffer start ptr.
-                    cmpa      #$FE                Is it going to overwrite Vector or I/O pages?
-                    bhs       L0A01               Yes, exit without error
-                    leas      -$10,s              make a buffer for DAT image
-                    leay      ,s                  point to it
-                    pshs      y,u                 Preserve stack buffer ptr & register stack pointer
-                    ldx       <D.Proc             Get caller's task #
-                    ldf       P$Task,x            get task # of caller
-                    leay      P$DATImg,x          Point to DAT image in callers's process dsc.
-                    ldx       R$D,u               get caller's DAT image pointer
-                    lde       #$08                counter (for double byte moves)
-                    ldu       ,s                  get temp. stack buffer pointer
+FCpyMem             ldd       R$Y,u     ; get byte count
+                    beq       L0A01     ; nothing there so nothing to move, return
+                    addd      R$U,u     ; add it caller's buffer start ptr.
+                    cmpa      #$FE      ; is it going to overwrite Vector or I/O pages?
+                    bhs       L0A01     ; yes, exit without error
+                    leas      -$10,s    ; make a buffer for DAT image
+                    leay      ,s        ; point to it
+                    pshs      y,u       ; preserve stack buffer ptr & register stack pointer
+                    ldx       <D.Proc   ; get caller's task #
+                    ldf       P$Task,x  ; get task # of caller
+                    leay      P$DATImg,x ; point to DAT image in callers's process dsc.
+                    ldx       R$D,u     ; get caller's DAT image pointer
+                    lde       #$08      ; counter (for double byte moves)
+                    ldu       ,s        ; get temp. stack buffer pointer
 
 * This loop copies the DAT image from the caller's process descriptor into
 * a temporary buffer on the stack
-L09C7               equ       *
-                    clrd                          Clear offset to 0
-                    bsr       L0B02               Short cut OS9 F$LDDDXY
-                    std       ,u++                save it to buffer
-                    leax      2,x                 Bump ptr
-                    dece                          Decrement loop counter
-                    bne       L09C7               Keep doing until 16 bytes is done
+L09C7               equ       *         ; define assembler symbol L09C7
+                    clrd                ; clear offset to 0
+                    bsr       L0B02     ; short cut OS9 F$LDDDXY
+                    std       ,u++      ; save it to buffer
+                    leax      2,x       ; bump ptr
+                    dece                ; decrement loop counter
+                    bne       L09C7     ; keep doing until 16 bytes is done
 
-                    ldu       2,s                 Get back register stack pointer
-                    lbsr      L0CA6               Short cut OS9 F$ResTsk
-                    bcs       L09FB               If error, deallocate our stack & exit with error
-                    tfr       b,e                 New temp task # into E
-                    lslb                          Multiply by 2 for 2 byte entries
-                    ldx       <D.TskIPt           Get ptr to task image table
+                    ldu       2,s       ; get back register stack pointer
+                    lbsr      L0CA6     ; short cut OS9 F$ResTsk
+                    bcs       L09FB     ; if error, deallocate our stack & exit with error
+                    tfr       b,e       ; new temp task # into E
+                    lslb                ; multiply by 2 for 2 byte entries
+                    ldx       <D.TskIPt ; get ptr to task image table
 * Make new temporary task use the memory blocks from the requested DAT image
 *   from the caller, to help do a 1 shot F$Move command, because in general
 * the temporary DAT image is not associated with a task.
-                    ldu       ,s                  Get pointer to DAT image we just copied
-                    stu       b,x                 Point new task image table to our DAT image copy
-                    ldu       2,s                 Get back data area pointer
-                    tfr       w,d                 Move temp & caller's task #'s into proper regs.
-                    pshs      a                   Save new task #
-                    bsr       L0B25               F$Move the memory into the caller's requested area
+                    ldu       ,s        ; get pointer to DAT image we just copied
+                    stu       b,x       ; point new task image table to our DAT image copy
+                    ldu       2,s       ; get back data area pointer
+                    tfr       w,d       ; move temp & caller's task #'s into proper regs.
+                    pshs      a         ; save new task #
+                    bsr       L0B25     ; f$Move the memory into the caller's requested area
 * BAD Bug! Well, maybe not.  F$Move NEVER returns an error code
 * but if it did, we'd skip the $RelTsk, and have an orphan task
 * left over.
 *         bcs   L09FB        If error, purge stack & return with error code
-                    puls      b                   Get back new task #
-                    lbsr      L0CC3               Short cut OS9 F$RelTsk
-L09FB               leas      <$14,s              Purge our stack buffer & return
-                    rts
+                    puls      b         ; get back new task #
+                    lbsr      L0CC3     ; short cut OS9 F$RelTsk
+L09FB               leas      <$14,s    ; purge our stack buffer & return
+                    rts                 ; return to caller
 
-L0A01               clrb                          No error & exit
-                    rts
+L0A01               clrb                ; no error & exit
+                    rts                 ; return to caller
 
 
-                    else
+                  ELSE
 
 * F$CpyMem for OS-9 Level Two- 6809 - for back in KRN
 * Entry: U=ptr to stack contents from caller (parameters)
-FCpyMem             ldd       R$Y,u               Get # of bytes to copy
-                    beq       L0A01               If 0, exit
-                    addd      R$U,u               plus dest buff
+FCpyMem             ldd       R$Y,u     ; get # of bytes to copy
+                    beq       L0A01     ; if 0, exit
+                    addd      R$U,u     ; plus dest buff
 * LCB - Added check to match 6309 version
-                    cmpa      #$FE                Is it going to overwrite Vector or I/O pages?
-                    bhs       L0A01               Yes, exit without error
-                    leas      -$10,s              Make room on stack for temp DAT image
-                    leay      ,s                  Point to it
-                    pshs      y,u                 Save temp DAT img & register stack ptrs
-                    ldx       <D.Proc             Get current process descriptor ptr
-                    lda       #8                  # of 16 bit words to copy
-                    ldb       P$Task,x            Get current process;s task #
-                    pshs      d                   save ctr & caller task #
-                    leay      P$DATImg,x          Point to DAT image of caller
-                    ldx       R$D,u               Get caller's ptr to the DAT image they provided
-                    ldu       2,s                 Get temp DAT IMG Ptr
-L09C7               clra                          Set offset to offset to 0
-                    clrb
-                    bsr       L0B02               Short cut OS9 F$LDDDXY
-                    std       ,u++                to our temp DAT img
-                    leax      2,x                 2 bytes per entry
-                    dec       ,s                  copy all 8 sets of 2 bytes
-                    bne       L09C7
-                    ldu       4,s                 get callers register stack pr back
-                    lbsr      L0CA6               short cut os9 F$ResTsk (returns in B, destroys A)
-                    bcs       L09FB               If error, deallocate our stack & exit with error
-                    stb       ,s                  Save copy of new temp task # (overtop temp ctr)
+                    cmpa      #$FE      ; is it going to overwrite Vector or I/O pages?
+                    bhs       L0A01     ; yes, exit without error
+                    leas      -$10,s    ; make room on stack for temp DAT image
+                    leay      ,s        ; point to it
+                    pshs      y,u       ; save temp DAT img & register stack ptrs
+                    ldx       <D.Proc   ; get current process descriptor ptr
+                    lda       #8        ; # of 16 bit words to copy
+                    ldb       P$Task,x  ; get current process;s task #
+                    pshs      d         ; save ctr & caller task #
+                    leay      P$DATImg,x ; point to DAT image of caller
+                    ldx       R$D,u     ; get caller's ptr to the DAT image they provided
+                    ldu       2,s       ; get temp DAT IMG Ptr
+L09C7               clra                ; set offset to offset to 0
+                    clrb                ; clear B
+                    bsr       L0B02     ; short cut OS9 F$LDDDXY
+                    std       ,u++      ; to our temp DAT img
+                    leax      2,x       ; 2 bytes per entry
+                    dec       ,s        ; copy all 8 sets of 2 bytes
+                    bne       L09C7     ; branch if zero is clear to L09C7
+                    ldu       4,s       ; get callers register stack pr back
+                    lbsr      L0CA6     ; short cut os9 F$ResTsk (returns in B, destroys A)
+                    bcs       L09FB     ; if error, deallocate our stack & exit with error
+                    stb       ,s        ; save copy of new temp task # (overtop temp ctr)
 * 0,s   =new temp task #
 * 1,s   =task # of caller
 * 2-3,s =temp DAT image buffer ptr
 * 4-5,s =callers register stack ptr
 * 6-21,s=temp DAT image
-                    lslb                          *2 for 2 byte entries
-                    ldx       <D.TskIPt           Get ptr to task image table
+                    lslb                ; *2 for 2 byte entries
+                    ldx       <D.TskIPt ; get ptr to task image table
 * Use new temporary task for 1 shot F$Move command
-                    ldu       2,s                 Get ptr to DAT image we just copied
-                    stu       b,x                 Point new task image table to our DAT image copy
-                    ldu       4,s                 Get back callers register stack ptr
-                    ldd       ,s+                 A=temp task #,B=callers task #, eat temp task#
+                    ldu       2,s       ; get ptr to DAT image we just copied
+                    stu       b,x       ; point new task image table to our DAT image copy
+                    ldu       4,s       ; get back callers register stack ptr
+                    ldd       ,s+       ; A=temp task #,B=callers task #, eat temp task#
 * 0,s   =task # of caller
 * 1-2,s =temp DAT image buffer ptr
 * 3-4,s =callers register stack ptr
 * 5-20,s=temp DAT image
-                    sta       ,s                  Save temp task #
-                    bsr       L0B25               Shortcut F$Move memory into callers requested area
-                    puls      b                   get back temp task #
-                    lbsr      L0CC3               Shortcut OS9 F$RelTsk
-                    leas      -2,s                Adjust stack for fall thru
-L09FB               leas      $16,s               Purge our stack buffer ptr & return
-                    rts
+                    sta       ,s        ; save temp task #
+                    bsr       L0B25     ; shortcut F$Move memory into callers requested area
+                    puls      b         ; get back temp task #
+                    lbsr      L0CC3     ; shortcut OS9 F$RelTsk
+                    leas      -2,s      ; adjust stack for fall thru
+L09FB               leas      $16,s     ; purge our stack buffer ptr & return
+                    rts                 ; return to caller
 
-L0A01               clrb
-                    rts
-                    ENDC
+L0A01               clrb                ; clear B
+                    rts                 ; return to caller
+                  ENDC

--- a/level2/modules/kernel/fcpymem.asm
+++ b/level2/modules/kernel/fcpymem.asm
@@ -22,10 +22,10 @@
 * and I/O ($FE00-$FFFF)???
 *
 FCpyMem             ldd       R$Y,u     ; get byte count
-                    beq       L0A01     ; nothing there so nothing to move, return
+                    beq       FCpymemErrorExit ; nothing there so nothing to move, return
                     addd      R$U,u     ; add it caller's buffer start ptr.
                     cmpa      #$FE      ; is it going to overwrite Vector or I/O pages?
-                    bhs       L0A01     ; yes, exit without error
+                    bhs       FCpymemErrorExit ; yes, exit without error
                     leas      -$10,s    ; make a buffer for DAT image
                     leay      ,s        ; point to it
                     pshs      y,u       ; preserve stack buffer ptr & register stack pointer
@@ -38,17 +38,17 @@ FCpyMem             ldd       R$Y,u     ; get byte count
 
 * This loop copies the DAT image from the caller's process descriptor into
 * a temporary buffer on the stack
-L09C7               equ       *         ; define assembler symbol L09C7
+FCpymemJoin         equ       *         ; define assembler symbol FCpymemJoin
                     clrd                ; clear offset to 0
-                    bsr       L0B02     ; short cut OS9 F$LDDDXY
+                    bsr       FLdTarget ; short cut OS9 F$LDDDXY
                     std       ,u++      ; save it to buffer
                     leax      2,x       ; bump ptr
                     dece                ; decrement loop counter
-                    bne       L09C7     ; keep doing until 16 bytes is done
+                    bne       FCpymemJoin ; keep doing until 16 bytes is done
 
                     ldu       2,s       ; get back register stack pointer
-                    lbsr      L0CA6     ; short cut OS9 F$ResTsk
-                    bcs       L09FB     ; if error, deallocate our stack & exit with error
+                    lbsr      FAlltskTarget2 ; short cut OS9 F$ResTsk
+                    bcs       FCpymemPurgeOurBuffer ; if error, deallocate our stack & exit with error
                     tfr       b,e       ; new temp task # into E
                     lslb                ; multiply by 2 for 2 byte entries
                     ldx       <D.TskIPt ; get ptr to task image table
@@ -60,17 +60,17 @@ L09C7               equ       *         ; define assembler symbol L09C7
                     ldu       2,s       ; get back data area pointer
                     tfr       w,d       ; move temp & caller's task #'s into proper regs.
                     pshs      a         ; save new task #
-                    bsr       L0B25     ; f$Move the memory into the caller's requested area
+                    bsr       FMoveBytes ; f$Move the memory into the caller's requested area
 * BAD Bug! Well, maybe not.  F$Move NEVER returns an error code
 * but if it did, we'd skip the $RelTsk, and have an orphan task
 * left over.
 *         bcs   L09FB        If error, purge stack & return with error code
                     puls      b         ; get back new task #
-                    lbsr      L0CC3     ; short cut OS9 F$RelTsk
-L09FB               leas      <$14,s    ; purge our stack buffer & return
+                    lbsr      FAlltskTarget3 ; short cut OS9 F$RelTsk
+FCpymemPurgeOurBuffer leas      <$14,s    ; purge our stack buffer & return
                     rts                 ; return to caller
 
-L0A01               clrb                ; no error & exit
+FCpymemErrorExit    clrb                ; no error & exit
                     rts                 ; return to caller
 
 
@@ -79,11 +79,11 @@ L0A01               clrb                ; no error & exit
 * F$CpyMem for OS-9 Level Two- 6809 - for back in KRN
 * Entry: U=ptr to stack contents from caller (parameters)
 FCpyMem             ldd       R$Y,u     ; get # of bytes to copy
-                    beq       L0A01     ; if 0, exit
+                    beq       FCpymemErrorExit ; if 0, exit
                     addd      R$U,u     ; plus dest buff
 * LCB - Added check to match 6309 version
                     cmpa      #$FE      ; is it going to overwrite Vector or I/O pages?
-                    bhs       L0A01     ; yes, exit without error
+                    bhs       FCpymemErrorExit ; yes, exit without error
                     leas      -$10,s    ; make room on stack for temp DAT image
                     leay      ,s        ; point to it
                     pshs      y,u       ; save temp DAT img & register stack ptrs
@@ -94,16 +94,16 @@ FCpyMem             ldd       R$Y,u     ; get # of bytes to copy
                     leay      P$DATImg,x ; point to DAT image of caller
                     ldx       R$D,u     ; get caller's ptr to the DAT image they provided
                     ldu       2,s       ; get temp DAT IMG Ptr
-L09C7               clra                ; set offset to offset to 0
+FCpymemJoin         clra                ; set offset to offset to 0
                     clrb                ; clear B
-                    bsr       L0B02     ; short cut OS9 F$LDDDXY
+                    bsr       FLdTarget ; short cut OS9 F$LDDDXY
                     std       ,u++      ; to our temp DAT img
                     leax      2,x       ; 2 bytes per entry
                     dec       ,s        ; copy all 8 sets of 2 bytes
-                    bne       L09C7     ; branch if zero is clear to L09C7
+                    bne       FCpymemJoin ; branch if zero is clear to FCpymemJoin
                     ldu       4,s       ; get callers register stack pr back
-                    lbsr      L0CA6     ; short cut os9 F$ResTsk (returns in B, destroys A)
-                    bcs       L09FB     ; if error, deallocate our stack & exit with error
+                    lbsr      FAlltskTarget2 ; short cut os9 F$ResTsk (returns in B, destroys A)
+                    bcs       FCpymemPurgeOurBuffer ; if error, deallocate our stack & exit with error
                     stb       ,s        ; save copy of new temp task # (overtop temp ctr)
 * 0,s   =new temp task #
 * 1,s   =task # of caller
@@ -122,13 +122,13 @@ L09C7               clra                ; set offset to offset to 0
 * 3-4,s =callers register stack ptr
 * 5-20,s=temp DAT image
                     sta       ,s        ; save temp task #
-                    bsr       L0B25     ; shortcut F$Move memory into callers requested area
+                    bsr       FMoveBytes ; shortcut F$Move memory into callers requested area
                     puls      b         ; get back temp task #
-                    lbsr      L0CC3     ; shortcut OS9 F$RelTsk
+                    lbsr      FAlltskTarget3 ; shortcut OS9 F$RelTsk
                     leas      -2,s      ; adjust stack for fall thru
-L09FB               leas      $16,s     ; purge our stack buffer ptr & return
+FCpymemPurgeOurBuffer leas      $16,s     ; purge our stack buffer ptr & return
                     rts                 ; return to caller
 
-L0A01               clrb                ; clear B
+FCpymemErrorExit    clrb                ; clear B
                     rts                 ; return to caller
                   ENDC

--- a/level2/modules/kernel/fcrcmod.asm
+++ b/level2/modules/kernel/fcrcmod.asm
@@ -9,14 +9,14 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FCRCMod             lda       R$A,u               do they want a report or a toggle?
-                    beq       CRCRep              a report only
-                    deca                          check for OFF
-                    bne       GoCRCon             no, must be on
-                    fcb       $8C                 skip 2 bytes, saves 3 bytes of memory
-GoCRCon             lda       #$1                 CRC checking on
-                    sta       <D.CRC              turn CRC checking on
-CRCRep              lda       <D.CRC              get current CRC flag for return
-CRCRep2             sta       R$A,u               save it to their register stack
-                    clrb                          no error
-                    rts                           and exit
+FCRCMod             lda       R$A,u     ; do they want a report or a toggle?
+                    beq       CRCRep    ; a report only
+                    deca                ; check for OFF
+                    bne       GoCRCon   ; no, must be on
+                    fcb       $8C       ; skip 2 bytes, saves 3 bytes of memory
+GoCRCon             lda       #$1       ; cRC checking on
+                    sta       <D.CRC    ; turn CRC checking on
+CRCRep              lda       <D.CRC    ; get current CRC flag for return
+CRCRep2             sta       R$A,u     ; save it to their register stack
+                    clrb                ; no error
+                    rts                 ; and exit

--- a/level2/modules/kernel/fdatlog.asm
+++ b/level2/modules/kernel/fdatlog.asm
@@ -10,26 +10,26 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FDATLog        ldb       R$B,u               Get logical Block #
-               ldx       R$X,u               Get offset into block
-               bsr       CmpLBlk             Go modify X to be Logical address
-               stx       R$X,u               Save in callers X register
-               clrb                          No error & return
-               rts       
+FDATLog             ldb       R$B,u     ; get logical Block #
+                    ldx       R$X,u     ; get offset into block
+                    bsr       CmpLBlk   ; go modify X to be Logical address
+                    stx       R$X,u     ; save in callers X register
+                    clrb                ; no error & return
+                    rts                 ; return to caller
 
 * Compute logical address given B=Logical Block # & X=offset into block
 * Exits with B being logical block & X=logical address
-CmpLBlk        pshs      b                   Preserve logical block #
-               tfr       b,a                 Move log. block # to A
-               lsla                          Multiply logical block by 32
-               lsla      
-               lsla      
-               lsla      
-               lsla      
-               clrb                          D=8k offset value
-               ifne      H6309
-               addr      d,x                 X=logical address in 64k workspace
-               else      
-               leax      d,x
-               endc      
-               puls      b,pc                Restore A, block # & return
+CmpLBlk             pshs      b         ; preserve logical block #
+                    tfr       b,a       ; move log. block # to A
+                    lsla                ; multiply logical block by 32
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    clrb                ; D=8k offset value
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,x       ; X=logical address in 64k workspace
+                  ELSE
+                    leax      d,x       ; compute d,x into X
+                  ENDC
+                    puls      b,pc      ; restore A, block # & return

--- a/level2/modules/kernel/fdebug.asm
+++ b/level2/modules/kernel/fdebug.asm
@@ -6,58 +6,58 @@
 * Input:  A = Function code
 *
 
-FDebug         equ       *
+FDebug              equ       *         ; define assembler symbol FDebug
 * Determine if this is a system process or super user
 * Only they have permission to reboot
-               lda       R$A,u
-               cmpa      #255                reboot request
-               bne       leave               nope
-               ldx       <D.Proc
-               ldd       P$User,x            get user ID
-               beq       REBOOT
-               comb      
-               ldb       #E$UnkSvc
-leave          rts       
+                    lda       R$A,u     ; load A from R$A,u
+                    cmpa      #255      ; reboot request
+                    bne       leave     ; nope
+                    ldx       <D.Proc   ; load X from <D.Proc
+                    ldd       P$User,x  ; get user ID
+                    beq       REBOOT    ; branch if zero is set to REBOOT
+                    comb                ; update processor state
+                    ldb       #E$UnkSvc ; load B from #E$UnkSvc
+leave               rts                 ; return to caller
 
 * NOTE: HIGHLY MACHINE DEPENDENT CODE!
 * THIS CODE IS SPECIFIC TO THE COCO 3!
-REBOOT         orcc      #IntMasks           turn off IRQ's
-               clrb      
-               stb       >DAT.Regs           map in block 0
-               stb       >$0071              cold reboot
-               lda       #$38                bottom of DECB block mapping
-               sta       >DAT.Regs           map in block zero
-               stb       >$0071              and cold reboot here, too
-               ldu       #$0000              force code to go at offset $0000
-               leax      ReBootLoc,pc        reboot code
-               ldy       #CodeSize
-cit.loop       lda       ,x+
-               sta       ,u+
-               leay      -1,y
-               bne       cit.loop
-               clr       >$FEED              cold reboot
-               clr       >$FFD8              go to low speed
-               jmp       >$0000              jump to the reset code
+REBOOT              orcc      #IntMasks ; turn off IRQ's
+                    clrb                ; clear B
+                    stb       >DAT.Regs ; map in block 0
+                    stb       >$0071    ; cold reboot
+                    lda       #$38      ; bottom of DECB block mapping
+                    sta       >DAT.Regs ; map in block zero
+                    stb       >$0071    ; and cold reboot here, too
+                    ldu       #$0000    ; force code to go at offset $0000
+                    leax      ReBootLoc,pc ; reboot code
+                    ldy       #CodeSize ; load Y from #CodeSize
+cit.loop            lda       ,x+       ; load A from ,x+
+                    sta       ,u+       ; store A at ,u+
+                    leay      -1,y      ; compute -1,y into Y
+                    bne       cit.loop  ; branch if zero is clear to cit.loop
+                    clr       >$FEED    ; cold reboot
+                    clr       >$FFD8    ; go to low speed
+                    jmp       >$0000    ; jump to the reset code
 
-ReBootLoc                
-               ldd       #$3808              block $38, 8 times
-               ldx       #DAT.Regs           where to put it
-Lp             sta       8,x                 put into map 1
-               sta       ,x+                 and into map 0
-               inca      
-               decb                          count down
-               bne       Lp
+ReBootLoc
+                    ldd       #$3808    ; block $38, 8 times
+                    ldx       #DAT.Regs ; where to put it
+Lp                  sta       8,x       ; put into map 1
+                    sta       ,x+       ; and into map 0
+                    inca                ; increment A
+                    decb                ; count down
+                    bne       Lp        ; branch if zero is clear to Lp
 
-               lda       #$4C                standard DECB mapping
-               sta       >$FF90
-               clr       >DAT.Task           go to map type 0
-               clr       >$FFDE              and to all-ROM mode
-               ldd       #$FFFF
+                    lda       #$4C      ; standard DECB mapping
+                    sta       >$FF90    ; store A at >$FF90
+                    clr       >DAT.Task ; go to map type 0
+                    clr       >$FFDE    ; and to all-ROM mode
+                    ldd       #$FFFF    ; load D from #$FFFF
 *         clrd              executes as CLRA on a 6809
-               fdb       $104F
-               tstb                          is it a 6809?
-               bne       Reset               yup, skip ahead
+                    fdb       $104F     ; define word value(s) $104F
+                    tstb                ; is it a 6809?
+                    bne       Reset     ; yup, skip ahead
 *         ldmd  #$00        go to 6809 mode!
-               fcb       $11,$3D,$00
-Reset          jmp       [$FFFE]             do a reset
-CodeSize       equ       *-ReBootLoc
+                    fcb       $11,$3D,$00 ; define byte value(s) $11,$3D,$00
+Reset               jmp       [$FFFE]   ; do a reset
+CodeSize            equ       *-ReBootLoc ; define assembler symbol CodeSize

--- a/level2/modules/kernel/fdelimg.asm
+++ b/level2/modules/kernel/fdelimg.asm
@@ -11,41 +11,41 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FDelImg             ldx       R$X,u               get process pointer
-                    ldd       R$D,u               get start block & block count
-                    leau      <P$DATImg,x         point to DAT image
-                    lsla                          2 bytes per block entry
-                    leau      a,u                 Point U to block entry
+FDelImg             ldx       R$X,u     ; get process pointer
+                    ldd       R$D,u     ; get start block & block count
+                    leau      <P$DATImg,x ; point to DAT image
+                    lsla                ; 2 bytes per block entry
+                    leau      a,u       ; point U to block entry
 * Block count in B
 L0B55
-                    ifne      H6309
-                    ldw       ,u                  Get block #
-                    addw      <D.BlkMap           Add it to map ptr
-                    aim       #^RAMinUse,0,w
-                    ldw       #DAT.Free           get empty block marker
-                    stw       ,u++                save it to process descriptor
-                    decb                          done?
-                    bne       L0B55               No, keep going
-                    oim       #ImgChg,P$State,x
-                    else
-                    clra
-                    tfr       d,y
-                    pshs      x
-L0BLoop             ldd       ,u
-                    addd      <D.BlkMap
-                    tfr       d,x
-                    lda       ,x
-                    anda      #^RAMinUse
-                    sta       ,x
-                    ldd       #DAT.Free
-                    std       ,u++
-                    leay      -1,y
-                    bne       L0BLoop
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       ,u        ; get block #
+                    addw      <D.BlkMap ; add it to map ptr
+                    aim       #^RAMinUse,0,w ; apply immediate bit operation #^RAMinUse,0,w
+                    ldw       #DAT.Free ; get empty block marker
+                    stw       ,u++      ; save it to process descriptor
+                    decb                ; done?
+                    bne       L0B55     ; no, keep going
+                    oim       #ImgChg,P$State,x ; apply immediate bit operation #ImgChg,P$State,x
+                  ELSE
+                    clra                ; clear A
+                    tfr       d,y       ; transfer register value d,y
+                    pshs      x         ; save x on the stack
+L0BLoop             ldd       ,u        ; load D from ,u
+                    addd      <D.BlkMap ; add <D.BlkMap to D
+                    tfr       d,x       ; transfer register value d,x
+                    lda       ,x        ; load A from ,x
+                    anda      #^RAMinUse ; mask A with #^RAMinUse
+                    sta       ,x        ; store A at ,x
+                    ldd       #DAT.Free ; load D from #DAT.Free
+                    std       ,u++      ; store D at ,u++
+                    leay      -1,y      ; compute -1,y into Y
+                    bne       L0BLoop   ; branch if zero is clear to L0BLoop
 
-                    puls      x
-                    lda       P$State,x
-                    ora       #ImgChg
-                    sta       P$State,x
-                    endc
-                    clrb
-                    rts
+                    puls      x         ; restore x from the stack
+                    lda       P$State,x ; load A from P$State,x
+                    ora       #ImgChg   ; merge #ImgChg into A
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
+                    clrb                ; clear B
+                    rts                 ; return to caller

--- a/level2/modules/kernel/fdelimg.asm
+++ b/level2/modules/kernel/fdelimg.asm
@@ -17,7 +17,7 @@ FDelImg             ldx       R$X,u     ; get process pointer
                     lsla                ; 2 bytes per block entry
                     leau      a,u       ; point U to block entry
 * Block count in B
-L0B55
+FreeImageBlock
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       ,u        ; get block #
                     addw      <D.BlkMap ; add it to map ptr
@@ -25,7 +25,7 @@ L0B55
                     ldw       #DAT.Free ; get empty block marker
                     stw       ,u++      ; save it to process descriptor
                     decb                ; done?
-                    bne       L0B55     ; no, keep going
+                    bne       FreeImageBlock ; no, keep going
                     oim       #ImgChg,P$State,x ; apply immediate bit operation #ImgChg,P$State,x
                   ELSE
                     clra                ; clear A

--- a/level2/modules/kernel/fdelram.asm
+++ b/level2/modules/kernel/fdelram.asm
@@ -10,30 +10,30 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FDelRAM        ldb       R$B,u               # of blocks to de-allocate
-               beq       DelRAM.2            if none, exit
-               ldd       <D.BlkMap+2         get end of the block map
-               subd      <D.BlkMap           subtract out start of the block map
-               subd      R$X,u               take out starting block number
-               bls       DelRAM.2            exit if the starting block is ># of blocks available
-               tsta                          check high byte of RAM #
-               bne       DelRAM.0            if not zero, skip it
-               cmpb      R$B,u               check against size of the block
-               bhs       DelRAM.0            if size is >RAM available
-               stb       R$B,u               save actual # of blocks deleted
-DelRAM.0       ldx       <D.BlkMap           get start address of the block map
-               ldd       R$X,u               starting address of the RAM to de-allocate
-               leax      d,x                 slower, but smaller than ADDR
-               ldb       R$B,u               get actual # of blocks to de-allocate
-DelRAM.1       equ       *
-               ifne      H6309
-               aim       #^RAMinUse,,x+      set to RAM not in use
-               else      
-               lda       ,x
-               anda      #^RAMinUse
-               sta       ,x+
-               endc      
-               decb                          count down a block
-               bne       DelRAM.1            continue
-DelRAM.2       clrb                          and exit
-               rts       
+FDelRAM             ldb       R$B,u     ; # of blocks to de-allocate
+                    beq       DelRAM.2  ; if none, exit
+                    ldd       <D.BlkMap+2 ; get end of the block map
+                    subd      <D.BlkMap ; subtract out start of the block map
+                    subd      R$X,u     ; take out starting block number
+                    bls       DelRAM.2  ; exit if the starting block is ># of blocks available
+                    tsta                ; check high byte of RAM #
+                    bne       DelRAM.0  ; if not zero, skip it
+                    cmpb      R$B,u     ; check against size of the block
+                    bhs       DelRAM.0  ; if size is >RAM available
+                    stb       R$B,u     ; save actual # of blocks deleted
+DelRAM.0            ldx       <D.BlkMap ; get start address of the block map
+                    ldd       R$X,u     ; starting address of the RAM to de-allocate
+                    leax      d,x       ; slower, but smaller than ADDR
+                    ldb       R$B,u     ; get actual # of blocks to de-allocate
+DelRAM.1            equ       *         ; define assembler symbol DelRAM.1
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^RAMinUse,,x+ ; set to RAM not in use
+                  ELSE
+                    lda       ,x        ; load A from ,x
+                    anda      #^RAMinUse ; mask A with #^RAMinUse
+                    sta       ,x+       ; store A at ,x+
+                  ENDC
+                    decb                ; count down a block
+                    bne       DelRAM.1  ; continue
+DelRAM.2            clrb                ; and exit
+                    rts                 ; return to caller

--- a/level2/modules/kernel/ffind64.asm
+++ b/level2/modules/kernel/ffind64.asm
@@ -50,12 +50,12 @@ FFind64Block        stx       R$Y,u     ; save address of block
 *
 *
 FAll64              ldx       R$X,u     ; get base address of page table
-                    bne       FFind64FindEmptySpotPathTable ; it's been allocated, skip ahead
+                    bne       FFind64FindEmpty ; it's been allocated, skip ahead
                     bsr       FFind64Target ; allocate the page
                     bcs       FFind64Return2 ; error allocating, return
                     stx       ,x        ; save base address in page table
                     stx       R$X,u     ; save base address to caller's X
-FFind64FindEmptySpotPathTable bsr       FFind64BasePagePtrs ; find a empty spot in path table
+FFind64FindEmpty    bsr       FFind64BasePagePtrs ; find a empty spot in path table
                     bcs       FFind64Return2 ; couldn't find one, return error
                     sta       R$A,u     ; save block #
                     sty       R$Y,u     ; save address of block
@@ -95,29 +95,29 @@ TFMNull             fcb       0         ; used to clear memory
 FFind64BasePagePtrs pshs      x,u       ; preserve base page & register stack ptrs
                     clra                ; index entry #=0
 * Main search loop
-FFind64WhichIndexEntryWeChecking pshs      a         ; save which index entry we are checking
+FFind64WhchIndx     pshs      a         ; save which index entry we are checking
                     clrb                ; set position within page we are checking to 0
                     lda       a,x       ; is the current index entry used?
-                    beq       FFind64FlagDidntFind ; no, skip ahead
+                    beq       FFind64FlagDdnt ; no, skip ahead
                     tfr       d,y       ; yes, Move ptr to 256 byte block to Y
                     clra                ; clear offset for 64 byte blocks to 0
-FFind64BlockAllocated tst       d,y       ; is this 64 byte block allocated?
+FFind64BlkAlloc     tst       d,y       ; is this 64 byte block allocated?
                     beq       FFind64Target3 ; no, skip ahead
                     addb      #$40      ; yes, point to next 64 byte block in page
-                    bcc       FFind64BlockAllocated ; if not done checking entire page, keep going
+                    bcc       FFind64BlkAlloc ; if not done checking entire page, keep going
 
 * Index entry has a totally unused 256 byte page
-FFind64FlagDidntFind orcc      #Carry    ; set flag (didn't find one)
+FFind64FlagDdnt     orcc      #Carry    ; set flag (didn't find one)
 FFind64Target3      leay      d,y       ; compute d,y into Y
                     puls      a         ; get which index entry we were checking
                     bcc       FFind64Join ; if we found a blank entry, go allocate it
                     inca                ; didn't, move to next index entry
                     cmpa      #64       ; done entire index?
-                    blo       FFind64WhichIndexEntryWeChecking ; no, keep looking
+                    blo       FFind64WhchIndx ; no, keep looking
 
                     clra                ; yes, clear out to first entry
 FFind64Used         tst       a,x       ; is this one used?
-                    beq       FFind64IndexIndexEntry ; no, skip ahead
+                    beq       FFind64IndxIndx ; no, skip ahead
                     inca                ; increment index entry #
                     cmpa      #64       ; done entire index?
                     blo       FFind64Used ; no, continue looking
@@ -126,7 +126,7 @@ FFind64Used         tst       a,x       ; is this one used?
                     ldb       #E$PthFul ; load B from #E$PthFul
                     puls      x,u,pc    ; restore x,u,pc from the stack
 * Found empty page
-FFind64IndexIndexEntry pshs      x,a       ; preserve index ptr & index entry #
+FFind64IndxIndx     pshs      x,a       ; preserve index ptr & index entry #
                     bsr       FFind64Target ; allocate & clear out new 256 byte page
                     bcs       FFind64AdjustBy ; if error,exit
                     leay      ,x        ; point Y to start of new page

--- a/level2/modules/kernel/ffind64.asm
+++ b/level2/modules/kernel/ffind64.asm
@@ -10,29 +10,29 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FFind64             ldx       R$X,u               Get block tbl ptr
-                    lda       R$A,u               get path block #
+FFind64             ldx       R$X,u     ; get block tbl ptr
+                    lda       R$A,u     ; get path block #
 * Find a empty path block
-                    beq       L0A70               None, return error
-                    clrb                          calculate address
-                    ifne      H6309
-                    lsrd                          (Divide by 4)
-                    lsrd
-                    else
-                    lsra
-                    rorb
-                    lsra
-                    rorb
-                    endc
-                    lda       a,x                 is that block allocated?
-                    tfr       d,x                 Move addr to X
-                    beq       L0A70               no, return error
-                    tst       ,x                  this the page table?
-                    bne       L0A71               no, we can use this one
-L0A70               coma                          set carry & return
-                    rts
-L0A71               stx       R$Y,u               save address of block
-                    rts                           return
+                    beq       L0A70     ; none, return error
+                    clrb                ; calculate address
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lsrd                ; (Divide by 4)
+                    lsrd                ; shift or rotate and update condition codes
+                  ELSE
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                  ENDC
+                    lda       a,x       ; is that block allocated?
+                    tfr       d,x       ; move addr to X
+                    beq       L0A70     ; no, return error
+                    tst       ,x        ; this the page table?
+                    bne       L0A71     ; no, we can use this one
+L0A70               coma                ; set carry & return
+                    rts                 ; return to caller
+L0A71               stx       R$Y,u     ; save address of block
+                    rts                 ; return
 
 
 **************************************************
@@ -49,117 +49,117 @@ L0A71               stx       R$Y,u               save address of block
 * Error:  CC = C bit set; B = error code
 *
 *
-FAll64              ldx       R$X,u               get base address of page table
-                    bne       L0A7F               it's been allocated, skip ahead
-                    bsr       L0A89               allocate the page
-                    bcs       L0A88               error allocating, return
-                    stx       ,x                  save base address in page table
-                    stx       R$X,u               save base address to caller's X
-L0A7F               bsr       L0A9F               find a empty spot in path table
-                    bcs       L0A88               couldn't find one, return error
-                    sta       R$A,u               save block #
-                    sty       R$Y,u               save address of block
-L0A88               rts                           return
+FAll64              ldx       R$X,u     ; get base address of page table
+                    bne       L0A7F     ; it's been allocated, skip ahead
+                    bsr       L0A89     ; allocate the page
+                    bcs       L0A88     ; error allocating, return
+                    stx       ,x        ; save base address in page table
+                    stx       R$X,u     ; save base address to caller's X
+L0A7F               bsr       L0A9F     ; find a empty spot in path table
+                    bcs       L0A88     ; couldn't find one, return error
+                    sta       R$A,u     ; save block #
+                    sty       R$Y,u     ; save address of block
+L0A88               rts                 ; return
 
 * Allocate a new base page
 * Exit: X=Ptr to newly allocated 256 byte page
-L0A89               pshs      u                   preserve register stack pointer
-                    ifne      H6309
-                    ldq       #$01000100          get block size (1 for SRqMem & 1 for TFM)
-                    else
-                    ldd       #$0100
-                    endc
-                    os9       F$SRqMem            request mem for it
-                    leax      ,u                  point to it
-                    ldu       ,s                  restore register stack pointer
-                    stx       ,s                  save pointer to new page on stack
-                    bcs       L0A9E               error on allocate, return
+L0A89               pshs      u         ; preserve register stack pointer
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$01000100 ; get block size (1 for SRqMem & 1 for TFM)
+                  ELSE
+                    ldd       #$0100    ; load D from #$0100
+                  ENDC
+                    os9       F$SRqMem  ; request mem for it
+                    leax      ,u        ; point to it
+                    ldu       ,s        ; restore register stack pointer
+                    stx       ,s        ; save pointer to new page on stack
+                    bcs       L0A9E     ; error on allocate, return
 * Clear freshly allocated page to 0's
-                    ifne      H6309
-                    leay      TFMNull,pc          point to NULL byte
-                    tfm       y,x+
-                    else
-                    clrb
-AllLoop             clr       ,x+
-                    decb
-                    bne       AllLoop
-                    endc
-L0A9E               puls      x,pc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leay      TFMNull,pc ; point to NULL byte
+                    tfm       y,x+      ; transfer memory block using y,x+
+                  ELSE
+                    clrb                ; clear B
+AllLoop             clr       ,x+       ; clear ,x+
+                    decb                ; decrement B
+                    bne       AllLoop   ; branch if zero is clear to AllLoop
+                  ENDC
+L0A9E               puls      x,pc      ; restore x,pc from the stack
 
-                    ifne      H6309
-TFMNull             fcb       0                   used to clear memory
-                    endc
+                  IFNE    H6309   ; begin conditional assembly for H6309
+TFMNull             fcb       0         ; used to clear memory
+                  ENDC
 
 * Search page table for a free 64 byte block
 * Entry: X=Ptr to base page (the one with the 64 entry page index)
-L0A9F               pshs      x,u                 preserve base page & register stack ptrs
-                    clra                          Index entry #=0
+L0A9F               pshs      x,u       ; preserve base page & register stack ptrs
+                    clra                ; index entry #=0
 * Main search loop
-L0AA2               pshs      a                   Save which index entry we are checking
-                    clrb                          Set position within page we are checking to 0
-                    lda       a,x                 Is the current index entry used?
-                    beq       L0AB4               no, skip ahead
-                    tfr       d,y                 Yes, Move ptr to 256 byte block to Y
-                    clra                          Clear offset for 64 byte blocks to 0
-L0AAC               tst       d,y                 Is this 64 byte block allocated?
-                    beq       L0AB6               No, skip ahead
-                    addb      #$40                Yes, point to next 64 byte block in page
-                    bcc       L0AAC               If not done checking entire page, keep going
+L0AA2               pshs      a         ; save which index entry we are checking
+                    clrb                ; set position within page we are checking to 0
+                    lda       a,x       ; is the current index entry used?
+                    beq       L0AB4     ; no, skip ahead
+                    tfr       d,y       ; yes, Move ptr to 256 byte block to Y
+                    clra                ; clear offset for 64 byte blocks to 0
+L0AAC               tst       d,y       ; is this 64 byte block allocated?
+                    beq       L0AB6     ; no, skip ahead
+                    addb      #$40      ; yes, point to next 64 byte block in page
+                    bcc       L0AAC     ; if not done checking entire page, keep going
 
 * Index entry has a totally unused 256 byte page
-L0AB4               orcc      #Carry              Set flag (didn't find one)
-L0AB6               leay      d,y
-                    puls      a                   Get which index entry we were checking
-                    bcc       L0AE1               If we found a blank entry, go allocate it
-                    inca                          Didn't, move to next index entry
-                    cmpa      #64                 Done entire index?
-                    blo       L0AA2               no, keep looking
+L0AB4               orcc      #Carry    ; set flag (didn't find one)
+L0AB6               leay      d,y       ; compute d,y into Y
+                    puls      a         ; get which index entry we were checking
+                    bcc       L0AE1     ; if we found a blank entry, go allocate it
+                    inca                ; didn't, move to next index entry
+                    cmpa      #64       ; done entire index?
+                    blo       L0AA2     ; no, keep looking
 
-                    clra                          Yes, clear out to first entry
-L0AC2               tst       a,x                 Is this one used?
-                    beq       L0AD0               No, skip ahead
-                    inca                          Increment index entry #
-                    cmpa      #64                 Done entire index?
-                    blo       L0AC2               No, continue looking
+                    clra                ; yes, clear out to first entry
+L0AC2               tst       a,x       ; is this one used?
+                    beq       L0AD0     ; no, skip ahead
+                    inca                ; increment index entry #
+                    cmpa      #64       ; done entire index?
+                    blo       L0AC2     ; no, continue looking
 
-                    comb                          Done all of them, exit with Path table full error
-                    ldb       #E$PthFul
-                    puls      x,u,pc
+                    comb                ; done all of them, exit with Path table full error
+                    ldb       #E$PthFul ; load B from #E$PthFul
+                    puls      x,u,pc    ; restore x,u,pc from the stack
 * Found empty page
-L0AD0               pshs      x,a                 Preserve index ptr & index entry #
-                    bsr       L0A89               Allocate & clear out new 256 byte page
-                    bcs       L0AF0               If error,exit
-                    leay      ,x                  Point Y to start of new page
-                    tfr       x,d                 Also copy to D
-                    tfr       a,b                 Page # into B
-                    puls      x,a                 Get back index ptr & index entry #
-                    stb       a,x                 Save page # in proper index entry
-                    clrb                          D=index entry #*256
+L0AD0               pshs      x,a       ; preserve index ptr & index entry #
+                    bsr       L0A89     ; allocate & clear out new 256 byte page
+                    bcs       L0AF0     ; if error,exit
+                    leay      ,x        ; point Y to start of new page
+                    tfr       x,d       ; also copy to D
+                    tfr       a,b       ; page # into B
+                    puls      x,a       ; get back index ptr & index entry #
+                    stb       a,x       ; save page # in proper index entry
+                    clrb                ; D=index entry #*256
 
 * D = Block Address
-L0AE1               equ       *
-                    ifne      H6309
-                    lsld                          ???Calculate 256 byte page #?
-                    lsld
-                    tfr       y,u                 U=Ptr to start of new page
-                    ldw       #$3f                Clear out the 64 byte block we are using
-                    leax      TFMNull,pc
-                    tfm       x,u+
-                    else
-                    aslb
-                    rola
-                    aslb
-                    rola
-                    ldb       #$3f
-ClrIt               clr       b,y
-                    decb
-                    bne       ClrIt
-                    endc
-                    sta       ,y                  Save 256 byte page # as 1st byte of block
-                    puls      x,u,pc
+L0AE1               equ       *         ; define assembler symbol L0AE1
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lsld                ; ???Calculate 256 byte page #?
+                    lsld                ; shift or rotate and update condition codes
+                    tfr       y,u       ; U=Ptr to start of new page
+                    ldw       #$3f      ; clear out the 64 byte block we are using
+                    leax      TFMNull,pc ; compute TFMNull,pc into X
+                    tfm       x,u+      ; transfer memory block using x,u+
+                  ELSE
+                    aslb                ; update processor state
+                    rola                ; shift or rotate and update condition codes
+                    aslb                ; update processor state
+                    rola                ; shift or rotate and update condition codes
+                    ldb       #$3f      ; load B from #$3f
+ClrIt               clr       b,y       ; clear b,y
+                    decb                ; decrement B
+                    bne       ClrIt     ; branch if zero is clear to ClrIt
+                  ENDC
+                    sta       ,y        ; save 256 byte page # as 1st byte of block
+                    puls      x,u,pc    ; restore x,u,pc from the stack
 
-L0AF0               leas      3,s
-                    puls      x,u,pc
+L0AF0               leas      3,s       ; adjust stack pointer by 3,s
+                    puls      x,u,pc    ; restore x,u,pc from the stack
 
 
 **************************************************
@@ -174,36 +174,36 @@ L0AF0               leas      3,s
 *
 * Error:  CC = C bit set; B = error code
 *
-FRet64              lda       R$A,u
-                    ldx       R$X,u
-                    pshs      u,y,x,d
-                    clrb
-                    tsta
-                    beq       L0B22
-                    ifne      H6309
-                    lsrd                          (Divide by 4)
-                    lsrd
-                    else
-                    lsra
-                    rorb
-                    lsra
-                    rorb
-                    endc
-                    pshs      a
-                    lda       a,x
-                    beq       L0B20
-                    tfr       d,y
-                    clr       ,y
-                    clrb
-                    tfr       d,u
-                    clra
-L0B10               tst       d,u
-                    bne       L0B20
-                    addb      #$40
-                    bne       L0B10
-                    inca
-                    os9       F$SRtMem
-                    lda       ,s
-                    clr       a,x
-L0B20               clr       ,s+
-L0B22               puls      pc,u,y,x,d
+FRet64              lda       R$A,u     ; load A from R$A,u
+                    ldx       R$X,u     ; load X from R$X,u
+                    pshs      u,y,x,d   ; save u,y,x,d on the stack
+                    clrb                ; clear B
+                    tsta                ; test A and update condition codes
+                    beq       L0B22     ; branch if zero is set to L0B22
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lsrd                ; (Divide by 4)
+                    lsrd                ; shift or rotate and update condition codes
+                  ELSE
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    rorb                ; shift or rotate and update condition codes
+                  ENDC
+                    pshs      a         ; save a on the stack
+                    lda       a,x       ; load A from a,x
+                    beq       L0B20     ; branch if zero is set to L0B20
+                    tfr       d,y       ; transfer register value d,y
+                    clr       ,y        ; clear ,y
+                    clrb                ; clear B
+                    tfr       d,u       ; transfer register value d,u
+                    clra                ; clear A
+L0B10               tst       d,u       ; test d,u and update condition codes
+                    bne       L0B20     ; branch if zero is clear to L0B20
+                    addb      #$40      ; add #$40 to B
+                    bne       L0B10     ; branch if zero is clear to L0B10
+                    inca                ; increment A
+                    os9       F$SRtMem  ; call OS-9 service F$SRtMem
+                    lda       ,s        ; load A from ,s
+                    clr       a,x       ; clear a,x
+L0B20               clr       ,s+       ; clear ,s+
+L0B22               puls      pc,u,y,x,d ; restore pc,u,y,x,d from the stack

--- a/level2/modules/kernel/ffind64.asm
+++ b/level2/modules/kernel/ffind64.asm
@@ -13,7 +13,7 @@
 FFind64             ldx       R$X,u     ; get block tbl ptr
                     lda       R$A,u     ; get path block #
 * Find a empty path block
-                    beq       L0A70     ; none, return error
+                    beq       FFind64Return ; none, return error
                     clrb                ; calculate address
                   IFNE    H6309   ; begin conditional assembly for H6309
                     lsrd                ; (Divide by 4)
@@ -26,12 +26,12 @@ FFind64             ldx       R$X,u     ; get block tbl ptr
                   ENDC
                     lda       a,x       ; is that block allocated?
                     tfr       d,x       ; move addr to X
-                    beq       L0A70     ; no, return error
+                    beq       FFind64Return ; no, return error
                     tst       ,x        ; this the page table?
-                    bne       L0A71     ; no, we can use this one
-L0A70               coma                ; set carry & return
+                    bne       FFind64Block ; no, we can use this one
+FFind64Return       coma                ; set carry & return
                     rts                 ; return to caller
-L0A71               stx       R$Y,u     ; save address of block
+FFind64Block        stx       R$Y,u     ; save address of block
                     rts                 ; return
 
 
@@ -50,20 +50,20 @@ L0A71               stx       R$Y,u     ; save address of block
 *
 *
 FAll64              ldx       R$X,u     ; get base address of page table
-                    bne       L0A7F     ; it's been allocated, skip ahead
-                    bsr       L0A89     ; allocate the page
-                    bcs       L0A88     ; error allocating, return
+                    bne       FFind64FindEmptySpotPathTable ; it's been allocated, skip ahead
+                    bsr       FFind64Target ; allocate the page
+                    bcs       FFind64Return2 ; error allocating, return
                     stx       ,x        ; save base address in page table
                     stx       R$X,u     ; save base address to caller's X
-L0A7F               bsr       L0A9F     ; find a empty spot in path table
-                    bcs       L0A88     ; couldn't find one, return error
+FFind64FindEmptySpotPathTable bsr       FFind64BasePagePtrs ; find a empty spot in path table
+                    bcs       FFind64Return2 ; couldn't find one, return error
                     sta       R$A,u     ; save block #
                     sty       R$Y,u     ; save address of block
-L0A88               rts                 ; return
+FFind64Return2      rts                 ; return
 
 * Allocate a new base page
 * Exit: X=Ptr to newly allocated 256 byte page
-L0A89               pshs      u         ; preserve register stack pointer
+FFind64Target       pshs      u         ; preserve register stack pointer
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldq       #$01000100 ; get block size (1 for SRqMem & 1 for TFM)
                   ELSE
@@ -73,7 +73,7 @@ L0A89               pshs      u         ; preserve register stack pointer
                     leax      ,u        ; point to it
                     ldu       ,s        ; restore register stack pointer
                     stx       ,s        ; save pointer to new page on stack
-                    bcs       L0A9E     ; error on allocate, return
+                    bcs       FFind64Target2 ; error on allocate, return
 * Clear freshly allocated page to 0's
                   IFNE    H6309   ; begin conditional assembly for H6309
                     leay      TFMNull,pc ; point to NULL byte
@@ -84,7 +84,7 @@ AllLoop             clr       ,x+       ; clear ,x+
                     decb                ; decrement B
                     bne       AllLoop   ; branch if zero is clear to AllLoop
                   ENDC
-L0A9E               puls      x,pc      ; restore x,pc from the stack
+FFind64Target2      puls      x,pc      ; restore x,pc from the stack
 
                   IFNE    H6309   ; begin conditional assembly for H6309
 TFMNull             fcb       0         ; used to clear memory
@@ -92,43 +92,43 @@ TFMNull             fcb       0         ; used to clear memory
 
 * Search page table for a free 64 byte block
 * Entry: X=Ptr to base page (the one with the 64 entry page index)
-L0A9F               pshs      x,u       ; preserve base page & register stack ptrs
+FFind64BasePagePtrs pshs      x,u       ; preserve base page & register stack ptrs
                     clra                ; index entry #=0
 * Main search loop
-L0AA2               pshs      a         ; save which index entry we are checking
+FFind64WhichIndexEntryWeChecking pshs      a         ; save which index entry we are checking
                     clrb                ; set position within page we are checking to 0
                     lda       a,x       ; is the current index entry used?
-                    beq       L0AB4     ; no, skip ahead
+                    beq       FFind64FlagDidntFind ; no, skip ahead
                     tfr       d,y       ; yes, Move ptr to 256 byte block to Y
                     clra                ; clear offset for 64 byte blocks to 0
-L0AAC               tst       d,y       ; is this 64 byte block allocated?
-                    beq       L0AB6     ; no, skip ahead
+FFind64BlockAllocated tst       d,y       ; is this 64 byte block allocated?
+                    beq       FFind64Target3 ; no, skip ahead
                     addb      #$40      ; yes, point to next 64 byte block in page
-                    bcc       L0AAC     ; if not done checking entire page, keep going
+                    bcc       FFind64BlockAllocated ; if not done checking entire page, keep going
 
 * Index entry has a totally unused 256 byte page
-L0AB4               orcc      #Carry    ; set flag (didn't find one)
-L0AB6               leay      d,y       ; compute d,y into Y
+FFind64FlagDidntFind orcc      #Carry    ; set flag (didn't find one)
+FFind64Target3      leay      d,y       ; compute d,y into Y
                     puls      a         ; get which index entry we were checking
-                    bcc       L0AE1     ; if we found a blank entry, go allocate it
+                    bcc       FFind64Join ; if we found a blank entry, go allocate it
                     inca                ; didn't, move to next index entry
                     cmpa      #64       ; done entire index?
-                    blo       L0AA2     ; no, keep looking
+                    blo       FFind64WhichIndexEntryWeChecking ; no, keep looking
 
                     clra                ; yes, clear out to first entry
-L0AC2               tst       a,x       ; is this one used?
-                    beq       L0AD0     ; no, skip ahead
+FFind64Used         tst       a,x       ; is this one used?
+                    beq       FFind64IndexIndexEntry ; no, skip ahead
                     inca                ; increment index entry #
                     cmpa      #64       ; done entire index?
-                    blo       L0AC2     ; no, continue looking
+                    blo       FFind64Used ; no, continue looking
 
                     comb                ; done all of them, exit with Path table full error
                     ldb       #E$PthFul ; load B from #E$PthFul
                     puls      x,u,pc    ; restore x,u,pc from the stack
 * Found empty page
-L0AD0               pshs      x,a       ; preserve index ptr & index entry #
-                    bsr       L0A89     ; allocate & clear out new 256 byte page
-                    bcs       L0AF0     ; if error,exit
+FFind64IndexIndexEntry pshs      x,a       ; preserve index ptr & index entry #
+                    bsr       FFind64Target ; allocate & clear out new 256 byte page
+                    bcs       FFind64AdjustBy ; if error,exit
                     leay      ,x        ; point Y to start of new page
                     tfr       x,d       ; also copy to D
                     tfr       a,b       ; page # into B
@@ -137,7 +137,7 @@ L0AD0               pshs      x,a       ; preserve index ptr & index entry #
                     clrb                ; D=index entry #*256
 
 * D = Block Address
-L0AE1               equ       *         ; define assembler symbol L0AE1
+FFind64Join         equ       *         ; define assembler symbol FFind64Join
                   IFNE    H6309   ; begin conditional assembly for H6309
                     lsld                ; ???Calculate 256 byte page #?
                     lsld                ; shift or rotate and update condition codes
@@ -158,7 +158,7 @@ ClrIt               clr       b,y       ; clear b,y
                     sta       ,y        ; save 256 byte page # as 1st byte of block
                     puls      x,u,pc    ; restore x,u,pc from the stack
 
-L0AF0               leas      3,s       ; adjust stack pointer by 3,s
+FFind64AdjustBy     leas      3,s       ; adjust stack pointer by 3,s
                     puls      x,u,pc    ; restore x,u,pc from the stack
 
 
@@ -179,7 +179,7 @@ FRet64              lda       R$A,u     ; load A from R$A,u
                     pshs      u,y,x,d   ; save u,y,x,d on the stack
                     clrb                ; clear B
                     tsta                ; test A and update condition codes
-                    beq       L0B22     ; branch if zero is set to L0B22
+                    beq       FFind64Target5 ; branch if zero is set to FFind64Target5
                   IFNE    H6309   ; begin conditional assembly for H6309
                     lsrd                ; (Divide by 4)
                     lsrd                ; shift or rotate and update condition codes
@@ -191,19 +191,19 @@ FRet64              lda       R$A,u     ; load A from R$A,u
                   ENDC
                     pshs      a         ; save a on the stack
                     lda       a,x       ; load A from a,x
-                    beq       L0B20     ; branch if zero is set to L0B20
+                    beq       FFind64Target4 ; branch if zero is set to FFind64Target4
                     tfr       d,y       ; transfer register value d,y
                     clr       ,y        ; clear ,y
                     clrb                ; clear B
                     tfr       d,u       ; transfer register value d,u
                     clra                ; clear A
-L0B10               tst       d,u       ; test d,u and update condition codes
-                    bne       L0B20     ; branch if zero is clear to L0B20
+FFind64TestCodes    tst       d,u       ; test d,u and update condition codes
+                    bne       FFind64Target4 ; branch if zero is clear to FFind64Target4
                     addb      #$40      ; add #$40 to B
-                    bne       L0B10     ; branch if zero is clear to L0B10
+                    bne       FFind64TestCodes ; branch if zero is clear to FFind64TestCodes
                     inca                ; increment A
                     os9       F$SRtMem  ; call OS-9 service F$SRtMem
                     lda       ,s        ; load A from ,s
                     clr       a,x       ; clear a,x
-L0B20               clr       ,s+       ; clear ,s+
-L0B22               puls      pc,u,y,x,d ; restore pc,u,y,x,d from the stack
+FFind64Target4      clr       ,s+       ; clear ,s+
+FFind64Target5      puls      pc,u,y,x,d ; restore pc,u,y,x,d from the stack

--- a/level2/modules/kernel/ffmodul.asm
+++ b/level2/modules/kernel/ffmodul.asm
@@ -14,35 +14,35 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FFModul             pshs      u                   preserve register stack pointer
-                    lda       R$A,u               get module type
-                    ldx       R$X,u               get pointer to name
-                    ldy       R$Y,u               get pointer to DAT image of name (from caller)
-                    bsr       L068D               go find it
-                    puls      y                   restore register stack pointer
-                    std       R$D,y               save type & revision
-                    stx       R$X,y               save updated name pointer
-                    stu       R$U,y               save pointer to directory entry
-                    rts                           return
+FFModul             pshs      u         ; preserve register stack pointer
+                    lda       R$A,u     ; get module type
+                    ldx       R$X,u     ; get pointer to name
+                    ldy       R$Y,u     ; get pointer to DAT image of name (from caller)
+                    bsr       L068D     ; go find it
+                    puls      y         ; restore register stack pointer
+                    std       R$D,y     ; save type & revision
+                    stx       R$X,y     ; save updated name pointer
+                    stu       R$U,y     ; save pointer to directory entry
+                    rts                 ; return
 
 * Find module in module directory
 * Entry: A=Module type
 *        X=Pointer to module name
 *        Y=DAT image pointer for module name
-L068D               equ       *
-                    IFNE      H6309
-                    tfr       0,u                 init directory pointer to nothing
-                    ELSE
-                    ldu       #$0000
-                    ENDC
-                    pshs      d,u                 preserve (Why B?)
-                    bsr       L0712               Go find 1st char of module name requested
-                    cmpa      #PDELIM             Is it a '/'?
-                    beq       L070B               yes, exit with error
-                    lbsr      ParseNam            parse the name to find the end & length
-                    bcs       L070E               error (illegal name), exit
-                    ldu       <D.ModEnd           get module directory end pointer
-                    bra       L0700               start looking for it
+L068D               equ       *         ; define assembler symbol L068D
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,u       ; init directory pointer to nothing
+                  ELSE
+                    ldu       #$0000    ; load U from #$0000
+                  ENDC
+                    pshs      d,u       ; preserve (Why B?)
+                    bsr       L0712     ; go find 1st char of module name requested
+                    cmpa      #PDELIM   ; is it a '/'?
+                    beq       L070B     ; yes, exit with error
+                    lbsr      ParseNam  ; parse the name to find the end & length
+                    bcs       L070E     ; error (illegal name), exit
+                    ldu       <D.ModEnd ; get module directory end pointer
+                    bra       L0700     ; start looking for it
 
 * Main module directory search
 * Entry: A=Module type
@@ -50,23 +50,23 @@ L068D               equ       *
 *        X=Logical address of name in Caller's 64k space
 *        Y=DAT image of caller (for module name)
 *        U=Module directory Entry ptr (current module being checked)
-L06A1               pshs      d,x,y               Preserve Mod type/nm len, Log. Addr, DAT Img ptr
-                    pshs      x,y                 Preserve Log. addr & DAT Img ptr
-                    ldy       MD$MPDAT,u          Does the module have a DAT Image ptr?
-                    beq       L06F6               no, skip module
-                    ldx       MD$MPtr,u           get module pointer
-                    pshs      x,y                 Save module ptr & DAT Img ptr of module
-                    ldd       #M$Name             # bytes to go in to get module name ptr
-                    lbsr      L0B02               Go get the module name offset from module start (direct F$LDDXY call)
-                    IFNE      H6309
-                    addr      d,x                 add it to module start
-                    ELSE
-                    leax      d,x
-                    ENDC
-                    pshs      x,y                 preserve module name ptr & DAT pointer
-                    leax      8,s                 Point to addr of name we are searching for
-                    ldb       13,s                get name length
-                    leay      ,s                  point to module name name ptr within module DAT
+L06A1               pshs      d,x,y     ; preserve Mod type/nm len, Log. Addr, DAT Img ptr
+                    pshs      x,y       ; preserve Log. addr & DAT Img ptr
+                    ldy       MD$MPDAT,u ; does the module have a DAT Image ptr?
+                    beq       L06F6     ; no, skip module
+                    ldx       MD$MPtr,u ; get module pointer
+                    pshs      x,y       ; save module ptr & DAT Img ptr of module
+                    ldd       #M$Name   ; # bytes to go in to get module name ptr
+                    lbsr      L0B02     ; go get the module name offset from module start (direct F$LDDXY call)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,x       ; add it to module start
+                  ELSE
+                    leax      d,x       ; compute d,x into X
+                  ENDC
+                    pshs      x,y       ; preserve module name ptr & DAT pointer
+                    leax      8,s       ; point to addr of name we are searching for
+                    ldb       13,s      ; get name length
+                    leay      ,s        ; point to module name name ptr within module DAT
 * Stack:
 * 0-1,s = Ptr to module name within Module DAT Img
 * 2-3,s = Ptr to module's DAT Img
@@ -81,49 +81,49 @@ L06A1               pshs      d,x,y               Preserve Mod type/nm len, Log.
 * 12,s  = Module type looking for
 * 13,s  = ??? (B from entry)
 * 14-15,s = Module directory ptr (inited to 0)
-                    lbsr      L07DE               compare the names (direct call to F$CmpNam)
-                    leas      4,s                 purge stack
-                    puls      y,x                 restore module pointer & DAT image
-                    leas      4,s                 purge stack
-                    bcs       L06FE               name didn't match, skip ahead
-                    ldd       #M$Type             Offset ptr to module type
-                    lbsr      L0B02               Get it
-                    sta       ,s                  Save high byte
-                    stb       $07,s               And low byte
-                    lda       $06,s               Get type/language we are looking for
-                    beq       L06ED               0 means don't care on either, so skip ahead
-                    anda      #TypeMask           Keep just type
-                    beq       L06E1               Type 0 means don't care, skip ahead
-                    eora      ,s
-                    anda      #TypeMask           does it match?
-                    bne       L06FE               No, check next module
-L06E1               lda       $06,s               Get type/language we are looking for again
-                    anda      #LangMask           Keep just Language
-                    beq       L06ED               0=don't care, skip ahead
-                    eora      ,s                  Does it match language we are looking for?
-                    anda      #LangMask
-                    bne       L06FE               No, check next module
-L06ED               puls      y,x,d               Found match, restore regs
-                    abx
-                    clrb
-                    ldb       1,s
-                    leas      4,s                 purge stack and return no error
-                    rts
+                    lbsr      L07DE     ; compare the names (direct call to F$CmpNam)
+                    leas      4,s       ; purge stack
+                    puls      y,x       ; restore module pointer & DAT image
+                    leas      4,s       ; purge stack
+                    bcs       L06FE     ; name didn't match, skip ahead
+                    ldd       #M$Type   ; offset ptr to module type
+                    lbsr      L0B02     ; get it
+                    sta       ,s        ; save high byte
+                    stb       $07,s     ; and low byte
+                    lda       $06,s     ; get type/language we are looking for
+                    beq       L06ED     ; 0 means don't care on either, so skip ahead
+                    anda      #TypeMask ; keep just type
+                    beq       L06E1     ; type 0 means don't care, skip ahead
+                    eora      ,s        ; exclusive-OR A with ,s
+                    anda      #TypeMask ; does it match?
+                    bne       L06FE     ; no, check next module
+L06E1               lda       $06,s     ; get type/language we are looking for again
+                    anda      #LangMask ; keep just Language
+                    beq       L06ED     ; 0=don't care, skip ahead
+                    eora      ,s        ; does it match language we are looking for?
+                    anda      #LangMask ; mask A with #LangMask
+                    bne       L06FE     ; no, check next module
+L06ED               puls      y,x,d     ; found match, restore regs
+                    abx                 ; update processor state
+                    clrb                ; clear B
+                    ldb       1,s       ; load B from 1,s
+                    leas      4,s       ; purge stack and return no error
+                    rts                 ; return to caller
 
-L06F6               leas      4,s                 purge stack
-                    ldd       8,s                 do we have a directory pointer?
-                    bne       L06FE               yes, skip ahead
-                    stu       8,s                 save directory entry pointer
-L06FE               puls      d,x,y               restore pointers
-L0700               leau      -MD$ESize,u         move back 1 entry in module table
-                    cmpu      <D.ModDir           at the beginning?
-                    bhs       L06A1               no, check entry
-                    ldb       #E$MNF              get error code (module not found)
-                    fcb       $8C                 skip 2 bytes
-L070B               ldb       #E$BNam             get error code
-                    coma                          set carry for error
-L070E               stb       1,s                 save error code for caller
-                    puls      d,u,pc              return
+L06F6               leas      4,s       ; purge stack
+                    ldd       8,s       ; do we have a directory pointer?
+                    bne       L06FE     ; yes, skip ahead
+                    stu       8,s       ; save directory entry pointer
+L06FE               puls      d,x,y     ; restore pointers
+L0700               leau      -MD$ESize,u ; move back 1 entry in module table
+                    cmpu      <D.ModDir ; at the beginning?
+                    bhs       L06A1     ; no, check entry
+                    ldb       #E$MNF    ; get error code (module not found)
+                    fcb       $8C       ; skip 2 bytes
+L070B               ldb       #E$BNam   ; get error code
+                    coma                ; set carry for error
+L070E               stb       1,s       ; save error code for caller
+                    puls      d,u,pc    ; return
 
 * Skip spaces in name string & return first character of name
 * Entry: X=Pointer to name
@@ -131,16 +131,16 @@ L070E               stb       1,s                 save error code for caller
 * Exit : A=First character of name
 *        B=DAT image block offset
 *        X=Logical address of name
-L0712               pshs      y                   preserve DAT image pointer
-L0714               lbsr      AdjBlk0             adjust pointer to offset for mapping in
-                    lbsr      L0AC8               map in block
-                    leax      1,x
-                    cmpa      #C$SPAC             space?
-                    beq       L0714               yes, eat it
-                    leax      -1,x                move back to first character
-L0720               pshs      d,cc                preserve char
-                    tfr       y,d                 copy DAT pointer to D
-                    subd      3,s                 calculate DAT image offset
-                    asrb                          divide it by 2
-                    lbsr      CmpLBlk             convert X to logical address in 64k map
-                    puls      cc,d,y,pc           restore & return
+L0712               pshs      y         ; preserve DAT image pointer
+L0714               lbsr      AdjBlk0   ; adjust pointer to offset for mapping in
+                    lbsr      L0AC8     ; map in block
+                    leax      1,x       ; compute 1,x into X
+                    cmpa      #C$SPAC   ; space?
+                    beq       L0714     ; yes, eat it
+                    leax      -1,x      ; move back to first character
+L0720               pshs      d,cc      ; preserve char
+                    tfr       y,d       ; copy DAT pointer to D
+                    subd      3,s       ; calculate DAT image offset
+                    asrb                ; divide it by 2
+                    lbsr      CmpLBlk   ; convert X to logical address in 64k map
+                    puls      cc,d,y,pc ; restore & return

--- a/level2/modules/kernel/ffmodul.asm
+++ b/level2/modules/kernel/ffmodul.asm
@@ -18,7 +18,7 @@ FFModul             pshs      u         ; preserve register stack pointer
                     lda       R$A,u     ; get module type
                     ldx       R$X,u     ; get pointer to name
                     ldy       R$Y,u     ; get pointer to DAT image of name (from caller)
-                    bsr       L068D     ; go find it
+                    bsr       FFmodulJoin ; go find it
                     puls      y         ; restore register stack pointer
                     std       R$D,y     ; save type & revision
                     stx       R$X,y     ; save updated name pointer
@@ -29,20 +29,20 @@ FFModul             pshs      u         ; preserve register stack pointer
 * Entry: A=Module type
 *        X=Pointer to module name
 *        Y=DAT image pointer for module name
-L068D               equ       *         ; define assembler symbol L068D
+FFmodulJoin         equ       *         ; define assembler symbol FFmodulJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       0,u       ; init directory pointer to nothing
                   ELSE
                     ldu       #$0000    ; load U from #$0000
                   ENDC
                     pshs      d,u       ; preserve (Why B?)
-                    bsr       L0712     ; go find 1st char of module name requested
+                    bsr       FFmodulDATImage ; go find 1st char of module name requested
                     cmpa      #PDELIM   ; is it a '/'?
-                    beq       L070B     ; yes, exit with error
+                    beq       FFmodulError ; yes, exit with error
                     lbsr      ParseNam  ; parse the name to find the end & length
-                    bcs       L070E     ; error (illegal name), exit
+                    bcs       FFmodulError2 ; error (illegal name), exit
                     ldu       <D.ModEnd ; get module directory end pointer
-                    bra       L0700     ; start looking for it
+                    bra       FFmodulBackEntryModuleTable ; start looking for it
 
 * Main module directory search
 * Entry: A=Module type
@@ -50,14 +50,14 @@ L068D               equ       *         ; define assembler symbol L068D
 *        X=Logical address of name in Caller's 64k space
 *        Y=DAT image of caller (for module name)
 *        U=Module directory Entry ptr (current module being checked)
-L06A1               pshs      d,x,y     ; preserve Mod type/nm len, Log. Addr, DAT Img ptr
+FFmodulModuleTypeNmLenLog pshs      d,x,y     ; preserve Mod type/nm len, Log. Addr, DAT Img ptr
                     pshs      x,y       ; preserve Log. addr & DAT Img ptr
                     ldy       MD$MPDAT,u ; does the module have a DAT Image ptr?
-                    beq       L06F6     ; no, skip module
+                    beq       FFmodulPurge ; no, skip module
                     ldx       MD$MPtr,u ; get module pointer
                     pshs      x,y       ; save module ptr & DAT Img ptr of module
                     ldd       #M$Name   ; # bytes to go in to get module name ptr
-                    lbsr      L0B02     ; go get the module name offset from module start (direct F$LDDXY call)
+                    lbsr      FLdTarget ; go get the module name offset from module start (direct F$LDDXY call)
                   IFNE    H6309   ; begin conditional assembly for H6309
                     addr      d,x       ; add it to module start
                   ELSE
@@ -81,48 +81,48 @@ L06A1               pshs      d,x,y     ; preserve Mod type/nm len, Log. Addr, D
 * 12,s  = Module type looking for
 * 13,s  = ??? (B from entry)
 * 14-15,s = Module directory ptr (inited to 0)
-                    lbsr      L07DE     ; compare the names (direct call to F$CmpNam)
+                    lbsr      FCmpnamTarget ; compare the names (direct call to F$CmpNam)
                     leas      4,s       ; purge stack
                     puls      y,x       ; restore module pointer & DAT image
                     leas      4,s       ; purge stack
-                    bcs       L06FE     ; name didn't match, skip ahead
+                    bcs       FFmodulPointers ; name didn't match, skip ahead
                     ldd       #M$Type   ; offset ptr to module type
-                    lbsr      L0B02     ; get it
+                    lbsr      FLdTarget ; get it
                     sta       ,s        ; save high byte
                     stb       $07,s     ; and low byte
                     lda       $06,s     ; get type/language we are looking for
-                    beq       L06ED     ; 0 means don't care on either, so skip ahead
+                    beq       FFmodulFoundMatch ; 0 means don't care on either, so skip ahead
                     anda      #TypeMask ; keep just type
-                    beq       L06E1     ; type 0 means don't care, skip ahead
+                    beq       FFmodulTypeLanguageWeLookingAgain ; type 0 means don't care, skip ahead
                     eora      ,s        ; exclusive-OR A with ,s
                     anda      #TypeMask ; does it match?
-                    bne       L06FE     ; no, check next module
-L06E1               lda       $06,s     ; get type/language we are looking for again
+                    bne       FFmodulPointers ; no, check next module
+FFmodulTypeLanguageWeLookingAgain lda       $06,s     ; get type/language we are looking for again
                     anda      #LangMask ; keep just Language
-                    beq       L06ED     ; 0=don't care, skip ahead
+                    beq       FFmodulFoundMatch ; 0=don't care, skip ahead
                     eora      ,s        ; does it match language we are looking for?
                     anda      #LangMask ; mask A with #LangMask
-                    bne       L06FE     ; no, check next module
-L06ED               puls      y,x,d     ; found match, restore regs
+                    bne       FFmodulPointers ; no, check next module
+FFmodulFoundMatch   puls      y,x,d     ; found match, restore regs
                     abx                 ; update processor state
                     clrb                ; clear B
                     ldb       1,s       ; load B from 1,s
                     leas      4,s       ; purge stack and return no error
                     rts                 ; return to caller
 
-L06F6               leas      4,s       ; purge stack
+FFmodulPurge        leas      4,s       ; purge stack
                     ldd       8,s       ; do we have a directory pointer?
-                    bne       L06FE     ; yes, skip ahead
+                    bne       FFmodulPointers ; yes, skip ahead
                     stu       8,s       ; save directory entry pointer
-L06FE               puls      d,x,y     ; restore pointers
-L0700               leau      -MD$ESize,u ; move back 1 entry in module table
+FFmodulPointers     puls      d,x,y     ; restore pointers
+FFmodulBackEntryModuleTable leau      -MD$ESize,u ; move back 1 entry in module table
                     cmpu      <D.ModDir ; at the beginning?
-                    bhs       L06A1     ; no, check entry
+                    bhs       FFmodulModuleTypeNmLenLog ; no, check entry
                     ldb       #E$MNF    ; get error code (module not found)
                     fcb       $8C       ; skip 2 bytes
-L070B               ldb       #E$BNam   ; get error code
+FFmodulError        ldb       #E$BNam   ; get error code
                     coma                ; set carry for error
-L070E               stb       1,s       ; save error code for caller
+FFmodulError2       stb       1,s       ; save error code for caller
                     puls      d,u,pc    ; return
 
 * Skip spaces in name string & return first character of name
@@ -131,14 +131,14 @@ L070E               stb       1,s       ; save error code for caller
 * Exit : A=First character of name
 *        B=DAT image block offset
 *        X=Logical address of name
-L0712               pshs      y         ; preserve DAT image pointer
-L0714               lbsr      AdjBlk0   ; adjust pointer to offset for mapping in
-                    lbsr      L0AC8     ; map in block
+FFmodulDATImage     pshs      y         ; preserve DAT image pointer
+FFmodulAdjustOffsetMapping lbsr      AdjBlk0   ; adjust pointer to offset for mapping in
+                    lbsr      FLdMMUBlockData ; map in block
                     leax      1,x       ; compute 1,x into X
                     cmpa      #C$SPAC   ; space?
-                    beq       L0714     ; yes, eat it
+                    beq       FFmodulAdjustOffsetMapping ; yes, eat it
                     leax      -1,x      ; move back to first character
-L0720               pshs      d,cc      ; preserve char
+FFmodulChar         pshs      d,cc      ; preserve char
                     tfr       y,d       ; copy DAT pointer to D
                     subd      3,s       ; calculate DAT image offset
                     asrb                ; divide it by 2

--- a/level2/modules/kernel/ffmodul.asm
+++ b/level2/modules/kernel/ffmodul.asm
@@ -42,7 +42,7 @@ FFmodulJoin         equ       *         ; define assembler symbol FFmodulJoin
                     lbsr      ParseNam  ; parse the name to find the end & length
                     bcs       FFmodulError2 ; error (illegal name), exit
                     ldu       <D.ModEnd ; get module directory end pointer
-                    bra       FFmodulBackEntryModuleTable ; start looking for it
+                    bra       FFmodulBackEntryMod ; start looking for it
 
 * Main module directory search
 * Entry: A=Module type
@@ -50,7 +50,7 @@ FFmodulJoin         equ       *         ; define assembler symbol FFmodulJoin
 *        X=Logical address of name in Caller's 64k space
 *        Y=DAT image of caller (for module name)
 *        U=Module directory Entry ptr (current module being checked)
-FFmodulModuleTypeNmLenLog pshs      d,x,y     ; preserve Mod type/nm len, Log. Addr, DAT Img ptr
+FFmodulModTypeNm    pshs      d,x,y     ; preserve Mod type/nm len, Log. Addr, DAT Img ptr
                     pshs      x,y       ; preserve Log. addr & DAT Img ptr
                     ldy       MD$MPDAT,u ; does the module have a DAT Image ptr?
                     beq       FFmodulPurge ; no, skip module
@@ -93,11 +93,11 @@ FFmodulModuleTypeNmLenLog pshs      d,x,y     ; preserve Mod type/nm len, Log. A
                     lda       $06,s     ; get type/language we are looking for
                     beq       FFmodulFoundMatch ; 0 means don't care on either, so skip ahead
                     anda      #TypeMask ; keep just type
-                    beq       FFmodulTypeLanguageWeLookingAgain ; type 0 means don't care, skip ahead
+                    beq       FFmodulTypeLangWe ; type 0 means don't care, skip ahead
                     eora      ,s        ; exclusive-OR A with ,s
                     anda      #TypeMask ; does it match?
                     bne       FFmodulPointers ; no, check next module
-FFmodulTypeLanguageWeLookingAgain lda       $06,s     ; get type/language we are looking for again
+FFmodulTypeLangWe   lda       $06,s     ; get type/language we are looking for again
                     anda      #LangMask ; keep just Language
                     beq       FFmodulFoundMatch ; 0=don't care, skip ahead
                     eora      ,s        ; does it match language we are looking for?
@@ -115,9 +115,9 @@ FFmodulPurge        leas      4,s       ; purge stack
                     bne       FFmodulPointers ; yes, skip ahead
                     stu       8,s       ; save directory entry pointer
 FFmodulPointers     puls      d,x,y     ; restore pointers
-FFmodulBackEntryModuleTable leau      -MD$ESize,u ; move back 1 entry in module table
+FFmodulBackEntryMod leau      -MD$ESize,u ; move back 1 entry in module table
                     cmpu      <D.ModDir ; at the beginning?
-                    bhs       FFmodulModuleTypeNmLenLog ; no, check entry
+                    bhs       FFmodulModTypeNm ; no, check entry
                     ldb       #E$MNF    ; get error code (module not found)
                     fcb       $8C       ; skip 2 bytes
 FFmodulError        ldb       #E$BNam   ; get error code
@@ -132,11 +132,11 @@ FFmodulError2       stb       1,s       ; save error code for caller
 *        B=DAT image block offset
 *        X=Logical address of name
 FFmodulDATImage     pshs      y         ; preserve DAT image pointer
-FFmodulAdjustOffsetMapping lbsr      AdjBlk0   ; adjust pointer to offset for mapping in
+FFmodulAdjstOffMap  lbsr      AdjBlk0   ; adjust pointer to offset for mapping in
                     lbsr      FLdMMUBlockData ; map in block
                     leax      1,x       ; compute 1,x into X
                     cmpa      #C$SPAC   ; space?
-                    beq       FFmodulAdjustOffsetMapping ; yes, eat it
+                    beq       FFmodulAdjstOffMap ; yes, eat it
                     leax      -1,x      ; move back to first character
 FFmodulChar         pshs      d,cc      ; preserve char
                     tfr       y,d       ; copy DAT pointer to D

--- a/level2/modules/kernel/ffreehb.asm
+++ b/level2/modules/kernel/ffreehb.asm
@@ -12,44 +12,44 @@
 
 FFreeHB             ldb       R$B,u     ; get the number blocks requested
                     ldy       R$Y,u     ; get the DAT image pointer
-                    bsr       L0A31     ; go find free blocks in high part of DAT
-L0A2C               bcs       L0A30     ; couldn't find any, exit with error
+                    bsr       FFreehbNumberBlocksRequested ; go find free blocks in high part of DAT
+FFreehbErrorExit    bcs       FFreehbReturn ; couldn't find any, exit with error
                     sta       R$A,u     ; save the starting block number
-L0A30               rts                 ; return
+FFreehbReturn       rts                 ; return
 
-L0A31               tfr       b,a       ; copy the number blocks requested to A
+FFreehbNumberBlocksRequested tfr       b,a       ; copy the number blocks requested to A
 * This gets called directly from within F$Link
-L0A33               suba      #$09      ; invert within 8
+FFreehbInvertWithin suba      #$09      ; invert within 8
                     nega                ; negate
                     pshs      x,d       ; save X, the block number and the block count
                     ldd       #$FFFF    ; -1
-L0A56               pshs      d         ; save the value on the stack
+FFreehbTarget       pshs      d         ; save the value on the stack
 
 * Move to next block - SHOULD OPTIMIZE WITH W
-L0A58               clra                ; number free blocks found so far=0
+FFreehbNumberFreeBlocksFoundSo clra                ; number free blocks found so far=0
                     ldb       2,s       ; get the block number
                     addb      ,s        ; add the block increment (point to next block)
                     stb       2,s       ; save the new block number to check
                     cmpb      1,s       ; same as block count?
-                    bne       L0A75     ; no, skip ahead
+                    bne       FFreehbMultiplyBlockNumberBy ; no, skip ahead
                     ldb       #E$MemFul ; preset error for 207 (process memory full)
                     cmpy      <D.SysDAT ; is it the system process?
-                    bne       L0A6C     ; no, exit with error 207
+                    bne       FFreehbError ; no, exit with error 207
                     ldb       #E$NoRAM  ; system memory full (237)
-L0A6C               stb       3,s       ; save the error code
+FFreehbError        stb       3,s       ; save the error code
                     comb                ; set the carry
-                    bra       L0A82     ; exit with error
+                    bra       FFreehbEatTemporary ; exit with error
 
-L0A71               tfr       a,b       ; copy the number of blocks to B
+FFreehbNumberBlocks tfr       a,b       ; copy the number of blocks to B
                     addb      2,s       ; add the current start block number
-L0A75               lslb                ; multiply the block number by 2
+FFreehbMultiplyBlockNumberBy lslb                ; multiply the block number by 2
                     ldx       b,y       ; get the DAT marker for that block
                     cmpx      #DAT.Free ; is it an empty block?
-                    bne       L0A58     ; no, move to the next block
+                    bne       FFreehbNumberFreeBlocksFoundSo ; no, move to the next block
                     inca                ; bump up the number blocks free counter
                     cmpa      3,s       ; have we got enough?
-                    bne       L0A71     ; no, keep looking
-L0A82               leas      2,s       ; eat the temporary stack
+                    bne       FFreehbNumberBlocks ; no, keep looking
+FFreehbEatTemporary leas      2,s       ; eat the temporary stack
                     puls      d,x,pc    ; restore registers, error code, and return
 
 
@@ -69,16 +69,16 @@ L0A82               leas      2,s       ; eat the temporary stack
 * Rodney says: "It's called via os9p1 syscall vector in line 393"
 FSFreeLB            ldb       R$B,u     ; get the block count
                     ldy       R$Y,u     ; get the pointer to DAT Image
-                    bsr       L0A4B     ; go find the block numbers
-                    bra       L0A2C     ; do error checking and exit
+                    bsr       FFreehbStartLoopBlockLoop ; go find the block numbers
+                    bra       FFreehbErrorExit ; do error checking and exit
 
-L0A4B               lda       #$FF      ; the value to start the loop at block 0
+FFreehbStartLoopBlockLoop lda       #$FF      ; the value to start the loop at block 0
                     pshs      x,d       ; preserve X, flag, and block count
 *         lda   #$01           number to add to go to the next block (positive here)
                     nega                ; -(-1)=+1
                     subb      #9        ; drop the block count to -8 to -1 (invert within 8)
                     negb                ; negate so it is a positive number again
-                    bra       L0A56     ; go into the main find loop
+                    bra       FFreehbTarget ; go into the main find loop
 
 
 ;;; F$SetImg
@@ -98,7 +98,7 @@ L0A4B               lda       #$FF      ; the value to start the loop at block 0
 FSetImg             ldd       R$D,u     ; get the starting image block number and blcok count
                     ldx       R$X,u     ; get the process descriptor pointer
                     ldu       R$U,u     ; get the new image pointer
-L0A8C               pshs      d,x,y,u   ; save these onto the stack
+FFreehbTheseOnto    pshs      d,x,y,u   ; save these onto the stack
                     leay      <P$DATImg,x ; point to the DAT image within the process descriptor
                     lsla                ; multiply the starting image block number by 2
                     leay      a,y       ; point Y into the starting point of the DAT image area of the process descriptor

--- a/level2/modules/kernel/ffreehb.asm
+++ b/level2/modules/kernel/ffreehb.asm
@@ -12,12 +12,12 @@
 
 FFreeHB             ldb       R$B,u     ; get the number blocks requested
                     ldy       R$Y,u     ; get the DAT image pointer
-                    bsr       FFreehbNumberBlocksRequested ; go find free blocks in high part of DAT
+                    bsr       FFreehbNumBlksReq ; go find free blocks in high part of DAT
 FFreehbErrorExit    bcs       FFreehbReturn ; couldn't find any, exit with error
                     sta       R$A,u     ; save the starting block number
 FFreehbReturn       rts                 ; return
 
-FFreehbNumberBlocksRequested tfr       b,a       ; copy the number blocks requested to A
+FFreehbNumBlksReq   tfr       b,a       ; copy the number blocks requested to A
 * This gets called directly from within F$Link
 FFreehbInvertWithin suba      #$09      ; invert within 8
                     nega                ; negate
@@ -26,12 +26,12 @@ FFreehbInvertWithin suba      #$09      ; invert within 8
 FFreehbTarget       pshs      d         ; save the value on the stack
 
 * Move to next block - SHOULD OPTIMIZE WITH W
-FFreehbNumberFreeBlocksFoundSo clra                ; number free blocks found so far=0
+FFreehbNumFreeBlks  clra                ; number free blocks found so far=0
                     ldb       2,s       ; get the block number
                     addb      ,s        ; add the block increment (point to next block)
                     stb       2,s       ; save the new block number to check
                     cmpb      1,s       ; same as block count?
-                    bne       FFreehbMultiplyBlockNumberBy ; no, skip ahead
+                    bne       FFreehbMulBlkNum ; no, skip ahead
                     ldb       #E$MemFul ; preset error for 207 (process memory full)
                     cmpy      <D.SysDAT ; is it the system process?
                     bne       FFreehbError ; no, exit with error 207
@@ -42,10 +42,10 @@ FFreehbError        stb       3,s       ; save the error code
 
 FFreehbNumberBlocks tfr       a,b       ; copy the number of blocks to B
                     addb      2,s       ; add the current start block number
-FFreehbMultiplyBlockNumberBy lslb                ; multiply the block number by 2
+FFreehbMulBlkNum    lslb                ; multiply the block number by 2
                     ldx       b,y       ; get the DAT marker for that block
                     cmpx      #DAT.Free ; is it an empty block?
-                    bne       FFreehbNumberFreeBlocksFoundSo ; no, move to the next block
+                    bne       FFreehbNumFreeBlks ; no, move to the next block
                     inca                ; bump up the number blocks free counter
                     cmpa      3,s       ; have we got enough?
                     bne       FFreehbNumberBlocks ; no, keep looking
@@ -69,10 +69,10 @@ FFreehbEatTemporary leas      2,s       ; eat the temporary stack
 * Rodney says: "It's called via os9p1 syscall vector in line 393"
 FSFreeLB            ldb       R$B,u     ; get the block count
                     ldy       R$Y,u     ; get the pointer to DAT Image
-                    bsr       FFreehbStartLoopBlockLoop ; go find the block numbers
+                    bsr       FFreehbStartLoopBlk ; go find the block numbers
                     bra       FFreehbErrorExit ; do error checking and exit
 
-FFreehbStartLoopBlockLoop lda       #$FF      ; the value to start the loop at block 0
+FFreehbStartLoopBlk lda       #$FF      ; the value to start the loop at block 0
                     pshs      x,d       ; preserve X, flag, and block count
 *         lda   #$01           number to add to go to the next block (positive here)
                     nega                ; -(-1)=+1

--- a/level2/modules/kernel/ffreehb.asm
+++ b/level2/modules/kernel/ffreehb.asm
@@ -10,47 +10,47 @@
 ;;; Error:  B = A non-zero error code.
 ;;;        CC = Carry flag set to indicate error.
 
-FFreeHB             ldb       R$B,u               get the number blocks requested
-                    ldy       R$Y,u               get the DAT image pointer
-                    bsr       L0A31               go find free blocks in high part of DAT
-L0A2C               bcs       L0A30               couldn't find any, exit with error
-                    sta       R$A,u               save the starting block number
-L0A30               rts                           return
+FFreeHB             ldb       R$B,u     ; get the number blocks requested
+                    ldy       R$Y,u     ; get the DAT image pointer
+                    bsr       L0A31     ; go find free blocks in high part of DAT
+L0A2C               bcs       L0A30     ; couldn't find any, exit with error
+                    sta       R$A,u     ; save the starting block number
+L0A30               rts                 ; return
 
-L0A31               tfr       b,a                 copy the number blocks requested to A
+L0A31               tfr       b,a       ; copy the number blocks requested to A
 * This gets called directly from within F$Link
-L0A33               suba      #$09                invert within 8
-                    nega                          negate
-                    pshs      x,d                 save X, the block number and the block count
-                    ldd       #$FFFF              -1
-L0A56               pshs      d                   save the value on the stack
+L0A33               suba      #$09      ; invert within 8
+                    nega                ; negate
+                    pshs      x,d       ; save X, the block number and the block count
+                    ldd       #$FFFF    ; -1
+L0A56               pshs      d         ; save the value on the stack
 
 * Move to next block - SHOULD OPTIMIZE WITH W
-L0A58               clra                          number free blocks found so far=0
-                    ldb       2,s                 get the block number
-                    addb      ,s                  add the block increment (point to next block)
-                    stb       2,s                 save the new block number to check
-                    cmpb      1,s                 same as block count?
-                    bne       L0A75               no, skip ahead
-                    ldb       #E$MemFul           preset error for 207 (process memory full)
-                    cmpy      <D.SysDAT           is it the system process?
-                    bne       L0A6C               no, exit with error 207
-                    ldb       #E$NoRAM            system memory full (237)
-L0A6C               stb       3,s                 save the error code
-                    comb                          set the carry
-                    bra       L0A82               exit with error
+L0A58               clra                ; number free blocks found so far=0
+                    ldb       2,s       ; get the block number
+                    addb      ,s        ; add the block increment (point to next block)
+                    stb       2,s       ; save the new block number to check
+                    cmpb      1,s       ; same as block count?
+                    bne       L0A75     ; no, skip ahead
+                    ldb       #E$MemFul ; preset error for 207 (process memory full)
+                    cmpy      <D.SysDAT ; is it the system process?
+                    bne       L0A6C     ; no, exit with error 207
+                    ldb       #E$NoRAM  ; system memory full (237)
+L0A6C               stb       3,s       ; save the error code
+                    comb                ; set the carry
+                    bra       L0A82     ; exit with error
 
-L0A71               tfr       a,b                 copy the number of blocks to B
-                    addb      2,s                 add the current start block number
-L0A75               lslb                          multiply the block number by 2
-                    ldx       b,y                 get the DAT marker for that block
-                    cmpx      #DAT.Free           is it an empty block?
-                    bne       L0A58               no, move to the next block
-                    inca                          bump up the number blocks free counter
-                    cmpa      3,s                 have we got enough?
-                    bne       L0A71               no, keep looking
-L0A82               leas      2,s                 eat the temporary stack
-                    puls      d,x,pc              restore registers, error code, and return
+L0A71               tfr       a,b       ; copy the number of blocks to B
+                    addb      2,s       ; add the current start block number
+L0A75               lslb                ; multiply the block number by 2
+                    ldx       b,y       ; get the DAT marker for that block
+                    cmpx      #DAT.Free ; is it an empty block?
+                    bne       L0A58     ; no, move to the next block
+                    inca                ; bump up the number blocks free counter
+                    cmpa      3,s       ; have we got enough?
+                    bne       L0A71     ; no, keep looking
+L0A82               leas      2,s       ; eat the temporary stack
+                    puls      d,x,pc    ; restore registers, error code, and return
 
 
 ;;; F$FreeLB
@@ -67,18 +67,18 @@ L0A82               leas      2,s                 eat the temporary stack
 
 * WHERE DOES THIS EVER GET CALLED FROM???
 * Rodney says: "It's called via os9p1 syscall vector in line 393"
-FSFreeLB            ldb       R$B,u               get the block count
-                    ldy       R$Y,u               get the pointer to DAT Image
-                    bsr       L0A4B               go find the block numbers
-                    bra       L0A2C               do error checking and exit
+FSFreeLB            ldb       R$B,u     ; get the block count
+                    ldy       R$Y,u     ; get the pointer to DAT Image
+                    bsr       L0A4B     ; go find the block numbers
+                    bra       L0A2C     ; do error checking and exit
 
-L0A4B               lda       #$FF                the value to start the loop at block 0
-                    pshs      x,d                 preserve X, flag, and block count
+L0A4B               lda       #$FF      ; the value to start the loop at block 0
+                    pshs      x,d       ; preserve X, flag, and block count
 *         lda   #$01           number to add to go to the next block (positive here)
-                    nega                          -(-1)=+1
-                    subb      #9                  drop the block count to -8 to -1 (invert within 8)
-                    negb                          negate so it is a positive number again
-                    bra       L0A56               go into the main find loop
+                    nega                ; -(-1)=+1
+                    subb      #9        ; drop the block count to -8 to -1 (invert within 8)
+                    negb                ; negate so it is a positive number again
+                    bra       L0A56     ; go into the main find loop
 
 
 ;;; F$SetImg
@@ -95,28 +95,28 @@ L0A4B               lda       #$FF                the value to start the loop at
 ;;; Error:  B = A non-zero error code.
 ;;;        CC = Carry flag set to indicate error.
 
-FSetImg             ldd       R$D,u               get the starting image block number and blcok count
-                    ldx       R$X,u               get the process descriptor pointer
-                    ldu       R$U,u               get the new image pointer
-L0A8C               pshs      d,x,y,u             save these onto the stack
-                    leay      <P$DATImg,x         point to the DAT image within the process descriptor
-                    lsla                          multiply the starting image block number by 2
-                    leay      a,y                 point Y into the starting point of the DAT image area of the process descriptor
-                    ifne      H6309
-                    clra                          clear the upper 8 bits
-                    lslb                          and multiply the lower 8 bits by 2
-                    tfr       d,w                 transfer the count to W
-                    tfm       u+,y+               perform the transfer
-                    oim       #ImgChg,P$State,x   set the "image changed" flag
-                    else
-                    lslb                          multiply the block count by 2
-loop@               lda       ,u+                 get the new image value
-                    sta       ,y+                 and store it in the process descriptor image area
-                    decb                          decrement the counter
-                    bne       loop@               branch if not done
-                    lda       P$State,x           get the process' state
-                    ora       #ImgChg             set the "image changed" flag
-                    sta       P$State,x           and store it back
-                    endc
-                    clrb                          clear the carry
-                    puls      d,x,y,u,pc          restore the registers and return to the caller
+FSetImg             ldd       R$D,u     ; get the starting image block number and blcok count
+                    ldx       R$X,u     ; get the process descriptor pointer
+                    ldu       R$U,u     ; get the new image pointer
+L0A8C               pshs      d,x,y,u   ; save these onto the stack
+                    leay      <P$DATImg,x ; point to the DAT image within the process descriptor
+                    lsla                ; multiply the starting image block number by 2
+                    leay      a,y       ; point Y into the starting point of the DAT image area of the process descriptor
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clra                ; clear the upper 8 bits
+                    lslb                ; and multiply the lower 8 bits by 2
+                    tfr       d,w       ; transfer the count to W
+                    tfm       u+,y+     ; perform the transfer
+                    oim       #ImgChg,P$State,x ; set the "image changed" flag
+                  ELSE
+                    lslb                ; multiply the block count by 2
+loop@               lda       ,u+       ; get the new image value
+                    sta       ,y+       ; and store it in the process descriptor image area
+                    decb                ; decrement the counter
+                    bne       loop@     ; branch if not done
+                    lda       P$State,x ; get the process' state
+                    ora       #ImgChg   ; set the "image changed" flag
+                    sta       P$State,x ; and store it back
+                  ENDC
+                    clrb                ; clear the carry
+                    puls      d,x,y,u,pc ; restore the registers and return to the caller

--- a/level2/modules/kernel/fgblkmp.asm
+++ b/level2/modules/kernel/fgblkmp.asm
@@ -21,6 +21,6 @@ FGBlkMp             ldd       #DAT.BlSz ; # bytes per MMU block (8k)
                     ldx       <D.Proc   ; get caller's task #
                     ldb       P$Task,x  ; get task # of caller
                     ldx       <D.BlkMap ; get start ptr of system block map
-FGblkmpAddrPutRequested ldu       R$X,u     ; get addr to put it that caller requested
+FGblkmpAddrPutReq   ldu       R$X,u     ; get addr to put it that caller requested
                     os9       F$Move    ; move it into caller's space
                     rts                 ; return to caller

--- a/level2/modules/kernel/fgblkmp.asm
+++ b/level2/modules/kernel/fgblkmp.asm
@@ -11,16 +11,16 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FGBlkMp             ldd       #DAT.BlSz           # bytes per MMU block (8k)
-                    std       R$D,u               Put into caller's D register
-                    ldd       <D.BlkMap+2         Get end of system block map ptr
-                    subd      <D.BlkMap           Subtract start of system block map ptr
-                    std       R$Y,u               Store size of system block map in caller's Y reg.
-                    tfr       d,y
-                    lda       <D.SysTsk           Get system task #
-                    ldx       <D.Proc             Get caller's task #
-                    ldb       P$Task,x            get task # of caller
-                    ldx       <D.BlkMap           Get start ptr of system block map
-L0978               ldu       R$X,u               Get addr to put it that caller requested
-                    os9       F$Move              Move it into caller's space
-                    rts
+FGBlkMp             ldd       #DAT.BlSz ; # bytes per MMU block (8k)
+                    std       R$D,u     ; put into caller's D register
+                    ldd       <D.BlkMap+2 ; get end of system block map ptr
+                    subd      <D.BlkMap ; subtract start of system block map ptr
+                    std       R$Y,u     ; store size of system block map in caller's Y reg.
+                    tfr       d,y       ; transfer register value d,y
+                    lda       <D.SysTsk ; get system task #
+                    ldx       <D.Proc   ; get caller's task #
+                    ldb       P$Task,x  ; get task # of caller
+                    ldx       <D.BlkMap ; get start ptr of system block map
+L0978               ldu       R$X,u     ; get addr to put it that caller requested
+                    os9       F$Move    ; move it into caller's space
+                    rts                 ; return to caller

--- a/level2/modules/kernel/fgblkmp.asm
+++ b/level2/modules/kernel/fgblkmp.asm
@@ -21,6 +21,6 @@ FGBlkMp             ldd       #DAT.BlSz ; # bytes per MMU block (8k)
                     ldx       <D.Proc   ; get caller's task #
                     ldb       P$Task,x  ; get task # of caller
                     ldx       <D.BlkMap ; get start ptr of system block map
-L0978               ldu       R$X,u     ; get addr to put it that caller requested
+FGblkmpAddrPutRequested ldu       R$X,u     ; get addr to put it that caller requested
                     os9       F$Move    ; move it into caller's space
                     rts                 ; return to caller

--- a/level2/modules/kernel/fgcmdir.asm
+++ b/level2/modules/kernel/fgcmdir.asm
@@ -15,13 +15,13 @@
 * Error:  CC = C bit set; B = error code
 *
 FGCMDir             ldx       <D.ModDir ; get pointer to module directory start
-                    bra       FGcmdirEndModuleDirectory ; skip ahead
-FGcmdirDATInitialized ldu       MD$MPDAT,x ; dAT initialized?
+                    bra       FGcmdirEndModDir ; skip ahead
+FGcmdirDATInit      ldu       MD$MPDAT,x ; dAT initialized?
                     beq       FGcmdirEmptyEntry ; no it's empty skip ahead
                     leax      MD$ESize,x ; move to next entry
-FGcmdirEndModuleDirectory cmpx      <D.ModEnd ; end of module directory?
-                    bne       FGcmdirDATInitialized ; no, keep looking
-                    bra       FGcmdirModuleDirectoryDATEnd ; branch unconditionally to FGcmdirModuleDirectoryDATEnd
+FGcmdirEndModDir    cmpx      <D.ModEnd ; end of module directory?
+                    bne       FGcmdirDATInit ; no, keep looking
+                    bra       FGcmdirModDirDAT ; branch unconditionally to FGcmdirModDirDAT
 * Move all entrys up 1 slot in directory
 FGcmdirEmptyEntry   tfr       x,y       ; move empty entry pointer to Y
                     bra       FGcmdirEsize ; branch unconditionally to FGcmdirEsize
@@ -30,7 +30,7 @@ FGcmdirMpdat        ldu       MD$MPDAT,y ; load U from MD$MPDAT,y
 FGcmdirEsize        leay      MD$ESize,y ; compute MD$ESize,y into Y
                     cmpy      <D.ModEnd ; done complete directory?
                     bne       FGcmdirMpdat ; no, keep going
-                    bra       FGcmdirNewModuleDirectoryEnd ; branch unconditionally to FGcmdirNewModuleDirectoryEnd
+                    bra       FGcmdirNewModDir ; branch unconditionally to FGcmdirNewModDir
 * Move entry up 1 slot in directory
 FGcmdirJoin         equ       *         ; define assembler symbol FGcmdirJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -46,24 +46,24 @@ FGcmdirJoin         equ       *         ; define assembler symbol FGcmdirJoin
                     ldu       ,y++      ; load U from ,y++
                     stu       ,x++      ; store U at ,x++
                   ENDC
-FGcmdirCompleteDirectory cmpy      <D.ModEnd ; done complete directory?
+FGcmdirDoneDir      cmpy      <D.ModEnd ; done complete directory?
                     bne       FGcmdirMpdat ; no, keep going
 
-FGcmdirNewModuleDirectoryEnd stx       <D.ModEnd ; save new module directory end pointer
+FGcmdirNewModDir    stx       <D.ModEnd ; save new module directory end pointer
 * Shrink DAT table
-FGcmdirModuleDirectoryDATEnd ldx       <D.ModDir+2 ; get module directory DAT end pointer
-                    bra       FGcmdirBumpModuleDownBy ; branch unconditionally to FGcmdirBumpModuleDownBy
+FGcmdirModDirDAT    ldx       <D.ModDir+2 ; get module directory DAT end pointer
+                    bra       FGcmdirBumpModDown ; branch unconditionally to FGcmdirBumpModDown
 
 FGcmdirTarget       ldu       ,x        ; load U from ,x
                     beq       FGcmdirTarget2 ; branch if zero is set to FGcmdirTarget2
-FGcmdirBumpModuleDownBy leax      -2,x      ; bump module ptr down by 2
+FGcmdirBumpModDown  leax      -2,x      ; bump module ptr down by 2
                     cmpx      <D.ModDAT ; hit beginning yet?
                     bne       FGcmdirTarget ; no, keep checking
                     clrb                ; yes, return without error
                     rts                 ; return to caller
 
 FGcmdirTarget2      ldu       -2,x      ; load U from -2,x
-                    bne       FGcmdirBumpModuleDownBy ; branch if zero is clear to FGcmdirBumpModuleDownBy
+                    bne       FGcmdirBumpModDown ; branch if zero is clear to FGcmdirBumpModDown
                     tfr       x,y       ; transfer register value x,y
                     bra       FGcmdirTarget4 ; branch unconditionally to FGcmdirTarget4
 

--- a/level2/modules/kernel/fgcmdir.asm
+++ b/level2/modules/kernel/fgcmdir.asm
@@ -15,24 +15,24 @@
 * Error:  CC = C bit set; B = error code
 *
 FGCMDir             ldx       <D.ModDir ; get pointer to module directory start
-                    bra       L0C1D     ; skip ahead
-L0C17               ldu       MD$MPDAT,x ; dAT initialized?
-                    beq       L0C23     ; no it's empty skip ahead
+                    bra       FGcmdirEndModuleDirectory ; skip ahead
+FGcmdirDATInitialized ldu       MD$MPDAT,x ; dAT initialized?
+                    beq       FGcmdirEmptyEntry ; no it's empty skip ahead
                     leax      MD$ESize,x ; move to next entry
-L0C1D               cmpx      <D.ModEnd ; end of module directory?
-                    bne       L0C17     ; no, keep looking
-                    bra       L0C4B     ; branch unconditionally to L0C4B
+FGcmdirEndModuleDirectory cmpx      <D.ModEnd ; end of module directory?
+                    bne       FGcmdirDATInitialized ; no, keep looking
+                    bra       FGcmdirModuleDirectoryDATEnd ; branch unconditionally to FGcmdirModuleDirectoryDATEnd
 * Move all entrys up 1 slot in directory
-L0C23               tfr       x,y       ; move empty entry pointer to Y
-                    bra       L0C2B     ; branch unconditionally to L0C2B
-L0C27               ldu       MD$MPDAT,y ; load U from MD$MPDAT,y
-                    bne       L0C34     ; branch if zero is clear to L0C34
-L0C2B               leay      MD$ESize,y ; compute MD$ESize,y into Y
+FGcmdirEmptyEntry   tfr       x,y       ; move empty entry pointer to Y
+                    bra       FGcmdirEsize ; branch unconditionally to FGcmdirEsize
+FGcmdirMpdat        ldu       MD$MPDAT,y ; load U from MD$MPDAT,y
+                    bne       FGcmdirJoin ; branch if zero is clear to FGcmdirJoin
+FGcmdirEsize        leay      MD$ESize,y ; compute MD$ESize,y into Y
                     cmpy      <D.ModEnd ; done complete directory?
-                    bne       L0C27     ; no, keep going
-                    bra       L0C49     ; branch unconditionally to L0C49
+                    bne       FGcmdirMpdat ; no, keep going
+                    bra       FGcmdirNewModuleDirectoryEnd ; branch unconditionally to FGcmdirNewModuleDirectoryEnd
 * Move entry up 1 slot in directory
-L0C34               equ       *         ; define assembler symbol L0C34
+FGcmdirJoin         equ       *         ; define assembler symbol FGcmdirJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       #MD$ESize ; load W from #MD$ESize
                     tfm       y+,x+     ; transfer memory block using y+,x+
@@ -46,62 +46,62 @@ L0C34               equ       *         ; define assembler symbol L0C34
                     ldu       ,y++      ; load U from ,y++
                     stu       ,x++      ; store U at ,x++
                   ENDC
-L0C44               cmpy      <D.ModEnd ; done complete directory?
-                    bne       L0C27     ; no, keep going
+FGcmdirCompleteDirectory cmpy      <D.ModEnd ; done complete directory?
+                    bne       FGcmdirMpdat ; no, keep going
 
-L0C49               stx       <D.ModEnd ; save new module directory end pointer
+FGcmdirNewModuleDirectoryEnd stx       <D.ModEnd ; save new module directory end pointer
 * Shrink DAT table
-L0C4B               ldx       <D.ModDir+2 ; get module directory DAT end pointer
-                    bra       L0C53     ; branch unconditionally to L0C53
+FGcmdirModuleDirectoryDATEnd ldx       <D.ModDir+2 ; get module directory DAT end pointer
+                    bra       FGcmdirBumpModuleDownBy ; branch unconditionally to FGcmdirBumpModuleDownBy
 
-L0C4F               ldu       ,x        ; load U from ,x
-                    beq       L0C5B     ; branch if zero is set to L0C5B
-L0C53               leax      -2,x      ; bump module ptr down by 2
+FGcmdirTarget       ldu       ,x        ; load U from ,x
+                    beq       FGcmdirTarget2 ; branch if zero is set to FGcmdirTarget2
+FGcmdirBumpModuleDownBy leax      -2,x      ; bump module ptr down by 2
                     cmpx      <D.ModDAT ; hit beginning yet?
-                    bne       L0C4F     ; no, keep checking
+                    bne       FGcmdirTarget ; no, keep checking
                     clrb                ; yes, return without error
                     rts                 ; return to caller
 
-L0C5B               ldu       -2,x      ; load U from -2,x
-                    bne       L0C53     ; branch if zero is clear to L0C53
+FGcmdirTarget2      ldu       -2,x      ; load U from -2,x
+                    bne       FGcmdirBumpModuleDownBy ; branch if zero is clear to FGcmdirBumpModuleDownBy
                     tfr       x,y       ; transfer register value x,y
-                    bra       L0C67     ; branch unconditionally to L0C67
+                    bra       FGcmdirTarget4 ; branch unconditionally to FGcmdirTarget4
 
-L0C63               ldu       ,y        ; load U from ,y
-                    bne       L0C70     ; branch if zero is clear to L0C70
-L0C67               leay      -2,y      ; compute -2,y into Y
-L0C69               cmpy      <D.ModDAT ; compare Y with <D.ModDAT
-                    bcc       L0C63     ; branch if carry is clear to L0C63
-                    bra       L0C81     ; branch unconditionally to L0C81
-L0C70               leay      2,y       ; compute 2,y into Y
+FGcmdirTarget3      ldu       ,y        ; load U from ,y
+                    bne       FGcmdirTarget5 ; branch if zero is clear to FGcmdirTarget5
+FGcmdirTarget4      leay      -2,y      ; compute -2,y into Y
+FGcmdirDmoddat      cmpy      <D.ModDAT ; compare Y with <D.ModDAT
+                    bcc       FGcmdirTarget3 ; branch if carry is clear to FGcmdirTarget3
+                    bra       FGcmdirDmoddat2 ; branch unconditionally to FGcmdirDmoddat2
+FGcmdirTarget5      leay      2,y       ; compute 2,y into Y
                     ldu       ,y        ; load U from ,y
                     stu       ,x        ; store U at ,x
-L0C76               ldu       ,--y      ; load U from ,--y
+FGcmdirTarget6      ldu       ,--y      ; load U from ,--y
                     stu       ,--x      ; store U at ,--x
-                    beq       L0C87     ; branch if zero is set to L0C87
+                    beq       FGcmdirTarget7 ; branch if zero is set to FGcmdirTarget7
                     cmpy      <D.ModDAT ; compare Y with <D.ModDAT
-                    bne       L0C76     ; branch if zero is clear to L0C76
+                    bne       FGcmdirTarget6 ; branch if zero is clear to FGcmdirTarget6
 
-L0C81               stx       <D.ModDAT ; store X at <D.ModDAT
-                    bsr       L0C95     ; call local routine L0C95
+FGcmdirDmoddat2     stx       <D.ModDAT ; store X at <D.ModDAT
+                    bsr       FGcmdirTarget8 ; call local routine FGcmdirTarget8
                     clrb                ; yes, return without error
                     rts                 ; return to caller
 
-L0C87               leay      2,y       ; compute 2,y into Y
+FGcmdirTarget7      leay      2,y       ; compute 2,y into Y
                     leax      2,x       ; compute 2,x into X
-                    bsr       L0C95     ; call local routine L0C95
+                    bsr       FGcmdirTarget8 ; call local routine FGcmdirTarget8
                     leay      -4,y      ; compute -4,y into Y
                     leax      -2,x      ; compute -2,x into X
-                    bra       L0C69     ; branch unconditionally to L0C69
+                    bra       FGcmdirDmoddat ; branch unconditionally to FGcmdirDmoddat
 
 * Update Module Dir Image Ptrs
-L0C95               pshs      u         ; save u on the stack
+FGcmdirTarget8      pshs      u         ; save u on the stack
                     ldu       <D.ModDir ; load U from <D.ModDir
-                    bra       L0CA4     ; branch unconditionally to L0CA4
-L0C9B               cmpy      MD$MPDAT,u ; same DAT ptrs?
-                    bne       L0CA2     ; no, skip
+                    bra       FGcmdirLastEntry ; branch unconditionally to FGcmdirLastEntry
+FGcmdirSameDATPtrs  cmpy      MD$MPDAT,u ; same DAT ptrs?
+                    bne       FGcmdirEntry ; no, skip
                     stx       MD$MPDAT,u ; else update ptrs
-L0CA2               leau      MD$ESize,u ; next entry
-L0CA4               cmpu      <D.ModEnd ; last entry?
-                    bne       L0C9B     ; no
+FGcmdirEntry        leau      MD$ESize,u ; next entry
+FGcmdirLastEntry    cmpu      <D.ModEnd ; last entry?
+                    bne       FGcmdirSameDATPtrs ; no
                     puls      u,pc      ; else yes... return

--- a/level2/modules/kernel/fgcmdir.asm
+++ b/level2/modules/kernel/fgcmdir.asm
@@ -14,94 +14,94 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FGCMDir        ldx       <D.ModDir           get pointer to module directory start
-               bra       L0C1D               skip ahead
-L0C17          ldu       MD$MPDAT,x          DAT initialized?
-               beq       L0C23               no it's empty skip ahead
-               leax      MD$ESize,x          move to next entry
-L0C1D          cmpx      <D.ModEnd           end of module directory?
-               bne       L0C17               no, keep looking
-               bra       L0C4B
+FGCMDir             ldx       <D.ModDir ; get pointer to module directory start
+                    bra       L0C1D     ; skip ahead
+L0C17               ldu       MD$MPDAT,x ; dAT initialized?
+                    beq       L0C23     ; no it's empty skip ahead
+                    leax      MD$ESize,x ; move to next entry
+L0C1D               cmpx      <D.ModEnd ; end of module directory?
+                    bne       L0C17     ; no, keep looking
+                    bra       L0C4B     ; branch unconditionally to L0C4B
 * Move all entrys up 1 slot in directory
-L0C23          tfr       x,y                 move empty entry pointer to Y
-               bra       L0C2B
-L0C27          ldu       MD$MPDAT,y
-               bne       L0C34
-L0C2B          leay      MD$ESize,y
-               cmpy      <D.ModEnd           done complete directory?
-               bne       L0C27               no, keep going
-               bra       L0C49
+L0C23               tfr       x,y       ; move empty entry pointer to Y
+                    bra       L0C2B     ; branch unconditionally to L0C2B
+L0C27               ldu       MD$MPDAT,y ; load U from MD$MPDAT,y
+                    bne       L0C34     ; branch if zero is clear to L0C34
+L0C2B               leay      MD$ESize,y ; compute MD$ESize,y into Y
+                    cmpy      <D.ModEnd ; done complete directory?
+                    bne       L0C27     ; no, keep going
+                    bra       L0C49     ; branch unconditionally to L0C49
 * Move entry up 1 slot in directory
-L0C34          equ       *
-               ifne      H6309
-               ldw       #MD$ESize
-               tfm       y+,x+
-               else      
-               ldu       ,y++
-               stu       ,x++
-               ldu       ,y++
-               stu       ,x++
-               ldu       ,y++
-               stu       ,x++
-               ldu       ,y++
-               stu       ,x++
-               endc      
-L0C44          cmpy      <D.ModEnd           done complete directory?
-               bne       L0C27               no, keep going
+L0C34               equ       *         ; define assembler symbol L0C34
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #MD$ESize ; load W from #MD$ESize
+                    tfm       y+,x+     ; transfer memory block using y+,x+
+                  ELSE
+                    ldu       ,y++      ; load U from ,y++
+                    stu       ,x++      ; store U at ,x++
+                    ldu       ,y++      ; load U from ,y++
+                    stu       ,x++      ; store U at ,x++
+                    ldu       ,y++      ; load U from ,y++
+                    stu       ,x++      ; store U at ,x++
+                    ldu       ,y++      ; load U from ,y++
+                    stu       ,x++      ; store U at ,x++
+                  ENDC
+L0C44               cmpy      <D.ModEnd ; done complete directory?
+                    bne       L0C27     ; no, keep going
 
-L0C49          stx       <D.ModEnd           save new module directory end pointer
+L0C49               stx       <D.ModEnd ; save new module directory end pointer
 * Shrink DAT table
-L0C4B          ldx       <D.ModDir+2         get module directory DAT end pointer
-               bra       L0C53
+L0C4B               ldx       <D.ModDir+2 ; get module directory DAT end pointer
+                    bra       L0C53     ; branch unconditionally to L0C53
 
-L0C4F          ldu       ,x
-               beq       L0C5B
-L0C53          leax      -2,x                Bump module ptr down by 2
-               cmpx      <D.ModDAT           Hit beginning yet?
-               bne       L0C4F               No, keep checking
-               clrb                          Yes, return without error
-               rts       
+L0C4F               ldu       ,x        ; load U from ,x
+                    beq       L0C5B     ; branch if zero is set to L0C5B
+L0C53               leax      -2,x      ; bump module ptr down by 2
+                    cmpx      <D.ModDAT ; hit beginning yet?
+                    bne       L0C4F     ; no, keep checking
+                    clrb                ; yes, return without error
+                    rts                 ; return to caller
 
-L0C5B          ldu       -2,x
-               bne       L0C53
-               tfr       x,y
-               bra       L0C67
+L0C5B               ldu       -2,x      ; load U from -2,x
+                    bne       L0C53     ; branch if zero is clear to L0C53
+                    tfr       x,y       ; transfer register value x,y
+                    bra       L0C67     ; branch unconditionally to L0C67
 
-L0C63          ldu       ,y
-               bne       L0C70
-L0C67          leay      -2,y
-L0C69          cmpy      <D.ModDAT
-               bcc       L0C63
-               bra       L0C81
-L0C70          leay      2,y
-               ldu       ,y
-               stu       ,x
-L0C76          ldu       ,--y
-               stu       ,--x
-               beq       L0C87
-               cmpy      <D.ModDAT
-               bne       L0C76
+L0C63               ldu       ,y        ; load U from ,y
+                    bne       L0C70     ; branch if zero is clear to L0C70
+L0C67               leay      -2,y      ; compute -2,y into Y
+L0C69               cmpy      <D.ModDAT ; compare Y with <D.ModDAT
+                    bcc       L0C63     ; branch if carry is clear to L0C63
+                    bra       L0C81     ; branch unconditionally to L0C81
+L0C70               leay      2,y       ; compute 2,y into Y
+                    ldu       ,y        ; load U from ,y
+                    stu       ,x        ; store U at ,x
+L0C76               ldu       ,--y      ; load U from ,--y
+                    stu       ,--x      ; store U at ,--x
+                    beq       L0C87     ; branch if zero is set to L0C87
+                    cmpy      <D.ModDAT ; compare Y with <D.ModDAT
+                    bne       L0C76     ; branch if zero is clear to L0C76
 
-L0C81          stx       <D.ModDAT
-               bsr       L0C95
-               clrb                          Yes, return without error
-               rts       
+L0C81               stx       <D.ModDAT ; store X at <D.ModDAT
+                    bsr       L0C95     ; call local routine L0C95
+                    clrb                ; yes, return without error
+                    rts                 ; return to caller
 
-L0C87          leay      2,y
-               leax      2,x
-               bsr       L0C95
-               leay      -4,y
-               leax      -2,x
-               bra       L0C69
+L0C87               leay      2,y       ; compute 2,y into Y
+                    leax      2,x       ; compute 2,x into X
+                    bsr       L0C95     ; call local routine L0C95
+                    leay      -4,y      ; compute -4,y into Y
+                    leax      -2,x      ; compute -2,x into X
+                    bra       L0C69     ; branch unconditionally to L0C69
 
 * Update Module Dir Image Ptrs
-L0C95          pshs      u
-               ldu       <D.ModDir
-               bra       L0CA4
-L0C9B          cmpy      MD$MPDAT,u          same DAT ptrs?
-               bne       L0CA2               no, skip
-               stx       MD$MPDAT,u          else update ptrs
-L0CA2          leau      MD$ESize,u          next entry
-L0CA4          cmpu      <D.ModEnd           last entry?
-               bne       L0C9B               no
-               puls      u,pc                else yes... return
+L0C95               pshs      u         ; save u on the stack
+                    ldu       <D.ModDir ; load U from <D.ModDir
+                    bra       L0CA4     ; branch unconditionally to L0CA4
+L0C9B               cmpy      MD$MPDAT,u ; same DAT ptrs?
+                    bne       L0CA2     ; no, skip
+                    stx       MD$MPDAT,u ; else update ptrs
+L0CA2               leau      MD$ESize,u ; next entry
+L0CA4               cmpu      <D.ModEnd ; last entry?
+                    bne       L0C9B     ; no
+                    puls      u,pc      ; else yes... return

--- a/level2/modules/kernel/fgmoddr.asm
+++ b/level2/modules/kernel/fgmoddr.asm
@@ -28,7 +28,7 @@ FGModDr             ldd       <D.ModDir+2 ; get end ptr of module directory
                     ldx       <D.Proc   ; get current process task #
                     ldb       P$Task,x  ; load B from P$Task,x
                     ldx       <D.ModDir ; get start ptr of module directory
-                    bra       FGblkmpAddrPutRequested ; --- saves 4 bytes, adds 3 cycles
+                    bra       FGblkmpAddrPutReq ; --- saves 4 bytes, adds 3 cycles
 ***         ldu   R$X,u       Get caller's buffer ptr
 ***         os9   F$Move      Copy module directory in caller's buffer
 ***         rts

--- a/level2/modules/kernel/fgmoddr.asm
+++ b/level2/modules/kernel/fgmoddr.asm
@@ -9,26 +9,26 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FGModDr             ldd       <D.ModDir+2         Get end ptr of module directory
-                    subd      <D.ModDir           Calculate maximum size of module directory
-                    tfr       d,y                 Put max. size in Y
-                    ldd       <D.ModEnd           Get real end ptr of module dir
-                    subd      <D.ModDir           Calculate real size of module dir
-                    ldx       R$X,u               Get requested buffer ptr to put it from caller
-                    ifne      H6309
-                    addr      d,x                 Calculate end addr. of directory after its copied
-                    else
-                    leax      d,x
-                    endc
-                    stx       R$Y,u               Preserve in caller's Y register
-                    ldx       <D.ModDir           Get start ptr of module directory
-                    stx       R$U,u               Preserve in caller's U register
+FGModDr             ldd       <D.ModDir+2 ; get end ptr of module directory
+                    subd      <D.ModDir ; calculate maximum size of module directory
+                    tfr       d,y       ; put max. size in Y
+                    ldd       <D.ModEnd ; get real end ptr of module dir
+                    subd      <D.ModDir ; calculate real size of module dir
+                    ldx       R$X,u     ; get requested buffer ptr to put it from caller
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,x       ; calculate end addr. of directory after its copied
+                  ELSE
+                    leax      d,x       ; compute d,x into X
+                  ENDC
+                    stx       R$Y,u     ; preserve in caller's Y register
+                    ldx       <D.ModDir ; get start ptr of module directory
+                    stx       R$U,u     ; preserve in caller's U register
 
-                    lda       <D.SysTsk           Get system task #
-                    ldx       <D.Proc             Get current process task #
-                    ldb       P$Task,x
-                    ldx       <D.ModDir           Get start ptr of module directory
-                    bra       L0978               --- saves 4 bytes, adds 3 cycles
+                    lda       <D.SysTsk ; get system task #
+                    ldx       <D.Proc   ; get current process task #
+                    ldb       P$Task,x  ; load B from P$Task,x
+                    ldx       <D.ModDir ; get start ptr of module directory
+                    bra       L0978     ; --- saves 4 bytes, adds 3 cycles
 ***         ldu   R$X,u       Get caller's buffer ptr
 ***         os9   F$Move      Copy module directory in caller's buffer
 ***         rts

--- a/level2/modules/kernel/fgmoddr.asm
+++ b/level2/modules/kernel/fgmoddr.asm
@@ -28,7 +28,7 @@ FGModDr             ldd       <D.ModDir+2 ; get end ptr of module directory
                     ldx       <D.Proc   ; get current process task #
                     ldb       P$Task,x  ; load B from P$Task,x
                     ldx       <D.ModDir ; get start ptr of module directory
-                    bra       L0978     ; --- saves 4 bytes, adds 3 cycles
+                    bra       FGblkmpAddrPutRequested ; --- saves 4 bytes, adds 3 cycles
 ***         ldu   R$X,u       Get caller's buffer ptr
 ***         os9   F$Move      Copy module directory in caller's buffer
 ***         rts

--- a/level2/modules/kernel/fgprdsc.asm
+++ b/level2/modules/kernel/fgprdsc.asm
@@ -10,14 +10,14 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FGPrDsc             ldx       <D.Proc             Get current process dsc. ptr.
-                    ldb       P$Task,x            Get task number
-                    lda       R$A,u               Get requested process ID #
-                    os9       F$GProcP            Get ptr to process to descriptor
-                    bcs       L0962               Error, exit with it
-                    lda       <D.SysTsk           Get system task #
-                    leax      ,y                  Point X to the process descriptor
-                    ldy       #P$Size             Y=Size of process descriptor (512 bytes)
-                    ldu       R$X,u               Get requested place to put copy of process dsc.
-                    os9       F$Move              Move it into caller's space
-L0962               rts
+FGPrDsc             ldx       <D.Proc   ; get current process dsc. ptr.
+                    ldb       P$Task,x  ; get task number
+                    lda       R$A,u     ; get requested process ID #
+                    os9       F$GProcP  ; get ptr to process to descriptor
+                    bcs       L0962     ; error, exit with it
+                    lda       <D.SysTsk ; get system task #
+                    leax      ,y        ; point X to the process descriptor
+                    ldy       #P$Size   ; Y=Size of process descriptor (512 bytes)
+                    ldu       R$X,u     ; get requested place to put copy of process dsc.
+                    os9       F$Move    ; move it into caller's space
+L0962               rts                 ; return to caller

--- a/level2/modules/kernel/fgprdsc.asm
+++ b/level2/modules/kernel/fgprdsc.asm
@@ -14,10 +14,10 @@ FGPrDsc             ldx       <D.Proc   ; get current process dsc. ptr.
                     ldb       P$Task,x  ; get task number
                     lda       R$A,u     ; get requested process ID #
                     os9       F$GProcP  ; get ptr to process to descriptor
-                    bcs       L0962     ; error, exit with it
+                    bcs       FGprdscReturn ; error, exit with it
                     lda       <D.SysTsk ; get system task #
                     leax      ,y        ; point X to the process descriptor
                     ldy       #P$Size   ; Y=Size of process descriptor (512 bytes)
                     ldu       R$X,u     ; get requested place to put copy of process dsc.
                     os9       F$Move    ; move it into caller's space
-L0962               rts                 ; return to caller
+FGprdscReturn       rts                 ; return to caller

--- a/level2/modules/kernel/fgprocp.asm
+++ b/level2/modules/kernel/fgprocp.asm
@@ -9,27 +9,27 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FGProcP             lda       R$A,u               get process #
-                    bsr       L0B2E               Get ptr to process descriptor
-                    bcs       L0B2D               If error, exit with it
-                    sty       R$Y,u               Save ptr in caller's Y
-L0B2D               rts                           Return
+FGProcP             lda       R$A,u     ; get process #
+                    bsr       L0B2E     ; get ptr to process descriptor
+                    bcs       L0B2D     ; if error, exit with it
+                    sty       R$Y,u     ; save ptr in caller's Y
+L0B2D               rts                 ; return
 
 * Entry: A=Process #
 * Exit:  Y=Ptr to process descriptor
 *  All others preserved
-L0B2E               pshs      d,x                 Preserve regs
-                    ldb       ,s                  Get process # into B
-                    beq       L0B40               0, skip ahead
-                    ldx       <D.PrcDBT           Get ptr to process descriptor block table
-                    abx                           Point to specific process' entry
-                    lda       ,x                  Get MSB of process dsc. ptr
-                    beq       L0B40               None there, exit with error
-                    clrb                          Clear LSB of process dsc. ptr (always fall on $200
-                    tfr       d,y                 boundaries) & move ptr to Y
-                    puls      d,x,pc              Restore regs & return
+L0B2E               pshs      d,x       ; preserve regs
+                    ldb       ,s        ; get process # into B
+                    beq       L0B40     ; 0, skip ahead
+                    ldx       <D.PrcDBT ; get ptr to process descriptor block table
+                    abx                 ; point to specific process' entry
+                    lda       ,x        ; get MSB of process dsc. ptr
+                    beq       L0B40     ; none there, exit with error
+                    clrb                ; clear LSB of process dsc. ptr (always fall on $200
+                    tfr       d,y       ; boundaries) & move ptr to Y
+                    puls      d,x,pc    ; restore regs & return
 
-L0B40               puls      d,x                 Get regs back
-                    comb                          Exit with Bad process ID error
-                    ldb       #E$BPrcID
-                    rts
+L0B40               puls      d,x       ; get regs back
+                    comb                ; exit with Bad process ID error
+                    ldb       #E$BPrcID ; load B from #E$BPrcID
+                    rts                 ; return to caller

--- a/level2/modules/kernel/fgprocp.asm
+++ b/level2/modules/kernel/fgprocp.asm
@@ -10,26 +10,26 @@
 * Error:  CC = C bit set; B = error code
 *
 FGProcP             lda       R$A,u     ; get process #
-                    bsr       L0B2E     ; get ptr to process descriptor
-                    bcs       L0B2D     ; if error, exit with it
+                    bsr       FGprocpTarget ; get ptr to process descriptor
+                    bcs       FGprocpReturn ; if error, exit with it
                     sty       R$Y,u     ; save ptr in caller's Y
-L0B2D               rts                 ; return
+FGprocpReturn       rts                 ; return
 
 * Entry: A=Process #
 * Exit:  Y=Ptr to process descriptor
 *  All others preserved
-L0B2E               pshs      d,x       ; preserve regs
+FGprocpTarget       pshs      d,x       ; preserve regs
                     ldb       ,s        ; get process # into B
-                    beq       L0B40     ; 0, skip ahead
+                    beq       FGprocpBack ; 0, skip ahead
                     ldx       <D.PrcDBT ; get ptr to process descriptor block table
                     abx                 ; point to specific process' entry
                     lda       ,x        ; get MSB of process dsc. ptr
-                    beq       L0B40     ; none there, exit with error
+                    beq       FGprocpBack ; none there, exit with error
                     clrb                ; clear LSB of process dsc. ptr (always fall on $200
                     tfr       d,y       ; boundaries) & move ptr to Y
                     puls      d,x,pc    ; restore regs & return
 
-L0B40               puls      d,x       ; get regs back
+FGprocpBack         puls      d,x       ; get regs back
                     comb                ; exit with Bad process ID error
                     ldb       #E$BPrcID ; load B from #E$BPrcID
                     rts                 ; return to caller

--- a/level2/modules/kernel/fld.asm
+++ b/level2/modules/kernel/fld.asm
@@ -10,49 +10,49 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FLDAXY              ldx       R$X,u               Get offset within block (S/B $0000-$1FFF)
-                    ldy       R$Y,u               Get ptr to DAT block entry
-                    bsr       L0AC8               Go get byte
-                    sta       R$A,u               Save in caller's A reg.
-                    rts
+FLDAXY              ldx       R$X,u     ; get offset within block (S/B $0000-$1FFF)
+                    ldy       R$Y,u     ; get ptr to DAT block entry
+                    bsr       L0AC8     ; go get byte
+                    sta       R$A,u     ; save in caller's A reg.
+                    rts                 ; return to caller
 
 * Entry: X=offset ($0000-$1fff) to get from block pointed to by Y (DAT entry
 * format)
-L0AC8               lda       1,y                 Get MMU block # to get data from
-                    clrb                          Clear carry/setup for STB
-                    pshs      cc                  Preserve interrupt status/settings
-                    orcc      #IntMasks           shut IRQ's off
-                    ifne      mc09
-                    ldb       <D.TINIT            Current MMU mask - selects block 0
-                    stb       >MMUADR             Select block 0
-                    sta       >MMUDAT             Map block into $0000-$1FFF
-                    lda       ,x                  Get byte
-                    clrb
-                    stb       >MMUDAT             Map block 0 into $0000-$1FFF
-                    else
-                    sta       >DAT.Regs           Map block into $0000-$1FFF
-                    lda       ,x                  Get byte
-                    stb       >DAT.Regs           Map block 0 into $0000-$1FFF
-                    endc
-                    puls      pc,cc               Get interrupt status/(or turn on) & return
+L0AC8               lda       1,y       ; get MMU block # to get data from
+                    clrb                ; clear carry/setup for STB
+                    pshs      cc        ; preserve interrupt status/settings
+                    orcc      #IntMasks ; shut IRQ's off
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    ldb       <D.TINIT  ; current MMU mask - selects block 0
+                    stb       >MMUADR   ; select block 0
+                    sta       >MMUDAT   ; map block into $0000-$1FFF
+                    lda       ,x        ; get byte
+                    clrb                ; clear B
+                    stb       >MMUDAT   ; map block 0 into $0000-$1FFF
+                  ELSE
+                    sta       >DAT.Regs ; map block into $0000-$1FFF
+                    lda       ,x        ; get byte
+                    stb       >DAT.Regs ; map block 0 into $0000-$1FFF
+                  ENDC
+                    puls      pc,cc     ; get interrupt status/(or turn on) & return
 
 * Get 1st byte of LDDDXY - also used by many other routines
 * Increments X on exit; adjusts X for within 8K block & Y (DAT img ptr)
-LDAXY               lda       1,y                 Get MMU block #
-                    pshs      b,cc                Save regs
-                    clrb
-                    orcc      #IntMasks           Shut off interrupts
-                    sta       >DAT.Regs           Map in MMU block into slot 0
-                    lda       ,x+                 Get byte
-                    stb       >DAT.Regs           Map MMU block #0 back
-                    puls      b,cc
-                    bra       AdjBlk0
+LDAXY               lda       1,y       ; get MMU block #
+                    pshs      b,cc      ; save regs
+                    clrb                ; clear B
+                    orcc      #IntMasks ; shut off interrupts
+                    sta       >DAT.Regs ; map in MMU block into slot 0
+                    lda       ,x+       ; get byte
+                    stb       >DAT.Regs ; map MMU block #0 back
+                    puls      b,cc      ; restore b,cc from the stack
+                    bra       AdjBlk0   ; branch unconditionally to AdjBlk0
 
-L0AEA               leax      >-DAT.BlSz,x        Bump offset ptr to start of block again
-                    leay      2,y                 Bump source MMU block up to next one in DAT Image
-AdjBlk0             cmpx      #DAT.BlSz           Going to wrap out of our block?
-                    bhs       L0AEA               Yes, go adjust
-                    rts                           No, return
+L0AEA               leax      >-DAT.BlSz,x ; bump offset ptr to start of block again
+                    leay      2,y       ; bump source MMU block up to next one in DAT Image
+AdjBlk0             cmpx      #DAT.BlSz ; going to wrap out of our block?
+                    bhs       L0AEA     ; yes, go adjust
+                    rts                 ; no, return
 
 
 **************************************************
@@ -68,31 +68,31 @@ AdjBlk0             cmpx      #DAT.BlSz           Going to wrap out of our block
 *
 * Error:  CC = C bit set; B = error code
 *
-FLDDDXY             ldd       R$D,u               Get offset to offset within DAT Image
-                    leau      R$X,u               Point U to Offset
-                    pulu      x,y                 Y=Offset within DAT Image, X=DAT Image ptr
-                    bsr       L0B02               Go get 2 bytes
-                    std       -(R$X+3),u          Save into caller's X
-                    clrb                          No error & return
-                    rts
+FLDDDXY             ldd       R$D,u     ; get offset to offset within DAT Image
+                    leau      R$X,u     ; point U to Offset
+                    pulu      x,y       ; Y=Offset within DAT Image, X=DAT Image ptr
+                    bsr       L0B02     ; go get 2 bytes
+                    std       -(R$X+3),u ; save into caller's X
+                    clrb                ; no error & return
+                    rts                 ; return to caller
 * Get 2 bytes for LDDDXY (also called by other routines)
 * Should simply map in 2 blocks, and do a LDD (don't have to worry about wrap)
-L0B02               pshs      u,y,x               Preserve regs
-                    IFNE      H6309
-                    addr      d,x                 Point X to X+D
-                    ELSE
-                    leax      d,x
-                    ENDC
-                    bsr       AdjBlk0             Wrap address around for 1 block
-                    ldu       <D.SysDAT           Get sys DAT Image ptr
-                    clra                          system block 0 =0 always
-                    ldb       3,u                 Get MMU block #1
-                    tfr       d,u                 make U=blocks to re-map in once done
-                    lda       1,y                 Get MMU block #0
-                    ldb       3,y                 Get MMU block #1
-                    pshs      cc                  Preserve int. status
-                    orcc      #IntMasks           shut off int.
-                    std       >DAT.Regs           Map in both blocks
-                    ldd       ,x                  Get 2 bytes
-                    stu       >DAT.Regs           Map original blocks in
-                    puls      pc,u,y,x,cc         Restore regs & return
+L0B02               pshs      u,y,x     ; preserve regs
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    addr      d,x       ; point X to X+D
+                  ELSE
+                    leax      d,x       ; compute d,x into X
+                  ENDC
+                    bsr       AdjBlk0   ; wrap address around for 1 block
+                    ldu       <D.SysDAT ; get sys DAT Image ptr
+                    clra                ; system block 0 =0 always
+                    ldb       3,u       ; get MMU block #1
+                    tfr       d,u       ; make U=blocks to re-map in once done
+                    lda       1,y       ; get MMU block #0
+                    ldb       3,y       ; get MMU block #1
+                    pshs      cc        ; preserve int. status
+                    orcc      #IntMasks ; shut off int.
+                    std       >DAT.Regs ; map in both blocks
+                    ldd       ,x        ; get 2 bytes
+                    stu       >DAT.Regs ; map original blocks in
+                    puls      pc,u,y,x,cc ; restore regs & return

--- a/level2/modules/kernel/fld.asm
+++ b/level2/modules/kernel/fld.asm
@@ -48,10 +48,10 @@ LDAXY               lda       1,y       ; get MMU block #
                     puls      b,cc      ; restore b,cc from the stack
                     bra       AdjBlk0   ; branch unconditionally to AdjBlk0
 
-FLdBumpOffsetStartBlockAgain leax      >-DAT.BlSz,x ; bump offset ptr to start of block again
+FLdBumpOffStart     leax      >-DAT.BlSz,x ; bump offset ptr to start of block again
                     leay      2,y       ; bump source MMU block up to next one in DAT Image
 AdjBlk0             cmpx      #DAT.BlSz ; going to wrap out of our block?
-                    bhs       FLdBumpOffsetStartBlockAgain ; yes, go adjust
+                    bhs       FLdBumpOffStart ; yes, go adjust
                     rts                 ; no, return
 
 

--- a/level2/modules/kernel/fld.asm
+++ b/level2/modules/kernel/fld.asm
@@ -12,13 +12,13 @@
 *
 FLDAXY              ldx       R$X,u     ; get offset within block (S/B $0000-$1FFF)
                     ldy       R$Y,u     ; get ptr to DAT block entry
-                    bsr       L0AC8     ; go get byte
+                    bsr       FLdMMUBlockData ; go get byte
                     sta       R$A,u     ; save in caller's A reg.
                     rts                 ; return to caller
 
 * Entry: X=offset ($0000-$1fff) to get from block pointed to by Y (DAT entry
 * format)
-L0AC8               lda       1,y       ; get MMU block # to get data from
+FLdMMUBlockData     lda       1,y       ; get MMU block # to get data from
                     clrb                ; clear carry/setup for STB
                     pshs      cc        ; preserve interrupt status/settings
                     orcc      #IntMasks ; shut IRQ's off
@@ -48,10 +48,10 @@ LDAXY               lda       1,y       ; get MMU block #
                     puls      b,cc      ; restore b,cc from the stack
                     bra       AdjBlk0   ; branch unconditionally to AdjBlk0
 
-L0AEA               leax      >-DAT.BlSz,x ; bump offset ptr to start of block again
+FLdBumpOffsetStartBlockAgain leax      >-DAT.BlSz,x ; bump offset ptr to start of block again
                     leay      2,y       ; bump source MMU block up to next one in DAT Image
 AdjBlk0             cmpx      #DAT.BlSz ; going to wrap out of our block?
-                    bhs       L0AEA     ; yes, go adjust
+                    bhs       FLdBumpOffsetStartBlockAgain ; yes, go adjust
                     rts                 ; no, return
 
 
@@ -71,13 +71,13 @@ AdjBlk0             cmpx      #DAT.BlSz ; going to wrap out of our block?
 FLDDDXY             ldd       R$D,u     ; get offset to offset within DAT Image
                     leau      R$X,u     ; point U to Offset
                     pulu      x,y       ; Y=Offset within DAT Image, X=DAT Image ptr
-                    bsr       L0B02     ; go get 2 bytes
+                    bsr       FLdTarget ; go get 2 bytes
                     std       -(R$X+3),u ; save into caller's X
                     clrb                ; no error & return
                     rts                 ; return to caller
 * Get 2 bytes for LDDDXY (also called by other routines)
 * Should simply map in 2 blocks, and do a LDD (don't have to worry about wrap)
-L0B02               pshs      u,y,x     ; preserve regs
+FLdTarget           pshs      u,y,x     ; preserve regs
                   IFNE    H6309   ; begin conditional assembly for H6309
                     addr      d,x       ; point X to X+D
                   ELSE

--- a/level2/modules/kernel/fldabx.asm
+++ b/level2/modules/kernel/fldabx.asm
@@ -17,8 +17,8 @@ FLDABX              ldb       R$B,u     ; get task # to get byte from
 * Entry: B=Task #
 *        X=Pointer to data
 * Exit : B=Byte from other task
-L0C40               pshs      cc,a,x,u  ; save cc,a,x,u on the stack
-                    bsr       L0BF5     ; calculate offset into DAT image (fmove.asm)
+FLdabxTarget        pshs      cc,a,x,u  ; save cc,a,x,u on the stack
+                    bsr       FMoveTaskImageTable ; calculate offset into DAT image (fmove.asm)
                     ldd       a,u       ; [NAC HACK 2017Jan25] why ldd when a is never used??
                     orcc      #IntMasks ; set condition-code bits using #IntMasks
                   IFNE    mc09    ; begin conditional assembly for mc09
@@ -68,9 +68,9 @@ FSTABX              ldd       R$D,u     ; load D from R$D,u
 * Entry: A=Byte to store
 *        B=Task #
 *        X=Pointer to data
-L0C28               andcc     #^Carry   ; clear condition-code bits using #^Carry
+FLdabxCarry         andcc     #^Carry   ; clear condition-code bits using #^Carry
                     pshs      cc,d,x,u  ; save cc,d,x,u on the stack
-                    bsr       L0BF5     ; calculate offset into DAT image (fmove.asm)
+                    bsr       FMoveTaskImageTable ; calculate offset into DAT image (fmove.asm)
                     ldd       a,u       ; get memory block
                   IFNE    mc09    ; begin conditional assembly for mc09
                     orcc      #IntMasks ; set condition-code bits using #IntMasks

--- a/level2/modules/kernel/fldabx.asm
+++ b/level2/modules/kernel/fldabx.asm
@@ -10,34 +10,34 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FLDABX         ldb       R$B,u               Get task # to get byte from
-               ldx       R$X,u               Get offset into task's DAT image to get byte from
+FLDABX              ldb       R$B,u     ; get task # to get byte from
+                    ldx       R$X,u     ; get offset into task's DAT image to get byte from
 
 * Load a byte from another task
 * Entry: B=Task #
 *        X=Pointer to data
 * Exit : B=Byte from other task
-L0C40          pshs      cc,a,x,u
-               bsr       L0BF5               Calculate offset into DAT image (fmove.asm)
-               ldd       a,u                 [NAC HACK 2017Jan25] why ldd when a is never used??
-               orcc      #IntMasks
-               ifne      mc09
-               lda       <D.TINIT            Current MMU mask - selects block 0
-               sta       >MMUADR             Select block 0
+L0C40               pshs      cc,a,x,u  ; save cc,a,x,u on the stack
+                    bsr       L0BF5     ; calculate offset into DAT image (fmove.asm)
+                    ldd       a,u       ; [NAC HACK 2017Jan25] why ldd when a is never used??
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    lda       <D.TINIT  ; current MMU mask - selects block 0
+                    sta       >MMUADR   ; select block 0
 
-               stb       >MMUDAT             Map selected block into $0000-$1FFF
-               ldb       ,x
-               clr       >MMUDAT             Restore mapping at $0000-$1FFF
-               else      
-               stb       >DAT.Regs           Map block into $0000-$1FFF
-               ldb       ,x
-               clr       >DAT.Regs           Restore mapping at $0000-$1FFF
-               endif     
-               puls      cc,a,x,u
+                    stb       >MMUDAT   ; map selected block into $0000-$1FFF
+                    ldb       ,x        ; load B from ,x
+                    clr       >MMUDAT   ; restore mapping at $0000-$1FFF
+                  ELSE
+                    stb       >DAT.Regs ; map block into $0000-$1FFF
+                    ldb       ,x        ; load B from ,x
+                    clr       >DAT.Regs ; restore mapping at $0000-$1FFF
+                    endif
+                    puls      cc,a,x,u  ; restore cc,a,x,u from the stack
 
-               stb       R$A,u               Save into caller's A & return
-               clrb                          set to no errors
-               rts       
+                    stb       R$A,u     ; save into caller's A & return
+                    clrb                ; set to no errors
+                    rts                 ; return to caller
 
 * Get pointer to task DAT image
 * Entry: B=Task #
@@ -61,32 +61,32 @@ L0C40          pshs      cc,a,x,u
 *
 * Error:  CC = C bit set; B = error code
 *
-FSTABX         ldd       R$D,u
-               ldx       R$X,u
+FSTABX              ldd       R$D,u     ; load D from R$D,u
+                    ldx       R$X,u     ; load X from R$X,u
 
 * Store a byte in another task
 * Entry: A=Byte to store
 *        B=Task #
 *        X=Pointer to data
-L0C28          andcc     #^Carry
-               pshs      cc,d,x,u
-               bsr       L0BF5               Calculate offset into DAT image (fmove.asm)
-               ldd       a,u                 Get memory block
-               ifne      mc09
-               orcc      #IntMasks
-               lda       <D.TINIT            Current MMU mask - selects block 0
-               sta       >MMUADR             Select block 0
+L0C28               andcc     #^Carry   ; clear condition-code bits using #^Carry
+                    pshs      cc,d,x,u  ; save cc,d,x,u on the stack
+                    bsr       L0BF5     ; calculate offset into DAT image (fmove.asm)
+                    ldd       a,u       ; get memory block
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+                    lda       <D.TINIT  ; current MMU mask - selects block 0
+                    sta       >MMUADR   ; select block 0
 
-               lda       1,s                 Haven't lost stack yet so this is safe
+                    lda       1,s       ; haven't lost stack yet so this is safe
 
-               stb       >MMUDAT             Map selected block into $0000-$1FFF
-               sta       ,x
-               clr       >MMUDAT             Restore mapping at $0000-$1FFF
-               else      
-               lda       1,s
-               orcc      #IntMasks
-               stb       >DAT.Regs           Map selected block into $0000-$1FFF
-               sta       ,x
-               clr       >DAT.Regs           Restore mapping at $0000-$1FFF
-               endif     
-               puls      cc,d,x,u,pc
+                    stb       >MMUDAT   ; map selected block into $0000-$1FFF
+                    sta       ,x        ; store A at ,x
+                    clr       >MMUDAT   ; restore mapping at $0000-$1FFF
+                  ELSE
+                    lda       1,s       ; load A from 1,s
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+                    stb       >DAT.Regs ; map selected block into $0000-$1FFF
+                    sta       ,x        ; store A at ,x
+                    clr       >DAT.Regs ; restore mapping at $0000-$1FFF
+                    endif
+                    puls      cc,d,x,u,pc ; restore cc,d,x,u,pc from the stack

--- a/level2/modules/kernel/fmapblk.asm
+++ b/level2/modules/kernel/fmapblk.asm
@@ -10,53 +10,53 @@
 ;;; Error:  B = A non-zero error code.
 ;;;        CC = Carry flag set to indicate error.
 
-stackbuff           set       DAT.BlCt*2
+stackbuff           set       DAT.BlCt*2 ; define assembler symbol stackbuff
 
-FMapBlk             lda       R$B,u               get the number of blocks from the caller's B
-                    beq       IllBlkErr           if zero, we can't map 0 blocks, so return an error
-                    cmpa      #DAT.BlCt           is the block count within range of DAT image?
-                    bhi       IllBlkErr           no, return an error
-                    leas      -stackbuff,s        make a buffer on the stack to hold the DAT image
-                    ldx       R$X,u               get the start block number from the caller's X
-                    ldb       #1                  load the block increment value
-                    ifne      H6309
+FMapBlk             lda       R$B,u     ; get the number of blocks from the caller's B
+                    beq       IllBlkErr ; if zero, we can't map 0 blocks, so return an error
+                    cmpa      #DAT.BlCt ; is the block count within range of DAT image?
+                    bhi       IllBlkErr ; no, return an error
+                    leas      -stackbuff,s ; make a buffer on the stack to hold the DAT image
+                    ldx       R$X,u     ; get the start block number from the caller's X
+                    ldb       #1        ; load the block increment value
+                  IFNE    H6309   ; begin conditional assembly for H6309
 * Change to W 05/19/93 - used W since one cycle faster per block
-                    tfr       s,w                 point to the buffer
-loop@               stx       ,w++                save the block number to the buffer
-                    else
-                    tfr       s,y                 point to the buffer
-loop@               stx       ,y++                save the block number to the buffer
-                    endc
-                    abx                           add the block increment
-                    deca                          decrement the number of blocks we need
-                    bne       loop@               branch if we need more
-                    ldb       R$B,u               get the block count again
-                    ldx       <D.Proc             get the current process pointer
-                    leay      <P$DATImg,x         point to the DAT image
-                    os9       F$FreeHB            find the highest free block offset
-                    bcs       L0BA6               return with error if carry is set (no room)
-                    ifne      H6309
-                    tfr       d,w                 preserve the starting block number and the number of blocks
-                    else
-                    pshs      d                   preserve the starting block number and the number of blocks
-                    endc
-                    lsla                          multiply the start block number by 2
-                    lsla                          and by 2 again (total is 4)
-                    lsla                          and by 2 again (total is 8)
-                    lsla                          and by 2 again (total is 16)
-                    lsla                          and by 2 again (total is 32)
-                    clrb                          clear the lower 8 bits
-                    std       R$U,u               save the address of the first block
-                    ifne      H6309
-                    tfr       w,d                 restore the offset
-                    else
-                    puls      d                   restore the offset
-                    endc
-                    leau      ,s                  move the DAT image into the process descriptor
-                    os9       F$SetImg            change the process descriptor to reflect new blocks
-L0BA6               leas      <stackbuff,s        eat the DAT image copy on the stack
-                    rts                           return to the caller
+                    tfr       s,w       ; point to the buffer
+loop@               stx       ,w++      ; save the block number to the buffer
+                  ELSE
+                    tfr       s,y       ; point to the buffer
+loop@               stx       ,y++      ; save the block number to the buffer
+                  ENDC
+                    abx                 ; add the block increment
+                    deca                ; decrement the number of blocks we need
+                    bne       loop@     ; branch if we need more
+                    ldb       R$B,u     ; get the block count again
+                    ldx       <D.Proc   ; get the current process pointer
+                    leay      <P$DATImg,x ; point to the DAT image
+                    os9       F$FreeHB  ; find the highest free block offset
+                    bcs       L0BA6     ; return with error if carry is set (no room)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       d,w       ; preserve the starting block number and the number of blocks
+                  ELSE
+                    pshs      d         ; preserve the starting block number and the number of blocks
+                  ENDC
+                    lsla                ; multiply the start block number by 2
+                    lsla                ; and by 2 again (total is 4)
+                    lsla                ; and by 2 again (total is 8)
+                    lsla                ; and by 2 again (total is 16)
+                    lsla                ; and by 2 again (total is 32)
+                    clrb                ; clear the lower 8 bits
+                    std       R$U,u     ; save the address of the first block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       w,d       ; restore the offset
+                  ELSE
+                    puls      d         ; restore the offset
+                  ENDC
+                    leau      ,s        ; move the DAT image into the process descriptor
+                    os9       F$SetImg  ; change the process descriptor to reflect new blocks
+L0BA6               leas      <stackbuff,s ; eat the DAT image copy on the stack
+                    rts                 ; return to the caller
 
-IllBlkErr           comb                          set the carry
-                    ldb       #E$IBA              illegal block address error
-                    rts                           return to the caller
+IllBlkErr           comb                ; set the carry
+                    ldb       #E$IBA    ; illegal block address error
+                    rts                 ; return to the caller

--- a/level2/modules/kernel/fmapblk.asm
+++ b/level2/modules/kernel/fmapblk.asm
@@ -34,7 +34,7 @@ loop@               stx       ,y++      ; save the block number to the buffer
                     ldx       <D.Proc   ; get the current process pointer
                     leay      <P$DATImg,x ; point to the DAT image
                     os9       F$FreeHB  ; find the highest free block offset
-                    bcs       L0BA6     ; return with error if carry is set (no room)
+                    bcs       FMapblkEatDATImage ; return with error if carry is set (no room)
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       d,w       ; preserve the starting block number and the number of blocks
                   ELSE
@@ -54,7 +54,7 @@ loop@               stx       ,y++      ; save the block number to the buffer
                   ENDC
                     leau      ,s        ; move the DAT image into the process descriptor
                     os9       F$SetImg  ; change the process descriptor to reflect new blocks
-L0BA6               leas      <stackbuff,s ; eat the DAT image copy on the stack
+FMapblkEatDATImage  leas      <stackbuff,s ; eat the DAT image copy on the stack
                     rts                 ; return to the caller
 
 IllBlkErr           comb                ; set the carry

--- a/level2/modules/kernel/fmove.asm
+++ b/level2/modules/kernel/fmove.asm
@@ -28,43 +28,43 @@
 * Attempted change to size of copy from 64 to 96 bytes with new faster routine
 *   (still has IRQ's off for 17 cycles less than 6309 version)
 * Should speed up larger F$Moves
-fbye                clrb
-                    rts
-                    
-FMove               ldd       R$D,u               get source & destination task #'s
+fbye                clrb                ; clear B
+                    rts                 ; return to caller
+
+FMove               ldd       R$D,u     ; get source & destination task #'s
 * Entry point from F$CRC
-L0B25               ldy       R$Y,u               Get # bytes to move
-                    beq       fbye                None, exit without error
-                    ldx       R$X,u               get source pointer
-                    ldu       R$U,u               get destination pointer
-L0B2C               pshs      d,x,y,u             preserve it all
-                    pshs      d,y                 save task #'s & byte count
-                    tfr       a,b                 copy source task to B
-                    lbsr      L0BF5               calculate block offset of source
-                    leay      a,u                 point to block
-                    pshs      x,y                 save source pointer & DAT pointer of source
-                    ldb       9,s                 get destination task #
-                    ldx       14,s                get destination pointer
-                    lbsr      L0BF5               calculate block offset
-                    leay      a,u                 point to block
-                    pshs      x,y                 save dest. pointer & DAT pointer to dest.
+L0B25               ldy       R$Y,u     ; get # bytes to move
+                    beq       fbye      ; none, exit without error
+                    ldx       R$X,u     ; get source pointer
+                    ldu       R$U,u     ; get destination pointer
+L0B2C               pshs      d,x,y,u   ; preserve it all
+                    pshs      d,y       ; save task #'s & byte count
+                    tfr       a,b       ; copy source task to B
+                    lbsr      L0BF5     ; calculate block offset of source
+                    leay      a,u       ; point to block
+                    pshs      x,y       ; save source pointer & DAT pointer of source
+                    ldb       9,s       ; get destination task #
+                    ldx       14,s      ; get destination pointer
+                    lbsr      L0BF5     ; calculate block offset
+                    leay      a,u       ; point to block
+                    pshs      x,y       ; save dest. pointer & DAT pointer to dest.
 * try ldq #$20002000/ subr x,w / pshsw (+3), take out ldd (-3)
-                    ldd       #DAT.BlSz           get block size
-                    subd      ,s                  take off offset
-                    pshs      d                   preserve
-                    ldd       #DAT.BlSz           init offset in block
-                    subd      6,s
-                    pshs      d                   save distance to end??
-                    ldx       8,s                 get source pointer
-                    leax      -$6000,x            make X point to where we'll map block ($a000)
-                    ldu       4,s                 get destination pointer
-                    leau      -$4000,u            make U point to where we'll map block ($c000)
-                    ldy       <D.SysDAT           Get ptr to system DAT image
-                    lda       11,y                Get MMU block #5
-                    ldb       13,y                Get MMU block #6
-                    IFNE      H6309
-                    tfr       d,y                 Move to Y since unused in loop below
-                    ENDC
+                    ldd       #DAT.BlSz ; get block size
+                    subd      ,s        ; take off offset
+                    pshs      d         ; preserve
+                    ldd       #DAT.BlSz ; init offset in block
+                    subd      6,s       ; subtract 6,s from D
+                    pshs      d         ; save distance to end??
+                    ldx       8,s       ; get source pointer
+                    leax      -$6000,x  ; make X point to where we'll map block ($a000)
+                    ldu       4,s       ; get destination pointer
+                    leau      -$4000,u  ; make U point to where we'll map block ($c000)
+                    ldy       <D.SysDAT ; get ptr to system DAT image
+                    lda       11,y      ; get MMU block #5
+                    ldb       13,y      ; get MMU block #6
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       d,y       ; move to Y since unused in loop below
+                  ENDC
 * Main move loop
 * Stack:  0,s=distance to end of source block
 *         2,s=distance to end of destination block
@@ -77,56 +77,56 @@ L0B2C               pshs      d,x,y,u             preserve it all
 *        14,s=total byte count of move
 * Registers: X=Source pointer
 *            U=Destination pointer
-L0B6A               equ       *
-                    IFNE      H6309
-                    ldd       [<6,s]              [B]=Block # of source
-                    ldw       [<10,s]             [A]=Block # of destination
-                    tfr       f,a
+L0B6A               equ       *         ; define assembler symbol L0B6A
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldd       [<6,s]    ; [B]=Block # of source
+                    ldw       [<10,s]   ; [A]=Block # of destination
+                    tfr       f,a       ; transfer register value f,a
 * Calculate move length for this pass
-                    ldw       14,s                get full byte count
-                    cmpw      ,s                  we gonna overlap source?
-                    bls       L0B82               no, skip ahead
-                    ldw       ,s                  get remaining bytes in source block
-L0B82               cmpw      2,s                 we gonna overlap destination?
-                    bls       L0B89               no, skip ahead
-                    ldw       2,s                 get remaining bytes in destination block
-L0B89               cmpw      #$0100              less than 256 bytes?
-                    bls       L0B92               yes, skip ahead
-                    ldw       #$0100              force to 256 bytes
-L0B92               stw       12,s                save count
-                    orcc      #IntMasks           Shut off interrupts
-                    std       >DAT.Regs+5         map in the blocks
-                    tfm       x+,u+               Copy up to 256 bytes (max 774 cycles)
-                    sty       >DAT.Regs+5         Restore system blocks 5&6 to normal
-                    andcc     #^IntMasks
-                    ldd       14,s                get full count
-                    subd      12,s                done?
-                    beq       L0BEF               yes, return
-                    std       14,s                save updated count
-                    ldd       ,s                  get current offset in block
-                    subd      12,s                need to switch source block?
-                    bne       L0BD7               no, skip ahead
-                    lda       #$20                B=0 from 'bne' above
-                    subr      d,x                 reset source back to begining of block
-                    inc       11,s                add 2 to source DAT pointer
-                    inc       11,s
-L0BD7               std       ,s                  save updated source offset in block
-                    ldd       2,s                 get destination offset
-                    subd      12,s                need to switch destination block?
-                    bne       L0BEA               no, skip ahead
-                    lda       #$20                B=0 from 'bne', above
-                    subr      d,u                 reset destination back to beginning of block
-                    inc       7,s                 add 2 to destination DAT pointer
-                    inc       7,s
-L0BEA               std       2,s                 save updated destination offset in block
-                    bra       L0B6A               go do next block
+                    ldw       14,s      ; get full byte count
+                    cmpw      ,s        ; we gonna overlap source?
+                    bls       L0B82     ; no, skip ahead
+                    ldw       ,s        ; get remaining bytes in source block
+L0B82               cmpw      2,s       ; we gonna overlap destination?
+                    bls       L0B89     ; no, skip ahead
+                    ldw       2,s       ; get remaining bytes in destination block
+L0B89               cmpw      #$0100    ; less than 256 bytes?
+                    bls       L0B92     ; yes, skip ahead
+                    ldw       #$0100    ; force to 256 bytes
+L0B92               stw       12,s      ; save count
+                    orcc      #IntMasks ; shut off interrupts
+                    std       >DAT.Regs+5 ; map in the blocks
+                    tfm       x+,u+     ; copy up to 256 bytes (max 774 cycles)
+                    sty       >DAT.Regs+5 ; restore system blocks 5&6 to normal
+                    andcc     #^IntMasks ; clear condition-code bits using #^IntMasks
+                    ldd       14,s      ; get full count
+                    subd      12,s      ; done?
+                    beq       L0BEF     ; yes, return
+                    std       14,s      ; save updated count
+                    ldd       ,s        ; get current offset in block
+                    subd      12,s      ; need to switch source block?
+                    bne       L0BD7     ; no, skip ahead
+                    lda       #$20      ; B=0 from 'bne' above
+                    subr      d,x       ; reset source back to begining of block
+                    inc       11,s      ; add 2 to source DAT pointer
+                    inc       11,s      ; increment 11,s
+L0BD7               std       ,s        ; save updated source offset in block
+                    ldd       2,s       ; get destination offset
+                    subd      12,s      ; need to switch destination block?
+                    bne       L0BEA     ; no, skip ahead
+                    lda       #$20      ; B=0 from 'bne', above
+                    subr      d,u       ; reset destination back to beginning of block
+                    inc       7,s       ; add 2 to destination DAT pointer
+                    inc       7,s       ; increment 7,s
+L0BEA               std       2,s       ; save updated destination offset in block
+                    bra       L0B6A     ; go do next block
 
 * Block move done, return
-L0BEF               leas      16,s                purge stack
-L0BF2               clrb                          clear errors
-                    puls      d,x,y,u,pc          return
+L0BEF               leas      16,s      ; purge stack
+L0BF2               clrb                ; clear errors
+                    puls      d,x,y,u,pc ; return
 
-                    ELSE
+                  ELSE
 
 * Main move loop
 * Stack:  0,s=distance to end of source block
@@ -140,114 +140,114 @@ L0BF2               clrb                          clear errors
 *        14,s=total byte count of move
 * Registers: X=Source pointer
 *            U=Destination pointer
-L0BXA               ldd       [<$6,s]             Get block # of source into B
-                    pshs      b                   Save on stack
-                    ldd       [<10+1,s]           Get block # of dest into B
-                    pshs      b                   Save on stack
-                    ldd       <14+2,s             Get total byte count left we are copying
-                    cmpd      0+2,s               Will that go past end of source block?
-                    bls       L0B82               No, check destination
-                    ldd       0+2,s               Get # of bytes until end of source block
-L0B82               cmpd      2+2,s               Will that go past end of dest block?
-                    bls       L0B89               No, check max size we want IRQ's of
-                    ldd       2+2,s               Get # of bytes until end of dest block
-L0B89               cmpd      #$0060              >96 bytes to copy left?
-                    bls       L0B84               No, do entire # of bytes left
-                    ldd       #$0060              Yes, force to 96
-L0B84               std       12+2,s              Save size of current copy block
-                    puls      y                   Get source & dest MMU block #'s
-                    orcc      #IntMasks           Shut IRQ's off
-                    stb       <D.IRQTmp+1         Save copy of current copy block size
-                    sty       >DAT.Regs+5         Swap in source/dest MMU blocks into $A000-$DFFF
+L0BXA               ldd       [<$6,s]   ; get block # of source into B
+                    pshs      b         ; save on stack
+                    ldd       [<10+1,s] ; get block # of dest into B
+                    pshs      b         ; save on stack
+                    ldd       <14+2,s   ; get total byte count left we are copying
+                    cmpd      0+2,s     ; will that go past end of source block?
+                    bls       L0B82     ; no, check destination
+                    ldd       0+2,s     ; get # of bytes until end of source block
+L0B82               cmpd      2+2,s     ; will that go past end of dest block?
+                    bls       L0B89     ; no, check max size we want IRQ's of
+                    ldd       2+2,s     ; get # of bytes until end of dest block
+L0B89               cmpd      #$0060    ; >96 bytes to copy left?
+                    bls       L0B84     ; no, do entire # of bytes left
+                    ldd       #$0060    ; yes, force to 96
+L0B84               std       12+2,s    ; save size of current copy block
+                    puls      y         ; get source & dest MMU block #'s
+                    orcc      #IntMasks ; shut IRQ's off
+                    stb       <D.IRQTmp+1 ; save copy of current copy block size
+                    sty       >DAT.Regs+5 ; swap in source/dest MMU blocks into $A000-$DFFF
 ***** NO STACK USE BETWEEN HERE.....
-                    andb      #$07                2 1st, do single byte copies for 1-7 leftover bytes
-                    beq       L0B99               3 No leftovers, go to 8 byte copy routine
-L0B92               lda       ,x+                 6 Copy 1-7 leftover bytes
-                    sta       ,u+                 6
-                    decb                          2
-                    bne       L0B92               3
-L0B99               lda       <D.IRQTmp+1         +4 Get copy size back into A
-                    lsra                          Divide size by 8 (since 8 byte chunks copying)
-                    lsra
-                    lsra
-                    beq       L0BBC
-                    sta       <D.IRQTmp           Save loop counter (# 8 byte blocks) +4
-                    exg       x,u                 Swap source/destination ptrs for PULU routine
-L0BA4               pulu      y,d                 9 55 cycles per 8 bytes copied
-                    std       ,x                  5 (old pulu y/sty ,x++ was 69)
-                    sty       2,x                 6
-                    pulu      y,d                 9
-                    std       4,x                 6
-                    sty       6,x                 6
-                    leax      8,x                 5
-                    dec       <D.IRQTmp           6
-                    bne       L0BA4               3
-                    exg       x,u                 8 Swap updated source/dest ptrs
-L0BBC               ldy       <D.SysDAT           6 Get system DAT pointer
-                    lda       $0B,y               5 Get original MMU blocks
-                    ldb       $0D,y               5
-                    std       >DAT.Regs+5         6 Restore originals
+                    andb      #$07      ; 2 1st, do single byte copies for 1-7 leftover bytes
+                    beq       L0B99     ; 3 No leftovers, go to 8 byte copy routine
+L0B92               lda       ,x+       ; 6 Copy 1-7 leftover bytes
+                    sta       ,u+       ; 6
+                    decb                ; 2
+                    bne       L0B92     ; 3
+L0B99               lda       <D.IRQTmp+1 ; +4 Get copy size back into A
+                    lsra                ; divide size by 8 (since 8 byte chunks copying)
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    beq       L0BBC     ; branch if zero is set to L0BBC
+                    sta       <D.IRQTmp ; save loop counter (# 8 byte blocks) +4
+                    exg       x,u       ; swap source/destination ptrs for PULU routine
+L0BA4               pulu      y,d       ; 9 55 cycles per 8 bytes copied
+                    std       ,x        ; 5 (old pulu y/sty ,x++ was 69)
+                    sty       2,x       ; 6
+                    pulu      y,d       ; 9
+                    std       4,x       ; 6
+                    sty       6,x       ; 6
+                    leax      8,x       ; 5
+                    dec       <D.IRQTmp ; 6
+                    bne       L0BA4     ; 3
+                    exg       x,u       ; 8 Swap updated source/dest ptrs
+L0BBC               ldy       <D.SysDAT ; 6 Get system DAT pointer
+                    lda       $0B,y     ; 5 Get original MMU blocks
+                    ldb       $0D,y     ; 5
+                    std       >DAT.Regs+5 ; 6 Restore originals
 ***** AND HERE...........
-                    andcc     #^IntMasks          Turn IRQ's back on
-                    ldd       14,s                Get # of bytes left to copy
-                    subd      12,s                Subtract # bytes we copied
-                    beq       L0BEF               Done Move
-                    std       14,s                Save new # of bytes left to copy
-                    ldd       ,s                  Get # bytes until end of source block
-                    subd      12,s                Subtract # bytes copied
-                    bne       L0BD7               Still more in current source MMU block
-                    ldd       #DAT.BlSz           Size of MMU block (8K)
+                    andcc     #^IntMasks ; turn IRQ's back on
+                    ldd       14,s      ; get # of bytes left to copy
+                    subd      12,s      ; subtract # bytes we copied
+                    beq       L0BEF     ; done Move
+                    std       14,s      ; save new # of bytes left to copy
+                    ldd       ,s        ; get # bytes until end of source block
+                    subd      12,s      ; subtract # bytes copied
+                    bne       L0BD7     ; still more in current source MMU block
+                    ldd       #DAT.BlSz ; size of MMU block (8K)
 * Since we know where the blocks are mapped, we can change this leax
 * and the later leau to ldx #$A000 and ldu #$C000 (faster smaller)
-                    leax      >-DAT.BlSz,x        Move source ptr back to beginning of MMU block
+                    leax      >-DAT.BlSz,x ; move source ptr back to beginning of MMU block
 * If we do lda 11,s/adda #2/sta 11,s (2 more bytes, -2 cycles), move above
 * ldd #DAT.BlSz to after the sta 11,s
 * Not sure if worth the extra code space - these only get done when 8K
 * boundaries are crossed, so not often at all
-                    inc       11,s                7 Add 2 to source DAT ptr
-                    inc       11,s
-L0BD7               std       ,s                  Save new distance (8K) to end of source block
-                    ldd       2,s                 Get # bytes until end of dest block
-                    subd      12,s                Subtract # bytes copied
-                    bne       L0BEA               Still more in current dest MMU block
-                    ldd       #DAT.BlSz
-                    leau      >-DAT.BlSz,u        Wrap dest pr back
-                    inc       7,s                 7 Add 2 to dest DAT ptr
-                    inc       7,s
-L0BEA               std       2,s                 Save # of bytes left in dest block
-                    lbra      L0BXA
+                    inc       11,s      ; 7 Add 2 to source DAT ptr
+                    inc       11,s      ; increment 11,s
+L0BD7               std       ,s        ; save new distance (8K) to end of source block
+                    ldd       2,s       ; get # bytes until end of dest block
+                    subd      12,s      ; subtract # bytes copied
+                    bne       L0BEA     ; still more in current dest MMU block
+                    ldd       #DAT.BlSz ; load D from #DAT.BlSz
+                    leau      >-DAT.BlSz,u ; wrap dest pr back
+                    inc       7,s       ; 7 Add 2 to dest DAT ptr
+                    inc       7,s       ; increment 7,s
+L0BEA               std       2,s       ; save # of bytes left in dest block
+                    lbra      L0BXA     ; branch unconditionally to L0BXA
 
-L0BEF               leas      <$10,s              Eat temp stack
-L0BF2               clrb                          Exit w/o error
-                    puls      pc,u,y,x,d
+L0BEF               leas      <$10,s    ; eat temp stack
+L0BF2               clrb                ; exit w/o error
+                    puls      pc,u,y,x,d ; restore pc,u,y,x,d from the stack
 
-                    ENDC
+                  ENDC
 
-L0BF3               tfr       u,y                 save a copy of U for later
+L0BF3               tfr       u,y       ; save a copy of U for later
 * Calculate offset within DAT image
 * Entry: B=Task #
 *        X=Pointer to data
 * Exit : A=Offset into DAT image
 *        X=Offset within block from original pointer
 * Possible bug:  No one ever checks if the DAT image, in fact, exists.
-L0BF5               ldu       <D.TskIPt           get task image ptr table
-                    lslb
-                    ldu       b,u                 get ptr to this task's DAT image
-                    tfr       x,d                 copy logical address to D
-                    anda      #%11100000          Keep only which 8K bank it's in
-                    beq       L0C07               Bank 0, no further calcs needed
-                    clrb                          force it to start on an 8K boundary
-                    IFNE      H6309
-                    subr      d,x                 now X=offset into the block
-                    ELSE
-                    pshs      d
-                    tfr       x,d
-                    subd      ,s
-                    tfr       d,x
-                    puls      d
-                    ENDC
-                    lsra                          Calculate offset into DAT image to get proper
-                    lsra                          8K bank (remember that each entry in a DAT image
-                    lsra                          is 2 bytes)
-                    lsra
-L0C07               rts
+L0BF5               ldu       <D.TskIPt ; get task image ptr table
+                    lslb                ; shift or rotate and update condition codes
+                    ldu       b,u       ; get ptr to this task's DAT image
+                    tfr       x,d       ; copy logical address to D
+                    anda      #%11100000 ; keep only which 8K bank it's in
+                    beq       L0C07     ; bank 0, no further calcs needed
+                    clrb                ; force it to start on an 8K boundary
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    subr      d,x       ; now X=offset into the block
+                  ELSE
+                    pshs      d         ; save d on the stack
+                    tfr       x,d       ; transfer register value x,d
+                    subd      ,s        ; subtract ,s from D
+                    tfr       d,x       ; transfer register value d,x
+                    puls      d         ; restore d from the stack
+                  ENDC
+                    lsra                ; calculate offset into DAT image to get proper
+                    lsra                ; 8K bank (remember that each entry in a DAT image
+                    lsra                ; is 2 bytes)
+                    lsra                ; shift or rotate and update condition codes
+L0C07               rts                 ; return to caller

--- a/level2/modules/kernel/fmove.asm
+++ b/level2/modules/kernel/fmove.asm
@@ -33,19 +33,19 @@ fbye                clrb                ; clear B
 
 FMove               ldd       R$D,u     ; get source & destination task #'s
 * Entry point from F$CRC
-L0B25               ldy       R$Y,u     ; get # bytes to move
+FMoveBytes          ldy       R$Y,u     ; get # bytes to move
                     beq       fbye      ; none, exit without error
                     ldx       R$X,u     ; get source pointer
                     ldu       R$U,u     ; get destination pointer
-L0B2C               pshs      d,x,y,u   ; preserve it all
+FMoveTarget         pshs      d,x,y,u   ; preserve it all
                     pshs      d,y       ; save task #'s & byte count
                     tfr       a,b       ; copy source task to B
-                    lbsr      L0BF5     ; calculate block offset of source
+                    lbsr      FMoveTaskImageTable ; calculate block offset of source
                     leay      a,u       ; point to block
                     pshs      x,y       ; save source pointer & DAT pointer of source
                     ldb       9,s       ; get destination task #
                     ldx       14,s      ; get destination pointer
-                    lbsr      L0BF5     ; calculate block offset
+                    lbsr      FMoveTaskImageTable ; calculate block offset
                     leay      a,u       ; point to block
                     pshs      x,y       ; save dest. pointer & DAT pointer to dest.
 * try ldq #$20002000/ subr x,w / pshsw (+3), take out ldd (-3)
@@ -77,7 +77,7 @@ L0B2C               pshs      d,x,y,u   ; preserve it all
 *        14,s=total byte count of move
 * Registers: X=Source pointer
 *            U=Destination pointer
-L0B6A               equ       *         ; define assembler symbol L0B6A
+FMoveJoin           equ       *         ; define assembler symbol FMoveJoin
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldd       [<6,s]    ; [B]=Block # of source
                     ldw       [<10,s]   ; [A]=Block # of destination
@@ -85,15 +85,15 @@ L0B6A               equ       *         ; define assembler symbol L0B6A
 * Calculate move length for this pass
                     ldw       14,s      ; get full byte count
                     cmpw      ,s        ; we gonna overlap source?
-                    bls       L0B82     ; no, skip ahead
+                    bls       FMoveWeGonnaOverlapDestination ; no, skip ahead
                     ldw       ,s        ; get remaining bytes in source block
-L0B82               cmpw      2,s       ; we gonna overlap destination?
-                    bls       L0B89     ; no, skip ahead
+FMoveWeGonnaOverlapDestination cmpw      2,s       ; we gonna overlap destination?
+                    bls       FMoveBytes2 ; no, skip ahead
                     ldw       2,s       ; get remaining bytes in destination block
-L0B89               cmpw      #$0100    ; less than 256 bytes?
-                    bls       L0B92     ; yes, skip ahead
+FMoveBytes2         cmpw      #$0100    ; less than 256 bytes?
+                    bls       FMoveCount ; yes, skip ahead
                     ldw       #$0100    ; force to 256 bytes
-L0B92               stw       12,s      ; save count
+FMoveCount          stw       12,s      ; save count
                     orcc      #IntMasks ; shut off interrupts
                     std       >DAT.Regs+5 ; map in the blocks
                     tfm       x+,u+     ; copy up to 256 bytes (max 774 cycles)
@@ -101,29 +101,29 @@ L0B92               stw       12,s      ; save count
                     andcc     #^IntMasks ; clear condition-code bits using #^IntMasks
                     ldd       14,s      ; get full count
                     subd      12,s      ; done?
-                    beq       L0BEF     ; yes, return
+                    beq       FMovePurge ; yes, return
                     std       14,s      ; save updated count
                     ldd       ,s        ; get current offset in block
                     subd      12,s      ; need to switch source block?
-                    bne       L0BD7     ; no, skip ahead
+                    bne       FMoveUpdatedSourceOffsetBlock ; no, skip ahead
                     lda       #$20      ; B=0 from 'bne' above
                     subr      d,x       ; reset source back to begining of block
                     inc       11,s      ; add 2 to source DAT pointer
                     inc       11,s      ; increment 11,s
-L0BD7               std       ,s        ; save updated source offset in block
+FMoveUpdatedSourceOffsetBlock std       ,s        ; save updated source offset in block
                     ldd       2,s       ; get destination offset
                     subd      12,s      ; need to switch destination block?
-                    bne       L0BEA     ; no, skip ahead
+                    bne       FMoveUpdatedDestinationOffsetBlock ; no, skip ahead
                     lda       #$20      ; B=0 from 'bne', above
                     subr      d,u       ; reset destination back to beginning of block
                     inc       7,s       ; add 2 to destination DAT pointer
                     inc       7,s       ; increment 7,s
-L0BEA               std       2,s       ; save updated destination offset in block
-                    bra       L0B6A     ; go do next block
+FMoveUpdatedDestinationOffsetBlock std       2,s       ; save updated destination offset in block
+                    bra       FMoveJoin ; go do next block
 
 * Block move done, return
-L0BEF               leas      16,s      ; purge stack
-L0BF2               clrb                ; clear errors
+FMovePurge          leas      16,s      ; purge stack
+FMoveErrors         clrb                ; clear errors
                     puls      d,x,y,u,pc ; return
 
                   ELSE
@@ -146,34 +146,34 @@ L0BXA               ldd       [<$6,s]   ; get block # of source into B
                     pshs      b         ; save on stack
                     ldd       <14+2,s   ; get total byte count left we are copying
                     cmpd      0+2,s     ; will that go past end of source block?
-                    bls       L0B82     ; no, check destination
+                    bls       FMoveWeGonnaOverlapDestination ; no, check destination
                     ldd       0+2,s     ; get # of bytes until end of source block
-L0B82               cmpd      2+2,s     ; will that go past end of dest block?
-                    bls       L0B89     ; no, check max size we want IRQ's of
+FMoveWeGonnaOverlapDestination cmpd      2+2,s     ; will that go past end of dest block?
+                    bls       FMoveBytes2 ; no, check max size we want IRQ's of
                     ldd       2+2,s     ; get # of bytes until end of dest block
-L0B89               cmpd      #$0060    ; >96 bytes to copy left?
-                    bls       L0B84     ; no, do entire # of bytes left
+FMoveBytes2         cmpd      #$0060    ; >96 bytes to copy left?
+                    bls       FMoveSizeBlock ; no, do entire # of bytes left
                     ldd       #$0060    ; yes, force to 96
-L0B84               std       12+2,s    ; save size of current copy block
+FMoveSizeBlock      std       12+2,s    ; save size of current copy block
                     puls      y         ; get source & dest MMU block #'s
                     orcc      #IntMasks ; shut IRQ's off
                     stb       <D.IRQTmp+1 ; save copy of current copy block size
                     sty       >DAT.Regs+5 ; swap in source/dest MMU blocks into $A000-$DFFF
 ***** NO STACK USE BETWEEN HERE.....
                     andb      #$07      ; 2 1st, do single byte copies for 1-7 leftover bytes
-                    beq       L0B99     ; 3 No leftovers, go to 8 byte copy routine
-L0B92               lda       ,x+       ; 6 Copy 1-7 leftover bytes
+                    beq       FMoveSizeBack ; 3 No leftovers, go to 8 byte copy routine
+FMoveCount          lda       ,x+       ; 6 Copy 1-7 leftover bytes
                     sta       ,u+       ; 6
                     decb                ; 2
-                    bne       L0B92     ; 3
-L0B99               lda       <D.IRQTmp+1 ; +4 Get copy size back into A
+                    bne       FMoveCount ; 3
+FMoveSizeBack       lda       <D.IRQTmp+1 ; +4 Get copy size back into A
                     lsra                ; divide size by 8 (since 8 byte chunks copying)
                     lsra                ; shift or rotate and update condition codes
                     lsra                ; shift or rotate and update condition codes
-                    beq       L0BBC     ; branch if zero is set to L0BBC
+                    beq       FMoveSystemDAT ; branch if zero is set to FMoveSystemDAT
                     sta       <D.IRQTmp ; save loop counter (# 8 byte blocks) +4
                     exg       x,u       ; swap source/destination ptrs for PULU routine
-L0BA4               pulu      y,d       ; 9 55 cycles per 8 bytes copied
+FMoveCyclesPerBytesCopied pulu      y,d       ; 9 55 cycles per 8 bytes copied
                     std       ,x        ; 5 (old pulu y/sty ,x++ was 69)
                     sty       2,x       ; 6
                     pulu      y,d       ; 9
@@ -181,9 +181,9 @@ L0BA4               pulu      y,d       ; 9 55 cycles per 8 bytes copied
                     sty       6,x       ; 6
                     leax      8,x       ; 5
                     dec       <D.IRQTmp ; 6
-                    bne       L0BA4     ; 3
+                    bne       FMoveCyclesPerBytesCopied ; 3
                     exg       x,u       ; 8 Swap updated source/dest ptrs
-L0BBC               ldy       <D.SysDAT ; 6 Get system DAT pointer
+FMoveSystemDAT      ldy       <D.SysDAT ; 6 Get system DAT pointer
                     lda       $0B,y     ; 5 Get original MMU blocks
                     ldb       $0D,y     ; 5
                     std       >DAT.Regs+5 ; 6 Restore originals
@@ -191,11 +191,11 @@ L0BBC               ldy       <D.SysDAT ; 6 Get system DAT pointer
                     andcc     #^IntMasks ; turn IRQ's back on
                     ldd       14,s      ; get # of bytes left to copy
                     subd      12,s      ; subtract # bytes we copied
-                    beq       L0BEF     ; done Move
+                    beq       FMovePurge ; done Move
                     std       14,s      ; save new # of bytes left to copy
                     ldd       ,s        ; get # bytes until end of source block
                     subd      12,s      ; subtract # bytes copied
-                    bne       L0BD7     ; still more in current source MMU block
+                    bne       FMoveUpdatedSourceOffsetBlock ; still more in current source MMU block
                     ldd       #DAT.BlSz ; size of MMU block (8K)
 * Since we know where the blocks are mapped, we can change this leax
 * and the later leau to ldx #$A000 and ldu #$C000 (faster smaller)
@@ -206,36 +206,36 @@ L0BBC               ldy       <D.SysDAT ; 6 Get system DAT pointer
 * boundaries are crossed, so not often at all
                     inc       11,s      ; 7 Add 2 to source DAT ptr
                     inc       11,s      ; increment 11,s
-L0BD7               std       ,s        ; save new distance (8K) to end of source block
+FMoveUpdatedSourceOffsetBlock std       ,s        ; save new distance (8K) to end of source block
                     ldd       2,s       ; get # bytes until end of dest block
                     subd      12,s      ; subtract # bytes copied
-                    bne       L0BEA     ; still more in current dest MMU block
+                    bne       FMoveUpdatedDestinationOffsetBlock ; still more in current dest MMU block
                     ldd       #DAT.BlSz ; load D from #DAT.BlSz
                     leau      >-DAT.BlSz,u ; wrap dest pr back
                     inc       7,s       ; 7 Add 2 to dest DAT ptr
                     inc       7,s       ; increment 7,s
-L0BEA               std       2,s       ; save # of bytes left in dest block
+FMoveUpdatedDestinationOffsetBlock std       2,s       ; save # of bytes left in dest block
                     lbra      L0BXA     ; branch unconditionally to L0BXA
 
-L0BEF               leas      <$10,s    ; eat temp stack
-L0BF2               clrb                ; exit w/o error
+FMovePurge          leas      <$10,s    ; eat temp stack
+FMoveErrors         clrb                ; exit w/o error
                     puls      pc,u,y,x,d ; restore pc,u,y,x,d from the stack
 
                   ENDC
 
-L0BF3               tfr       u,y       ; save a copy of U for later
+FMoveLater          tfr       u,y       ; save a copy of U for later
 * Calculate offset within DAT image
 * Entry: B=Task #
 *        X=Pointer to data
 * Exit : A=Offset into DAT image
 *        X=Offset within block from original pointer
 * Possible bug:  No one ever checks if the DAT image, in fact, exists.
-L0BF5               ldu       <D.TskIPt ; get task image ptr table
+FMoveTaskImageTable ldu       <D.TskIPt ; get task image ptr table
                     lslb                ; shift or rotate and update condition codes
                     ldu       b,u       ; get ptr to this task's DAT image
                     tfr       x,d       ; copy logical address to D
                     anda      #%11100000 ; keep only which 8K bank it's in
-                    beq       L0C07     ; bank 0, no further calcs needed
+                    beq       FMoveReturn ; bank 0, no further calcs needed
                     clrb                ; force it to start on an 8K boundary
                   IFNE    H6309   ; begin conditional assembly for H6309
                     subr      d,x       ; now X=offset into the block
@@ -250,4 +250,4 @@ L0BF5               ldu       <D.TskIPt ; get task image ptr table
                     lsra                ; 8K bank (remember that each entry in a DAT image
                     lsra                ; is 2 bytes)
                     lsra                ; shift or rotate and update condition codes
-L0C07               rts                 ; return to caller
+FMoveReturn         rts                 ; return to caller

--- a/level2/modules/kernel/fmove.asm
+++ b/level2/modules/kernel/fmove.asm
@@ -85,9 +85,9 @@ FMoveJoin           equ       *         ; define assembler symbol FMoveJoin
 * Calculate move length for this pass
                     ldw       14,s      ; get full byte count
                     cmpw      ,s        ; we gonna overlap source?
-                    bls       FMoveWeGonnaOverlapDestination ; no, skip ahead
+                    bls       FMoveWeGnnOvrlp ; no, skip ahead
                     ldw       ,s        ; get remaining bytes in source block
-FMoveWeGonnaOverlapDestination cmpw      2,s       ; we gonna overlap destination?
+FMoveWeGnnOvrlp     cmpw      2,s       ; we gonna overlap destination?
                     bls       FMoveBytes2 ; no, skip ahead
                     ldw       2,s       ; get remaining bytes in destination block
 FMoveBytes2         cmpw      #$0100    ; less than 256 bytes?
@@ -105,20 +105,20 @@ FMoveCount          stw       12,s      ; save count
                     std       14,s      ; save updated count
                     ldd       ,s        ; get current offset in block
                     subd      12,s      ; need to switch source block?
-                    bne       FMoveUpdatedSourceOffsetBlock ; no, skip ahead
+                    bne       FMoveUpdSrcOff ; no, skip ahead
                     lda       #$20      ; B=0 from 'bne' above
                     subr      d,x       ; reset source back to begining of block
                     inc       11,s      ; add 2 to source DAT pointer
                     inc       11,s      ; increment 11,s
-FMoveUpdatedSourceOffsetBlock std       ,s        ; save updated source offset in block
+FMoveUpdSrcOff      std       ,s        ; save updated source offset in block
                     ldd       2,s       ; get destination offset
                     subd      12,s      ; need to switch destination block?
-                    bne       FMoveUpdatedDestinationOffsetBlock ; no, skip ahead
+                    bne       FMoveUpdDstOff ; no, skip ahead
                     lda       #$20      ; B=0 from 'bne', above
                     subr      d,u       ; reset destination back to beginning of block
                     inc       7,s       ; add 2 to destination DAT pointer
                     inc       7,s       ; increment 7,s
-FMoveUpdatedDestinationOffsetBlock std       2,s       ; save updated destination offset in block
+FMoveUpdDstOff      std       2,s       ; save updated destination offset in block
                     bra       FMoveJoin ; go do next block
 
 * Block move done, return
@@ -146,9 +146,9 @@ L0BXA               ldd       [<$6,s]   ; get block # of source into B
                     pshs      b         ; save on stack
                     ldd       <14+2,s   ; get total byte count left we are copying
                     cmpd      0+2,s     ; will that go past end of source block?
-                    bls       FMoveWeGonnaOverlapDestination ; no, check destination
+                    bls       FMoveWeGnnOvrlp ; no, check destination
                     ldd       0+2,s     ; get # of bytes until end of source block
-FMoveWeGonnaOverlapDestination cmpd      2+2,s     ; will that go past end of dest block?
+FMoveWeGnnOvrlp     cmpd      2+2,s     ; will that go past end of dest block?
                     bls       FMoveBytes2 ; no, check max size we want IRQ's of
                     ldd       2+2,s     ; get # of bytes until end of dest block
 FMoveBytes2         cmpd      #$0060    ; >96 bytes to copy left?
@@ -173,7 +173,7 @@ FMoveSizeBack       lda       <D.IRQTmp+1 ; +4 Get copy size back into A
                     beq       FMoveSystemDAT ; branch if zero is set to FMoveSystemDAT
                     sta       <D.IRQTmp ; save loop counter (# 8 byte blocks) +4
                     exg       x,u       ; swap source/destination ptrs for PULU routine
-FMoveCyclesPerBytesCopied pulu      y,d       ; 9 55 cycles per 8 bytes copied
+FMoveCyclsPerByts   pulu      y,d       ; 9 55 cycles per 8 bytes copied
                     std       ,x        ; 5 (old pulu y/sty ,x++ was 69)
                     sty       2,x       ; 6
                     pulu      y,d       ; 9
@@ -181,7 +181,7 @@ FMoveCyclesPerBytesCopied pulu      y,d       ; 9 55 cycles per 8 bytes copied
                     sty       6,x       ; 6
                     leax      8,x       ; 5
                     dec       <D.IRQTmp ; 6
-                    bne       FMoveCyclesPerBytesCopied ; 3
+                    bne       FMoveCyclsPerByts ; 3
                     exg       x,u       ; 8 Swap updated source/dest ptrs
 FMoveSystemDAT      ldy       <D.SysDAT ; 6 Get system DAT pointer
                     lda       $0B,y     ; 5 Get original MMU blocks
@@ -195,7 +195,7 @@ FMoveSystemDAT      ldy       <D.SysDAT ; 6 Get system DAT pointer
                     std       14,s      ; save new # of bytes left to copy
                     ldd       ,s        ; get # bytes until end of source block
                     subd      12,s      ; subtract # bytes copied
-                    bne       FMoveUpdatedSourceOffsetBlock ; still more in current source MMU block
+                    bne       FMoveUpdSrcOff ; still more in current source MMU block
                     ldd       #DAT.BlSz ; size of MMU block (8K)
 * Since we know where the blocks are mapped, we can change this leax
 * and the later leau to ldx #$A000 and ldu #$C000 (faster smaller)
@@ -206,15 +206,15 @@ FMoveSystemDAT      ldy       <D.SysDAT ; 6 Get system DAT pointer
 * boundaries are crossed, so not often at all
                     inc       11,s      ; 7 Add 2 to source DAT ptr
                     inc       11,s      ; increment 11,s
-FMoveUpdatedSourceOffsetBlock std       ,s        ; save new distance (8K) to end of source block
+FMoveUpdSrcOff      std       ,s        ; save new distance (8K) to end of source block
                     ldd       2,s       ; get # bytes until end of dest block
                     subd      12,s      ; subtract # bytes copied
-                    bne       FMoveUpdatedDestinationOffsetBlock ; still more in current dest MMU block
+                    bne       FMoveUpdDstOff ; still more in current dest MMU block
                     ldd       #DAT.BlSz ; load D from #DAT.BlSz
                     leau      >-DAT.BlSz,u ; wrap dest pr back
                     inc       7,s       ; 7 Add 2 to dest DAT ptr
                     inc       7,s       ; increment 7,s
-FMoveUpdatedDestinationOffsetBlock std       2,s       ; save # of bytes left in dest block
+FMoveUpdDstOff      std       2,s       ; save # of bytes left in dest block
                     lbra      L0BXA     ; branch unconditionally to L0BXA
 
 FMovePurge          leas      <$10,s    ; eat temp stack

--- a/level2/modules/kernel/fsuser.asm
+++ b/level2/modules/kernel/fsuser.asm
@@ -9,8 +9,8 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FSUser         ldx       <D.Proc             get current process dsc ptr
-               ldd       R$Y,u               get requested user number
-               std       P$User,x            save new user # in process descriptor
-               clrb                          no error
-               rts                           and return
+FSUser              ldx       <D.Proc   ; get current process dsc ptr
+                    ldd       R$Y,u     ; get requested user number
+                    std       P$User,x  ; save new user # in process descriptor
+                    clrb                ; no error
+                    rts                 ; and return

--- a/level2/modules/kernel/funload.asm
+++ b/level2/modules/kernel/funload.asm
@@ -17,34 +17,34 @@ FUnLoad             pshs      u         ; preserve register stack pointer
                     ldx       R$X,u     ; get pointer to name
                     os9       F$FModul  ; find it in module directory
                     puls      y         ; restore register stack pointer
-                    bcs       L0A4F     ; couldn't find it, return error
+                    bcs       FUnloadReturn ; couldn't find it, return error
                     stx       R$X,y     ; save update name pointer
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       MD$Link,u ; get link count
-                    beq       L0A21     ; already 0 check if it's a I/O module
+                    beq       FUnloadModule ; already 0 check if it's a I/O module
                     decw                ; subtract 1
                     stw       MD$Link,u ; save it back
                   ELSE
                     ldx       MD$Link,u ; get module link count
-                    beq       L0A21     ; branch if zero
+                    beq       FUnloadModule ; branch if zero
                     leax      -1,x      ; else decrement
                     stx       MD$Link,u ; store X at MD$Link,u
                   ENDC
-                    bne       L0A4E     ; not zero, don't remove from memory, return
+                    bne       FUnloadErrors ; not zero, don't remove from memory, return
 
 * Link count is zero, check if module can be removed from memory
-L0A21               cmpa      #FlMgr    ; is it a I/O module?
-                    blo       L0A4B     ; no, remove module from memory
+FUnloadModule       cmpa      #FlMgr    ; is it a I/O module?
+                    blo       FUnloadDeleteModuleMemory ; no, remove module from memory
 
 * Special handling for I/O module deletion
                     clra                ; clear A
                     ldx       [MD$MPDAT,u] ; get 1st 2 blocks in DAT image of module
                     ldy       <D.SysDAT ; get pointer to system DAT image
-L0A2B               adda      #2        ; add #2 to A
+FUnloadTarget       adda      #2        ; add #2 to A
                     cmpa      #DAT.ImSz ; done entire DAT?
-                    bcc       L0A4B     ; yes, delete the module from memory
+                    bcc       FUnloadDeleteModuleMemory ; yes, delete the module from memory
                     cmpx      a,y       ; find block?
-                    bne       L0A2B     ; no, keep looking
+                    bne       FUnloadTarget ; no, keep looking
                     lsla                ; multiply by 16 to calculate the offset
                     lsla                ; shift or rotate and update condition codes
                     lsla                ; shift or rotate and update condition codes
@@ -53,7 +53,7 @@ L0A2B               adda      #2        ; add #2 to A
                     addd      MD$MPtr,u ; add in the pointer
                     tfr       d,x       ; copy it to X
                     os9       F$IODel   ; delete the device from memory
-                    bcc       L0A4B     ; no error, skip ahead
+                    bcc       FUnloadDeleteModuleMemory ; no error, skip ahead
 
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       MD$Link,u ; put link count back
@@ -67,6 +67,6 @@ L0A2B               adda      #2        ; add #2 to A
                     rts                 ; return with error
 
 * Delete module from memory
-L0A4B               lbsr      DelMod    ; delete module from memory
-L0A4E               clrb                ; clear errors
-L0A4F               rts                 ; return
+FUnloadDeleteModuleMemory lbsr      DelMod    ; delete module from memory
+FUnloadErrors       clrb                ; clear errors
+FUnloadReturn       rts                 ; return

--- a/level2/modules/kernel/funload.asm
+++ b/level2/modules/kernel/funload.asm
@@ -10,63 +10,63 @@
 *
 * Error:  CC = C bit set; B = error code
 *
-FUnLoad        pshs      u                   preserve register stack pointer
-               lda       R$A,u               get module type
-               ldx       <D.Proc             get current process pointer
-               leay      P$DATImg,x          point to DAT image
-               ldx       R$X,u               get pointer to name
-               os9       F$FModul            find it in module directory
-               puls      y                   restore register stack pointer
-               bcs       L0A4F               couldn't find it, return error
-               stx       R$X,y               save update name pointer
-               ifne      H6309
-               ldw       MD$Link,u           get link count
-               beq       L0A21               already 0 check if it's a I/O module
-               decw                          subtract 1
-               stw       MD$Link,u           save it back
-               else      
-               ldx       MD$Link,u           get module link count
-               beq       L0A21               branch if zero
-               leax      -1,x                else decrement
-               stx       MD$Link,u
-               endc      
-               bne       L0A4E               not zero, don't remove from memory, return
+FUnLoad             pshs      u         ; preserve register stack pointer
+                    lda       R$A,u     ; get module type
+                    ldx       <D.Proc   ; get current process pointer
+                    leay      P$DATImg,x ; point to DAT image
+                    ldx       R$X,u     ; get pointer to name
+                    os9       F$FModul  ; find it in module directory
+                    puls      y         ; restore register stack pointer
+                    bcs       L0A4F     ; couldn't find it, return error
+                    stx       R$X,y     ; save update name pointer
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       MD$Link,u ; get link count
+                    beq       L0A21     ; already 0 check if it's a I/O module
+                    decw                ; subtract 1
+                    stw       MD$Link,u ; save it back
+                  ELSE
+                    ldx       MD$Link,u ; get module link count
+                    beq       L0A21     ; branch if zero
+                    leax      -1,x      ; else decrement
+                    stx       MD$Link,u ; store X at MD$Link,u
+                  ENDC
+                    bne       L0A4E     ; not zero, don't remove from memory, return
 
 * Link count is zero, check if module can be removed from memory
-L0A21          cmpa      #FlMgr              is it a I/O module?
-               blo       L0A4B               no, remove module from memory
+L0A21               cmpa      #FlMgr    ; is it a I/O module?
+                    blo       L0A4B     ; no, remove module from memory
 
 * Special handling for I/O module deletion
-               clra      
-               ldx       [MD$MPDAT,u]        get 1st 2 blocks in DAT image of module
-               ldy       <D.SysDAT           get pointer to system DAT image
-L0A2B          adda      #2
-               cmpa      #DAT.ImSz           done entire DAT?
-               bcc       L0A4B               yes, delete the module from memory
-               cmpx      a,y                 find block?
-               bne       L0A2B               no, keep looking
-               lsla                          multiply by 16 to calculate the offset
-               lsla      
-               lsla      
-               lsla      
-               clrb      
-               addd      MD$MPtr,u           add in the pointer
-               tfr       d,x                 copy it to X
-               os9       F$IODel             delete the device from memory
-               bcc       L0A4B               no error, skip ahead
+                    clra                ; clear A
+                    ldx       [MD$MPDAT,u] ; get 1st 2 blocks in DAT image of module
+                    ldy       <D.SysDAT ; get pointer to system DAT image
+L0A2B               adda      #2        ; add #2 to A
+                    cmpa      #DAT.ImSz ; done entire DAT?
+                    bcc       L0A4B     ; yes, delete the module from memory
+                    cmpx      a,y       ; find block?
+                    bne       L0A2B     ; no, keep looking
+                    lsla                ; multiply by 16 to calculate the offset
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    lsla                ; shift or rotate and update condition codes
+                    clrb                ; clear B
+                    addd      MD$MPtr,u ; add in the pointer
+                    tfr       d,x       ; copy it to X
+                    os9       F$IODel   ; delete the device from memory
+                    bcc       L0A4B     ; no error, skip ahead
 
-               ifne      H6309
-               ldw       MD$Link,u           put link count back
-               incw      
-               stw       MD$Link,u
-               else      
-               ldx       MD$Link,u           put link count back
-               leax      1,x
-               stx       MD$Link,u
-               endc      
-               rts                           Return with error
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       MD$Link,u ; put link count back
+                    incw                ; increment W
+                    stw       MD$Link,u ; store W at MD$Link,u
+                  ELSE
+                    ldx       MD$Link,u ; put link count back
+                    leax      1,x       ; compute 1,x into X
+                    stx       MD$Link,u ; store X at MD$Link,u
+                  ENDC
+                    rts                 ; return with error
 
 * Delete module from memory
-L0A4B          lbsr      DelMod              Delete module from memory
-L0A4E          clrb                          clear errors
-L0A4F          rts                           return
+L0A4B               lbsr      DelMod    ; delete module from memory
+L0A4E               clrb                ; clear errors
+L0A4F               rts                 ; return

--- a/level2/modules/kernel/funload.asm
+++ b/level2/modules/kernel/funload.asm
@@ -34,7 +34,7 @@ FUnLoad             pshs      u         ; preserve register stack pointer
 
 * Link count is zero, check if module can be removed from memory
 FUnloadModule       cmpa      #FlMgr    ; is it a I/O module?
-                    blo       FUnloadDeleteModuleMemory ; no, remove module from memory
+                    blo       FUnloadDltModMem ; no, remove module from memory
 
 * Special handling for I/O module deletion
                     clra                ; clear A
@@ -42,7 +42,7 @@ FUnloadModule       cmpa      #FlMgr    ; is it a I/O module?
                     ldy       <D.SysDAT ; get pointer to system DAT image
 FUnloadTarget       adda      #2        ; add #2 to A
                     cmpa      #DAT.ImSz ; done entire DAT?
-                    bcc       FUnloadDeleteModuleMemory ; yes, delete the module from memory
+                    bcc       FUnloadDltModMem ; yes, delete the module from memory
                     cmpx      a,y       ; find block?
                     bne       FUnloadTarget ; no, keep looking
                     lsla                ; multiply by 16 to calculate the offset
@@ -53,7 +53,7 @@ FUnloadTarget       adda      #2        ; add #2 to A
                     addd      MD$MPtr,u ; add in the pointer
                     tfr       d,x       ; copy it to X
                     os9       F$IODel   ; delete the device from memory
-                    bcc       FUnloadDeleteModuleMemory ; no error, skip ahead
+                    bcc       FUnloadDltModMem ; no error, skip ahead
 
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldw       MD$Link,u ; put link count back
@@ -67,6 +67,6 @@ FUnloadTarget       adda      #2        ; add #2 to A
                     rts                 ; return with error
 
 * Delete module from memory
-FUnloadDeleteModuleMemory lbsr      DelMod    ; delete module from memory
+FUnloadDltModMem    lbsr      DelMod    ; delete module from memory
 FUnloadErrors       clrb                ; clear errors
 FUnloadReturn       rts                 ; return

--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -92,7 +92,7 @@ MName               fcs       /Krn/
 
 * The dispatch table.
 * The kernel copies this to low RAM starting at D.Clock.
-DisTable            fdb       FAlltskSleepingProcessQueue+Where ; d.Clock absolute address at the start
+DisTable            fdb       FAlltskSleepProcQ+Where ; d.Clock absolute address at the start
                     fdb       XSWI3+Where ; d.XSWI3
                     fdb       XSWI2+Where ; d.XSWI2
                     fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
@@ -542,9 +542,9 @@ KrnBlock            aslb                ; B <= 1 (hi bit goes into carry, 0 goes
 * $0280 = 1024KB (128 8KB blocks)
 * $0300 = 2048KB (256 8KB blocks)
                     bitb      #%00110000 ; is the block above 128K-256K?
-                    beq       Mc09KrnStartBootTrackMemory ; yes, no need to mark block map
+                    beq       Mc09KrnStart ; yes, no need to mark block map
                     tstb                ; is it 2 meg?
-                    beq       Mc09KrnStartBootTrackMemory ; yes, skip this
+                    beq       Mc09KrnStart ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM.
                     abx                 ; add the maximum block number to block map start address
                     leax      -1,x      ; skip good blocks that are RAM
@@ -555,7 +555,7 @@ l@                  sta       ,x+       ; mark them all
                     bne       l@        ; not yet
 
 * ASSUME: however we got here, B=0
-Mc09KrnStartBootTrackMemory
+Mc09KrnStart
                     ldx       #Bt.Start ; start address of the boot track in memory
                     lda       #18       ; size of the boot track is $1800
                   ENDC
@@ -568,11 +568,11 @@ Mc09KrnStartBootTrackMemory
 * BGP - Load bootfile and link to init. We no longer try to link to init first and then
 * call F$Boot. This saves bytes.
                     os9       F$Boot    ; load bootfile here +BGP+
-                    bcs       KrnObviouslyCantCrashMachine ; error, go crash +BGP+
+                    bcs       KrnBadCantCrsh ; error, go crash +BGP+
                   ENDC
                     leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
-                    bcs       KrnObviouslyCantCrashMachine ; error, go crash
+                    bcs       KrnBadCantCrsh ; error, go crash
 
 * BGP - Commented out the following lines since I moved F$Boot above
 *                    bcc       L01BF               no error, go on
@@ -608,7 +608,7 @@ KrnKrnp2sName       leax      <krnp2,pc ; point to krnp2's name
 KrnJumpKrnp2        jmp       ,y        ; jump into krnp2
 
 * BGP - This line was above L01D0 but now moved below since above lines are commented.
-KrnObviouslyCantCrashMachine jmp       <D.Crash  ; obviously can't do it, crash machine
+KrnBadCantCrsh      jmp       <D.Crash  ; obviously can't do it, crash machine
 
 * Update the system memory map to reserve the area the kernel uses.
 KrnSystemMemoryMap  ldx       <D.SysMem ; get the system memory map pointer
@@ -718,7 +718,7 @@ XSWI3               lda       #P$SWI3   ; point to the SWI3 vector
 XSWI                lda       #P$SWI    ; point to the SWI vector
                     ldx       <D.Proc   ; get the current process descriptor
                     ldu       a,x       ; is this a user defined SWI[x]?
-                    beq       KrnSystemCallServiceVector ; no, go get the option byte
+                    beq       KrnSysCallSvc ; no, go get the option byte
 GoUser              lbra      KrnJoin3  ; else call the users's routine
 
 * SWI2 vector entry
@@ -730,7 +730,7 @@ XSWI2               ldx       <D.Proc   ; get the current process descriptor
 *
 * Entry: X = The process descriptor pointer of process that made system call.
 *        U = The register stack pointer.
-KrnSystemCallServiceVector ldu       <D.SysSvc ; get the system call service vector
+KrnSysCallSvc       ldu       <D.SysSvc ; get the system call service vector
                     stu       <D.XSWI2  ; set the cross-SWI2 vector
                     ldu       <D.SysIRQ ; get the interrupt service vector
                     stu       <D.XIRQ   ; set the cross-IRQ vector
@@ -766,7 +766,7 @@ l@                  ldx       ,--y      ; get the source bytes
                     stx       R$PC,u    ; save updated the update program counter back
 * Execute the system call.
                     ldy       <D.UsrDis ; get the user dispatch table pointer
-                    lbsr      ExecSvcCall     ; go execute the op-code
+                    lbsr      ExecSvcCall ; go execute the op-code
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^IntMasks,R$CC,u ; unmask interrupts in the caller's CC
                   ELSE
@@ -791,7 +791,7 @@ l@                  ldx       ,--y      ; get the source bytes
                     sta       <D.Quick  ; save quick return flag
                     beq       AllClr    ; if nothing changed, do full checks
 
-DoFull              bsr       CopySystemStackToUser ; move the stack frame back to user state
+DoFull              bsr       CpSysStkTo ; move the stack frame back to user state
                     lbra      KrnJoin   ; go back to the process
 
 * add ldu P$SP,x, etc...
@@ -825,7 +825,7 @@ l@                  lda       ,u+       ; get the source byte
 * Copy the register stack from user to system.
 *
 * Entry: U = The pointer to the register stack in the process descriptor.
-CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
+CpUsrStkTo          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get the task #
                     ldx       P$SP,x    ; and the stack pointer
                     lbsr      FMoveLater ; calculate the block offset (only affects A&X)
@@ -835,7 +835,7 @@ CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
 * Copy the register stack from system to user.
 *
 * Entry: U = The pointer to the register stack in the process descriptor.
-CopySystemStackToUser          pshs      cc,x,y,u  ; preserve registers
+CpSysStkTo          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get the task # of destination
                     ldx       P$SP,x    ; and the stack pointer
                     lbsr      FMoveLater ; calculate the block offset (only affects A&X)
@@ -882,9 +882,9 @@ SysCall             leau      ,s        ; get the pointer to the register stack
                     leax      1,x       ; move the PC to next position
                     stx       R$PC,u    ; save my caller's updated PC register
                     ldy       <D.SysDis ; get the system dispatch table pointer
-                    bsr       ExecSvcCall     ; execute the system call
+                    bsr       ExecSvcCall ; execute the system call
                     puls      a         ; restore the system state task number
-                    lbra      KrnSystemProcessDescriptor ; return to the process
+                    lbra      KrnSysProcDesc ; return to the process
 
 * Entry: X = system call vector to jump to
 Sys.Vec             jmp       ,x        ; execute the service call
@@ -899,13 +899,13 @@ ExecSvcCall
 * Execute I/O system calls.
                     ldx       IOEntry,y ; else get IOMan vector
 * Execute the system call.
-CallSvcVector          pshs      u         ; preserve the register stack pointer
+CallSvcVector       pshs      u         ; preserve the register stack pointer
                     jsr       [D.SysVec] ; perform a vectored system call
                     puls      u         ; restore the pointer
-UpdateCallerCC          tfr       cc,a      ; move CC to A for a stack update
-                    bcc       MergeCallerCC    ; go update it if no error from call
+UpdateCallerCC      tfr       cc,a      ; move CC to A for a stack update
+                    bcc       MergeCallerCC ; go update it if no error from call
                     stb       R$B,u     ; save the error code to caller's B
-MergeCallerCC              ldb       R$CC,u    ; get the caller's CC, R$CC = $00
+MergeCallerCC       ldb       R$CC,u    ; get the caller's CC, R$CC = $00
                   IFNE    H6309   ; begin conditional assembly for H6309
                     andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
                     orr       b,a       merge them together
@@ -972,7 +972,7 @@ XIRQ                ldx       <D.Proc   ; get the current process pointer
                     ldd       <D.SysIRQ ; set the system IRQ routine to current
                     std       <D.XIRQ   ; store it in the cross-IRQ vector
                     jsr       [>D.SvcIRQ] ; execute interrupt service routine
-                    bcc       KrnShutDownInterrupts ; branch if the routine was serviced
+                    bcc       KrnShutDownInts ; branch if the routine was serviced
 
                     ldx       <D.Proc   ; get the current process pointer
                     ldb       P$Task,x  ; and the task of the process
@@ -985,7 +985,7 @@ XIRQ                ldx       <D.Proc   ; get the current process pointer
 
                     ora       #IntMasks ; disable its interrupts
                     lbsr      FLdabxCarry ; save it back
-KrnShutDownInterrupts orcc      #IntMasks ; shut down interrupts
+KrnShutDownInts     orcc      #IntMasks ; shut down interrupts
                     ldx       <D.Proc   ; get the current process pointer
                     tst       <D.QIRQ   ; was it a clock interrupt?
                     lbne      FNprocJoin ; if not, do a quick return
@@ -1004,8 +1004,8 @@ KrnActiveProcess    ldu       P$Queue,u ; get an active process pointer
                     cmpb      P$Prior,u ; do we bump this one?
                     blo       KrnTimeoutFlag ; branch if lower
 
-UseProcessStack          ldu       P$SP,x    ; get the stack pointer
-                    bra       FNprocCondemnedByDeadlySignal ; and branch
+UseProcessStack     ldu       P$SP,x    ; get the stack pointer
+                    bra       FNprocCndmnByDdly ; and branch
 
 KrnTimeoutFlag      anda      #^TimOut  ; clear the timeout flag
                     sta       P$State,x ; and save it to the process descriptor
@@ -1044,8 +1044,8 @@ DoneIRQ             bcc       KrnReturn ; no error on IRQ, so exit
 KrnReturn           rti                 ; return
 
 * Return from a system call.
-KrnForceSystemTaskSystem clra                ; force system task # to 0 (system)
-KrnSystemProcessDescriptor ldx       <D.SysPrc ; get the system process descriptor pointer
+KrnFrcSysTask       clra                ; force system task # to 0 (system)
+KrnSysProcDesc      ldx       <D.SysPrc ; get the system process descriptor pointer
                     lbsr      TstImg    ; check the image, and F$SetTsk (preserves A)
                     orcc      #IntMasks ; shut off interrupts
                     sta       <D.SSTskN ; save the task number for system state
@@ -1074,7 +1074,7 @@ KrnJoin2            equ       *         ; define assembler symbol KrnJoin2
                     tstb                ; is the stack at SWISTACK?
                     bne       MyRTI     ; no, we're doing a system-state rti
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    ldf       #R$Size   ; e=0 from call to KrnWeGoingBackSameTask before
+                    ldf       #R$Size   ; e=0 from call to KrnWeGngBack before
                     ldu       #Where+SWIStack ; point to the stack
                     tfm       u+,y+     ; move the stack from the top of memory to user memory
                   ELSE
@@ -1105,7 +1105,7 @@ KrnJoin3            equ       *         ; define assembler symbol KrnJoin3
 * Flip to task 1 (used by WindInt to switch to GrfDrv) (pointed to
 *  by <D.Flip1). All registers are already preserved on stack for the RTI.
 S.Flip1             ldb       #2        ; get the tsk image entry number x2 for Grfdrv (task 1)
-                    bsr       KrnWeGoingBackSameTask ; copy over the DAT image
+                    bsr       KrnWeGngBack ; copy over the DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch the shadow register to task 1
                     lda       <D.TINIT  ; get a copy of the shadow register
@@ -1119,7 +1119,7 @@ S.Flip1             ldb       #2        ; get the tsk image entry number x2 for 
                     rti                 ; return
 
 * Set up the MMU in task 1, B=Task # to swap to, shifted left 1 bit.
-KrnWeGoingBackSameTask cmpb      <D.Task1N ; are we going back to the same task?
+KrnWeGngBack        cmpb      <D.Task1N ; are we going back to the same task?
                     beq       KrnReturn2 ; without the DAT image changing?
                     stb       <D.Task1N ; no, save current task in map type 1
 *[[[ Wildbits PORT

--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -45,7 +45,7 @@
                     nam       krn
                     ttl       NitrOS-9 Level 2 Kernel
 
-                  ifp1
+                  IFP1
                     use       defsfile  ; include source file defsfile
                   ENDC
 
@@ -92,7 +92,7 @@ MName               fcs       /Krn/
 
 * The dispatch table.
 * The kernel copies this to low RAM starting at D.Clock.
-DisTable            fdb       L0CD2+Where ; d.Clock absolute address at the start
+DisTable            fdb       FAlltskSleepingProcessQueue+Where ; d.Clock absolute address at the start
                     fdb       XSWI3+Where ; d.XSWI3
                     fdb       XSWI2+Where ; d.XSWI2
                     fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
@@ -449,9 +449,9 @@ l@                  stu       ,x++      ; store it
 * Walk through the map, changing the corresponding elements from 0
 * (the initialization value) to 1 (indicating 'used'). Higher
 * entries in the map remain as 0 (indicating 'unused').
-L0104               inc       ,x+       ; mark it as used
+KrnMarkUsed         inc       ,x+       ; mark it as used
                     decb                ; done?
-                    bne       L0104     ; no, go back till done
+                    bne       KrnMarkUsed ; no, go back till done
 
 *[[[ Wildbits PORT
                   IFNE    wildbits ; begin conditional assembly for wildbits
@@ -506,16 +506,16 @@ l@                  sta       b,x       ; store the flag in the appropriate offs
 
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldq       #$00080100 ; e=Marker, D=Block # to check
-L0111               asld                ; get next block #
+KrnBlock            asld                ; get next block #
                     stb       >DAT.Regs+5 ; map block into block 6 of my task
                     ste       >-$6000,x ; save marker to that block
                     cmpe      ,x        ; did it ghost to block 0?
-                    bne       L0111     ; no, keep going till ghost is found
+                    bne       KrnBlock  ; no, keep going till ghost is found
                     stb       <D.MemSz  ; save # of 8KB memory blocks that exist
                     addr      x,d       ; add number of blocks to block map start
                   ELSE
                     ldd       #$0008    ; load the initial value
-L0111               aslb                ; B <= 1 (hi bit goes into carry, 0 goes into low bit)
+KrnBlock            aslb                ; B <= 1 (hi bit goes into carry, 0 goes into low bit)
                     rola                ; A <= 1 (carry goes into low bit, hi bit goes into carry)
                     stb       >DAT.Regs+5 ; save B into the slot
                     pshs      a         ; save A onto the stack
@@ -523,7 +523,7 @@ L0111               aslb                ; B <= 1 (hi bit goes into carry, 0 goes
                     sta       >-$6000,x ; save it in the offset value
                     cmpa      ,x        ; compare against the value here
                     puls      a         ; recover A
-                    bne       L0111     ; branch if the previous comparison failed
+                    bne       KrnBlock  ; branch if the previous comparison failed
                     stb       <D.MemSz  ; else we have our memory size now
                     pshs      x         ; save X
                     addd      ,s++      ; add X into D and recover the stack
@@ -542,9 +542,9 @@ L0111               aslb                ; B <= 1 (hi bit goes into carry, 0 goes
 * $0280 = 1024KB (128 8KB blocks)
 * $0300 = 2048KB (256 8KB blocks)
                     bitb      #%00110000 ; is the block above 128K-256K?
-                    beq       L0170     ; yes, no need to mark block map
+                    beq       Mc09KrnStartBootTrackMemory ; yes, no need to mark block map
                     tstb                ; is it 2 meg?
-                    beq       L0170     ; yes, skip this
+                    beq       Mc09KrnStartBootTrackMemory ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM.
                     abx                 ; add the maximum block number to block map start address
                     leax      -1,x      ; skip good blocks that are RAM
@@ -555,24 +555,24 @@ l@                  sta       ,x+       ; mark them all
                     bne       l@        ; not yet
 
 * ASSUME: however we got here, B=0
-L0170
+Mc09KrnStartBootTrackMemory
                     ldx       #Bt.Start ; start address of the boot track in memory
                     lda       #18       ; size of the boot track is $1800
                   ENDC
 
 * Verify the modules in the boot area and update/build a module index.
                     lbsr      I.VBlock  ; perform module validation
-                    bsr       L01D2     ; then mark the system map
+                    bsr       KrnSystemMemoryMap ; then mark the system map
 
                   IFEQ    wildbits ; begin conditional assembly for wildbits
 * BGP - Load bootfile and link to init. We no longer try to link to init first and then
 * call F$Boot. This saves bytes.
                     os9       F$Boot    ; load bootfile here +BGP+
-                    bcs       L01CE     ; error, go crash +BGP+
+                    bcs       KrnObviouslyCantCrashMachine ; error, go crash +BGP+
                   ENDC
                     leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
-                    bcs       L01CE     ; error, go crash
+                    bcs       KrnObviouslyCantCrashMachine ; error, go crash
 
 * BGP - Commented out the following lines since I moved F$Boot above
 *                    bcc       L01BF               no error, go on
@@ -581,7 +581,7 @@ L0170
 *                    bra       L01CE               error, re-booting do D.Crash
 
 * So far, so good. Save the pointer to the init module and execute krnp2.
-L01BF               stu       <D.Init   ; save the init module pointer
+KrnInitModule       stu       <D.Init   ; save the init module pointer
                     lda       Feature1,u ; get feature byte #1 from the init module
                     bita      #CRCOn    ; is the CRC feature on?
                     beq       ShowI     ; if not, continue
@@ -593,7 +593,7 @@ ShowI
                     jsr       <D.BtBug  ; perform the action
                   ENDC
 
-L01C1               leax      <krnp2,pc ; point to krnp2's name
+KrnKrnp2sName       leax      <krnp2,pc ; point to krnp2's name
                     bsr       link      ; try to link it
 
 * BGP - Removed the following lines as krnp2 is ALWAYS in the bootfile and F$Boot is called above.
@@ -605,13 +605,13 @@ L01C1               leax      <krnp2,pc ; point to krnp2's name
 *                    bcc       L01C1               branch if no error, let's try to link it again
 *
 
-L01D0               jmp       ,y        ; jump into krnp2
+KrnJumpKrnp2        jmp       ,y        ; jump into krnp2
 
 * BGP - This line was above L01D0 but now moved below since above lines are commented.
-L01CE               jmp       <D.Crash  ; obviously can't do it, crash machine
+KrnObviouslyCantCrashMachine jmp       <D.Crash  ; obviously can't do it, crash machine
 
 * Update the system memory map to reserve the area the kernel uses.
-L01D2               ldx       <D.SysMem ; get the system memory map pointer
+KrnSystemMemoryMap  ldx       <D.SysMem ; get the system memory map pointer
                   IFNE    wildbits ; begin conditional assembly for wildbits
                     lda       #NotRAM   ; get the "not RAM" flag
                     ldb       <D.BtPtr  ; and the boot pointer MSB
@@ -621,10 +621,10 @@ L01D2               ldx       <D.SysMem ; get the system memory map pointer
                     abx                 ; point to Bt.Start - start of the boot area
                     comb                ; we have $FF-$ED pages to mark as "RAM in use"
                     sta       b,x       ; mark I/O as not RAM
-L01DF               lda       #RAMinUse ; get the "RAM in use" flag
-L01E1               sta       ,x+       ; mark this page
+KrnRAMUseFlag       lda       #RAMinUse ; get the "RAM in use" flag
+KrnMarkPage         sta       ,x+       ; mark this page
                     decb                ; done?
-                    bne       L01E1     ; no, keep going
+                    bne       KrnMarkPage ; no, keep going
                     ldx       <D.BlkMap ; get the pointer to the start of the block map
                     sta       <KrnBlk,x ; mark kernel block as "RAM in use", instead of "Module in block"
 S.AltIRQ            rts                 ; return
@@ -718,8 +718,8 @@ XSWI3               lda       #P$SWI3   ; point to the SWI3 vector
 XSWI                lda       #P$SWI    ; point to the SWI vector
                     ldx       <D.Proc   ; get the current process descriptor
                     ldu       a,x       ; is this a user defined SWI[x]?
-                    beq       L028E     ; no, go get the option byte
-GoUser              lbra      L0E5E     ; else call the users's routine
+                    beq       KrnSystemCallServiceVector ; no, go get the option byte
+GoUser              lbra      KrnJoin3  ; else call the users's routine
 
 * SWI2 vector entry
 XSWI2               ldx       <D.Proc   ; get the current process descriptor
@@ -730,7 +730,7 @@ XSWI2               ldx       <D.Proc   ; get the current process descriptor
 *
 * Entry: X = The process descriptor pointer of process that made system call.
 *        U = The register stack pointer.
-L028E               ldu       <D.SysSvc ; get the system call service vector
+KrnSystemCallServiceVector ldu       <D.SysSvc ; get the system call service vector
                     stu       <D.XSWI2  ; set the cross-SWI2 vector
                     ldu       <D.SysIRQ ; get the interrupt service vector
                     stu       <D.XIRQ   ; set the cross-IRQ vector
@@ -766,7 +766,7 @@ l@                  ldx       ,--y      ; get the source bytes
                     stx       R$PC,u    ; save updated the update program counter back
 * Execute the system call.
                     ldy       <D.UsrDis ; get the user dispatch table pointer
-                    lbsr      L033B     ; go execute the op-code
+                    lbsr      ExecSvcCall     ; go execute the op-code
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^IntMasks,R$CC,u ; unmask interrupts in the caller's CC
                   ELSE
@@ -791,8 +791,8 @@ l@                  ldx       ,--y      ; get the source bytes
                     sta       <D.Quick  ; save quick return flag
                     beq       AllClr    ; if nothing changed, do full checks
 
-DoFull              bsr       L02DA     ; move the stack frame back to user state
-                    lbra      L0D80     ; go back to the process
+DoFull              bsr       CopySystemStackToUser ; move the stack frame back to user state
+                    lbra      KrnJoin   ; go back to the process
 
 * add ldu P$SP,x, etc...
 AllClr              equ       *         ; define assembler symbol AllClr
@@ -825,20 +825,20 @@ l@                  lda       ,u+       ; get the source byte
 * Copy the register stack from user to system.
 *
 * Entry: U = The pointer to the register stack in the process descriptor.
-L02CB               pshs      cc,x,y,u  ; preserve registers
+CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get the task #
                     ldx       P$SP,x    ; and the stack pointer
-                    lbsr      L0BF3     ; calculate the block offset (only affects A&X)
+                    lbsr      FMoveLater ; calculate the block offset (only affects A&X)
                     leax      -$6000,x  ; adjust the pointer to where the memory map will be
-                    bra       L02E9     ; go copy it
+                    bra       KrnBlockNumberWhere ; go copy it
 
 * Copy the register stack from system to user.
 *
 * Entry: U = The pointer to the register stack in the process descriptor.
-L02DA               pshs      cc,x,y,u  ; preserve registers
+CopySystemStackToUser          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get the task # of destination
                     ldx       P$SP,x    ; and the stack pointer
-                    lbsr      L0BF3     ; calculate the block offset (only affects A&X)
+                    lbsr      FMoveLater ; calculate the block offset (only affects A&X)
                     leax      -$6000,x  ; adjust the pointer to where the memory map will be
                     exg       x,y       ; swap pointers & copy
 
@@ -848,7 +848,7 @@ L02DA               pshs      cc,x,y,u  ; preserve registers
 *        Y = The destination register stack.
 *        A = The offset into the DAT image of stack.
 *        B = The task number.
-L02E9               leau      a,u       ; point to the block number where stack is
+KrnBlockNumberWhere leau      a,u       ; point to the block number where stack is
                     lda       1,u       ; get the first block
                     ldb       3,u       ; get a second just in case of overlap
                     orcc      #IntMasks ; shutdown interrupts while we do this
@@ -882,9 +882,9 @@ SysCall             leau      ,s        ; get the pointer to the register stack
                     leax      1,x       ; move the PC to next position
                     stx       R$PC,u    ; save my caller's updated PC register
                     ldy       <D.SysDis ; get the system dispatch table pointer
-                    bsr       L033B     ; execute the system call
+                    bsr       ExecSvcCall     ; execute the system call
                     puls      a         ; restore the system state task number
-                    lbra      L0E2B     ; return to the process
+                    lbra      KrnSystemProcessDescriptor ; return to the process
 
 * Entry: X = system call vector to jump to
 Sys.Vec             jmp       ,x        ; execute the service call
@@ -893,19 +893,19 @@ Sys.Vec             jmp       ,x        ; execute the service call
 *
 * Entry: B = System call op-code
 *        Y = System dispatch table pointer (D.SysDis or D.UsrDis)
-L033B
+ExecSvcCall
                     lslb                ; is it a I/O call? (also multiplies by 2 for offset)
-                    bcc       L0345     ; no, go get normal vector
+                    bcc       GetSvcVector ; no, go get normal vector
 * Execute I/O system calls.
                     ldx       IOEntry,y ; else get IOMan vector
 * Execute the system call.
-L034F               pshs      u         ; preserve the register stack pointer
+CallSvcVector          pshs      u         ; preserve the register stack pointer
                     jsr       [D.SysVec] ; perform a vectored system call
                     puls      u         ; restore the pointer
-L0355               tfr       cc,a      ; move CC to A for a stack update
-                    bcc       L035B     ; go update it if no error from call
+UpdateCallerCC          tfr       cc,a      ; move CC to A for a stack update
+                    bcc       MergeCallerCC    ; go update it if no error from call
                     stb       R$B,u     ; save the error code to caller's B
-L035B               ldb       R$CC,u    ; get the caller's CC, R$CC = $00
+MergeCallerCC              ldb       R$CC,u    ; get the caller's CC, R$CC = $00
                   IFNE    H6309   ; begin conditional assembly for H6309
                     andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
                     orr       b,a       merge them together
@@ -919,13 +919,13 @@ L035B               ldb       R$CC,u    ; get the caller's CC, R$CC = $00
                     rts                 ; return
 
 * Execute regular system calls
-L0345
+GetSvcVector
                     clra                ; clear the MSB of the offset
                     ldx       d,y       ; get the vector to call
-                    bne       L034F     ; it's initialized, go execute it
+                    bne       CallSvcVector ; it's initialized, go execute it
                     comb                ; set the carry for error
                     ldb       #E$UnkSvc ; get the error code
-                    bra       L0355     ; return with it
+                    bra       UpdateCallerCC ; return with it
 
                     use       fssvc.asm ; include source file fssvc.asm
 
@@ -972,7 +972,7 @@ XIRQ                ldx       <D.Proc   ; get the current process pointer
                     ldd       <D.SysIRQ ; set the system IRQ routine to current
                     std       <D.XIRQ   ; store it in the cross-IRQ vector
                     jsr       [>D.SvcIRQ] ; execute interrupt service routine
-                    bcc       L0D5B     ; branch if the routine was serviced
+                    bcc       KrnShutDownInterrupts ; branch if the routine was serviced
 
                     ldx       <D.Proc   ; get the current process pointer
                     ldb       P$Task,x  ; and the task of the process
@@ -980,38 +980,38 @@ XIRQ                ldx       <D.Proc   ; get the current process pointer
 
                     pshs      u,d,cc    ; save some registers
                     leau      ,s        ; point to a 'caller register stack'
-                    lbsr      L0C40     ; do a LDB 0,X in task B
+                    lbsr      FLdabxTarget ; do a LDB 0,X in task B
                     puls      u,d,cc    ; and now A (R$A,U) = the CC we want
 
                     ora       #IntMasks ; disable its interrupts
-                    lbsr      L0C28     ; save it back
-L0D5B               orcc      #IntMasks ; shut down interrupts
+                    lbsr      FLdabxCarry ; save it back
+KrnShutDownInterrupts orcc      #IntMasks ; shut down interrupts
                     ldx       <D.Proc   ; get the current process pointer
                     tst       <D.QIRQ   ; was it a clock interrupt?
-                    lbne      L0DF7     ; if not, do a quick return
+                    lbne      FNprocJoin ; if not, do a quick return
 
                     lda       P$State,x ; get its state
                     bita      #TimOut   ; is it timed out?
-                    bne       L0D7C     ; yes, wake it up
+                    bne       KrnTimeoutFlag ; yes, wake it up
 * Update the active process queue.
                     ldu       #(D.AProcQ-P$Queue) ; point to the active process queue
                     ldb       #Suspend  ; get the suspend flag
-L0D6A               ldu       P$Queue,u ; get an active process pointer
-                    beq       L0D78     ; branch if empty
+KrnActiveProcess    ldu       P$Queue,u ; get an active process pointer
+                    beq       UseProcessStack ; branch if empty
                     bitb      P$State,u ; is it suspended?
-                    bne       L0D6A     ; yes, go to the next one in the chain
+                    bne       KrnActiveProcess ; yes, go to the next one in the chain
                     ldb       P$Prior,x ; get the current process priority
                     cmpb      P$Prior,u ; do we bump this one?
-                    blo       L0D7C     ; branch if lower
+                    blo       KrnTimeoutFlag ; branch if lower
 
-L0D78               ldu       P$SP,x    ; get the stack pointer
-                    bra       L0DB9     ; and branch
+UseProcessStack          ldu       P$SP,x    ; get the stack pointer
+                    bra       FNprocCondemnedByDeadlySignal ; and branch
 
-L0D7C               anda      #^TimOut  ; clear the timeout flag
+KrnTimeoutFlag      anda      #^TimOut  ; clear the timeout flag
                     sta       P$State,x ; and save it to the process descriptor
 
-L0D80               equ       *         ; define assembler symbol L0D80
-L0D83               bsr       L0D11     ; activate next process
+KrnJoin             equ       *         ; define assembler symbol KrnJoin
+KrnActivateProcess  bsr       FAprocTarget ; activate next process
 
                     use       fnproc.asm ; include source file fnproc.asm
 
@@ -1033,7 +1033,7 @@ S.SysIRQ
                     bra       DoneIRQ   ; check for error and exit
 
 FastIRQ             jsr       [>D.SvcIRQ] ; call the orutine (normally Clock calling D.Poll)
-DoneIRQ             bcc       L0E28     ; no error on IRQ, so exit
+DoneIRQ             bcc       KrnReturn ; no error on IRQ, so exit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #IntMasks,0,s ; setup RTI to shut interrupts off again
                   ELSE
@@ -1041,11 +1041,11 @@ DoneIRQ             bcc       L0E28     ; no error on IRQ, so exit
                     ora       #IntMasks ; mask interrupts
                     sta       ,s        ; and store it back
                   ENDC
-L0E28               rti                 ; return
+KrnReturn           rti                 ; return
 
 * Return from a system call.
-L0E29               clra                ; force system task # to 0 (system)
-L0E2B               ldx       <D.SysPrc ; get the system process descriptor pointer
+KrnForceSystemTaskSystem clra                ; force system task # to 0 (system)
+KrnSystemProcessDescriptor ldx       <D.SysPrc ; get the system process descriptor pointer
                     lbsr      TstImg    ; check the image, and F$SetTsk (preserves A)
                     orcc      #IntMasks ; shut off interrupts
                     sta       <D.SSTskN ; save the task number for system state
@@ -1060,7 +1060,7 @@ Fst2                leas      ,u        ; put stack ptr into U
 *
 * Entry: X = The Process descriptor pointer.
 *        U = The stack pointer.
-L0E4C               equ       *         ; define assembler symbol L0E4C
+KrnJoin2            equ       *         ; define assembler symbol KrnJoin2
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch the shadow register to task 1
                     lda       <D.TINIT  ; get the shadow register
@@ -1074,7 +1074,7 @@ L0E4C               equ       *         ; define assembler symbol L0E4C
                     tstb                ; is the stack at SWISTACK?
                     bne       MyRTI     ; no, we're doing a system-state rti
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    ldf       #R$Size   ; e=0 from call to L0E8D before
+                    ldf       #R$Size   ; e=0 from call to KrnWeGoingBackSameTask before
                     ldu       #Where+SWIStack ; point to the stack
                     tfm       u+,y+     ; move the stack from the top of memory to user memory
                   ELSE
@@ -1090,7 +1090,7 @@ MyRTI               rti                 ; return from IRQ
 
 * Execute routine in task 1 pointed to by U.
 * This comes from user requested SWI vectors.
-L0E5E               equ       *         ; define assembler symbol L0E5E
+KrnJoin3            equ       *         ; define assembler symbol KrnJoin3
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch the shadow register to task 1
                     ldb       <D.TINIT  ; get the shadow register
@@ -1105,7 +1105,7 @@ L0E5E               equ       *         ; define assembler symbol L0E5E
 * Flip to task 1 (used by WindInt to switch to GrfDrv) (pointed to
 *  by <D.Flip1). All registers are already preserved on stack for the RTI.
 S.Flip1             ldb       #2        ; get the tsk image entry number x2 for Grfdrv (task 1)
-                    bsr       L0E8D     ; copy over the DAT image
+                    bsr       KrnWeGoingBackSameTask ; copy over the DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch the shadow register to task 1
                     lda       <D.TINIT  ; get a copy of the shadow register
@@ -1119,8 +1119,8 @@ S.Flip1             ldb       #2        ; get the tsk image entry number x2 for 
                     rti                 ; return
 
 * Set up the MMU in task 1, B=Task # to swap to, shifted left 1 bit.
-L0E8D               cmpb      <D.Task1N ; are we going back to the same task?
-                    beq       L0EA3     ; without the DAT image changing?
+KrnWeGoingBackSameTask cmpb      <D.Task1N ; are we going back to the same task?
+                    beq       KrnReturn2 ; without the DAT image changing?
                     stb       <D.Task1N ; no, save current task in map type 1
 *[[[ Wildbits PORT
                   IFNE    wildbits ; begin conditional assembly for wildbits
@@ -1139,14 +1139,14 @@ L0E8D               cmpb      <D.Task1N ; are we going back to the same task?
 * Update 8 MMU mappings.
 * X = address of 1st DAT MMU register to update
 * U = address of DAT image to update into MMU
-L0E93               leau      1,u       ; point to the actual MMU block
+KrnActualMMUBlock   leau      1,u       ; point to the actual MMU block
                   IFNE    H6309   ; begin conditional assembly for H6309
                     lde       #4        ; get the number of banks/2 for the task
                   ELSE
                     lda       #4        ; get the number of banks/2 for the task
                     pshs      a         ; save A
                   ENDC
-L0E9B               lda       ,u++      ; get a bank
+KrnBank             lda       ,u++      ; get a bank
                     ldb       ,u++      ; and next one
                     std       ,x++      ; save it to MMU
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -1154,7 +1154,7 @@ L0E9B               lda       ,u++      ; get a bank
                   ELSE
                     dec       ,s        ; done?
                   ENDC
-                    bne       L0E9B     ; no, keep going
+                    bne       KrnBank   ; no, keep going
                   IFEQ    H6309   ; begin conditional assembly for H6309
 * 6809 - 10 cyc down to 8
 *                   leas      1,s                 eat temporary stack
@@ -1165,7 +1165,7 @@ L0E9B               lda       ,u++      ; get a bank
                     clr       MMU_MEM_CTRL ; clear the DAT control flags
                   ENDC
 *]]] Wildbits PORT
-L0EA3               rts                 ; return
+KrnReturn2          rts                 ; return
 
 *[[[ Wildbits PORT
                   IFNE    wildbits ; begin conditional assembly for wildbits
@@ -1175,14 +1175,14 @@ CrashDump           fill      255,32
 
 * Execute FIRQ vector (called from $FEF4)
 FIRQVCT             ldx       #D.FIRQ   ; get the DP offset of the vector
-                    bra       L0EB8     ; go execute it
+                    bra       KrnFasterClrXxxx ; go execute it
 
 * Execute IRQ vector (called from $FEF7)
 IRQVCT              orcc      #IntMasks ; disable interrupts
                     ldx       #D.IRQ    ; get the DP offset of the vector
 
 * Execute interrupt vector, B=DP Vector offset
-L0EB8               clra                ; (faster than CLR >$xxxx)
+KrnFasterClrXxxx    clra                ; (faster than CLR >$xxxx)
                     sta       >DAT.Task ; force to task 0 (system state)
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       0,dp      ; setup the DP
@@ -1254,14 +1254,14 @@ SWICall             ldb       [R$PC,s]  ; get the op-code of the system call
                     tfm       u+,y+     ; move the stack to the top of memory
                   ELSE
                     pshs      x         ; save X
-                    lda       #R$Size/2 ; move stack to top of memory (A is reset in L0EB8, no need to preserve)
+                    lda       #R$Size/2 ; move stack to top of memory (A is reset in KrnFasterClrXxxx, no need to preserve)
 l@                  ldx       ,u++      ; get the bytes
                     stx       ,y++      ; and save them
                     deca                ; decrement the counter
                     bne       l@        ; branch if not done
                     puls      x         ; restore X
                   ENDC
-                    bra       L0EB8     ; go from map type 1 to map type 0
+                    bra       KrnFasterClrXxxx ; go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
 SWIVCT              ldx       #D.SWI    ; get the DP offset of the vector
@@ -1269,7 +1269,7 @@ SWIVCT              ldx       #D.SWI    ; get the DP offset of the vector
 
 * Execute NMI vector (called from $FEFD)
 NMIVCT              ldx       #D.NMI    ; get the DP offset of the vector
-                    bra       L0EB8     ; go execute it
+                    bra       KrnFasterClrXxxx ; go execute it
 
 * The end of the kernel module is here
                     emod
@@ -1297,16 +1297,16 @@ SWIStack
 * $FFF0-$FFFE and get directed to here. From here, the BRA takes CPU control
 * to the various handlers in the kernel.
                     bra       SWI3VCT   ; sWI3 vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       SWI2VCT   ; sWI2 vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       FIRQVCT   ; fIRQ vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       IRQVCT    ; iRQ vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       SWIVCT    ; sWI vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       NMIVCT    ; nMI vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
 
                     end

--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -45,28 +45,28 @@
                     nam       krn
                     ttl       NitrOS-9 Level 2 Kernel
 
-                    ifp1
-                    use       defsfile
+                  ifp1
+                    use       defsfile  ; include source file defsfile
                   ENDC
 
 * defines for customizations
-Revision            set       00                  module revision
-Edition             set       20                  module Edition
+Revision            set       00        ; module revision
+Edition             set       20        ; module Edition
 
 * The absolute address of where Kernel starts in memory.
-                  IFNE        wildbits
-Where               equ       $EE00               Wildbits
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+Where               equ       $EE00     ; wildbits
                   ELSE
-Where               equ       $F000               CoCo 3
+Where               equ       $F000     ; coCo 3
                   ENDC
 
-                    mod       eom,MName,Systm,ReEnt+Revision,entry,0
+                    mod       eom,MName,Systm,ReEnt+Revision,entry,0 ; define OS-9 module header
 
 MName               fcs       /Krn/
-                    fcb       Edition
+                    fcb       Edition   ; define byte value(s) Edition
 
 * FILL - all unused bytes are now here
-                  IFNE        H6309
+                  IFNE    H6309   ; begin conditional assembly for H6309
                     fcc       /www.nitros9.org /
                     fcc       /www.nitros9.org /
                     fcc       /www.nitros9.org /
@@ -76,7 +76,7 @@ MName               fcs       /Krn/
                     fcc       /www.nitros9.org /
                     fcc       /www/
                   ELSE
-                  IFNE        wildbits
+                  IFNE    wildbits ; begin conditional assembly for wildbits
                     fcc       /www.nitros9.org /
                     fcc       /www.nitros9.org /
                     fcc       /www.nitros9.org /
@@ -92,163 +92,163 @@ MName               fcs       /Krn/
 
 * The dispatch table.
 * The kernel copies this to low RAM starting at D.Clock.
-DisTable            fdb       L0CD2+Where         D.Clock absolute address at the start
-                    fdb       XSWI3+Where         D.XSWI3
-                    fdb       XSWI2+Where         D.XSWI2
-                    fdb       D.Crash             D.XFIRQ crash on an FIRQ
-                    fdb       XIRQ+Where          D.XIRQ
-                    fdb       XSWI+Where          D.XSWI
-                    fdb       D.Crash             D.XNMI crash on an NMI
-                    fdb       $0055               D.ErrRst ??? Not used as far as I can tell
-                    fdb       Sys.Vec+Where       Initial Kernel system call vector
-DisSize             equ       *-DisTable
+DisTable            fdb       L0CD2+Where ; d.Clock absolute address at the start
+                    fdb       XSWI3+Where ; d.XSWI3
+                    fdb       XSWI2+Where ; d.XSWI2
+                    fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
+                    fdb       XIRQ+Where ; d.XIRQ
+                    fdb       XSWI+Where ; d.XSWI
+                    fdb       D.Crash   ; d.XNMI crash on an NMI
+                    fdb       $0055     ; d.ErrRst ??? Not used as far as I can tell
+                    fdb       Sys.Vec+Where ; initial Kernel system call vector
+DisSize             equ       *-DisTable ; define assembler symbol DisSize
 
 * DO NOT ADD ANYTHING BETWEEN THESE 2 TABLES: see code using 'SubSiz', below
-LowSub              equ       $0160               start of low memory subroutines
-SubStrt             equ       *
+LowSub              equ       $0160     ; start of low memory subroutines
+SubStrt             equ       *         ; define assembler symbol SubStrt
 * D.Flip0 - switch to system task 0.
-R.Flip0             equ       *
-                  IFNE        H6309
-                    aim       #$FE,<D.TINIT       map type 0
-                    lde       <D.TINIT            another 2 bytes saved if GrfDrv does: tfr cc,e
-                    ste       >DAT.Task           and we can use A here, instead of E
+R.Flip0             equ       *         ; define assembler symbol R.Flip0
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #$FE,<D.TINIT ; map type 0
+                    lde       <D.TINIT  ; another 2 bytes saved if GrfDrv does: tfr cc,e
+                    ste       >DAT.Task ; and we can use A here, instead of E
                   ELSE
-                    pshs      a                   save off A
-                    lda       <D.TINIT            get the value from the shadow register
-                    anda      #$FE                force the task register to 0
-                    sta       <D.TINIT            save it back to the shadow register
-                    sta       >DAT.Task           and to the DAT hardware
-                    puls      a                   recover A
+                    pshs      a         ; save off A
+                    lda       <D.TINIT  ; get the value from the shadow register
+                    anda      #$FE      ; force the task register to 0
+                    sta       <D.TINIT  ; save it back to the shadow register
+                    sta       >DAT.Task ; and to the DAT hardware
+                    puls      a         ; recover A
                   ENDC
-                    clr       <D.SSTskN           clear the system task number
-                    tfr       x,s                 transfer X to the stack
-                    tfr       a,cc                and A to CC
-                    rts
+                    clr       <D.SSTskN ; clear the system task number
+                    tfr       x,s       ; transfer X to the stack
+                    tfr       a,cc      ; and A to CC
+                    rts                 ; return to caller
 * Don't add any code here: See L0065, below.
-SubSiz              equ       *-SubStrt
+SubSiz              equ       *-SubStrt ; define assembler symbol SubSiz
 * Interrupt service routine
-Vectors             jmp       [<-(D.SWI3-D.XSWI3),x] (-$10) (Jmp to 2ndary vector)
+Vectors             jmp       [<-(D.SWI3-D.XSWI3),x] ; (-$10) (Jmp to 2ndary vector)
 
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
 * Wildbits crash code dumps the registers at the shadow RAM page in $FDXX and
 * then loops forever
 CrashCode
 * Dump the registers.
-                    orcc      #IntMasks           mask interrupts
-                    pshs      u                   save U
-                    ldu       #$20                point to where registers will go
-                    pshu      x,s,pc              save X, S, PC (X just a placeholder)
-                    pshu      cc,dp,d,x,y         push the rest of the registers
-                    puls      d                   get U on the stack into D
-                    std       8,u                 store it in the "hole" created earlier
-                    ldd       #$DEAD              get a marker value so we can visually see the crash when dumping
-                    pshu      d                   push it
+                    orcc      #IntMasks ; mask interrupts
+                    pshs      u         ; save U
+                    ldu       #$20      ; point to where registers will go
+                    pshu      x,s,pc    ; save X, S, PC (X just a placeholder)
+                    pshu      cc,dp,d,x,y ; push the rest of the registers
+                    puls      d         ; get U on the stack into D
+                    std       8,u       ; store it in the "hole" created earlier
+                    ldd       #$DEAD    ; get a marker value so we can visually see the crash when dumping
+                    pshu      d         ; push it
 * Copy state of MMU registers.
-                    ldx       #MMU_MEM_CTRL       get the address of the MMU registers
-                    ldy       #0                  point to the crash dump area
-loop@               ldd       ,x++                get two source bytes
-                    std       ,y++                and save them
-                    cmpx      #$FFB0              are we at the end of the MMU register space?
-                    blt       loop@               branch if not
+                    ldx       #MMU_MEM_CTRL ; get the address of the MMU registers
+                    ldy       #0        ; point to the crash dump area
+loop@               ldd       ,x++      ; get two source bytes
+                    std       ,y++      ; and save them
+                    cmpx      #$FFB0    ; are we at the end of the MMU register space?
+                    blt       loop@     ; branch if not
 * Branch forever.
-forever@            bra       forever@            simply branch forever
+forever@            bra       forever@  ; simply branch forever
                   ENDC
-*<<<<<<<<<< Wildbits PORT
+*]]] Wildbits PORT
 
 * The Kernel entry point.
-entry               equ       *
+entry               equ       *         ; define assembler symbol entry
 * Initialize the system block (the lowest 8KB of memory).
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
 * Wildbits-specific initialization to get the Wildbits to a sane state.
-                    orcc      #IntMasks           mask interrupts
-                    stx       $2000               stash pointer to bootfile in memory
-                    sty       $2002               stash size of bootfile
-                    ldd       #$FF00              A = $FF, B = $00
-                    tfr       b,dp                transfer 0 to direct page
-                    sta       INT_MASK_0          A = $FF; mask all set 0 interrupts
-                    sta       INT_MASK_1          A = $FF; mask all set 1 interrupts
-                    sta       INT_PENDING_0       A = $FF; clear any pending set 0 interrupts
-                    sta       INT_PENDING_1       A = $FF; clear any pending set 1 interrupts
+                    orcc      #IntMasks ; mask interrupts
+                    stx       $2000     ; stash pointer to bootfile in memory
+                    sty       $2002     ; stash size of bootfile
+                    ldd       #$FF00    ; A = $FF, B = $00
+                    tfr       b,dp      ; transfer 0 to direct page
+                    sta       INT_MASK_0 ; A = $FF; mask all set 0 interrupts
+                    sta       INT_MASK_1 ; A = $FF; mask all set 1 interrupts
+                    sta       INT_PENDING_0 ; A = $FF; clear any pending set 0 interrupts
+                    sta       INT_PENDING_1 ; A = $FF; clear any pending set 1 interrupts
 * Set up DAT registers. Here, B = 0
-                    ldx       #DAT.Regs           point X to the DAT registers
-loop@               stb       ,x+                 write 8K bank to DAT to bank register
-                    incb                          increment B
-                    cmpb      #8                  are we done?
-                    bne       loop@               branch if not
+                    ldx       #DAT.Regs ; point X to the DAT registers
+loop@               stb       ,x+       ; write 8K bank to DAT to bank register
+                    incb                ; increment B
+                    cmpb      #8        ; are we done?
+                    bne       loop@     ; branch if not
 
 * The Wildbits allows for both $FDXX and $FFFX to be held constant regardless of the
 * state of the MMU DAT registers. This feature is turned on by two bits that
 * expose internal RAM of those areas.
 * When the kernel loads in RAM, we must copy $FDXX into this internal RAM by
 * flipping bit 0 in the I/O control register back and forth.
-                    ldx       #$FD00              point to the shadow RAM area
-                    ldb       MMU_IO_CTRL         get the control byte
-l@                  andb      #~%00000001         clear the FDXX bit to disable shadow RAM
-                    stb       MMU_IO_CTRL         turn off the FDXX internal RAM bit
-                    lda       ,x                  get the source byte
-                    orb       #%00000011          set the FDXX bit to enable shadow RAM (also turn on FFFX  bit)
-                    stb       MMU_IO_CTRL         turn on the FDXX internal RAM bit
-                    sta       ,x+                 save byte to internal RAM
-                    cmpx      #$FE00              are we at the end yet?
-                    bne       l@                  branch if not
+                    ldx       #$FD00    ; point to the shadow RAM area
+                    ldb       MMU_IO_CTRL ; get the control byte
+l@                  andb      #~%00000001 ; clear the FDXX bit to disable shadow RAM
+                    stb       MMU_IO_CTRL ; turn off the FDXX internal RAM bit
+                    lda       ,x        ; get the source byte
+                    orb       #%00000011 ; set the FDXX bit to enable shadow RAM (also turn on FFFX  bit)
+                    stb       MMU_IO_CTRL ; turn on the FDXX internal RAM bit
+                    sta       ,x+       ; save byte to internal RAM
+                    cmpx      #$FE00    ; are we at the end yet?
+                    bne       l@        ; branch if not
 
 * The bit for FFFX is also on now. Copy the known Level 2 vectors.
-                    ldx       #$FFF2              load the vector destination
-                    ldd       #$FDEE              start at the first vector value
-l@                  std       ,x++                store the vector value in the destination
-                    cmpx      #$0000              are we done?
-                    beq       done@               branch if so
-                    addd      #$0003              else add 3
-                    bra       l@                  and do again
-done@               ldx       #$0000              start clearing at this address
-                    ldy       #$2000              for this many bytes
-*<<<<<<<<<< Wildbits PORT
+                    ldx       #$FFF2    ; load the vector destination
+                    ldd       #$FDEE    ; start at the first vector value
+l@                  std       ,x++      ; store the vector value in the destination
+                    cmpx      #$0000    ; are we done?
+                    beq       done@     ; branch if so
+                    addd      #$0003    ; else add 3
+                    bra       l@        ; and do again
+done@               ldx       #$0000    ; start clearing at this address
+                    ldy       #$2000    ; for this many bytes
+*]]] Wildbits PORT
                   ELSE
 * REL has cleared page 0 already, so start at address $100.
-                  IFNE        H6309
-                    ldq       #$01001f00          start address to clear & # bytes to clear
-                    leay      <entry+2,pc         point to a 0
-                    tfm       y,d+
-                    std       <D.CCStk            set pointer to top of global memory to $2000
-                    lda       #$01                set task user table to $0100
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$01001f00 ; start address to clear & # bytes to clear
+                    leay      <entry+2,pc ; point to a 0
+                    tfm       y,d+      ; transfer memory block using y,d+
+                    std       <D.CCStk  ; set pointer to top of global memory to $2000
+                    lda       #$01      ; set task user table to $0100
                   ELSE
-                    ldx       #$100               start clearing at this address
-                    ldy       #$2000-$100         for this many bytes
+                    ldx       #$100     ; start clearing at this address
+                    ldy       #$2000-$100 ; for this many bytes
                   ENDC
                   ENDC
 
-                  IFEQ        H6309
-                    clra                          set D
-                    clrb                          to $0000
-l@                  std       ,x++                now clear memory 16 bits at a time
-                    leay      -2,y                decrement the counter
-                    bne       l@                  and continue until done
-                    stx       <D.CCStk            set pointer to top of global memory to $2000
-                    inca                          set D to $0100
+                  IFEQ    H6309   ; begin conditional assembly for H6309
+                    clra                ; set D
+                    clrb                ; to $0000
+l@                  std       ,x++      ; now clear memory 16 bits at a time
+                    leay      -2,y      ; decrement the counter
+                    bne       l@        ; and continue until done
+                    stx       <D.CCStk  ; set pointer to top of global memory to $2000
+                    inca                ; set D to $0100
                   ENDC
 
-*>>>>>>>>>> Wildbits PORT
+*[[[ Wildbits PORT
 * Use <D.Crash to store a crash routine that we can use for debugging.
-                  IFNE        wildbits
-                    pshs      b                   save B onto the stack
-                    ldb       #$7E                get the JMP instruction op-code
-                    stb       <D.Crash            and save it at D.Crash
-                    leax      CrashCode,pcr       then get the address of the crash code
-                    stx       <D.Crash+1          and store it at D.Crash+1
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    pshs      b         ; save B onto the stack
+                    ldb       #$7E      ; get the JMP instruction op-code
+                    stb       <D.Crash  ; and save it at D.Crash
+                    leax      CrashCode,pcr ; then get the address of the crash code
+                    stx       <D.Crash+1 ; and store it at D.Crash+1
 * Wildbits doesn't use D.BtBug. We put an RTS here just in case it's called somewhere.
-                    ldb       #$39                put RTS instruction
-                    stb       <D.BtBug            in D.BtBug since we don't use it
-                    puls      b                   recover B from the stack
+                    ldb       #$39      ; put RTS instruction
+                    stb       <D.BtBug  ; in D.BtBug since we don't use it
+                    puls      b         ; recover B from the stack
                   ENDC
-*<<<<<<<<<< Wildbits PORT
+*]]] Wildbits PORT
 
 * Set up system variables in DP
-                    std       <D.Tasks            set the task structure pointer to $0100
-                    addb      #$20                D is now $0120
-                    std       <D.TskIPt           set the task image table pointer
-                    clrb                          D is now $0100
+                    std       <D.Tasks  ; set the task structure pointer to $0100
+                    addb      #$20      ; D is now $0120
+                    std       <D.TskIPt ; set the task image table pointer
+                    clrb                ; D is now $0100
 
 ********************************************************************
 * The memory block map is a data structure that kernel uses to manage
@@ -266,170 +266,170 @@ l@                  std       ,x++                now clear memory 16 bits at a 
 * below, after the memory sizing.
 * See "Level 2 flags" in os9.d for other byte values.
 
-                    inca                          D is now $0200
-                    std       <D.BlkMap           save this as the block map pointer
-                    addb      #$40                D is now $0240
-                    std       <D.BlkMap+2         save this as the end map pointer
-                    clrb                          D is now $0200
-                    inca                          D is now $0300
-                    std       <D.SysDis           set the system service dispatch table pointer
-                    inca                          D is now $0400
-                    std       <D.UsrDis           set the user dispatch table pointer
-                    inca                          D is now $0500
-                    std       <D.PrcDBT           set the process descriptor block pointer
-                    inca                          D is now $0600
-                    std       <D.SysPrc           set the system process descriptor pointer
-                    std       <D.Proc             set the user process descriptor pointer
-                    adda      #$02                D is now $0800
-                    tfr       d,s                 set the stack pointer
-                    inca                          D is now $0900
-                    std       <D.SysStk           set the system stack base pointer
-                    std       <D.SysMem           set the system memory map pointer
-                    inca                          D is now $0A00
-                    std       <D.ModDir           set the module directory start pointer
-                    std       <D.ModEnd           set the module directory end pointer
-                    adda      #$06                D is now $1000
-                    std       <D.ModDir+2         set the secondary module directory start pointer
-                    std       <D.ModDAT           set the module directory DAT pointer
-                    std       <D.CCMem            set the start of global memory pointer
+                    inca                ; D is now $0200
+                    std       <D.BlkMap ; save this as the block map pointer
+                    addb      #$40      ; D is now $0240
+                    std       <D.BlkMap+2 ; save this as the end map pointer
+                    clrb                ; D is now $0200
+                    inca                ; D is now $0300
+                    std       <D.SysDis ; set the system service dispatch table pointer
+                    inca                ; D is now $0400
+                    std       <D.UsrDis ; set the user dispatch table pointer
+                    inca                ; D is now $0500
+                    std       <D.PrcDBT ; set the process descriptor block pointer
+                    inca                ; D is now $0600
+                    std       <D.SysPrc ; set the system process descriptor pointer
+                    std       <D.Proc   ; set the user process descriptor pointer
+                    adda      #$02      ; D is now $0800
+                    tfr       d,s       ; set the stack pointer
+                    inca                ; D is now $0900
+                    std       <D.SysStk ; set the system stack base pointer
+                    std       <D.SysMem ; set the system memory map pointer
+                    inca                ; D is now $0A00
+                    std       <D.ModDir ; set the module directory start pointer
+                    std       <D.ModEnd ; set the module directory end pointer
+                    adda      #$06      ; D is now $1000
+                    std       <D.ModDir+2 ; set the secondary module directory start pointer
+                    std       <D.ModDAT ; set the module directory DAT pointer
+                    std       <D.CCMem  ; set the start of global memory pointer
 * In following line, CRC=ON if it is STA <D.CRC, CRC=OFF if it is a STB <D.CRC
-                    stb       <D.CRC              set the CRC checking flag to off
+                    stb       <D.CRC    ; set the CRC checking flag to off
 
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
-                    ldx       $2000               get pointer to bootfile in memory stashed earlier
-                    stx       <D.BtPtr            save it in globals
-                    ldx       $2002               get bootfile size stashed earlier
-                    stx       <D.BtSz             save it in globals
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    ldx       $2000     ; get pointer to bootfile in memory stashed earlier
+                    stx       <D.BtPtr  ; save it in globals
+                    ldx       $2002     ; get bootfile size stashed earlier
+                    stx       <D.BtSz   ; save it in globals
                   ENDC
-*<<<<<<<<<< Wildbits PORT
+*]]] Wildbits PORT
 
 * Initialize the interrupt vector tables, and move pointer data down to page 0.
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
-                    leay      >DisTable,pcr       point to the table of absolute vector addresses
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    leay      >DisTable,pcr ; point to the table of absolute vector addresses
                   ELSE
-*<<<<<<<<<< Wildbits PORT
-                    leay      <DisTable,pcr       point to the table of absolute vector addresses
+*]]] Wildbits PORT
+                    leay      <DisTable,pcr ; point to the table of absolute vector addresses
                   ENDC
-                    ldx       #D.Clock            and get the address to put it in memory
-                  IFNE        H6309
-                    ldf       #DisSize            get the size of the table; E=0 from TFM, above
-                    tfm       y+,x+               move it over
+                    ldx       #D.Clock  ; and get the address to put it in memory
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #DisSize  ; get the size of the table; E=0 from TFM, above
+                    tfm       y+,x+     ; move it over
                   ELSE
-                    ldb       #DisSize            get the size of the table
-l@                  lda       ,y+                 load a byte from the source
-                    sta       ,x+                 store a byte to the destination
-                    decb                          bump up the counter
-                    bne       l@                  loop if we're not done
+                    ldb       #DisSize  ; get the size of the table
+l@                  lda       ,y+       ; load a byte from the source
+                    sta       ,x+       ; store a byte to the destination
+                    decb                ; bump up the counter
+                    bne       l@        ; loop if we're not done
                   ENDC
 
 * Initialize D.Flip0 routine in low memory by copying the lump of code down from R.Flip0.
 * ASSUME: Y is left pointing to R.Flip0 by the previous copy loop.
-                    ldu       #LowSub             somewhere in block 0 that's never modified
-                    stu       <D.Flip0            switch to system task 0
-                  IFNE        H6309
-                    ldf       #SubSiz             get the code size to copy
-                    tfm       y+,u+               then copy it over
+                    ldu       #LowSub   ; somewhere in block 0 that's never modified
+                    stu       <D.Flip0  ; switch to system task 0
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #SubSiz   ; get the code size to copy
+                    tfm       y+,u+     ; then copy it over
                   ELSE
-                    ldb       #SubSiz             get the code size to copy
-l@                  lda       ,y+                 load a byte from the source
-                    sta       ,u+                 store a byte to the destination
-                    decb                          bump up the countercounter
-                    bne       l@                  loop if not done
+                    ldb       #SubSiz   ; get the code size to copy
+l@                  lda       ,y+       ; load a byte from the source
+                    sta       ,u+       ; store a byte to the destination
+                    decb                ; bump up the countercounter
+                    bne       l@        ; loop if not done
                   ENDC
 
 * Initialize secondary interrupt vectors to all point to vectors for now.
 * ASSUME: Y is left pointing to vectors by the previous copy loop.
-                    leau      ,y                  move the pointer to a faster register
-l@                  stu       ,x++                set all IRQ vectors to go to vectors for now
-                    cmpx      #D.NMI              are we at the end?
-                    bls       l@                  branch if not
+                    leau      ,y        ; move the pointer to a faster register
+l@                  stu       ,x++      ; set all IRQ vectors to go to vectors for now
+                    cmpx      #D.NMI    ; are we at the end?
+                    bls       l@        ; branch if not
 
 * Initialize user interrupt vectors.
-                    ldx       <D.XSWI2            get the SWI2 (os9 command) service routine pointer
-                    stx       <D.UsrSvc           save it as the user service routine pointer
-                    ldx       <D.XIRQ             get the IRQ service routine pointer
-                    stx       <D.UsrIRQ           save it as the user IRQ routine pointer
-                    leax      >SysCall,pc         get the system state call entry point
-                    stx       <D.SysSvc           store it in the system state service routine vector
-                    stx       <D.XSWI2            and in the cross-SWI2 vector
-                    leax      >S.SysIRQ,pc        get the system state IRQ entry point
-                    stx       <D.SysIRQ           store it in the system state IRQ service routine vector
-                    stx       <D.XIRQ             and in the cross-IRQ vctor
-                    leax      >S.SvcIRQ,pc        get the user state IRQ entry point
-                    stx       <D.SvcIRQ           store it in the user state RIQ service routine vector
-                    leax      >S.Poll,pc          get the IRQ polling routine entry point
-                    stx       <D.Poll             and store it in the IRQ polling routine vector
-                    leax      >S.AltIRQ,pc        get the alternate IRQ entry point
-                    stx       <D.AltIRQ           and store it in the alternate IRQ polling routine vector
-                    ifeq      wildbits
-                    lda       #'K                 debug: signal that we are in Kernel
-                    jsr       <D.BtBug            ---
+                    ldx       <D.XSWI2  ; get the SWI2 (os9 command) service routine pointer
+                    stx       <D.UsrSvc ; save it as the user service routine pointer
+                    ldx       <D.XIRQ   ; get the IRQ service routine pointer
+                    stx       <D.UsrIRQ ; save it as the user IRQ routine pointer
+                    leax      >SysCall,pc ; get the system state call entry point
+                    stx       <D.SysSvc ; store it in the system state service routine vector
+                    stx       <D.XSWI2  ; and in the cross-SWI2 vector
+                    leax      >S.SysIRQ,pc ; get the system state IRQ entry point
+                    stx       <D.SysIRQ ; store it in the system state IRQ service routine vector
+                    stx       <D.XIRQ   ; and in the cross-IRQ vctor
+                    leax      >S.SvcIRQ,pc ; get the user state IRQ entry point
+                    stx       <D.SvcIRQ ; store it in the user state RIQ service routine vector
+                    leax      >S.Poll,pc ; get the IRQ polling routine entry point
+                    stx       <D.Poll   ; and store it in the IRQ polling routine vector
+                    leax      >S.AltIRQ,pc ; get the alternate IRQ entry point
+                    stx       <D.AltIRQ ; and store it in the alternate IRQ polling routine vector
+                  IFEQ    wildbits ; begin conditional assembly for wildbits
+                    lda       #'K       ; debug: signal that we are in Kernel
+                    jsr       <D.BtBug  ; ---
                   ENDC
-                    leax      >S.Flip1,pc         get the "flip 1" entry point
-                    stx       <D.Flip1            and store it in the "flip 1" vector
+                    leax      >S.Flip1,pc ; get the "flip 1" entry point
+                    stx       <D.Flip1  ; and store it in the "flip 1" vector
 * Setup system calls.
-                    leay      >SysCalls,pc        point to the system call address table
-                    lbsr      InstallSvc          and perform the installation
+                    leay      >SysCalls,pc ; point to the system call address table
+                    lbsr      InstallSvc ; and perform the installation
 * Initialize the system process descriptor.
-                    ldu       <D.PrcDBT           get the process table pointer
-                    ldx       <D.SysPrc           and the system process pointer
+                    ldu       <D.PrcDBT ; get the process table pointer
+                    ldx       <D.SysPrc ; and the system process pointer
 * These overlap because it is quicker than trying to strip the high byte from X.
-                    stx       ,u                  save it as the first process in table
-                    stx       1,u                 save it as the second as well
-                  IFNE        H6309
-                    oim       #$01,P$ID,x         set process ID to 1 (inited to 0)
-                    oim       #SysState,P$State,x set to system state (inited to 0)
+                    stx       ,u        ; save it as the first process in table
+                    stx       1,u       ; save it as the second as well
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,P$ID,x ; set process ID to 1 (inited to 0)
+                    oim       #SysState,P$State,x ; set to system state (inited to 0)
                   ELSE
-                    ldd       #$01*256+SysState   get the PID and system state flags
-                    sta       P$ID,x              set the PID
-                    stb       P$State,x           set state to system
+                    ldd       #$01*256+SysState ; get the PID and system state flags
+                    sta       P$ID,x    ; set the PID
+                    stb       P$State,x ; set state to system
                   ENDC
-                    clra                          A = 0
-                    sta       <D.SysTsk           set the system task as task #0
-                    sta       P$Task,x            and in the system process descriptor
-                    coma                          set up the priority & age ($FF)
-                    sta       P$Prior,x           set the priority
-                    sta       P$Age,x             and the age
-                    leax      <P$DATImg,x         point to the DAT image
-                    stx       <D.SysDAT           save it as a pointer in page 0
-                  IFNE        H6309
+                    clra                ; A = 0
+                    sta       <D.SysTsk ; set the system task as task #0
+                    sta       P$Task,x  ; and in the system process descriptor
+                    coma                ; set up the priority & age ($FF)
+                    sta       P$Prior,x ; set the priority
+                    sta       P$Age,x   ; and the age
+                    leax      <P$DATImg,x ; point to the DAT image
+                    stx       <D.SysDAT ; save it as a pointer in page 0
+                  IFNE    H6309   ; begin conditional assembly for H6309
 * actually, since block 0 is tfm'd to be zero, we can skip the next 2 lines
-                    clrd                          D = 0
+                    clrd                ; D = 0
                   ELSE
-                    clra                          A = 0
-                    clrb                          B = 0
+                    clra                ; A = 0
+                    clrb                ; B = 0
                   ENDC
-                    std       ,x++                initialize the first block to 0 (for this DP)
+                    std       ,x++      ; initialize the first block to 0 (for this DP)
 
 ********************************************************************
 * The DAT image is a data structure that indicates which
 * Dynamic Address Translator (DAT) mapping registers are in use.
-*>>>>>>>>>> Wildbits PORT
+*[[[ Wildbits PORT
 * Dat.BlCt-ROMCount-RAMCount = 8 - 1 = 7
-                  IFNE        wildbits
-                    lda       #$07                initialize all rest of the blocks to be free
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    lda       #$07      ; initialize all rest of the blocks to be free
                   ELSE
-*<<<<<<<<<< Wildbits PORT
+*]]] Wildbits PORT
 * Dat.BlCt-ROMCount-RAMCount = 8 - 1 - 1 = 6
-                    lda       #$06                initialize the rest of the blocks to be free
+                    lda       #$06      ; initialize the rest of the blocks to be free
                   ENDC
-                    ldu       #DAT.Free           load the free marker
-l@                  stu       ,x++                store it
-                    deca                          bump up the counter
-                    bne       l@                  loop if not done
+                    ldu       #DAT.Free ; load the free marker
+l@                  stu       ,x++      ; store it
+                    deca                ; bump up the counter
+                    bne       l@        ; loop if not done
 
 * Wildbits: we call F$SRqMem later on the entire bootfile which includes krn starting
 * at Bt.Start. So we DON'T mark the kernel block as allocated in our DAT image.
-                    ifeq      wildbits
-                    ldu       #KrnBlk             get the block where the kernel resides
-                    stu       ,x                  and save it in the last 8K slot
+                  IFEQ    wildbits ; begin conditional assembly for wildbits
+                    ldu       #KrnBlk   ; get the block where the kernel resides
+                    stu       ,x        ; and save it in the last 8K slot
                   ENDC
 
-                    ldx       <D.Tasks            point to the task user table
-                    inc       ,x                  mark the 1st entry as used (system)
-                    inc       1,x                 mark the 2nd entry as used (GrfDrv)
+                    ldx       <D.Tasks  ; point to the task user table
+                    inc       ,x        ; mark the 1st entry as used (system)
+                    inc       1,x       ; mark the 2nd entry as used (GrfDrv)
 
 ********************************************************************
 * The system memory map is a data structure that manages the
@@ -442,26 +442,26 @@ l@                  stu       ,x++                store it
 * See "Level 2 flags" in os9.d for other byte values.
 
 * Update the system memory map to reserve the area used for global memory.
-                    ldx       <D.SysMem           get the system memory map pointer
-                    ldb       <D.CCStk            get the MSB of the top of kernel memory
+                    ldx       <D.SysMem ; get the system memory map pointer
+                    ldb       <D.CCStk  ; get the MSB of the top of kernel memory
 * X indexes the system memory map.
 * B represents the number of 256-byte pages available.
 * Walk through the map, changing the corresponding elements from 0
 * (the initialization value) to 1 (indicating 'used'). Higher
 * entries in the map remain as 0 (indicating 'unused').
-L0104               inc       ,x+                 mark it as used
-                    decb                          done?
-                    bne       L0104               no, go back till done
+L0104               inc       ,x+       ; mark it as used
+                    decb                ; done?
+                    bne       L0104     ; no, go back till done
 
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
 * We already know we have 512K of RAM, so we won't go through a memory
 * sizing check.
-                    ldx       <D.BlkMap           get the pointer to 8KB block map
-                    ldd       #$0140              A = 1, B = $40 (512K of RAM)
-                    sta       ,x                  mark block 0 as allocated
-                    inca                          D = $240 (512K)
-                    std       <D.BlkMap+2         save the newly computed memory block map end pointer
+                    ldx       <D.BlkMap ; get the pointer to 8KB block map
+                    ldd       #$0140    ; A = 1, B = $40 (512K of RAM)
+                    sta       ,x        ; mark block 0 as allocated
+                    inca                ; D = $240 (512K)
+                    std       <D.BlkMap+2 ; save the newly computed memory block map end pointer
 * For the Wildbits port, the entire bootfile is loaded into RAM by FEU, so we call
 * F$SRqMem to allocate the memory we need (F$Boot would normally do this, but we
 * don't use F$Boot on Wildbits).
@@ -469,30 +469,30 @@ L0104               inc       ,x+                 mark it as used
 * to temporarly fake out the DAT block map to show lower blocks as allocated
 * so that F$SRqMem (and F$AllImg) allocate the correct 8K blocks that contain
 * the loaded bootfile.
-                    ldb       <D.BtPtr            get the pointer to the bootfile
-                    lsrb                          B = B / 2
-                    lsrb                          B = B / 4
-                    lsrb                          B = B / 8
-                    lsrb                          B = B / 16
-                    lsrb                          B = B / 32
-                    decb
-                    pshs      b                   save on the stack
-                    lda       #RAMInUse           get the "RAM in use flag"
-l@                  sta       b,x                 store the flag in the appropriate offset
-                    decb                          decrement the counter
-                    bne       l@                  branch if more
-                    ldd       <D.BtSz             get the bootfile size
-                    os9       F$SRqMem            allocate the needed amount of memory
+                    ldb       <D.BtPtr  ; get the pointer to the bootfile
+                    lsrb                ; B = B / 2
+                    lsrb                ; B = B / 4
+                    lsrb                ; B = B / 8
+                    lsrb                ; B = B / 16
+                    lsrb                ; B = B / 32
+                    decb                ; decrement B
+                    pshs      b         ; save on the stack
+                    lda       #RAMInUse ; get the "RAM in use flag"
+l@                  sta       b,x       ; store the flag in the appropriate offset
+                    decb                ; decrement the counter
+                    bne       l@        ; branch if more
+                    ldd       <D.BtSz   ; get the bootfile size
+                    os9       F$SRqMem  ; allocate the needed amount of memory
 
-                    clra                          set the "block free" flag
-                    puls      b                   recover the offset we saved earlier on the stack
-l@                  sta       b,x                 store the flag in the appropriate offset
-                    decb                          decrement the counter
-                    bne       l@                  branch if more
-                    ldx       <D.BtPtr            get start address of the bootfile in memory
-                    ldd       <D.BtSz             get MSB of bootfile size
+                    clra                ; set the "block free" flag
+                    puls      b         ; recover the offset we saved earlier on the stack
+l@                  sta       b,x       ; store the flag in the appropriate offset
+                    decb                ; decrement the counter
+                    bne       l@        ; branch if more
+                    ldx       <D.BtPtr  ; get start address of the bootfile in memory
+                    ldd       <D.BtSz   ; get MSB of bootfile size
                   ELSE
-*<<<<<<<<<< Wildbits PORT
+*]]] Wildbits PORT
 ********************************************************************
 * Determine how many 8KB blocks of physical memory are available and
 * update the memory block map end pointer (D.BlkMap+2) accordingly.
@@ -501,34 +501,34 @@ l@                  sta       b,x                 store the flag in the appropri
 * has the side-effect of marking block 0 as used. It is essential that
 * this occurs, because that block needs to be reserved as it's used for
 * global memory.
-                    ldx       <D.BlkMap           get the pointer to 8KB block map
-                    inc       <KrnBlk,x           mark the block holding kernel as used
+                    ldx       <D.BlkMap ; get the pointer to 8KB block map
+                    inc       <KrnBlk,x ; mark the block holding kernel as used
 
-                  IFNE        H6309
-                    ldq       #$00080100          E=Marker, D=Block # to check
-L0111               asld                          get next block #
-                    stb       >DAT.Regs+5         map block into block 6 of my task
-                    ste       >-$6000,x           save marker to that block
-                    cmpe      ,x                  did it ghost to block 0?
-                    bne       L0111               no, keep going till ghost is found
-                    stb       <D.MemSz            save # of 8KB memory blocks that exist
-                    addr      x,d                 add number of blocks to block map start
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$00080100 ; e=Marker, D=Block # to check
+L0111               asld                ; get next block #
+                    stb       >DAT.Regs+5 ; map block into block 6 of my task
+                    ste       >-$6000,x ; save marker to that block
+                    cmpe      ,x        ; did it ghost to block 0?
+                    bne       L0111     ; no, keep going till ghost is found
+                    stb       <D.MemSz  ; save # of 8KB memory blocks that exist
+                    addr      x,d       ; add number of blocks to block map start
                   ELSE
-                    ldd       #$0008              load the initial value
-L0111               aslb                          B <= 1 (hi bit goes into carry, 0 goes into low bit)
-                    rola                          A <= 1 (carry goes into low bit, hi bit goes into carry)
-                    stb       >DAT.Regs+5         save B into the slot
-                    pshs      a                   save A onto the stack
-                    lda       #$01                get the test value
-                    sta       >-$6000,x           save it in the offset value
-                    cmpa      ,x                  compare against the value here
-                    puls      a                   recover A
-                    bne       L0111               branch if the previous comparison failed
-                    stb       <D.MemSz            else we have our memory size now
-                    pshs      x                   save X
-                    addd      ,s++                add X into D and recover the stack
+                    ldd       #$0008    ; load the initial value
+L0111               aslb                ; B <= 1 (hi bit goes into carry, 0 goes into low bit)
+                    rola                ; A <= 1 (carry goes into low bit, hi bit goes into carry)
+                    stb       >DAT.Regs+5 ; save B into the slot
+                    pshs      a         ; save A onto the stack
+                    lda       #$01      ; get the test value
+                    sta       >-$6000,x ; save it in the offset value
+                    cmpa      ,x        ; compare against the value here
+                    puls      a         ; recover A
+                    bne       L0111     ; branch if the previous comparison failed
+                    stb       <D.MemSz  ; else we have our memory size now
+                    pshs      x         ; save X
+                    addd      ,s++      ; add X into D and recover the stack
                   ENDC
-                    std       <D.BlkMap+2         save the newly computed memory block map end pointer
+                    std       <D.BlkMap+2 ; save the newly computed memory block map end pointer
 
 ********************************************************************
 * Initial reservation of blocks in the memory block map. Code above
@@ -541,38 +541,38 @@ L0111               aslb                          B <= 1 (hi bit goes into carry
 * $0240 = 512KB  ( 64 8KB blocks)
 * $0280 = 1024KB (128 8KB blocks)
 * $0300 = 2048KB (256 8KB blocks)
-                    bitb      #%00110000          is the block above 128K-256K?
-                    beq       L0170               yes, no need to mark block map
-                    tstb                          is it 2 meg?
-                    beq       L0170               yes, skip this
+                    bitb      #%00110000 ; is the block above 128K-256K?
+                    beq       L0170     ; yes, no need to mark block map
+                    tstb                ; is it 2 meg?
+                    beq       L0170     ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM.
-                    abx                           add the maximum block number to block map start address
-                    leax      -1,x                skip good blocks that are RAM
-                    lda       #NotRAM             load the "Not RAM" flag
-                    subb      #$3F                calculate the number of blocks to mark as not RAM
-l@                  sta       ,x+                 mark them all
-                    decb                          are we done?
-                    bne       l@                  not yet
+                    abx                 ; add the maximum block number to block map start address
+                    leax      -1,x      ; skip good blocks that are RAM
+                    lda       #NotRAM   ; load the "Not RAM" flag
+                    subb      #$3F      ; calculate the number of blocks to mark as not RAM
+l@                  sta       ,x+       ; mark them all
+                    decb                ; are we done?
+                    bne       l@        ; not yet
 
 * ASSUME: however we got here, B=0
 L0170
-                    ldx       #Bt.Start           start address of the boot track in memory
-                    lda       #18                 size of the boot track is $1800
+                    ldx       #Bt.Start ; start address of the boot track in memory
+                    lda       #18       ; size of the boot track is $1800
                   ENDC
 
 * Verify the modules in the boot area and update/build a module index.
-                    lbsr      I.VBlock            perform module validation
-                    bsr       L01D2               then mark the system map
+                    lbsr      I.VBlock  ; perform module validation
+                    bsr       L01D2     ; then mark the system map
 
-                    ifeq      wildbits
+                  IFEQ    wildbits ; begin conditional assembly for wildbits
 * BGP - Load bootfile and link to init. We no longer try to link to init first and then
 * call F$Boot. This saves bytes.
-                    os9       F$Boot              load bootfile here +BGP+
-                    bcs       L01CE               error, go crash +BGP+
+                    os9       F$Boot    ; load bootfile here +BGP+
+                    bcs       L01CE     ; error, go crash +BGP+
                   ENDC
-                    leax      <init,pc            point to 'Init' module name
-                    bsr       link                try & link it
-                    bcs       L01CE               error, go crash
+                    leax      <init,pc  ; point to 'Init' module name
+                    bsr       link      ; try & link it
+                    bcs       L01CE     ; error, go crash
 
 * BGP - Commented out the following lines since I moved F$Boot above
 *                    bcc       L01BF               no error, go on
@@ -581,20 +581,20 @@ L0170
 *                    bra       L01CE               error, re-booting do D.Crash
 
 * So far, so good. Save the pointer to the init module and execute krnp2.
-L01BF               stu       <D.Init             save the init module pointer
-                    lda       Feature1,u          get feature byte #1 from the init module
-                    bita      #CRCOn              is the CRC feature on?
-                    beq       ShowI               if not, continue
-                    inc       <D.CRC              else increment the CRC flag
+L01BF               stu       <D.Init   ; save the init module pointer
+                    lda       Feature1,u ; get feature byte #1 from the init module
+                    bita      #CRCOn    ; is the CRC feature on?
+                    beq       ShowI     ; if not, continue
+                    inc       <D.CRC    ; else increment the CRC flag
 
 ShowI
-                    ifeq      wildbits
-                    lda       #'i                 debug: signal that we found the init module
-                    jsr       <D.BtBug            perform the action
+                  IFEQ    wildbits ; begin conditional assembly for wildbits
+                    lda       #'i       ; debug: signal that we found the init module
+                    jsr       <D.BtBug  ; perform the action
                   ENDC
 
-L01C1               leax      <krnp2,pc           point to krnp2's name
-                    bsr       link                try to link it
+L01C1               leax      <krnp2,pc ; point to krnp2's name
+                    bsr       link      ; try to link it
 
 * BGP - Removed the following lines as krnp2 is ALWAYS in the bootfile and F$Boot is called above.
 * Also saves needed critical space since F$CpyMem is now part of krn.
@@ -605,242 +605,242 @@ L01C1               leax      <krnp2,pc           point to krnp2's name
 *                    bcc       L01C1               branch if no error, let's try to link it again
 *
 
-L01D0               jmp       ,y                  jump into krnp2
+L01D0               jmp       ,y        ; jump into krnp2
 
 * BGP - This line was above L01D0 but now moved below since above lines are commented.
-L01CE               jmp       <D.Crash            obviously can't do it, crash machine
+L01CE               jmp       <D.Crash  ; obviously can't do it, crash machine
 
 * Update the system memory map to reserve the area the kernel uses.
-L01D2               ldx       <D.SysMem           get the system memory map pointer
-                  IFNE        wildbits
-                    lda       #NotRAM             get the "not RAM" flag
-                    ldb       <D.BtPtr            and the boot pointer MSB
+L01D2               ldx       <D.SysMem ; get the system memory map pointer
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    lda       #NotRAM   ; get the "not RAM" flag
+                    ldb       <D.BtPtr  ; and the boot pointer MSB
                   ELSE
-                    ldd       #NotRAM*256+(Bt.Start/256) B = MSB of start of the boot area
+                    ldd       #NotRAM*256+(Bt.Start/256) ; B = MSB of start of the boot area
                   ENDC
-                    abx                           point to Bt.Start - start of the boot area
-                    comb                          we have $FF-$ED pages to mark as "RAM in use"
-                    sta       b,x                 mark I/O as not RAM
-L01DF               lda       #RAMinUse           get the "RAM in use" flag
-L01E1               sta       ,x+                 mark this page
-                    decb                          done?
-                    bne       L01E1               no, keep going
-                    ldx       <D.BlkMap           get the pointer to the start of the block map
-                    sta       <KrnBlk,x           mark kernel block as "RAM in use", instead of "Module in block"
-S.AltIRQ            rts                           return
+                    abx                 ; point to Bt.Start - start of the boot area
+                    comb                ; we have $FF-$ED pages to mark as "RAM in use"
+                    sta       b,x       ; mark I/O as not RAM
+L01DF               lda       #RAMinUse ; get the "RAM in use" flag
+L01E1               sta       ,x+       ; mark this page
+                    decb                ; done?
+                    bne       L01E1     ; no, keep going
+                    ldx       <D.BlkMap ; get the pointer to the start of the block map
+                    sta       <KrnBlk,x ; mark kernel block as "RAM in use", instead of "Module in block"
+S.AltIRQ            rts                 ; return
 
 * Link module pointed to by X
-link                lda       #Systm              attempt to link to a system module
-                    os9       F$Link              link to it
-                    rts                           return
+link                lda       #Systm    ; attempt to link to a system module
+                    os9       F$Link    ; link to it
+                    rts                 ; return
 
 init                fcs       'Init'
 krnp2               fcs       'krnp2'
 
 * Service vector call pointers
-SysCalls            fcb       F$Link
-                    fdb       FLink-*-2
-                    fcb       F$PrsNam
-                    fdb       FPrsNam-*-2
-                    fcb       F$CmpNam
-                    fdb       FCmpNam-*-2
-                    fcb       F$CmpNam+SysState
-                    fdb       FSCmpNam-*-2
-                    fcb       F$CRC
-                    fdb       FCRC-*-2
-                    fcb       F$SRqMem+SysState
-                    fdb       FSRqMem-*-2
-                    fcb       F$SRtMem+SysState
-                    fdb       FSRtMem-*-2
-                    fcb       F$AProc+SysState
-                    fdb       FAProc-*-2
-                    fcb       F$NProc+SysState
-                    fdb       FNProc-*-2
-                    fcb       F$VModul+SysState
-                    fdb       FVModul-*-2
-                    fcb       F$SSvc+SysState
-                    fdb       FSSvc-*-2
-                    fcb       F$SLink+SysState
-                    fdb       FSLink-*-2
-                    fcb       F$Boot+SysState
-                    fdb       FBoot-*-2
-                    fcb       F$BtMem+SysState
-                    fdb       FSRqMem-*-2
-                    fcb       F$CpyMem
-                    fdb       FCpyMem-*-2
-                    fcb       F$Move+SysState
-                    fdb       FMove-*-2
-                    fcb       F$AllImg+SysState
-                    fdb       FAllImg-*-2
-                    fcb       F$SetImg+SysState
-                    fdb       FSetImg-*-2
-                    fcb       F$FreeLB+SysState
-                    fdb       FSFreeLB-*-2
-                    fcb       F$FreeHB+SysState
-                    fdb       FFreeHB-*-2
-                    fcb       F$AllTsk+SysState
-                    fdb       FAllTsk-*-2
-                    fcb       F$DelTsk+SysState
-                    fdb       FDelTsk-*-2
-                    fcb       F$SetTsk+SysState
-                    fdb       FSetTsk-*-2
-                    fcb       F$ResTsk+SysState
-                    fdb       FResTsk-*-2
-                    fcb       F$RelTsk+SysState
-                    fdb       FRelTsk-*-2
-                    fcb       F$DATLog+SysState
-                    fdb       FDATLog-*-2
-                    fcb       F$LDAXY+SysState
-                    fdb       FLDAXY-*-2
-                    fcb       F$LDDDXY+SysState
-                    fdb       FLDDDXY-*-2
-                    fcb       F$LDABX+SysState
-                    fdb       FLDABX-*-2
-                    fcb       F$STABX+SysState
-                    fdb       FSTABX-*-2
-                    fcb       F$ELink+SysState
-                    fdb       FELink-*-2
-                    fcb       F$FModul+SysState
-                    fdb       FFModul-*-2
-                    fcb       F$VBlock+SysState
-                    fdb       FVBlock-*-2
-                    IFNE      H6309+wildbits
-                    fcb       F$DelRAM
-                    fdb       FDelRAM-*-2
-                    ENDC
-                    fcb       $80
+SysCalls            fcb       F$Link    ; define byte value(s) F$Link
+                    fdb       FLink-*-2 ; define word value(s) FLink-*-2
+                    fcb       F$PrsNam  ; define byte value(s) F$PrsNam
+                    fdb       FPrsNam-*-2 ; define word value(s) FPrsNam-*-2
+                    fcb       F$CmpNam  ; define byte value(s) F$CmpNam
+                    fdb       FCmpNam-*-2 ; define word value(s) FCmpNam-*-2
+                    fcb       F$CmpNam+SysState ; define byte value(s) F$CmpNam+SysState
+                    fdb       FSCmpNam-*-2 ; define word value(s) FSCmpNam-*-2
+                    fcb       F$CRC     ; define byte value(s) F$CRC
+                    fdb       FCRC-*-2  ; define word value(s) FCRC-*-2
+                    fcb       F$SRqMem+SysState ; define byte value(s) F$SRqMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                    fcb       F$SRtMem+SysState ; define byte value(s) F$SRtMem+SysState
+                    fdb       FSRtMem-*-2 ; define word value(s) FSRtMem-*-2
+                    fcb       F$AProc+SysState ; define byte value(s) F$AProc+SysState
+                    fdb       FAProc-*-2 ; define word value(s) FAProc-*-2
+                    fcb       F$NProc+SysState ; define byte value(s) F$NProc+SysState
+                    fdb       FNProc-*-2 ; define word value(s) FNProc-*-2
+                    fcb       F$VModul+SysState ; define byte value(s) F$VModul+SysState
+                    fdb       FVModul-*-2 ; define word value(s) FVModul-*-2
+                    fcb       F$SSvc+SysState ; define byte value(s) F$SSvc+SysState
+                    fdb       FSSvc-*-2 ; define word value(s) FSSvc-*-2
+                    fcb       F$SLink+SysState ; define byte value(s) F$SLink+SysState
+                    fdb       FSLink-*-2 ; define word value(s) FSLink-*-2
+                    fcb       F$Boot+SysState ; define byte value(s) F$Boot+SysState
+                    fdb       FBoot-*-2 ; define word value(s) FBoot-*-2
+                    fcb       F$BtMem+SysState ; define byte value(s) F$BtMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                    fcb       F$CpyMem  ; define byte value(s) F$CpyMem
+                    fdb       FCpyMem-*-2 ; define word value(s) FCpyMem-*-2
+                    fcb       F$Move+SysState ; define byte value(s) F$Move+SysState
+                    fdb       FMove-*-2 ; define word value(s) FMove-*-2
+                    fcb       F$AllImg+SysState ; define byte value(s) F$AllImg+SysState
+                    fdb       FAllImg-*-2 ; define word value(s) FAllImg-*-2
+                    fcb       F$SetImg+SysState ; define byte value(s) F$SetImg+SysState
+                    fdb       FSetImg-*-2 ; define word value(s) FSetImg-*-2
+                    fcb       F$FreeLB+SysState ; define byte value(s) F$FreeLB+SysState
+                    fdb       FSFreeLB-*-2 ; define word value(s) FSFreeLB-*-2
+                    fcb       F$FreeHB+SysState ; define byte value(s) F$FreeHB+SysState
+                    fdb       FFreeHB-*-2 ; define word value(s) FFreeHB-*-2
+                    fcb       F$AllTsk+SysState ; define byte value(s) F$AllTsk+SysState
+                    fdb       FAllTsk-*-2 ; define word value(s) FAllTsk-*-2
+                    fcb       F$DelTsk+SysState ; define byte value(s) F$DelTsk+SysState
+                    fdb       FDelTsk-*-2 ; define word value(s) FDelTsk-*-2
+                    fcb       F$SetTsk+SysState ; define byte value(s) F$SetTsk+SysState
+                    fdb       FSetTsk-*-2 ; define word value(s) FSetTsk-*-2
+                    fcb       F$ResTsk+SysState ; define byte value(s) F$ResTsk+SysState
+                    fdb       FResTsk-*-2 ; define word value(s) FResTsk-*-2
+                    fcb       F$RelTsk+SysState ; define byte value(s) F$RelTsk+SysState
+                    fdb       FRelTsk-*-2 ; define word value(s) FRelTsk-*-2
+                    fcb       F$DATLog+SysState ; define byte value(s) F$DATLog+SysState
+                    fdb       FDATLog-*-2 ; define word value(s) FDATLog-*-2
+                    fcb       F$LDAXY+SysState ; define byte value(s) F$LDAXY+SysState
+                    fdb       FLDAXY-*-2 ; define word value(s) FLDAXY-*-2
+                    fcb       F$LDDDXY+SysState ; define byte value(s) F$LDDDXY+SysState
+                    fdb       FLDDDXY-*-2 ; define word value(s) FLDDDXY-*-2
+                    fcb       F$LDABX+SysState ; define byte value(s) F$LDABX+SysState
+                    fdb       FLDABX-*-2 ; define word value(s) FLDABX-*-2
+                    fcb       F$STABX+SysState ; define byte value(s) F$STABX+SysState
+                    fdb       FSTABX-*-2 ; define word value(s) FSTABX-*-2
+                    fcb       F$ELink+SysState ; define byte value(s) F$ELink+SysState
+                    fdb       FELink-*-2 ; define word value(s) FELink-*-2
+                    fcb       F$FModul+SysState ; define byte value(s) F$FModul+SysState
+                    fdb       FFModul-*-2 ; define word value(s) FFModul-*-2
+                    fcb       F$VBlock+SysState ; define byte value(s) F$VBlock+SysState
+                    fdb       FVBlock-*-2 ; define word value(s) FVBlock-*-2
+                  IFNE    H6309+wildbits ; begin conditional assembly for H6309+wildbits
+                    fcb       F$DelRAM  ; define byte value(s) F$DelRAM
+                    fdb       FDelRAM-*-2 ; define word value(s) FDelRAM-*-2
+                  ENDC
+                    fcb       $80       ; define byte value(s) $80
 
 * SWI3 vector entry
-XSWI3               lda       #P$SWI3             point to the SWI3 vector
-                    fcb       $8C                 skip 2 bytes
+XSWI3               lda       #P$SWI3   ; point to the SWI3 vector
+                    fcb       $8C       ; skip 2 bytes
 
 * SWI vector entry
-XSWI                lda       #P$SWI              point to the SWI vector
-                    ldx       <D.Proc             get the current process descriptor
-                    ldu       a,x                 is this a user defined SWI[x]?
-                    beq       L028E               no, go get the option byte
-GoUser              lbra      L0E5E               else call the users's routine
+XSWI                lda       #P$SWI    ; point to the SWI vector
+                    ldx       <D.Proc   ; get the current process descriptor
+                    ldu       a,x       ; is this a user defined SWI[x]?
+                    beq       L028E     ; no, go get the option byte
+GoUser              lbra      L0E5E     ; else call the users's routine
 
 * SWI2 vector entry
-XSWI2               ldx       <D.Proc             get the current process descriptor
-                    ldu       P$SWI2,x            any SWI vector?
-                    bne       GoUser              yes, go execute it
+XSWI2               ldx       <D.Proc   ; get the current process descriptor
+                    ldu       P$SWI2,x  ; any SWI vector?
+                    bne       GoUser    ; yes, go execute it
 
 * Process software interrupts from a user state.
 *
 * Entry: X = The process descriptor pointer of process that made system call.
 *        U = The register stack pointer.
-L028E               ldu       <D.SysSvc           get the system call service vector
-                    stu       <D.XSWI2            set the cross-SWI2 vector
-                    ldu       <D.SysIRQ           get the interrupt service vector
-                    stu       <D.XIRQ             set the cross-IRQ vector
-                  IFNE        H6309
-                    oim       #SysState,P$State,x mark the process as in system state
+L028E               ldu       <D.SysSvc ; get the system call service vector
+                    stu       <D.XSWI2  ; set the cross-SWI2 vector
+                    ldu       <D.SysIRQ ; get the interrupt service vector
+                    stu       <D.XIRQ   ; set the cross-IRQ vector
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #SysState,P$State,x ; mark the process as in system state
                   ELSE
-                    lda       P$State,x           get the process' state
-                    ora       #SysState           set the system state flag
-                    sta       P$State,x           store it back in the process descriptor
+                    lda       P$State,x ; get the process' state
+                    ora       #SysState ; set the system state flag
+                    sta       P$State,x ; store it back in the process descriptor
                   ENDC
 * Copy the register stack to the process descriptor.
-                    sts       P$SP,x              save the stack pointer
-                    leas      (P$Stack-R$Size),x  point S to the register stack destination
-                  IFNE        H6309
-                    leau      R$Size-1,s          point to the last byte of the destination register stack
-                    leay      -1,y                point to the caller's register stack in $FEE1
-                    ldw       #R$Size             get size of the register stack
-                    tfm       y-,u-               perform the transfer
-                    leau      ,s                  needed because the TFM is u-, not -u (post, not pre)
+                    sts       P$SP,x    ; save the stack pointer
+                    leas      (P$Stack-R$Size),x ; point S to the register stack destination
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leau      R$Size-1,s ; point to the last byte of the destination register stack
+                    leay      -1,y      ; point to the caller's register stack in $FEE1
+                    ldw       #R$Size   ; get size of the register stack
+                    tfm       y-,u-     ; perform the transfer
+                    leau      ,s        ; needed because the TFM is u-, not -u (post, not pre)
                   ELSE
 * Note! R$Size MUST BE an EVEN number of bytes for this to work!
-                    leau      R$Size,s            point to the last byte of the destination register stack
-                    lda       #R$Size/2           get the number of words to copy in A
-l@                  ldx       ,--y                get the source bytes
-                    stx       ,--u                save them in the destination
-                    deca                          decrement the counter
-                    bne       l@                  branch until done
+                    leau      R$Size,s  ; point to the last byte of the destination register stack
+                    lda       #R$Size/2 ; get the number of words to copy in A
+l@                  ldx       ,--y      ; get the source bytes
+                    stx       ,--u      ; save them in the destination
+                    deca                ; decrement the counter
+                    bne       l@        ; branch until done
                   ENDC
-                    andcc     #^IntMasks          unmask interrupts
+                    andcc     #^IntMasks ; unmask interrupts
 * B = the function code already from calling process: DON'T USE IT!
-                    ldx       R$PC,u              get where the program counter was from the process
-                    leax      1,x                 move the program counter past the op-code
-                    stx       R$PC,u              save updated the update program counter back
+                    ldx       R$PC,u    ; get where the program counter was from the process
+                    leax      1,x       ; move the program counter past the op-code
+                    stx       R$PC,u    ; save updated the update program counter back
 * Execute the system call.
-                    ldy       <D.UsrDis           get the user dispatch table pointer
-                    lbsr      L033B               go execute the op-code
-                  IFNE        H6309
-                    aim       #^IntMasks,R$CC,u   unmask interrupts in the caller's CC
+                    ldy       <D.UsrDis ; get the user dispatch table pointer
+                    lbsr      L033B     ; go execute the op-code
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^IntMasks,R$CC,u ; unmask interrupts in the caller's CC
                   ELSE
-                    lda       R$CC,u              get the caller's CC
-                    anda      #^IntMasks          unmask interrupts
-                    sta       R$CC,u              and save it back
+                    lda       R$CC,u    ; get the caller's CC
+                    anda      #^IntMasks ; unmask interrupts
+                    sta       R$CC,u    ; and save it back
                   ENDC
-                    ldx       <D.Proc             get the current process descriptor
-                  IFNE        H6309
-                    aim       #^(SysState+TimOut),P$State,x turn off the system state and timeout flags
+                    ldx       <D.Proc   ; get the current process descriptor
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^(SysState+TimOut),P$State,x ; turn off the system state and timeout flags
                   ELSE
-                    lda       P$State,x           get the process state
-                    anda      #^(SysState+TimOut) turn off the system state and timeout flags
-                    sta       P$State,x           and save it back
+                    lda       P$State,x ; get the process state
+                    anda      #^(SysState+TimOut) ; turn off the system state and timeout flags
+                    sta       P$State,x ; and save it back
                   ENDC
 
 * Check for image change now, which lets stuff like F$MapBlk and F$ClrBlk
 * do the short-circuit thing, too. Adds about 20 cycles to each system call.
-                    lbsr      TstImg              it doesn't hurt to call this twice
-                    lda       P$State,x           get current state of the process
-                    ora       <P$Signal,x         is there a pending signal?
-                    sta       <D.Quick            save quick return flag
-                    beq       AllClr              if nothing changed, do full checks
+                    lbsr      TstImg    ; it doesn't hurt to call this twice
+                    lda       P$State,x ; get current state of the process
+                    ora       <P$Signal,x ; is there a pending signal?
+                    sta       <D.Quick  ; save quick return flag
+                    beq       AllClr    ; if nothing changed, do full checks
 
-DoFull              bsr       L02DA               move the stack frame back to user state
-                    lbra      L0D80               go back to the process
+DoFull              bsr       L02DA     ; move the stack frame back to user state
+                    lbra      L0D80     ; go back to the process
 
 * add ldu P$SP,x, etc...
-AllClr              equ       *
-                  IFNE        H6309
-                    inc       <D.QCnt             increment the flag
-                    aim       #$1F,<D.QCnt
-                    beq       DoFull              every 32 system calls, do the full check
-                    ldw       #R$Size             get the size of the register stack
-                    ldy       #Where+SWIStack     and the stack at top of memory
-                    orcc      #IntMasks           mask interrupts
-                    tfm       u+,y+               move the stack to the top of memory
+AllClr              equ       *         ; define assembler symbol AllClr
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    inc       <D.QCnt   ; increment the flag
+                    aim       #$1F,<D.QCnt ; apply immediate bit operation #$1F,<D.QCnt
+                    beq       DoFull    ; every 32 system calls, do the full check
+                    ldw       #R$Size   ; get the size of the register stack
+                    ldy       #Where+SWIStack ; and the stack at top of memory
+                    orcc      #IntMasks ; mask interrupts
+                    tfm       u+,y+     ; move the stack to the top of memory
                   ELSE
-                    lda       <D.QCnt             get the flag
-                    inca                          increment it
-                    anda      #$1F                clear these bits
-                    sta       <D.QCnt             and save it back
-                    beq       DoFull              branch if zero
+                    lda       <D.QCnt   ; get the flag
+                    inca                ; increment it
+                    anda      #$1F      ; clear these bits
+                    sta       <D.QCnt   ; and save it back
+                    beq       DoFull    ; branch if zero
 * NOTE: Need to preserve X here - needed for BackTo1 routine
 *   (Currently in fnproc.asm). 145 cycles vs. original 213 cycles
-                    ldb       #R$Size             else get the size of the register stack
-                    ldy       #Where+SWIStack     and the stack at the top of memory
-                    orcc      #IntMasks           mask interrupts
-l@                  lda       ,u+                 get the source byte
-                    sta       ,y+                 save it at the destination
-                    decb                          decrement the counter
-                    bne       l@                  branch if not done
+                    ldb       #R$Size   ; else get the size of the register stack
+                    ldy       #Where+SWIStack ; and the stack at the top of memory
+                    orcc      #IntMasks ; mask interrupts
+l@                  lda       ,u+       ; get the source byte
+                    sta       ,y+       ; save it at the destination
+                    decb                ; decrement the counter
+                    bne       l@        ; branch if not done
                   ENDC
-                    lbra      BackTo1             return to the user
+                    lbra      BackTo1   ; return to the user
 
 * Copy the register stack from user to system.
 *
 * Entry: U = The pointer to the register stack in the process descriptor.
-L02CB               pshs      cc,x,y,u            preserve registers
-                    ldb       P$Task,x            get the task #
-                    ldx       P$SP,x              and the stack pointer
-                    lbsr      L0BF3               calculate the block offset (only affects A&X)
-                    leax      -$6000,x            adjust the pointer to where the memory map will be
-                    bra       L02E9               go copy it
+L02CB               pshs      cc,x,y,u  ; preserve registers
+                    ldb       P$Task,x  ; get the task #
+                    ldx       P$SP,x    ; and the stack pointer
+                    lbsr      L0BF3     ; calculate the block offset (only affects A&X)
+                    leax      -$6000,x  ; adjust the pointer to where the memory map will be
+                    bra       L02E9     ; go copy it
 
 * Copy the register stack from system to user.
 *
 * Entry: U = The pointer to the register stack in the process descriptor.
-L02DA               pshs      cc,x,y,u            preserve registers
-                    ldb       P$Task,x            get the task # of destination
-                    ldx       P$SP,x              and the stack pointer
-                    lbsr      L0BF3               calculate the block offset (only affects A&X)
-                    leax      -$6000,x            adjust the pointer to where the memory map will be
-                    exg       x,y                 swap pointers & copy
+L02DA               pshs      cc,x,y,u  ; preserve registers
+                    ldb       P$Task,x  ; get the task # of destination
+                    ldx       P$SP,x    ; and the stack pointer
+                    lbsr      L0BF3     ; calculate the block offset (only affects A&X)
+                    leax      -$6000,x  ; adjust the pointer to where the memory map will be
+                    exg       x,y       ; swap pointers & copy
 
 * Copy a register stack.
 *
@@ -848,172 +848,172 @@ L02DA               pshs      cc,x,y,u            preserve registers
 *        Y = The destination register stack.
 *        A = The offset into the DAT image of stack.
 *        B = The task number.
-L02E9               leau      a,u                 point to the block number where stack is
-                    lda       1,u                 get the first block
-                    ldb       3,u                 get a second just in case of overlap
-                    orcc      #IntMasks           shutdown interrupts while we do this
-                    std       >DAT.Regs+5         map in the blocks
-                  IFNE        H6309
-                    ldw       #R$Size             get the size of register stack
-                    tfm       x+,y+               copy it
+L02E9               leau      a,u       ; point to the block number where stack is
+                    lda       1,u       ; get the first block
+                    ldb       3,u       ; get a second just in case of overlap
+                    orcc      #IntMasks ; shutdown interrupts while we do this
+                    std       >DAT.Regs+5 ; map in the blocks
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get the size of register stack
+                    tfm       x+,y+     ; copy it
                   ELSE
-                    ldb       #R$Size/2           get the size of the register stack
-l@                  ldu       ,x++                get the source bytes
-                    stu       ,y++                and save them in the destination
-                    decb                          decrement the counter
-                    bne       l@                  branch if not done
+                    ldb       #R$Size/2 ; get the size of the register stack
+l@                  ldu       ,x++      ; get the source bytes
+                    stu       ,y++      ; and save them in the destination
+                    decb                ; decrement the counter
+                    bne       l@        ; branch if not done
                   ENDC
-                    ldx       <D.SysDAT           get the system DAT pointer
-                    lda       $0B,x               get the first block we took out
-                    ldb       $0D,x               and the second
-                    std       >DAT.Regs+5         and restore the DAT
-                    puls      cc,x,y,u,pc         restore & return
+                    ldx       <D.SysDAT ; get the system DAT pointer
+                    lda       $0B,x     ; get the first block we took out
+                    ldb       $0D,x     ; and the second
+                    std       >DAT.Regs+5 ; and restore the DAT
+                    puls      cc,x,y,u,pc ; restore & return
 
 * Process software interrupts from system state.
 *
 * Entry: U = The register stack pointer.
-SysCall             leau      ,s                  get the pointer to the register stack
-                    lda       <D.SSTskN           get the system task number (0 = system, 1 = GrfDrv)
-                    clr       <D.SSTskN           force the system process
-                    pshs      a                   save the system task number
-                    lda       ,u                  restore the caller's CC register (R$CC = $00)
-                    tfr       a,cc                make it current
-                    ldx       R$PC,u              get my caller's PC register
-                    leax      1,x                 move the PC to next position
-                    stx       R$PC,u              save my caller's updated PC register
-                    ldy       <D.SysDis           get the system dispatch table pointer
-                    bsr       L033B               execute the system call
-                    puls      a                   restore the system state task number
-                    lbra      L0E2B               return to the process
+SysCall             leau      ,s        ; get the pointer to the register stack
+                    lda       <D.SSTskN ; get the system task number (0 = system, 1 = GrfDrv)
+                    clr       <D.SSTskN ; force the system process
+                    pshs      a         ; save the system task number
+                    lda       ,u        ; restore the caller's CC register (R$CC = $00)
+                    tfr       a,cc      ; make it current
+                    ldx       R$PC,u    ; get my caller's PC register
+                    leax      1,x       ; move the PC to next position
+                    stx       R$PC,u    ; save my caller's updated PC register
+                    ldy       <D.SysDis ; get the system dispatch table pointer
+                    bsr       L033B     ; execute the system call
+                    puls      a         ; restore the system state task number
+                    lbra      L0E2B     ; return to the process
 
 * Entry: X = system call vector to jump to
-Sys.Vec             jmp       ,x                  execute the service call
+Sys.Vec             jmp       ,x        ; execute the service call
 
 * Execute the system call.
 *
 * Entry: B = System call op-code
 *        Y = System dispatch table pointer (D.SysDis or D.UsrDis)
 L033B
-                    lslb                          is it a I/O call? (also multiplies by 2 for offset)
-                    bcc       L0345               no, go get normal vector
+                    lslb                ; is it a I/O call? (also multiplies by 2 for offset)
+                    bcc       L0345     ; no, go get normal vector
 * Execute I/O system calls.
-                    ldx       IOEntry,y           else get IOMan vector
+                    ldx       IOEntry,y ; else get IOMan vector
 * Execute the system call.
-L034F               pshs      u                   preserve the register stack pointer
-                    jsr       [D.SysVec]          perform a vectored system call
-                    puls      u                   restore the pointer
-L0355               tfr       cc,a                move CC to A for a stack update
-                    bcc       L035B               go update it if no error from call
-                    stb       R$B,u               save the error code to caller's B
-L035B               ldb       R$CC,u              get the caller's CC, R$CC = $00
-                  IFNE        H6309
-                    andd      #$2FD0              [A]=H,N,Z,V,C [B]=E,F,I
-                    orr       b,a                 merge them together
+L034F               pshs      u         ; preserve the register stack pointer
+                    jsr       [D.SysVec] ; perform a vectored system call
+                    puls      u         ; restore the pointer
+L0355               tfr       cc,a      ; move CC to A for a stack update
+                    bcc       L035B     ; go update it if no error from call
+                    stb       R$B,u     ; save the error code to caller's B
+L035B               ldb       R$CC,u    ; get the caller's CC, R$CC = $00
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
+                    orr       b,a       merge them together
                   ELSE
-                    anda      #$2F                [A]=H,N,Z,V,C
-                    andb      #$D0                [B]=E,F,I
-                    pshs      b                   save B on the stack
-                    ora       ,s+                 OR A with it
+                    anda      #$2F      ; [A]=H,N,Z,V,C
+                    andb      #$D0      ; [B]=E,F,I
+                    pshs      b         ; save B on the stack
+                    ora       ,s+       ; oR A with it
                   ENDC
-                    sta       R$CC,u              store it in the caller's CC, R$CC = $00
-                    rts                           return
+                    sta       R$CC,u    ; store it in the caller's CC, R$CC = $00
+                    rts                 ; return
 
 * Execute regular system calls
 L0345
-                    clra                          clear the MSB of the offset
-                    ldx       d,y                 get the vector to call
-                    bne       L034F               it's initialized, go execute it
-                    comb                          set the carry for error
-                    ldb       #E$UnkSvc           get the error code
-                    bra       L0355               return with it
+                    clra                ; clear the MSB of the offset
+                    ldx       d,y       ; get the vector to call
+                    bne       L034F     ; it's initialized, go execute it
+                    comb                ; set the carry for error
+                    ldb       #E$UnkSvc ; get the error code
+                    bra       L0355     ; return with it
 
-                    use       fssvc.asm
+                    use       fssvc.asm ; include source file fssvc.asm
 
-                    use       flink.asm
+                    use       flink.asm ; include source file flink.asm
 
-                    use       fvmodul.asm
+                    use       fvmodul.asm ; include source file fvmodul.asm
 
-                    use       ffmodul.asm
+                    use       ffmodul.asm ; include source file ffmodul.asm
 
-                    use       fprsnam.asm
+                    use       fprsnam.asm ; include source file fprsnam.asm
 
-                    use       fcmpnam.asm
+                    use       fcmpnam.asm ; include source file fcmpnam.asm
 
-                    use       fsrqmem.asm
+                    use       fsrqmem.asm ; include source file fsrqmem.asm
 
-                    IFNE      H6309+wildbits
-                    use       fdelram.asm
-                    ENDC
+                  IFNE    H6309+wildbits ; begin conditional assembly for H6309+wildbits
+                    use       fdelram.asm ; include source file fdelram.asm
+                  ENDC
 
-                    use       fallimg.asm
+                    use       fallimg.asm ; include source file fallimg.asm
 
-                    use       ffreehb.asm
+                    use       ffreehb.asm ; include source file ffreehb.asm
 
-                    use       fdatlog.asm
+                    use       fdatlog.asm ; include source file fdatlog.asm
 
-                    use       fld.asm
+                    use       fld.asm   ; include source file fld.asm
 
-                    use       fcpymem.asm
+                    use       fcpymem.asm ; include source file fcpymem.asm
 
-                    use       fmove.asm
+                    use       fmove.asm ; include source file fmove.asm
 
-                    use       fldabx.asm
+                    use       fldabx.asm ; include source file fldabx.asm
 
-                    use       falltsk.asm
+                    use       falltsk.asm ; include source file falltsk.asm
 
-                    use       faproc.asm
+                    use       faproc.asm ; include source file faproc.asm
 
 * System IRQ service routine.
-XIRQ                ldx       <D.Proc             get the current process pointer
-                    sts       P$SP,x              save the stack pointer
-                    lds       <D.SysStk           get the system stack pointer
-                    ldd       <D.SysSvc           set the system service routine to current
-                    std       <D.XSWI2            store it in the cross-SWI2 vector
-                    ldd       <D.SysIRQ           set the system IRQ routine to current
-                    std       <D.XIRQ             store it in the cross-IRQ vector
-                    jsr       [>D.SvcIRQ]         execute interrupt service routine
-                    bcc       L0D5B               branch if the routine was serviced
+XIRQ                ldx       <D.Proc   ; get the current process pointer
+                    sts       P$SP,x    ; save the stack pointer
+                    lds       <D.SysStk ; get the system stack pointer
+                    ldd       <D.SysSvc ; set the system service routine to current
+                    std       <D.XSWI2  ; store it in the cross-SWI2 vector
+                    ldd       <D.SysIRQ ; set the system IRQ routine to current
+                    std       <D.XIRQ   ; store it in the cross-IRQ vector
+                    jsr       [>D.SvcIRQ] ; execute interrupt service routine
+                    bcc       L0D5B     ; branch if the routine was serviced
 
-                    ldx       <D.Proc             get the current process pointer
-                    ldb       P$Task,x            and the task of the process
-                    ldx       P$SP,x              get it's stack pointer
+                    ldx       <D.Proc   ; get the current process pointer
+                    ldb       P$Task,x  ; and the task of the process
+                    ldx       P$SP,x    ; get it's stack pointer
 
-                    pshs      u,d,cc              save some registers
-                    leau      ,s                  point to a 'caller register stack'
-                    lbsr      L0C40               do a LDB 0,X in task B
-                    puls      u,d,cc              and now A (R$A,U) = the CC we want
+                    pshs      u,d,cc    ; save some registers
+                    leau      ,s        ; point to a 'caller register stack'
+                    lbsr      L0C40     ; do a LDB 0,X in task B
+                    puls      u,d,cc    ; and now A (R$A,U) = the CC we want
 
-                    ora       #IntMasks           disable its interrupts
-                    lbsr      L0C28               save it back
-L0D5B               orcc      #IntMasks           shut down interrupts
-                    ldx       <D.Proc             get the current process pointer
-                    tst       <D.QIRQ             was it a clock interrupt?
-                    lbne      L0DF7               if not, do a quick return
+                    ora       #IntMasks ; disable its interrupts
+                    lbsr      L0C28     ; save it back
+L0D5B               orcc      #IntMasks ; shut down interrupts
+                    ldx       <D.Proc   ; get the current process pointer
+                    tst       <D.QIRQ   ; was it a clock interrupt?
+                    lbne      L0DF7     ; if not, do a quick return
 
-                    lda       P$State,x           get its state
-                    bita      #TimOut             is it timed out?
-                    bne       L0D7C               yes, wake it up
+                    lda       P$State,x ; get its state
+                    bita      #TimOut   ; is it timed out?
+                    bne       L0D7C     ; yes, wake it up
 * Update the active process queue.
-                    ldu       #(D.AProcQ-P$Queue) point to the active process queue
-                    ldb       #Suspend            get the suspend flag
-L0D6A               ldu       P$Queue,u           get an active process pointer
-                    beq       L0D78               branch if empty
-                    bitb      P$State,u           is it suspended?
-                    bne       L0D6A               yes, go to the next one in the chain
-                    ldb       P$Prior,x           get the current process priority
-                    cmpb      P$Prior,u           do we bump this one?
-                    blo       L0D7C               branch if lower
+                    ldu       #(D.AProcQ-P$Queue) ; point to the active process queue
+                    ldb       #Suspend  ; get the suspend flag
+L0D6A               ldu       P$Queue,u ; get an active process pointer
+                    beq       L0D78     ; branch if empty
+                    bitb      P$State,u ; is it suspended?
+                    bne       L0D6A     ; yes, go to the next one in the chain
+                    ldb       P$Prior,x ; get the current process priority
+                    cmpb      P$Prior,u ; do we bump this one?
+                    blo       L0D7C     ; branch if lower
 
-L0D78               ldu       P$SP,x              get the stack pointer
-                    bra       L0DB9               and branch
+L0D78               ldu       P$SP,x    ; get the stack pointer
+                    bra       L0DB9     ; and branch
 
-L0D7C               anda      #^TimOut            clear the timeout flag
-                    sta       P$State,x           and save it to the process descriptor
+L0D7C               anda      #^TimOut  ; clear the timeout flag
+                    sta       P$State,x ; and save it to the process descriptor
 
-L0D80               equ       *
-L0D83               bsr       L0D11               activate next process
+L0D80               equ       *         ; define assembler symbol L0D80
+L0D83               bsr       L0D11     ; activate next process
 
-                    use       fnproc.asm
+                    use       fnproc.asm ; include source file fnproc.asm
 
 * The following routines must appear no earlier than $E00 for the CoCo 3
 * (or $D00 for the Wildbits) when assembled, as they have to always be in the
@@ -1021,209 +1021,209 @@ L0D83               bsr       L0D11               activate next process
 
 * The default routine for D.SysIRQ.
 S.SysIRQ
-                    lda       <D.SSTskN           get the current task number
-                    beq       FastIRQ             use the super-fast version for system state
-                    clr       <D.SSTskN           clear out the memory copy (task 0)
-                    jsr       [>D.SvcIRQ]         call the routine (normally Clock calling D.Poll)
-                    inc       <D.SSTskN           save the task number for system state
-                    lda       #1                  get task 1
-                    ora       <D.TINIT            merge the task bit into the shadow version
-                    sta       <D.TINIT            update the shadow register
-                    sta       >DAT.Task           save to the DAT as well
-                    bra       DoneIRQ             check for error and exit
+                    lda       <D.SSTskN ; get the current task number
+                    beq       FastIRQ   ; use the super-fast version for system state
+                    clr       <D.SSTskN ; clear out the memory copy (task 0)
+                    jsr       [>D.SvcIRQ] ; call the routine (normally Clock calling D.Poll)
+                    inc       <D.SSTskN ; save the task number for system state
+                    lda       #1        ; get task 1
+                    ora       <D.TINIT  ; merge the task bit into the shadow version
+                    sta       <D.TINIT  ; update the shadow register
+                    sta       >DAT.Task ; save to the DAT as well
+                    bra       DoneIRQ   ; check for error and exit
 
-FastIRQ             jsr       [>D.SvcIRQ]         call the orutine (normally Clock calling D.Poll)
-DoneIRQ             bcc       L0E28               no error on IRQ, so exit
-                  IFNE        H6309
-                    oim       #IntMasks,0,s       setup RTI to shut interrupts off again
+FastIRQ             jsr       [>D.SvcIRQ] ; call the orutine (normally Clock calling D.Poll)
+DoneIRQ             bcc       L0E28     ; no error on IRQ, so exit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #IntMasks,0,s ; setup RTI to shut interrupts off again
                   ELSE
-                    lda       ,s                  get the CC on the stack
-                    ora       #IntMasks           mask interrupts
-                    sta       ,s                  and store it back
+                    lda       ,s        ; get the CC on the stack
+                    ora       #IntMasks ; mask interrupts
+                    sta       ,s        ; and store it back
                   ENDC
-L0E28               rti                           return
+L0E28               rti                 ; return
 
 * Return from a system call.
-L0E29               clra                          force system task # to 0 (system)
-L0E2B               ldx       <D.SysPrc           get the system process descriptor pointer
-                    lbsr      TstImg              check the image, and F$SetTsk (preserves A)
-                    orcc      #IntMasks           shut off interrupts
-                    sta       <D.SSTskN           save the task number for system state
-                    beq       Fst2                if task 0, we're done
-                    ora       <D.TINIT            merge task bit into the shadow register
-                    sta       <D.TINIT            update the shadow register
-                    sta       >DAT.Task           save to the DAT as well
-Fst2                leas      ,u                  put stack ptr into U
-                    rti                           return
+L0E29               clra                ; force system task # to 0 (system)
+L0E2B               ldx       <D.SysPrc ; get the system process descriptor pointer
+                    lbsr      TstImg    ; check the image, and F$SetTsk (preserves A)
+                    orcc      #IntMasks ; shut off interrupts
+                    sta       <D.SSTskN ; save the task number for system state
+                    beq       Fst2      ; if task 0, we're done
+                    ora       <D.TINIT  ; merge task bit into the shadow register
+                    sta       <D.TINIT  ; update the shadow register
+                    sta       >DAT.Task ; save to the DAT as well
+Fst2                leas      ,u        ; put stack ptr into U
+                    rti                 ; return
 
 * Switch to a new process.
 *
 * Entry: X = The Process descriptor pointer.
 *        U = The stack pointer.
-L0E4C               equ       *
-                  IFNE        H6309
-                    oim       #$01,<D.TINIT       switch the shadow register to task 1
-                    lda       <D.TINIT            get the shadow register
+L0E4C               equ       *         ; define assembler symbol L0E4C
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch the shadow register to task 1
+                    lda       <D.TINIT  ; get the shadow register
                   ELSE
-                    lda       <D.TINIT            get the shadow register
-                    ora       #$01                set it to task 1
-                    sta       <D.TINIT            save it back
+                    lda       <D.TINIT  ; get the shadow register
+                    ora       #$01      ; set it to task 1
+                    sta       <D.TINIT  ; save it back
                   ENDC
-                    sta       >DAT.Task           save it to the DAT
-                    leas      ,y                  point to the new stack
-                    tstb                          is the stack at SWISTACK?
-                    bne       MyRTI               no, we're doing a system-state rti
-                  IFNE        H6309
-                    ldf       #R$Size             E=0 from call to L0E8D before
-                    ldu       #Where+SWIStack     point to the stack
-                    tfm       u+,y+               move the stack from the top of memory to user memory
+                    sta       >DAT.Task ; save it to the DAT
+                    leas      ,y        ; point to the new stack
+                    tstb                ; is the stack at SWISTACK?
+                    bne       MyRTI     ; no, we're doing a system-state rti
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #R$Size   ; e=0 from call to L0E8D before
+                    ldu       #Where+SWIStack ; point to the stack
+                    tfm       u+,y+     ; move the stack from the top of memory to user memory
                   ELSE
-                    ldb       #R$Size/2           get the number of bytes to move
-                    ldu       #Where+SWIStack     point to the stack
-l@                  ldx       ,u++                get the bytes
-                    stx       ,y++                and store them in the destination
-                    decb                          decrement the counter
-                    bne       l@                  branch if not done
+                    ldb       #R$Size/2 ; get the number of bytes to move
+                    ldu       #Where+SWIStack ; point to the stack
+l@                  ldx       ,u++      ; get the bytes
+                    stx       ,y++      ; and store them in the destination
+                    decb                ; decrement the counter
+                    bne       l@        ; branch if not done
                   ENDC
-MyRTI               rti                           return from IRQ
+MyRTI               rti                 ; return from IRQ
 
 
 * Execute routine in task 1 pointed to by U.
 * This comes from user requested SWI vectors.
-L0E5E               equ       *
-                  IFNE        H6309
-                    oim       #$01,<D.TINIT       switch the shadow register to task 1
-                    ldb       <D.TINIT            get the shadow register
+L0E5E               equ       *         ; define assembler symbol L0E5E
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch the shadow register to task 1
+                    ldb       <D.TINIT  ; get the shadow register
                   ELSE
-                    ldb       <D.TINIT            get the shadow register
-                    orb       #$01                set it to task 1
-                    stb       <D.TINIT            save it back
+                    ldb       <D.TINIT  ; get the shadow register
+                    orb       #$01      ; set it to task 1
+                    stb       <D.TINIT  ; save it back
                   ENDC
-                    stb       >DAT.Task           save it to the DAT
-                    jmp       ,u                  jump to the routine
+                    stb       >DAT.Task ; save it to the DAT
+                    jmp       ,u        ; jump to the routine
 
 * Flip to task 1 (used by WindInt to switch to GrfDrv) (pointed to
 *  by <D.Flip1). All registers are already preserved on stack for the RTI.
-S.Flip1             ldb       #2                  get the tsk image entry number x2 for Grfdrv (task 1)
-                    bsr       L0E8D               copy over the DAT image
-                  IFNE        H6309
-                    oim       #$01,<D.TINIT       switch the shadow register to task 1
-                    lda       <D.TINIT            get a copy of the shadow register
+S.Flip1             ldb       #2        ; get the tsk image entry number x2 for Grfdrv (task 1)
+                    bsr       L0E8D     ; copy over the DAT image
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch the shadow register to task 1
+                    lda       <D.TINIT  ; get a copy of the shadow register
                   ELSE
-                    lda       <D.TINIT            get a copy of the shadow register
-                    ora       #$01                force task register to 1
-                    sta       <D.TINIT            save it back
+                    lda       <D.TINIT  ; get a copy of the shadow register
+                    ora       #$01      ; force task register to 1
+                    sta       <D.TINIT  ; save it back
                   ENDC
-                    sta       >DAT.Task           save it to the DAT
-                    inc       <D.SSTskN           increment the system state task number
-                    rti                           return
+                    sta       >DAT.Task ; save it to the DAT
+                    inc       <D.SSTskN ; increment the system state task number
+                    rti                 ; return
 
 * Set up the MMU in task 1, B=Task # to swap to, shifted left 1 bit.
-L0E8D               cmpb      <D.Task1N           are we going back to the same task?
-                    beq       L0EA3               without the DAT image changing?
-                    stb       <D.Task1N           no, save current task in map type 1
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
-                    lda       MMU_MEM_CTRL        get the memory control register
-                    anda      #~EDIT_LUT          turn off all EDIT_LUT bits
-                    ora       #EDIT_LUT_1         and OR with EDIT_LUT_1
-                    sta       MMU_MEM_CTRL        save it back to the memory control register
-                    ldx       #DAT.Regs           get the MMU start register for the process
-*<<<<<<<<<< Wildbits PORT
+L0E8D               cmpb      <D.Task1N ; are we going back to the same task?
+                    beq       L0EA3     ; without the DAT image changing?
+                    stb       <D.Task1N ; no, save current task in map type 1
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    lda       MMU_MEM_CTRL ; get the memory control register
+                    anda      #~EDIT_LUT ; turn off all EDIT_LUT bits
+                    ora       #EDIT_LUT_1 ; and OR with EDIT_LUT_1
+                    sta       MMU_MEM_CTRL ; save it back to the memory control register
+                    ldx       #DAT.Regs ; get the MMU start register for the process
+*]]] Wildbits PORT
                   ELSE
-                    ldx       #DAT.Regs+8         get the MMU start register for process
+                    ldx       #DAT.Regs+8 ; get the MMU start register for process
                   ENDC
-                    ldu       <D.TskIPt           get the task image pointer table
-                    ldu       b,u                 and the address of the DAT image
+                    ldu       <D.TskIPt ; get the task image pointer table
+                    ldu       b,u       ; and the address of the DAT image
 * COME HERE FROM FALLTSK
 * Update 8 MMU mappings.
 * X = address of 1st DAT MMU register to update
 * U = address of DAT image to update into MMU
-L0E93               leau      1,u                 point to the actual MMU block
-                  IFNE        H6309
-                    lde       #4                  get the number of banks/2 for the task
+L0E93               leau      1,u       ; point to the actual MMU block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lde       #4        ; get the number of banks/2 for the task
                   ELSE
-                    lda       #4                  get the number of banks/2 for the task
-                    pshs      a                   save A
+                    lda       #4        ; get the number of banks/2 for the task
+                    pshs      a         ; save A
                   ENDC
-L0E9B               lda       ,u++                get a bank
-                    ldb       ,u++                and next one
-                    std       ,x++                save it to MMU
-                  IFNE        H6309
-                    dece                          done?
+L0E9B               lda       ,u++      ; get a bank
+                    ldb       ,u++      ; and next one
+                    std       ,x++      ; save it to MMU
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    dece                ; done?
                   ELSE
-                    dec       ,s                  done?
+                    dec       ,s        ; done?
                   ENDC
-                    bne       L0E9B               no, keep going
-                    ifeq      H6309
+                    bne       L0E9B     ; no, keep going
+                  IFEQ    H6309   ; begin conditional assembly for H6309
 * 6809 - 10 cyc down to 8
 *                   leas      1,s                 eat temporary stack
-                    puls      a,pc                eat temporary stack and return
+                    puls      a,pc      ; eat temporary stack and return
                   ENDC
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
-                    clr       MMU_MEM_CTRL        clear the DAT control flags
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    clr       MMU_MEM_CTRL ; clear the DAT control flags
                   ENDC
-*<<<<<<<<<< Wildbits PORT
-L0EA3               rts                           return
+*]]] Wildbits PORT
+L0EA3               rts                 ; return
 
-*>>>>>>>>>> Wildbits PORT
-                  IFNE        wildbits
+*[[[ Wildbits PORT
+                  IFNE    wildbits ; begin conditional assembly for wildbits
 CrashDump           fill      255,32
                   ENDC
-*<<<<<<<<<< Wildbits PORT
+*]]] Wildbits PORT
 
 * Execute FIRQ vector (called from $FEF4)
-FIRQVCT             ldx       #D.FIRQ             get the DP offset of the vector
-                    bra       L0EB8               go execute it
+FIRQVCT             ldx       #D.FIRQ   ; get the DP offset of the vector
+                    bra       L0EB8     ; go execute it
 
 * Execute IRQ vector (called from $FEF7)
-IRQVCT              orcc      #IntMasks           disable interrupts
-                    ldx       #D.IRQ              get the DP offset of the vector
+IRQVCT              orcc      #IntMasks ; disable interrupts
+                    ldx       #D.IRQ    ; get the DP offset of the vector
 
 * Execute interrupt vector, B=DP Vector offset
-L0EB8               clra                          (faster than CLR >$xxxx)
-                    sta       >DAT.Task           force to task 0 (system state)
-                  IFNE        H6309
-                    tfr       0,dp                setup the DP
+L0EB8               clra                ; (faster than CLR >$xxxx)
+                    sta       >DAT.Task ; force to task 0 (system state)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,dp      ; setup the DP
                   ELSE
-                    tfr       a,dp                ASSUME: A=0 from earlier
+                    tfr       a,dp      ; aSSUME: A=0 from earlier
                   ENDC
-MapGrf              equ       *                   come here from elsewhere, too
-                  IFNE        H6309
-                    aim       #$FE,<D.TINIT       switch the shadow register to system state
-                    lda       <D.TINIT            set the DAT again just in case timer is used
+MapGrf              equ       *         ; come here from elsewhere, too
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #$FE,<D.TINIT ; switch the shadow register to system state
+                    lda       <D.TINIT  ; set the DAT again just in case timer is used
                   ELSE
-                    lda       <D.TINIT            get the shadow register
-                    anda      #$FE                clear the task 0 bit
-                    sta       <D.TINIT            and save it back
+                    lda       <D.TINIT  ; get the shadow register
+                    anda      #$FE      ; clear the task 0 bit
+                    sta       <D.TINIT  ; and save it back
                   ENDC
-MapT0               sta       >DAT.Task           come here from elsewhere, too
-                    jmp       [,x]                execute it
+MapT0               sta       >DAT.Task ; come here from elsewhere, too
+                    jmp       [,x]      ; execute it
 
 * Execute SWI3 vector (called from $FEEE).
-SWI3VCT             orcc      #IntMasks           disable interrupts
-                    ldx       #D.SWI3             get the DP offset of the vector
-                    bra       SWICall             go execute it
+SWI3VCT             orcc      #IntMasks ; disable interrupts
+                    ldx       #D.SWI3   ; get the DP offset of the vector
+                    bra       SWICall   ; go execute it
 
 * Execute SWI2 vector (called from $FEF1)
-SWI2VCT             orcc      #IntMasks           disable interrupts
-                    ldx       #D.SWI2             get the DP offset of the vector
+SWI2VCT             orcc      #IntMasks ; disable interrupts
+                    ldx       #D.SWI2   ; get the DP offset of the vector
 
 * This routine is called from an SWI, SWI2, or SWI3.
 * It saves 1 cycle on system state system calls.
 * It saves about 200 cycles (calls to I.LDABX and L029E) on GrvDrv system
 * and user state system calls.
-SWICall             ldb       [R$PC,s]            get the op-code of the system call
+SWICall             ldb       [R$PC,s]  ; get the op-code of the system call
 * NOTE: Alan DeKok claims that this is BAD.  It crashed Colin McKay's
 * CoCo 3.  Instead, we should do a clra/sta >DAT.Task.
 *         clr   >DAT.Task       go to map type 1
-                    clra                          clear A
-                    sta       >DAT.Task           and save it in the DAT
-                  IFNE        H6309
-                    tfr       0,dp                set the direct page to 0
+                    clra                ; clear A
+                    sta       >DAT.Task ; and save it in the DAT
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,dp      ; set the direct page to 0
                   ELSE
-                    tfr       a,dp                set the direct page to 0 (assume A = 0)
+                    tfr       a,dp      ; set the direct page to 0 (assume A = 0)
                   ENDC
 
 * These lines add a total of 81 addition cycles to each SWI(2,3) call,
@@ -1233,80 +1233,80 @@ SWICall             ldb       [R$PC,s]            get the op-code of the system 
 * For processes that re-vector SWI, SWI3, it adds 81 cycles, but SWI(3)
 * CANNOT be vectored to L0EBF because the user SWI service routine has been
 * changed.
-                    lda       <D.TINIT            get the shadow register
-                    bita      #$01                check it without changing it
+                    lda       <D.TINIT  ; get the shadow register
+                    bita      #$01      ; check it without changing it
 
 * Change to LBEQ R.SysSvc to avoid JMP [,X]
 * and add R.SysSvc STA >DAT.Task ???
-                    beq       MapT0               in map 0; restore the hardware and do system service
-                    tst       <D.SSTskN           get system state 0,1
-                    bne       MapGrf              if in grfdrv, go to map 0 and do system service
+                    beq       MapT0     ; in map 0; restore the hardware and do system service
+                    tst       <D.SSTskN ; get system state 0,1
+                    bne       MapGrf    ; if in grfdrv, go to map 0 and do system service
 
 * The preceding few lines are necessary, as all SWI's still pass through
 * here before being vectored to the system service routine, which
 * doesn't copy the stack from user state.
-                    sta       >DAT.Task           go to map type X again to get the user's stack
+                    sta       >DAT.Task ; go to map type X again to get the user's stack
 * a byte less, a cycle more than ldy #$FEED-R$Size, or ldy #$F000+SWIStack
-                    leay      <SWIStack,pc        where to put the register stack: to $DF in the constant page
-                    tfr       s,u                 get a copy of where the stack is
-                  IFNE        H6309
-                    ldw       #R$Size             get the size of the stack
-                    tfm       u+,y+               move the stack to the top of memory
+                    leay      <SWIStack,pc ; where to put the register stack: to $DF in the constant page
+                    tfr       s,u       ; get a copy of where the stack is
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get the size of the stack
+                    tfm       u+,y+     ; move the stack to the top of memory
                   ELSE
-                    pshs      x                   save X
-                    lda       #R$Size/2           move stack to top of memory (A is reset in L0EB8, no need to preserve)
-l@                  ldx       ,u++                get the bytes
-                    stx       ,y++                and save them
-                    deca                          decrement the counter
-                    bne       l@                  branch if not done
-                    puls      x                   restore X
+                    pshs      x         ; save X
+                    lda       #R$Size/2 ; move stack to top of memory (A is reset in L0EB8, no need to preserve)
+l@                  ldx       ,u++      ; get the bytes
+                    stx       ,y++      ; and save them
+                    deca                ; decrement the counter
+                    bne       l@        ; branch if not done
+                    puls      x         ; restore X
                   ENDC
-                    bra       L0EB8               go from map type 1 to map type 0
+                    bra       L0EB8     ; go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
-SWIVCT              ldx       #D.SWI              get the DP offset of the vector
-                    bra       SWICall             go execute it
+SWIVCT              ldx       #D.SWI    ; get the DP offset of the vector
+                    bra       SWICall   ; go execute it
 
 * Execute NMI vector (called from $FEFD)
-NMIVCT              ldx       #D.NMI              get the DP offset of the vector
-                    bra       L0EB8               go execute it
+NMIVCT              ldx       #D.NMI    ; get the DP offset of the vector
+                    bra       L0EB8     ; go execute it
 
 * The end of the kernel module is here
                     emod
-eom                 equ       *
+eom                 equ       *         ; define assembler symbol eom
 
 * What follows after the kernel module is the register stack, starting
 * at $FEDD (6309), $FEDF (CoCo 3 6809), or $FDDF (Wildbits).
 * The kernel uses this register stack area to save the caller's registers in
 * the constant page because it doesn't get "switched out" no matter the
 * contents of the MMU registers.
-                  IFNE        wildbits
-                    fdb       Where+CrashCode
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    fdb       Where+CrashCode ; define word value(s) Where+CrashCode
                   ENDC
 
 SWIStack
                     fcc       /REGISTER STACK/    same # bytes as R$Size for 6809
-                  IFNE        H6309
+                  IFNE    H6309   ; begin conditional assembly for H6309
                     fcc       /63/                if 6309, add two more spaces
                   ENDC
 
-                    fcb       $55                 D.ErrRst
+                    fcb       $55       ; d.ErrRst
 
 * This list of addresses ends up at $FEEE (CoCo 3) or $FDEE (Wildbits) after the
 * kernel loads into memory.  All interrupts come through the 6809 vectors at
 * $FFF0-$FFFE and get directed to here. From here, the BRA takes CPU control
 * to the various handlers in the kernel.
-                    bra       SWI3VCT             SWI3 vector comes here
-                    nop
-                    bra       SWI2VCT             SWI2 vector comes here
-                    nop
-                    bra       FIRQVCT             FIRQ vector comes here
-                    nop
-                    bra       IRQVCT              IRQ vector comes here
-                    nop
-                    bra       SWIVCT              SWI vector comes here
-                    nop
-                    bra       NMIVCT              NMI vector comes here
-                    nop
+                    bra       SWI3VCT   ; sWI3 vector comes here
+                    nop       ; no operation placeholder
+                    bra       SWI2VCT   ; sWI2 vector comes here
+                    nop       ; no operation placeholder
+                    bra       FIRQVCT   ; fIRQ vector comes here
+                    nop       ; no operation placeholder
+                    bra       IRQVCT    ; iRQ vector comes here
+                    nop       ; no operation placeholder
+                    bra       SWIVCT    ; sWI vector comes here
+                    nop       ; no operation placeholder
+                    bra       NMIVCT    ; nMI vector comes here
+                    nop       ; no operation placeholder
 
                     end

--- a/level2/modules/kernel/krnp2.asm
+++ b/level2/modules/kernel/krnp2.asm
@@ -77,7 +77,7 @@
 ** If Network I/O ptrs are disabled, F$Fork runs 72 cycles faster
 Network             equ       0         ; set to 1 to enable network I/O ptrs
 
-                  ifp1
+                  IFP1
                     use       defsfile  ; include source file defsfile
                     use       cocovtio.d ; include source file cocovtio.d
                   ENDC
@@ -186,26 +186,26 @@ krnp2               lda       #'2       ; debug: signal that we made it into krn
                     stx       <D.SWI    ; store X at <D.SWI
                   ENDC
 * Change to default directory
-L003A               ldu       <D.Init   ; get init module pointer
+Krnp2InitModule     ldu       <D.Init   ; get init module pointer
                     ldd       SysStr,u  ; get pointer to system device name (usually '/DD')
-                    beq       L004F     ; don't exist, open std device
+                    beq       Krnp2InitModule2 ; don't exist, open std device
                     leax      d,u       ; point to name
                     lda       #'x       ; debug: signal that we tried chd'ing
                     jsr       <D.BtBug  ; call routine at <D.BtBug
                     lda       #(EXEC.+READ.) ; get file mode
                     os9       I$ChgDir  ; change to it
-                    bcc       L004F     ; went ok, go on
+                    bcc       Krnp2InitModule2 ; went ok, go on
                     os9       F$Boot    ; try & load boot file
-                    bcc       L003A     ; go try again
-L004F               ldu       <D.Init   ; get init module pointer
+                    bcc       Krnp2InitModule ; go try again
+Krnp2InitModule2    ldu       <D.Init   ; get init module pointer
                     ldd       <StdStr,u ; point to default device (usually '/Term')
-                    beq       L0077     ; don't exist go do OS9P3
+                    beq       Krnp2Krnp3 ; don't exist go do OS9P3
                     leax      d,u       ; point to it
                     lda       #'o       ; debug: signal that we tried opening output window
                     jsr       <D.BtBug  ; call routine at <D.BtBug
                     lda       #UPDAT.   ; get file mode
                     os9       I$Open    ; open path to it
-                    bcc       L0066     ; went ok, save path #
+                    bcc       Krnp2Process ; went ok, save path #
 * LCB - not sure why this is remarked out and replaced with NOP's?
 *         os9    F$Boot      try & re-boot
 * nop
@@ -214,21 +214,21 @@ L004F               ldu       <D.Init   ; get init module pointer
 *         bcc    L004F       go try again
 * nop
 * nop
-                    bra       L009B     ; crash machine
+                    bra       Krnp2ControlDcrash ; crash machine
 
-L0066               ldx       <D.Proc   ; get current process pointer
+Krnp2Process        ldx       <D.Proc   ; get current process pointer
                     sta       <P$Path,x ; save stdin path
                     os9       I$Dup     ; dupe it
                     sta       <P$Path+1,x ; save stdout path
                     os9       I$Dup     ; dupe it again
                     sta       <P$Path+2,x ; save stderr path
-L0077               leax      <L0096,pc ; point to 'krnp3'
+Krnp2Krnp3          leax      <Krnp2Target,pc ; point to 'krnp3'
                     lda       #Systm    ; get type
                     os9       F$Link    ; try to link
-                    bcs       L0083     ; not there, go on
+                    bcs       Krnp2InitModule3 ; not there, go on
                     jsr       ,y        ; execute it
 * Execute module listed in Init module
-L0083               ldu       <D.Init   ; get init module pointer
+Krnp2InitModule3    ldu       <D.Init   ; get init module pointer
                     ldd       InitStr,u ; get offset to name of first module
                     leax      d,u       ; point to it
                     lda       #'C       ; debug: signal that we tried to go to SysGo
@@ -241,12 +241,12 @@ L0083               ldu       <D.Init   ; get init module pointer
                     ldy       #$0000    ; load Y from #$0000
                   ENDC
                     os9       F$Fork    ; fork it
-                    bcs       L009B     ; if error, crash the system
-L0093               os9       F$NProc   ; let it take over
+                    bcs       Krnp2ControlDcrash ; if error, crash the system
+Krnp2LetTakeOver    os9       F$NProc   ; let it take over
 
-L0096               fcs       /krnp3/
+Krnp2Target         fcs       /krnp3/
 
-L009B               jmp       <D.Crash  ; transfer control to <D.Crash
+Krnp2ControlDcrash  jmp       <D.Crash  ; transfer control to <D.Crash
 
 svctab              fcb       F$UnLink  ; define byte value(s) F$UnLink
                     fdb       FUnLink-*-2 ; define word value(s) FUnLink-*-2

--- a/level2/modules/kernel/krnp2.asm
+++ b/level2/modules/kernel/krnp2.asm
@@ -75,137 +75,137 @@
                     ttl       NitrOS-9 Level 2 Kernel Part 2
 
 ** If Network I/O ptrs are disabled, F$Fork runs 72 cycles faster
-Network             equ       0                   Set to 1 to enable network I/O ptrs
+Network             equ       0         ; set to 1 to enable network I/O ptrs
 
-                    ifp1
-                    use       defsfile
-                    use       cocovtio.d
-                    endc
+                  ifp1
+                    use       defsfile  ; include source file defsfile
+                    use       cocovtio.d ; include source file cocovtio.d
+                  ENDC
 
-TC9                 set       false               "true" use TC-9 6309 trap vector
-Edition             equ       20
-Revision            equ       0
+TC9                 set       false     ; "true" use TC-9 6309 trap vector
+Edition             equ       20        ; define assembler symbol Edition
+Revision            equ       0         ; define assembler symbol Revision
 
-                    mod       eom,MName,Systm+Objct,ReEnt+Revision,krnp2,$0100
+                    mod       eom,MName,Systm+Objct,ReEnt+Revision,krnp2,$0100 ; define OS-9 module header
 
 MName               fcs       /KrnP2/
-                    fcb       Edition
+                    fcb       Edition   ; define byte value(s) Edition
 
-                    ifeq      TC9-1
+                  IFEQ    TC9-1   ; begin conditional assembly for TC9-1
 * Entry: None
 * Exit : Process killed & register dump produced for user
-Trap                bitmd     #%01000000          illegal instruction?
-                    bne       BadIns              yes, go process
-                    bitmd     #%10000000          division by 0?
-                    bne       Div0                yes, go process
-                    jmp       [<D.XSWI]           act as if nothing happened
+Trap                bitmd     #%01000000 ; illegal instruction?
+                    bne       BadIns    ; yes, go process
+                    bitmd     #%10000000 ; division by 0?
+                    bne       Div0      ; yes, go process
+                    jmp       [<D.XSWI] ; act as if nothing happened
 
 * Process illegal instruction trap
-BadIns              bsr       SetProc             move the register stack here
-                    ldb       #18                 get error code for F$Exit
-                    bra       TrapDone
+BadIns              bsr       SetProc   ; move the register stack here
+                    ldb       #18       ; get error code for F$Exit
+                    bra       TrapDone  ; branch unconditionally to TrapDone
 
 * Process division by 0 trap
-Div0                bsr       SetProc             move the register stack
-                    ldb       #45                 get error code for F$Exit
+Div0                bsr       SetProc   ; move the register stack
+                    ldb       #45       ; get error code for F$Exit
 * Return to system after the trap
 * Entry: B=Error code
 *        U=Pointer to register stack
-TrapDone            stb       R$B,u               save the error code to register stack for F$Exit
-                    lbra      FExit               enter F$Exit directly
+TrapDone            stb       R$B,u     ; save the error code to register stack for F$Exit
+                    lbra      FExit     ; enter F$Exit directly
 
 * Set process to system state & copy register stack for trap processing
-SetProc             ldd       <D.SysSvc           set system call processor to system side
-                    std       <D.XSWI2
-                    ldd       <D.SysIRQ           do the same thing for IRQ's
-                    std       <D.XIRQ
-                    ldx       <D.Proc             get current process pointer
-                    ifne      H6309
-                    oim       #SysState,P$State,x mark process as system state
-                    else
-                    ldb       P$State,x
-                    orb       #SysState
-                    stb       P$State,x
-                    endc
+SetProc             ldd       <D.SysSvc ; set system call processor to system side
+                    std       <D.XSWI2  ; store D at <D.XSWI2
+                    ldd       <D.SysIRQ ; do the same thing for IRQ's
+                    std       <D.XIRQ   ; store D at <D.XIRQ
+                    ldx       <D.Proc   ; get current process pointer
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #SysState,P$State,x ; mark process as system state
+                  ELSE
+                    ldb       P$State,x ; load B from P$State,x
+                    orb       #SysState ; merge #SysState into B
+                    stb       P$State,x ; store B at P$State,x
+                  ENDC
 * copy register stack to process descriptor
-                    sts       P$SP,x              save stack pointer
-                    leas      (P$Stack-R$Size),x  point S to register stack destination
-                    andcc     #^IntMasks          force interrupts back on
-                    leau      ,s                  point to destination register stack
-                    ldb       P$Task,x            get task # of destination
-                    ldx       P$SP,x              get the user/system stack pointer
-                    pshs      b                   preserve task for a moment
-                    tfr       x,d                 copy it for easier calcs
-                    bita      #%11100000          offset above block 0?
-                    beq       done                yes, no calc needed get out
-                    anda      #%00011111          make it a offset within a block
-                    tfr       d,x                 copy new offset
-                    lsra                          make A an offset into DAT image
-                    lsra
-                    lsra
-                    lsra
-done                puls      b                   restore task #
-                    leax      -$6000,x            make it a pointer to where I'll map the block
-                    tfr       u,y
-                    pshs      cc,u                preserve IRQ status & dest pointer
-                    ldu       <D.TskIPt
-                    lslb                          adjust task # to fit table
-                    ldu       b,u                 get the DAT image pointer
-                    leau      a,u                 point to the blocks needed
-                    lda       1,u                 get 1st block
-                    ldb       3,u                 get a second in case of overlap
-                    orcc      #IntMasks           shut IRQ's down
-                    std       >DAT.Regs+5         map in the blocks
-                    ifne      H6309
-                    ldw       #R$Size             get size of register stack
-                    tfm       x+,y+               move 'em to process descriptor
-                    else
-                    ldb       #R$Size
-Uday                lda       ,x+
-                    sta       ,y+
-                    decb
-                    bne       Uday
-                    endc
-                    ldx       <D.SysDAT           get the system DAT image pointer
-                    lda       $0B,x               get the original blocks
-                    ldb       $0D,x
-                    std       >DAT.Regs+5         map 'em back in
-                    puls      cc,u,pc             restore IRQ's, register stack pointer & return
-                    endc
+                    sts       P$SP,x    ; save stack pointer
+                    leas      (P$Stack-R$Size),x ; point S to register stack destination
+                    andcc     #^IntMasks ; force interrupts back on
+                    leau      ,s        ; point to destination register stack
+                    ldb       P$Task,x  ; get task # of destination
+                    ldx       P$SP,x    ; get the user/system stack pointer
+                    pshs      b         ; preserve task for a moment
+                    tfr       x,d       ; copy it for easier calcs
+                    bita      #%11100000 ; offset above block 0?
+                    beq       done      ; yes, no calc needed get out
+                    anda      #%00011111 ; make it a offset within a block
+                    tfr       d,x       ; copy new offset
+                    lsra                ; make A an offset into DAT image
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+                    lsra                ; shift or rotate and update condition codes
+done                puls      b         ; restore task #
+                    leax      -$6000,x  ; make it a pointer to where I'll map the block
+                    tfr       u,y       ; transfer register value u,y
+                    pshs      cc,u      ; preserve IRQ status & dest pointer
+                    ldu       <D.TskIPt ; load U from <D.TskIPt
+                    lslb                ; adjust task # to fit table
+                    ldu       b,u       ; get the DAT image pointer
+                    leau      a,u       ; point to the blocks needed
+                    lda       1,u       ; get 1st block
+                    ldb       3,u       ; get a second in case of overlap
+                    orcc      #IntMasks ; shut IRQ's down
+                    std       >DAT.Regs+5 ; map in the blocks
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get size of register stack
+                    tfm       x+,y+     ; move 'em to process descriptor
+                  ELSE
+                    ldb       #R$Size   ; load B from #R$Size
+Uday                lda       ,x+       ; load A from ,x+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Uday      ; branch if zero is clear to Uday
+                  ENDC
+                    ldx       <D.SysDAT ; get the system DAT image pointer
+                    lda       $0B,x     ; get the original blocks
+                    ldb       $0D,x     ; load B from $0D,x
+                    std       >DAT.Regs+5 ; map 'em back in
+                    puls      cc,u,pc   ; restore IRQ's, register stack pointer & return
+                  ENDC
 
-krnp2               lda       #'2                 debug: signal that we made it into krnp2
-                    jsr       <D.BtBug
-                    ifne      H6309
-                    leay      <SvcTab,pc          install system calls
-                    else
-                    leay      SvcTab,pc           install system calls
-                    endc
-                    os9       F$SSvc
-                    ifeq      TC9-1
-                    leax      Trap,pc
-                    stx       <D.SWI
-                    endc
+krnp2               lda       #'2       ; debug: signal that we made it into krnp2
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leay      <SvcTab,pc ; install system calls
+                  ELSE
+                    leay      SvcTab,pc ; install system calls
+                  ENDC
+                    os9       F$SSvc    ; call OS-9 service F$SSvc
+                  IFEQ    TC9-1   ; begin conditional assembly for TC9-1
+                    leax      Trap,pc   ; compute Trap,pc into X
+                    stx       <D.SWI    ; store X at <D.SWI
+                  ENDC
 * Change to default directory
-L003A               ldu       <D.Init             get init module pointer
-                    ldd       SysStr,u            get pointer to system device name (usually '/DD')
-                    beq       L004F               don't exist, open std device
-                    leax      d,u                 point to name
-                    lda       #'x                 debug: signal that we tried chd'ing
-                    jsr       <D.BtBug
-                    lda       #(EXEC.+READ.)      get file mode
-                    os9       I$ChgDir            change to it
-                    bcc       L004F               went ok, go on
-                    os9       F$Boot              try & load boot file
-                    bcc       L003A               go try again
-L004F               ldu       <D.Init             get init module pointer
-                    ldd       <StdStr,u           point to default device (usually '/Term')
-                    beq       L0077               don't exist go do OS9P3
-                    leax      d,u                 point to it
-                    lda       #'o                 debug: signal that we tried opening output window
-                    jsr       <D.BtBug
-                    lda       #UPDAT.             get file mode
-                    os9       I$Open              open path to it
-                    bcc       L0066               went ok, save path #
+L003A               ldu       <D.Init   ; get init module pointer
+                    ldd       SysStr,u  ; get pointer to system device name (usually '/DD')
+                    beq       L004F     ; don't exist, open std device
+                    leax      d,u       ; point to name
+                    lda       #'x       ; debug: signal that we tried chd'ing
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    lda       #(EXEC.+READ.) ; get file mode
+                    os9       I$ChgDir  ; change to it
+                    bcc       L004F     ; went ok, go on
+                    os9       F$Boot    ; try & load boot file
+                    bcc       L003A     ; go try again
+L004F               ldu       <D.Init   ; get init module pointer
+                    ldd       <StdStr,u ; point to default device (usually '/Term')
+                    beq       L0077     ; don't exist go do OS9P3
+                    leax      d,u       ; point to it
+                    lda       #'o       ; debug: signal that we tried opening output window
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    lda       #UPDAT.   ; get file mode
+                    os9       I$Open    ; open path to it
+                    bcc       L0066     ; went ok, save path #
 * LCB - not sure why this is remarked out and replaced with NOP's?
 *         os9    F$Boot      try & re-boot
 * nop
@@ -214,212 +214,212 @@ L004F               ldu       <D.Init             get init module pointer
 *         bcc    L004F       go try again
 * nop
 * nop
-                    bra       L009B               crash machine
+                    bra       L009B     ; crash machine
 
-L0066               ldx       <D.Proc             get current process pointer
-                    sta       <P$Path,x           save stdin path
-                    os9       I$Dup               dupe it
-                    sta       <P$Path+1,x         save stdout path
-                    os9       I$Dup               dupe it again
-                    sta       <P$Path+2,x         save stderr path
-L0077               leax      <L0096,pc           point to 'krnp3'
-                    lda       #Systm              get type
-                    os9       F$Link              try to link
-                    bcs       L0083               not there, go on
-                    jsr       ,y                  execute it
+L0066               ldx       <D.Proc   ; get current process pointer
+                    sta       <P$Path,x ; save stdin path
+                    os9       I$Dup     ; dupe it
+                    sta       <P$Path+1,x ; save stdout path
+                    os9       I$Dup     ; dupe it again
+                    sta       <P$Path+2,x ; save stderr path
+L0077               leax      <L0096,pc ; point to 'krnp3'
+                    lda       #Systm    ; get type
+                    os9       F$Link    ; try to link
+                    bcs       L0083     ; not there, go on
+                    jsr       ,y        ; execute it
 * Execute module listed in Init module
-L0083               ldu       <D.Init             get init module pointer
-                    ldd       InitStr,u           get offset to name of first module
-                    leax      d,u                 point to it
-                    lda       #'C                 debug: signal that we tried to go to SysGo
-                    jsr       <D.BtBug
-                    lda       #Objct              get module type
-                    clrb                          get mem size
-                    ifne      H6309
-                    tfr       0,y                 Get parameter size
-                    else
-                    ldy       #$0000
-                    endc
-                    os9       F$Fork              fork it
-                    bcs       L009B               if error, crash the system
-L0093               os9       F$NProc             let it take over
+L0083               ldu       <D.Init   ; get init module pointer
+                    ldd       InitStr,u ; get offset to name of first module
+                    leax      d,u       ; point to it
+                    lda       #'C       ; debug: signal that we tried to go to SysGo
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
+                    lda       #Objct    ; get module type
+                    clrb                ; get mem size
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,y       ; get parameter size
+                  ELSE
+                    ldy       #$0000    ; load Y from #$0000
+                  ENDC
+                    os9       F$Fork    ; fork it
+                    bcs       L009B     ; if error, crash the system
+L0093               os9       F$NProc   ; let it take over
 
 L0096               fcs       /krnp3/
 
-L009B               jmp       <D.Crash
+L009B               jmp       <D.Crash  ; transfer control to <D.Crash
 
-svctab              fcb       F$UnLink
-                    fdb       FUnLink-*-2
-                    fcb       F$AllRAM
-                    fdb       FAllRAM-*-2
-                    fcb       F$AlHRAM+SysState
-                    fdb       FAlHRAM-*-2
-                    fcb       F$Fork
-                    fdb       FFork-*-2
-                    fcb       F$Wait
-                    fdb       FWait-*-2
-                    fcb       F$Chain
-                    fdb       FChain-*-2
-                    fcb       F$Exit
-                    fdb       FExit-*-2
-                    fcb       F$Mem
-                    fdb       FMem-*-2
-                    fcb       F$Send
-                    fdb       FSend-*-2
-                    fcb       F$Icpt
-                    fdb       FIcpt-*-2
-                    fcb       F$Sleep
-                    fdb       FSleep-*-2
-                    fcb       F$SPrior
-                    fdb       FSPrior-*-2
-                    fcb       F$ID
-                    fdb       FID-*-2
-                    fcb       F$SSWI
-                    fdb       FSSWI-*-2
-                    fcb       F$STime
-                    fdb       FSTime-*-2
-                    fcb       F$SchBit
-                    fdb       FSchBit-*-2
-                    fcb       F$SchBit+SysState
-                    fdb       FSSchBit-*-2
-                    fcb       F$AllBit
-                    fdb       FAllBit-*-2
-                    fcb       F$AllBit+SysState
-                    fdb       FSAllBit-*-2
-                    fcb       F$DelBit
-                    fdb       FDelBit-*-2
-                    fcb       F$DelBit+SysState
-                    fdb       FSDelBit-*-2
-                    fcb       F$GPrDsc
-                    fdb       FGPrDsc-*-2
-                    fcb       F$GBlkMp
-                    fdb       FGBlkMp-*-2
-                    fcb       F$GModDr
-                    fdb       FGModDr-*-2
-                    IFEQ      H6309+wildbits
-                    fcb       F$DelRAM
-                    fdb       FDelRAM-*-2
-                    ENDC
-                    fcb       F$SUser             Added back here for room in OS9p1
-                    fdb       FSUser-*-2
-                    fcb       F$UnLoad
-                    fdb       FUnLoad-*-2
-                    fcb       F$Find64+$80
-                    fdb       FFind64-*-2
-                    fcb       F$All64+$80
-                    fdb       FAll64-*-2
-                    fcb       F$Ret64+$80
-                    fdb       FRet64-*-2
-                    fcb       F$GProcP+$80
-                    fdb       FGProcP-*-2
-                    fcb       F$DelImg+$80
-                    fdb       FDelImg-*-2
-                    fcb       F$AllPrc+$80
-                    fdb       FAllPrc-*-2
-                    fcb       F$DelPrc+$80
-                    fdb       FDelPrc-*-2
-                    fcb       F$MapBlk
-                    fdb       FMapBlk-*-2
-                    fcb       F$ClrBlk
-                    fdb       FClrBlk-*-2
-                    fcb       F$GCMDir+$80
-                    fdb       FGCMDir-*-2
-                    fcb       F$Debug
-                    fdb       FDebug-*-2
-                    fcb       F$CRCMod            new system call to change module CRC calcs on/off
-                    fdb       FCRCMod-*-2
-                    fcb       $7f
-                    fdb       GetIOMan-*-2
-                    fcb       $80
+svctab              fcb       F$UnLink  ; define byte value(s) F$UnLink
+                    fdb       FUnLink-*-2 ; define word value(s) FUnLink-*-2
+                    fcb       F$AllRAM  ; define byte value(s) F$AllRAM
+                    fdb       FAllRAM-*-2 ; define word value(s) FAllRAM-*-2
+                    fcb       F$AlHRAM+SysState ; define byte value(s) F$AlHRAM+SysState
+                    fdb       FAlHRAM-*-2 ; define word value(s) FAlHRAM-*-2
+                    fcb       F$Fork    ; define byte value(s) F$Fork
+                    fdb       FFork-*-2 ; define word value(s) FFork-*-2
+                    fcb       F$Wait    ; define byte value(s) F$Wait
+                    fdb       FWait-*-2 ; define word value(s) FWait-*-2
+                    fcb       F$Chain   ; define byte value(s) F$Chain
+                    fdb       FChain-*-2 ; define word value(s) FChain-*-2
+                    fcb       F$Exit    ; define byte value(s) F$Exit
+                    fdb       FExit-*-2 ; define word value(s) FExit-*-2
+                    fcb       F$Mem     ; define byte value(s) F$Mem
+                    fdb       FMem-*-2  ; define word value(s) FMem-*-2
+                    fcb       F$Send    ; define byte value(s) F$Send
+                    fdb       FSend-*-2 ; define word value(s) FSend-*-2
+                    fcb       F$Icpt    ; define byte value(s) F$Icpt
+                    fdb       FIcpt-*-2 ; define word value(s) FIcpt-*-2
+                    fcb       F$Sleep   ; define byte value(s) F$Sleep
+                    fdb       FSleep-*-2 ; define word value(s) FSleep-*-2
+                    fcb       F$SPrior  ; define byte value(s) F$SPrior
+                    fdb       FSPrior-*-2 ; define word value(s) FSPrior-*-2
+                    fcb       F$ID      ; define byte value(s) F$ID
+                    fdb       FID-*-2   ; define word value(s) FID-*-2
+                    fcb       F$SSWI    ; define byte value(s) F$SSWI
+                    fdb       FSSWI-*-2 ; define word value(s) FSSWI-*-2
+                    fcb       F$STime   ; define byte value(s) F$STime
+                    fdb       FSTime-*-2 ; define word value(s) FSTime-*-2
+                    fcb       F$SchBit  ; define byte value(s) F$SchBit
+                    fdb       FSchBit-*-2 ; define word value(s) FSchBit-*-2
+                    fcb       F$SchBit+SysState ; define byte value(s) F$SchBit+SysState
+                    fdb       FSSchBit-*-2 ; define word value(s) FSSchBit-*-2
+                    fcb       F$AllBit  ; define byte value(s) F$AllBit
+                    fdb       FAllBit-*-2 ; define word value(s) FAllBit-*-2
+                    fcb       F$AllBit+SysState ; define byte value(s) F$AllBit+SysState
+                    fdb       FSAllBit-*-2 ; define word value(s) FSAllBit-*-2
+                    fcb       F$DelBit  ; define byte value(s) F$DelBit
+                    fdb       FDelBit-*-2 ; define word value(s) FDelBit-*-2
+                    fcb       F$DelBit+SysState ; define byte value(s) F$DelBit+SysState
+                    fdb       FSDelBit-*-2 ; define word value(s) FSDelBit-*-2
+                    fcb       F$GPrDsc  ; define byte value(s) F$GPrDsc
+                    fdb       FGPrDsc-*-2 ; define word value(s) FGPrDsc-*-2
+                    fcb       F$GBlkMp  ; define byte value(s) F$GBlkMp
+                    fdb       FGBlkMp-*-2 ; define word value(s) FGBlkMp-*-2
+                    fcb       F$GModDr  ; define byte value(s) F$GModDr
+                    fdb       FGModDr-*-2 ; define word value(s) FGModDr-*-2
+                  IFEQ    H6309+wildbits ; begin conditional assembly for H6309+wildbits
+                    fcb       F$DelRAM  ; define byte value(s) F$DelRAM
+                    fdb       FDelRAM-*-2 ; define word value(s) FDelRAM-*-2
+                  ENDC
+                    fcb       F$SUser   ; added back here for room in OS9p1
+                    fdb       FSUser-*-2 ; define word value(s) FSUser-*-2
+                    fcb       F$UnLoad  ; define byte value(s) F$UnLoad
+                    fdb       FUnLoad-*-2 ; define word value(s) FUnLoad-*-2
+                    fcb       F$Find64+$80 ; define byte value(s) F$Find64+$80
+                    fdb       FFind64-*-2 ; define word value(s) FFind64-*-2
+                    fcb       F$All64+$80 ; define byte value(s) F$All64+$80
+                    fdb       FAll64-*-2 ; define word value(s) FAll64-*-2
+                    fcb       F$Ret64+$80 ; define byte value(s) F$Ret64+$80
+                    fdb       FRet64-*-2 ; define word value(s) FRet64-*-2
+                    fcb       F$GProcP+$80 ; define byte value(s) F$GProcP+$80
+                    fdb       FGProcP-*-2 ; define word value(s) FGProcP-*-2
+                    fcb       F$DelImg+$80 ; define byte value(s) F$DelImg+$80
+                    fdb       FDelImg-*-2 ; define word value(s) FDelImg-*-2
+                    fcb       F$AllPrc+$80 ; define byte value(s) F$AllPrc+$80
+                    fdb       FAllPrc-*-2 ; define word value(s) FAllPrc-*-2
+                    fcb       F$DelPrc+$80 ; define byte value(s) F$DelPrc+$80
+                    fdb       FDelPrc-*-2 ; define word value(s) FDelPrc-*-2
+                    fcb       F$MapBlk  ; define byte value(s) F$MapBlk
+                    fdb       FMapBlk-*-2 ; define word value(s) FMapBlk-*-2
+                    fcb       F$ClrBlk  ; define byte value(s) F$ClrBlk
+                    fdb       FClrBlk-*-2 ; define word value(s) FClrBlk-*-2
+                    fcb       F$GCMDir+$80 ; define byte value(s) F$GCMDir+$80
+                    fdb       FGCMDir-*-2 ; define word value(s) FGCMDir-*-2
+                    fcb       F$Debug   ; define byte value(s) F$Debug
+                    fdb       FDebug-*-2 ; define word value(s) FDebug-*-2
+                    fcb       F$CRCMod  ; new system call to change module CRC calcs on/off
+                    fdb       FCRCMod-*-2 ; define word value(s) FCRCMod-*-2
+                    fcb       $7f       ; define byte value(s) $7f
+                    fdb       GetIOMan-*-2 ; define word value(s) GetIOMan-*-2
+                    fcb       $80       ; define byte value(s) $80
 
-                    use       fcrcmod.asm
+                    use       fcrcmod.asm ; include source file fcrcmod.asm
 
 * Link & execute IOMan
 * Entry: None
 * Exit : I/O handling installed & ready for use
-GetIOMan            pshs      d,x,y,u             preserve regs
-                    bsr       LnkIOMan            link to ioman
-                    bcc       GotIOMan            no errors, go on
-                    os9       F$Boot              re-load boot file
-                    bcs       IOManErr            error loading, return
-                    bsr       LnkIOMan            link to ioman
-                    bcs       IOManErr            error, save it & return
-GotIOMan            jsr       ,y                  execute IOMan's init routine
-                    puls      d,x,y,u             restore registers
-                    jmp       [IOEntry,y]         Execute I/O vector
+GetIOMan            pshs      d,x,y,u   ; preserve regs
+                    bsr       LnkIOMan  ; link to ioman
+                    bcc       GotIOMan  ; no errors, go on
+                    os9       F$Boot    ; re-load boot file
+                    bcs       IOManErr  ; error loading, return
+                    bsr       LnkIOMan  ; link to ioman
+                    bcs       IOManErr  ; error, save it & return
+GotIOMan            jsr       ,y        ; execute IOMan's init routine
+                    puls      d,x,y,u   ; restore registers
+                    jmp       [IOEntry,y] ; execute I/O vector
 
-IOManErr            stb       1,s                 save error if any
-                    puls      d,x,y,u,pc          restore & return
+IOManErr            stb       1,s       ; save error if any
+                    puls      d,x,y,u,pc ; restore & return
 
 * Link to IOMan
 * Entry: None
 * Exit : U=Pointer to IOMan module header
 *        Y=Pointer to IOMan entry point
-LnkIOMan            leax      <IOMan,pc           point to name
-                    lda       #(Systm+Objct)      get type
-                    os9       F$Link              link it
-                    rts                           return
+LnkIOMan            leax      <IOMan,pc ; point to name
+                    lda       #(Systm+Objct) ; get type
+                    os9       F$Link    ; link it
+                    rts                 ; return
 
 IOMan               fcs       /IOMan/
 
-                    use       funlink.asm
+                    use       funlink.asm ; include source file funlink.asm
 
-                    use       ffork.asm
+                    use       ffork.asm ; include source file ffork.asm
 
-                    use       fallprc.asm
+                    use       fallprc.asm ; include source file fallprc.asm
 
-                    use       fchain.asm
+                    use       fchain.asm ; include source file fchain.asm
 
-                    use       fexit.asm
+                    use       fexit.asm ; include source file fexit.asm
 
-                    use       fmem.asm
+                    use       fmem.asm  ; include source file fmem.asm
 
-                    use       fsend.asm
+                    use       fsend.asm ; include source file fsend.asm
 
-                    use       ficpt.asm
+                    use       ficpt.asm ; include source file ficpt.asm
 
-                    use       fsleep.asm
+                    use       fsleep.asm ; include source file fsleep.asm
 
-                    use       fallram.asm
+                    use       fallram.asm ; include source file fallram.asm
 
-                    use       fsprior.asm
+                    use       fsprior.asm ; include source file fsprior.asm
 
-                    use       fid.asm
+                    use       fid.asm   ; include source file fid.asm
 
-                    ifeq      H6309+wildbits
-                    use       fdelram.asm
-                    endc
+                  IFEQ    H6309+wildbits ; begin conditional assembly for H6309+wildbits
+                    use       fdelram.asm ; include source file fdelram.asm
+                  ENDC
 
-                    use       fsswi.asm
+                    use       fsswi.asm ; include source file fsswi.asm
 
-                    use       fstime.asm
+                    use       fstime.asm ; include source file fstime.asm
 
-                    use       fallbit.asm
+                    use       fallbit.asm ; include source file fallbit.asm
 
-                    use       fgprdsc.asm
+                    use       fgprdsc.asm ; include source file fgprdsc.asm
 
-                    use       fgblkmp.asm
+                    use       fgblkmp.asm ; include source file fgblkmp.asm
 
-                    use       fgmoddr.asm
+                    use       fgmoddr.asm ; include source file fgmoddr.asm
 
-                    use       fsuser.asm
+                    use       fsuser.asm ; include source file fsuser.asm
 
-                    use       funload.asm
+                    use       funload.asm ; include source file funload.asm
 
-                    use       ffind64.asm
+                    use       ffind64.asm ; include source file ffind64.asm
 
-                    use       fgprocp.asm
+                    use       fgprocp.asm ; include source file fgprocp.asm
 
-                    use       fdelimg.asm
+                    use       fdelimg.asm ; include source file fdelimg.asm
 
-                    use       fmapblk.asm
+                    use       fmapblk.asm ; include source file fmapblk.asm
 
-                    use       fclrblk.asm
+                    use       fclrblk.asm ; include source file fclrblk.asm
 
-                    use       fgcmdir.asm
+                    use       fgcmdir.asm ; include source file fgcmdir.asm
 
-                    use       fdebug.asm
+                    use       fdebug.asm ; include source file fdebug.asm
 
                     emod
-eom                 equ       *
+eom                 equ       *         ; define assembler symbol eom
                     end

--- a/level2/modules/kernel/mc09krn.asm
+++ b/level2/modules/kernel/mc09krn.asm
@@ -41,7 +41,7 @@ MName               fcs       /Krn/
 
 * Might as well have this here as just past the end of Kernel...
 DisTable
-                    fdb       FAlltskSleepingProcessQueue+Where ; d.Clock absolute address at the start
+                    fdb       FAlltskSleepProcQ+Where ; d.Clock absolute address at the start
                     fdb       XSWI3+Where ; d.XSWI3
                     fdb       XSWI2+Where ; d.XSWI2
                     fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
@@ -215,9 +215,9 @@ Loop2               lda       ,y+       ; load a byte from source
 * Initialize secondary interrupt vectors to all point to Vectors for now
 * ASSUME: Y left pointing to Vectors by previous copy loop
                     tfr       y,u       ; move the pointer to a faster register
-CcbkrnIRQVectorsVectorsNow stu       ,x++      ; set all IRQ vectors to go to Vectors for now
+CcbkrnIRQVctrsVctrs stu       ,x++      ; set all IRQ vectors to go to Vectors for now
                     cmpx      #D.NMI    ; compare X with #D.NMI
-                    bls       CcbkrnIRQVectorsVectorsNow ; branch if unsigned result is lower or same to CcbkrnIRQVectorsVectorsNow
+                    bls       CcbkrnIRQVctrsVctrs ; branch if unsigned result is lower or same to CcbkrnIRQVctrsVctrs
 
                   IFNE    mc09    ; begin conditional assembly for mc09
 * Initialize CPU vectors
@@ -390,9 +390,9 @@ KrnBlock            aslb                ; update processor state
 * $0280 - 1024k (128, 8KByte blocks)
 * $0300 - 2048k (256, 8KByte blocks)
                     bitb      #%00110000 ; block above 128K-256K?
-                    beq       Mc09KrnStartBootTrackMemory ; yes, no need to mark block map
+                    beq       Mc09KrnStart ; yes, no need to mark block map
                     tstb                ; 2 meg?
-                    beq       Mc09KrnStartBootTrackMemory ; yes, skip this
+                    beq       Mc09KrnStart ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
                     abx                 ; add maximum block number to block map start
                     leax      -1,x      ; skip good blocks that are RAM
@@ -403,7 +403,7 @@ CcbkrnMarkThem      sta       ,x+       ; mark them all
                     bne       CcbkrnMarkThem ; branch if zero is clear to CcbkrnMarkThem
 
 * ASSUME: however we got here, B=0
-Mc09KrnStartBootTrackMemory ldx       #Bt.Start ; start address of the boot track in memory
+Mc09KrnStart        ldx       #Bt.Start ; start address of the boot track in memory
                     lda       #18       ; size of the boot track is $1800
 
 * Verify the modules in the boot track and update/build a module index
@@ -411,12 +411,12 @@ Mc09KrnStartBootTrackMemory ldx       #Bt.Start ; start address of the boot trac
                     bsr       KrnSystemMemoryMap ; go mark system map
 
 * See if init module is in memory already
-CcbkrnInitModuleName leax      <init,pc  ; point to 'Init' module name
+CcbkrnInitModName   leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
                     bcc       KrnInitModule ; no error, go on
-CcbkrnErrorLinkingInitTryBoot os9       F$Boot    ; error linking init, try & load boot file
-                    bcc       CcbkrnInitModuleName ; got it, try init again
-                    bra       KrnObviouslyCantCrashMachine ; error, re-booting do D.Crash
+CcbkrnErrLnkngInit  os9       F$Boot    ; error linking init, try & load boot file
+                    bcc       CcbkrnInitModName ; got it, try init again
+                    bra       KrnBadCantCrsh ; error, re-booting do D.Crash
 
 * So far, so good. Save pointer to init module and execute krnp2
 KrnInitModule       stu       <D.Init   ; save init module pointer
@@ -433,7 +433,7 @@ KrnKrnp2sName       leax      <krnp2,pc ; point to its name
                     bcc       KrnJumpKrnp2 ; it worked, execute it
                     os9       F$Boot    ; it doesn't exist try re-booting
                     bcc       KrnKrnp2sName ; no error's, let's try to link it again
-KrnObviouslyCantCrashMachine jmp       <D.Crash  ; obviously can't do it, crash machine
+KrnBadCantCrsh      jmp       <D.Crash  ; obviously can't do it, crash machine
 KrnJumpKrnp2        jmp       ,y        ; execute krnp2
 
 * Update the system memory map to reserve the area used by the kernel
@@ -541,7 +541,7 @@ XSWI3               lda       #P$SWI3   ; point to SWI3 vector
 XSWI                lda       #P$SWI    ; point to SWI vector
                     ldx       <D.Proc   ; get process pointer
                     ldu       a,x       ; user defined SWI[x]?
-                    beq       KrnSystemCallServiceVector ; no, go get option byte
+                    beq       KrnSysCallSvc ; no, go get option byte
 GoUser              lbra      KrnJoin3  ; yes, go call users's routine
 
 * SWI2 vector entry
@@ -552,7 +552,7 @@ XSWI2               ldx       <D.Proc   ; get current process descriptor
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-KrnSystemCallServiceVector ldu       <D.SysSvc ; set system call processor to system side
+KrnSysCallSvc       ldu       <D.SysSvc ; set system call processor to system side
                     stu       <D.XSWI2  ; store U at <D.XSWI2
                     ldu       <D.SysIRQ ; do the same thing for IRQ's
                     stu       <D.XIRQ   ; store U at <D.XIRQ
@@ -614,7 +614,7 @@ Loop3               ldx       ,--y      ; load X from ,--y
                     sta       <D.Quick  ; save quick return flag
                     beq       AllClr    ; if nothing's have changed, do full checks
 
-DoFull              bsr       CopySystemStackToUser ; move the stack frame back to user state
+DoFull              bsr       CpSysStkTo ; move the stack frame back to user state
                     lbra      KrnJoin   ; go back to the process
 
 * add ldu P$SP,x, etc...
@@ -645,7 +645,7 @@ Loop4               lda       ,u+       ; load A from ,u+
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
+CpUsrStkTo          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task #
                     ldx       P$SP,x    ; get stack pointer
                     lbsr      FMoveLater ; calculate block offset (only affects A&X)
@@ -654,7 +654,7 @@ CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-CopySystemStackToUser          pshs      cc,x,y,u  ; preserve registers
+CpSysStkTo          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task # of destination
                     ldx       P$SP,x    ; get stack pointer
                     lbsr      FMoveLater ; calculate block offset (only affects A&X)
@@ -747,7 +747,7 @@ SysCall             leau      ,s        ; get pointer to register stack
                     ldy       <D.SysDis ; get system dispatch table pointer
                     bsr       ExecSvcCall ; execute system call
                     puls      a         ; restore system state task number
-                    lbra      KrnSystemProcessDescriptor ; return to process
+                    lbra      KrnSysProcDesc ; return to process
 
 * Entry: X = system call vector to jump to
 Sys.Vec             jmp       ,x        ; execute service call
@@ -761,13 +761,13 @@ ExecSvcCall
 * Execute I/O system calls
                     ldx       IOEntry,y ; get IOMan vector
 * Execute the system call
-CallSvcVector          pshs      u         ; preserve register stack pointer
+CallSvcVector       pshs      u         ; preserve register stack pointer
                     jsr       [D.SysVec] ; perform a vectored system call
                     puls      u         ; restore pointer
-UpdateCallerCC          tfr       cc,a      ; move CC to A for stack update
-                    bcc       MergeCallerCC    ; go update it if no error from call
+UpdateCallerCC      tfr       cc,a      ; move CC to A for stack update
+                    bcc       MergeCallerCC ; go update it if no error from call
                     stb       R$B,u     ; save error code to caller's B
-MergeCallerCC              ldb       R$CC,u    ; get callers CC, R$CC=$00
+MergeCallerCC       ldb       R$CC,u    ; get callers CC, R$CC=$00
                   IFNE    H6309   ; begin conditional assembly for H6309
                     andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
                     orr       b,a       merge them together
@@ -839,7 +839,7 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
                     ldd       <D.SysIRQ ; set system IRQ routine to current
                     std       <D.XIRQ   ; store D at <D.XIRQ
                     jsr       [>D.SvcIRQ] ; execute irq service
-                    bcc       KrnShutDownInterrupts ; branch if carry is clear to KrnShutDownInterrupts
+                    bcc       KrnShutDownInts ; branch if carry is clear to KrnShutDownInts
 
                     ldx       <D.Proc   ; get current process pointer
                     ldb       P$Task,x  ; load B from P$Task,x
@@ -852,7 +852,7 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
 
                     ora       #IntMasks ; disable it's IRQ's
                     lbsr      FLdabxCarry ; save it back
-KrnShutDownInterrupts orcc      #IntMasks ; shut down IRQ's
+KrnShutDownInts     orcc      #IntMasks ; shut down IRQ's
                     ldx       <D.Proc   ; get current process pointer
                     tst       <D.QIRQ   ; was it a clock IRQ?
                     lbne      FNprocJoin ; if not, do a quick return
@@ -871,8 +871,8 @@ KrnActiveProcess    ldu       P$Queue,u ; get a active process pointer
                     cmpb      P$Prior,u ; do we bump this one?
                     blo       KrnTimeoutFlag ; branch if unsigned result is lower to KrnTimeoutFlag
 
-UseProcessStack          ldu       P$SP,x    ; load U from P$SP,x
-                    bra       FNprocCondemnedByDeadlySignal ; branch unconditionally to FNprocCondemnedByDeadlySignal
+UseProcessStack     ldu       P$SP,x    ; load U from P$SP,x
+                    bra       FNprocCndmnByDdly ; branch unconditionally to FNprocCndmnByDdly
 
 KrnTimeoutFlag      anda      #^TimOut  ; mask A with #^TimOut
                     sta       P$State,x ; store A at P$State,x
@@ -928,8 +928,8 @@ DoneIRQ             bcc       KrnReturn ; no error on IRQ, exit
 KrnReturn           rti                 ; return from interrupt
 
 * return from a system call
-KrnForceSystemTaskSystem clra                ; force System task # to 0 (non-GRDRV)
-KrnSystemProcessDescriptor ldx       <D.SysPrc ; get system process dsc. ptr
+KrnFrcSysTask       clra                ; force System task # to 0 (non-GRDRV)
+KrnSysProcDesc      ldx       <D.SysPrc ; get system process dsc. ptr
                     lbsr      TstImg    ; check image, and F$SetTsk (PRESERVES A)
                     orcc      #IntMasks ; shut interrupts off
                     sta       <D.SSTskN ; save task # for system state
@@ -971,7 +971,7 @@ KrnJoin2            equ       *         ; define assembler symbol KrnJoin2
                     bne       MyRTI     ; no, we're doing a system-state rti
 
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    ldf       #R$Size   ; e=0 from call to KrnWeGoingBackSameTask before
+                    ldf       #R$Size   ; e=0 from call to KrnWeGngBack before
                     ldu       #Where+SWIStack ; point to the stack
                     tfm       u+,y+     ; move the stack from top of memory to user memory
                   ELSE
@@ -1010,7 +1010,7 @@ KrnJoin3            equ       *         ; define assembler symbol KrnJoin3
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
 S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfdrv (task 1)
-                    bsr       KrnWeGoingBackSameTask ; copy over the DAT image
+                    bsr       KrnWeGngBack ; copy over the DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; apply immediate bit operation #$01,<D.TINIT
                     lda       <D.TINIT  ; get copy of GIME Task side
@@ -1032,7 +1032,7 @@ S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfd
                     rti                 ; return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-KrnWeGoingBackSameTask cmpb      <D.Task1N ; are we going back to the same task
+KrnWeGngBack        cmpb      <D.Task1N ; are we going back to the same task
                     beq       KrnReturn2 ; without the DAT image changing?
                     stb       <D.Task1N ; nope, save current task in map type 1
                   IFNE    mc09    ; begin conditional assembly for mc09

--- a/level2/modules/kernel/mc09krn.asm
+++ b/level2/modules/kernel/mc09krn.asm
@@ -23,7 +23,7 @@
                     nam       krn
                     ttl       NitrOS-9 Level 2 Kernel
 
-                  ifp1
+                  IFP1
                     use       defsfile  ; include source file defsfile
                   ENDC
 
@@ -41,7 +41,7 @@ MName               fcs       /Krn/
 
 * Might as well have this here as just past the end of Kernel...
 DisTable
-                    fdb       L0CD2+Where ; d.Clock absolute address at the start
+                    fdb       FAlltskSleepingProcessQueue+Where ; d.Clock absolute address at the start
                     fdb       XSWI3+Where ; d.XSWI3
                     fdb       XSWI2+Where ; d.XSWI2
                     fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
@@ -117,9 +117,9 @@ entry               equ       *         ; define assembler symbol entry
                     ldy       #$2000-$100 ; bytes to clear
                     clra                ; clear A
                     clrb                ; clear B
-L001C               std       ,x++      ; clear it 16-bits at a time
+CcbkrnTarget        std       ,x++      ; clear it 16-bits at a time
                     leay      -2,y      ; compute -2,y into Y
-                    bne       L001C     ; branch if zero is clear to L001C
+                    bne       CcbkrnTarget ; branch if zero is clear to CcbkrnTarget
                     stx       <D.CCStk  ; set pointer to top of global memory to $2000
                     inca                ; D = $0100
                   ENDC
@@ -215,19 +215,19 @@ Loop2               lda       ,y+       ; load a byte from source
 * Initialize secondary interrupt vectors to all point to Vectors for now
 * ASSUME: Y left pointing to Vectors by previous copy loop
                     tfr       y,u       ; move the pointer to a faster register
-L0065               stu       ,x++      ; set all IRQ vectors to go to Vectors for now
+CcbkrnIRQVectorsVectorsNow stu       ,x++      ; set all IRQ vectors to go to Vectors for now
                     cmpx      #D.NMI    ; compare X with #D.NMI
-                    bls       L0065     ; branch if unsigned result is lower or same to L0065
+                    bls       CcbkrnIRQVectorsVectorsNow ; branch if unsigned result is lower or same to CcbkrnIRQVectorsVectorsNow
 
                   IFNE    mc09    ; begin conditional assembly for mc09
 * Initialize CPU vectors
                     leay      CPUVect,pcr ; data source
                     ldx       #$FFF2    ; data destination
                     ldb       #14       ; 7 vectors to copy
-L0067               lda       ,y+       ; load A from ,y+
+Mc09KrnTarget       lda       ,y+       ; load A from ,y+
                     sta       ,x+       ; store A at ,x+
                     decb                ; decrement B
-                    bne       L0067     ; branch if zero is clear to L0067
+                    bne       Mc09KrnTarget ; branch if zero is clear to Mc09KrnTarget
                   ENDC
 
 * Initialize user interupt vectors
@@ -301,9 +301,9 @@ L0067               lda       ,y+       ; load A from ,y+
 * DAT.BlCt-ROMCount-RAMCount = 8 - 1 - 1 = 6
                     lda       #$06      ; initialize the rest of the blocks to be free
                     ldu       #DAT.Free ; load U from #DAT.Free
-L00EF               stu       ,x++      ; store free "flag"
+CcbkrnFreeFlag      stu       ,x++      ; store free "flag"
                     deca                ; bump counter
-                    bne       L00EF     ; loop if not done
+                    bne       CcbkrnFreeFlag ; loop if not done
 
                     ldu       #KrnBlk   ; block where the kernel will live
                     stu       ,x        ; store U at ,x
@@ -331,9 +331,9 @@ L00EF               stu       ,x++      ; store free "flag"
 * Walk through the map changing the corresponding elements
 * from 0 (the initialisation value) to 1 (indicating 'used'). Higher
 * entries in the map remain as 0 (indicating 'unused').
-L0104               inc       ,x+       ; mark it as used
+KrnMarkUsed         inc       ,x+       ; mark it as used
                     decb                ; done?
-                    bne       L0104     ; no, go back till done
+                    bne       KrnMarkUsed ; no, go back till done
 
 ********************************************************************
 * Deduce how many 8Kbyte blocks of physical memory are available and
@@ -353,16 +353,16 @@ L0104               inc       ,x+       ; mark it as used
 * does need to be reserved; it's used for global memory.
                   IFNE    H6309   ; begin conditional assembly for H6309
                     ldq       #$00080100 ; e=Marker, D=Block # to check
-L0111               asld                ; get next block #
+KrnBlock            asld                ; get next block #
                     stb       >DAT.Regs+5 ; map block into block 6 of my task
                     ste       >-$6000,x ; save marker to that block
                     cmpe      ,x        ; did it ghost to block 0?
-                    bne       L0111     ; no, keep going till ghost is found
+                    bne       KrnBlock  ; no, keep going till ghost is found
                     stb       <D.MemSz  ; save # 8k mem blocks that exist
                     addr      x,d       ; add number of blocks to block map start
                   ELSE
                     ldd       #$0008    ; load D from #$0008
-L0111               aslb                ; update processor state
+KrnBlock            aslb                ; update processor state
                     rola                ; shift or rotate and update condition codes
                     stb       >DAT.Regs+5 ; store B at >DAT.Regs+5
                     pshs      a         ; save a on the stack
@@ -370,7 +370,7 @@ L0111               aslb                ; update processor state
                     sta       >-$6000,x ; store A at >-$6000,x
                     cmpa      ,x        ; compare A with ,x
                     puls      a         ; restore a from the stack
-                    bne       L0111     ; branch if zero is clear to L0111
+                    bne       KrnBlock  ; branch if zero is clear to KrnBlock
                     stb       <D.MemSz  ; store B at <D.MemSz
                     pshs      x         ; save x on the stack
                     addd      ,s++      ; add ,s++ to D
@@ -390,36 +390,36 @@ L0111               aslb                ; update processor state
 * $0280 - 1024k (128, 8KByte blocks)
 * $0300 - 2048k (256, 8KByte blocks)
                     bitb      #%00110000 ; block above 128K-256K?
-                    beq       L0170     ; yes, no need to mark block map
+                    beq       Mc09KrnStartBootTrackMemory ; yes, no need to mark block map
                     tstb                ; 2 meg?
-                    beq       L0170     ; yes, skip this
+                    beq       Mc09KrnStartBootTrackMemory ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
                     abx                 ; add maximum block number to block map start
                     leax      -1,x      ; skip good blocks that are RAM
                     lda       #NotRAM   ; not RAM flag
                     subb      #$3F      ; calculate # blocks to mark as not RAM
-L0127               sta       ,x+       ; mark them all
+CcbkrnMarkThem      sta       ,x+       ; mark them all
                     decb                ; decrement B
-                    bne       L0127     ; branch if zero is clear to L0127
+                    bne       CcbkrnMarkThem ; branch if zero is clear to CcbkrnMarkThem
 
 * ASSUME: however we got here, B=0
-L0170               ldx       #Bt.Start ; start address of the boot track in memory
+Mc09KrnStartBootTrackMemory ldx       #Bt.Start ; start address of the boot track in memory
                     lda       #18       ; size of the boot track is $1800
 
 * Verify the modules in the boot track and update/build a module index
                     lbsr      I.VBlock  ; call local routine I.VBlock
-                    bsr       L01D2     ; go mark system map
+                    bsr       KrnSystemMemoryMap ; go mark system map
 
 * See if init module is in memory already
-L01B0               leax      <init,pc  ; point to 'Init' module name
+CcbkrnInitModuleName leax      <init,pc  ; point to 'Init' module name
                     bsr       link      ; try & link it
-                    bcc       L01BF     ; no error, go on
-L01B8               os9       F$Boot    ; error linking init, try & load boot file
-                    bcc       L01B0     ; got it, try init again
-                    bra       L01CE     ; error, re-booting do D.Crash
+                    bcc       KrnInitModule ; no error, go on
+CcbkrnErrorLinkingInitTryBoot os9       F$Boot    ; error linking init, try & load boot file
+                    bcc       CcbkrnInitModuleName ; got it, try init again
+                    bra       KrnObviouslyCantCrashMachine ; error, re-booting do D.Crash
 
 * So far, so good. Save pointer to init module and execute krnp2
-L01BF               stu       <D.Init   ; save init module pointer
+KrnInitModule       stu       <D.Init   ; save init module pointer
                     lda       Feature1,u ; get feature byte #1 from init module
                     bita      #CRCOn    ; cRC feature on?
                     beq       ShowI     ; if not, continue
@@ -428,24 +428,24 @@ L01BF               stu       <D.Init   ; save init module pointer
 ShowI               lda       #'i       ; debug: signal that we found the init module
                     jsr       <D.BtBug  ; call routine at <D.BtBug
 
-L01C1               leax      <krnp2,pc ; point to its name
+KrnKrnp2sName       leax      <krnp2,pc ; point to its name
                     bsr       link      ; try to link it
-                    bcc       L01D0     ; it worked, execute it
+                    bcc       KrnJumpKrnp2 ; it worked, execute it
                     os9       F$Boot    ; it doesn't exist try re-booting
-                    bcc       L01C1     ; no error's, let's try to link it again
-L01CE               jmp       <D.Crash  ; obviously can't do it, crash machine
-L01D0               jmp       ,y        ; execute krnp2
+                    bcc       KrnKrnp2sName ; no error's, let's try to link it again
+KrnObviouslyCantCrashMachine jmp       <D.Crash  ; obviously can't do it, crash machine
+KrnJumpKrnp2        jmp       ,y        ; execute krnp2
 
 * Update the system memory map to reserve the area used by the kernel
-L01D2               ldx       <D.SysMem ; get system memory map pointer
+KrnSystemMemoryMap  ldx       <D.SysMem ; get system memory map pointer
                     ldd       #NotRAM*256+(Bt.Start/256) ; B = MSB of start of the boot
                     abx                 ; point to Bt.Start - start of boot track
                     comb                ; we have $FF-$ED pages to mark as inUse
                     sta       b,x       ; mark I/O as not RAM
-L01DF               lda       #RAMinUse ; get inUse flag
-L01E1               sta       ,x+       ; mark this page
+KrnRAMUseFlag       lda       #RAMinUse ; get inUse flag
+KrnMarkPage         sta       ,x+       ; mark this page
                     decb                ; done?
-                    bne       L01E1     ; no, keep going
+                    bne       KrnMarkPage ; no, keep going
                     ldx       <D.BlkMap ; get pointer to start of block map
                     sta       <KrnBlk,x ; mark kernel block as RAMinUse, instead of ModInBlk
 S.AltIRQ            rts                 ; return
@@ -541,8 +541,8 @@ XSWI3               lda       #P$SWI3   ; point to SWI3 vector
 XSWI                lda       #P$SWI    ; point to SWI vector
                     ldx       <D.Proc   ; get process pointer
                     ldu       a,x       ; user defined SWI[x]?
-                    beq       L028E     ; no, go get option byte
-GoUser              lbra      L0E5E     ; yes, go call users's routine
+                    beq       KrnSystemCallServiceVector ; no, go get option byte
+GoUser              lbra      KrnJoin3  ; yes, go call users's routine
 
 * SWI2 vector entry
 XSWI2               ldx       <D.Proc   ; get current process descriptor
@@ -552,7 +552,7 @@ XSWI2               ldx       <D.Proc   ; get current process descriptor
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-L028E               ldu       <D.SysSvc ; set system call processor to system side
+KrnSystemCallServiceVector ldu       <D.SysSvc ; set system call processor to system side
                     stu       <D.XSWI2  ; store U at <D.XSWI2
                     ldu       <D.SysIRQ ; do the same thing for IRQ's
                     stu       <D.XIRQ   ; store U at <D.XIRQ
@@ -589,7 +589,7 @@ Loop3               ldx       ,--y      ; load X from ,--y
                     stx       R$PC,u    ; save updated PC to process
 * execute function call
                     ldy       <D.UsrDis ; get user dispatch table pointer
-                    lbsr      L033B     ; go execute option
+                    lbsr      ExecSvcCall ; go execute option
                   IFNE    H6309   ; begin conditional assembly for H6309
                     aim       #^IntMasks,R$CC,u ; clear interrupt flags in caller's CC
                   ELSE
@@ -614,8 +614,8 @@ Loop3               ldx       ,--y      ; load X from ,--y
                     sta       <D.Quick  ; save quick return flag
                     beq       AllClr    ; if nothing's have changed, do full checks
 
-DoFull              bsr       L02DA     ; move the stack frame back to user state
-                    lbra      L0D80     ; go back to the process
+DoFull              bsr       CopySystemStackToUser ; move the stack frame back to user state
+                    lbra      KrnJoin   ; go back to the process
 
 * add ldu P$SP,x, etc...
 AllClr              equ       *         ; define assembler symbol AllClr
@@ -645,19 +645,19 @@ Loop4               lda       ,u+       ; load A from ,u+
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-L02CB               pshs      cc,x,y,u  ; preserve registers
+CopyUserStackToSystem           pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task #
                     ldx       P$SP,x    ; get stack pointer
-                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    lbsr      FMoveLater ; calculate block offset (only affects A&X)
                     leax      -$6000,x  ; adjust pointer to where memory map will be
-                    bra       L02E9     ; go copy it
+                    bra       KrnBlockNumberWhere ; go copy it
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-L02DA               pshs      cc,x,y,u  ; preserve registers
+CopySystemStackToUser          pshs      cc,x,y,u  ; preserve registers
                     ldb       P$Task,x  ; get task # of destination
                     ldx       P$SP,x    ; get stack pointer
-                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    lbsr      FMoveLater ; calculate block offset (only affects A&X)
                     leax      -$6000,x  ; adjust pointer to where memory map will be
                     exg       x,y       ; swap pointers & copy
 * Copy a register stack
@@ -665,7 +665,7 @@ L02DA               pshs      cc,x,y,u  ; preserve registers
 *        Y=Destination
 *        A=Offset into DAT image of stack
 *        B=Task #
-L02E9               leau      a,u       ; point to block # of where stack is
+KrnBlockNumberWhere leau      a,u       ; point to block # of where stack is
                   IFNE    mc09    ; begin conditional assembly for mc09
                     orcc      #IntMasks ; shutdown interupts while we do this
 
@@ -745,9 +745,9 @@ SysCall             leau      ,s        ; get pointer to register stack
                     leax      1,x       ; move PC to next position
                     stx       R$PC,u    ; save my caller's updated PC register
                     ldy       <D.SysDis ; get system dispatch table pointer
-                    bsr       L033B     ; execute system call
+                    bsr       ExecSvcCall ; execute system call
                     puls      a         ; restore system state task number
-                    lbra      L0E2B     ; return to process
+                    lbra      KrnSystemProcessDescriptor ; return to process
 
 * Entry: X = system call vector to jump to
 Sys.Vec             jmp       ,x        ; execute service call
@@ -755,19 +755,19 @@ Sys.Vec             jmp       ,x        ; execute service call
 * Execute system call
 * Entry: B=Function call #
 *        Y=Function dispatch table pointer (D.SysDis or D.UsrDis)
-L033B
+ExecSvcCall
                     lslb                ; is it a I/O call? (Also multiplys by 2 for offset)
-                    bcc       L0345     ; no, go get normal vector
+                    bcc       GetSvcVector ; no, go get normal vector
 * Execute I/O system calls
                     ldx       IOEntry,y ; get IOMan vector
 * Execute the system call
-L034F               pshs      u         ; preserve register stack pointer
+CallSvcVector          pshs      u         ; preserve register stack pointer
                     jsr       [D.SysVec] ; perform a vectored system call
                     puls      u         ; restore pointer
-L0355               tfr       cc,a      ; move CC to A for stack update
-                    bcc       L035B     ; go update it if no error from call
+UpdateCallerCC          tfr       cc,a      ; move CC to A for stack update
+                    bcc       MergeCallerCC    ; go update it if no error from call
                     stb       R$B,u     ; save error code to caller's B
-L035B               ldb       R$CC,u    ; get callers CC, R$CC=$00
+MergeCallerCC              ldb       R$CC,u    ; get callers CC, R$CC=$00
                   IFNE    H6309   ; begin conditional assembly for H6309
                     andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
                     orr       b,a       merge them together
@@ -781,13 +781,13 @@ L035B               ldb       R$CC,u    ; get callers CC, R$CC=$00
                     rts                 ; return to caller
 
 * Execute regular system calls
-L0345
+GetSvcVector
                     clra                ; clear MSB of offset
                     ldx       d,y       ; get vector to call
-                    bne       L034F     ; it's initialized, go execute it
+                    bne       CallSvcVector ; it's initialized, go execute it
                     comb                ; set carry for error
                     ldb       #E$UnkSvc ; get error code
-                    bra       L0355     ; return with it
+                    bra       UpdateCallerCC ; return with it
 
                     use       fssvc.asm ; include source file fssvc.asm
 
@@ -839,7 +839,7 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
                     ldd       <D.SysIRQ ; set system IRQ routine to current
                     std       <D.XIRQ   ; store D at <D.XIRQ
                     jsr       [>D.SvcIRQ] ; execute irq service
-                    bcc       L0D5B     ; branch if carry is clear to L0D5B
+                    bcc       KrnShutDownInterrupts ; branch if carry is clear to KrnShutDownInterrupts
 
                     ldx       <D.Proc   ; get current process pointer
                     ldb       P$Task,x  ; load B from P$Task,x
@@ -847,38 +847,38 @@ XIRQ                ldx       <D.Proc   ; get current process pointer
 
                     pshs      u,d,cc    ; save some registers
                     leau      ,s        ; point to a 'caller register stack'
-                    lbsr      L0C40     ; do a LDB 0,X in task B
+                    lbsr      FLdabxTarget ; do a LDB 0,X in task B
                     puls      u,d,cc    ; and now A ( R$A,U ) = the CC we want
 
                     ora       #IntMasks ; disable it's IRQ's
-                    lbsr      L0C28     ; save it back
-L0D5B               orcc      #IntMasks ; shut down IRQ's
+                    lbsr      FLdabxCarry ; save it back
+KrnShutDownInterrupts orcc      #IntMasks ; shut down IRQ's
                     ldx       <D.Proc   ; get current process pointer
                     tst       <D.QIRQ   ; was it a clock IRQ?
-                    lbne      L0DF7     ; if not, do a quick return
+                    lbne      FNprocJoin ; if not, do a quick return
 
                     lda       P$State,x ; get it's state
                     bita      #TimOut   ; is it timed out?
-                    bne       L0D7C     ; yes, wake it up
+                    bne       KrnTimeoutFlag ; yes, wake it up
 * Update active process queue
                     ldu       #(D.AProcQ-P$Queue) ; point to active process queue
                     ldb       #Suspend  ; get suspend flag
-L0D6A               ldu       P$Queue,u ; get a active process pointer
-                    beq       L0D78     ; branch if zero is set to L0D78
+KrnActiveProcess    ldu       P$Queue,u ; get a active process pointer
+                    beq       UseProcessStack ; branch if zero is set to UseProcessStack
                     bitb      P$State,u ; is it suspended?
-                    bne       L0D6A     ; yes, go to next one in chain
+                    bne       KrnActiveProcess ; yes, go to next one in chain
                     ldb       P$Prior,x ; get current process priority
                     cmpb      P$Prior,u ; do we bump this one?
-                    blo       L0D7C     ; branch if unsigned result is lower to L0D7C
+                    blo       KrnTimeoutFlag ; branch if unsigned result is lower to KrnTimeoutFlag
 
-L0D78               ldu       P$SP,x    ; load U from P$SP,x
-                    bra       L0DB9     ; branch unconditionally to L0DB9
+UseProcessStack          ldu       P$SP,x    ; load U from P$SP,x
+                    bra       FNprocCondemnedByDeadlySignal ; branch unconditionally to FNprocCondemnedByDeadlySignal
 
-L0D7C               anda      #^TimOut  ; mask A with #^TimOut
+KrnTimeoutFlag      anda      #^TimOut  ; mask A with #^TimOut
                     sta       P$State,x ; store A at P$State,x
 
-L0D80               equ       *         ; define assembler symbol L0D80
-L0D83               bsr       L0D11     ; activate next process
+KrnJoin             equ       *         ; define assembler symbol KrnJoin
+KrnActivateProcess  bsr       FAprocTarget ; activate next process
 
                     use       fnproc.asm ; include source file fnproc.asm
 
@@ -917,7 +917,7 @@ S.SysIRQ
                     bra       DoneIRQ   ; check for error and exit
 
 FastIRQ             jsr       [>D.SvcIRQ] ; (Normally routine in Clock calling D.Poll)
-DoneIRQ             bcc       L0E28     ; no error on IRQ, exit
+DoneIRQ             bcc       KrnReturn ; no error on IRQ, exit
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #IntMasks,0,s ; setup RTI to shut interrupts off again
                   ELSE
@@ -925,11 +925,11 @@ DoneIRQ             bcc       L0E28     ; no error on IRQ, exit
                     ora       #IntMasks ; merge #IntMasks into A
                     sta       ,s        ; store A at ,s
                   ENDC
-L0E28               rti                 ; return from interrupt
+KrnReturn           rti                 ; return from interrupt
 
 * return from a system call
-L0E29               clra                ; force System task # to 0 (non-GRDRV)
-L0E2B               ldx       <D.SysPrc ; get system process dsc. ptr
+KrnForceSystemTaskSystem clra                ; force System task # to 0 (non-GRDRV)
+KrnSystemProcessDescriptor ldx       <D.SysPrc ; get system process dsc. ptr
                     lbsr      TstImg    ; check image, and F$SetTsk (PRESERVES A)
                     orcc      #IntMasks ; shut interrupts off
                     sta       <D.SSTskN ; save task # for system state
@@ -948,7 +948,7 @@ Fst2                leas      ,u        ; stack ptr=U & return
                     rti                 ; return from interrupt
 
 * Switch to new process, X=Process descriptor pointer, U=Stack pointer
-L0E4C               equ       *         ; define assembler symbol L0E4C
+KrnJoin2            equ       *         ; define assembler symbol KrnJoin2
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch GIME shadow to user state
                     lda       <D.TINIT  ; load A from <D.TINIT
@@ -971,7 +971,7 @@ L0E4C               equ       *         ; define assembler symbol L0E4C
                     bne       MyRTI     ; no, we're doing a system-state rti
 
                   IFNE    H6309   ; begin conditional assembly for H6309
-                    ldf       #R$Size   ; e=0 from call to L0E8D before
+                    ldf       #R$Size   ; e=0 from call to KrnWeGoingBackSameTask before
                     ldu       #Where+SWIStack ; point to the stack
                     tfm       u+,y+     ; move the stack from top of memory to user memory
                   ELSE
@@ -987,7 +987,7 @@ MyRTI               rti                 ; return from IRQ
 
 * Execute routine in task 1 pointed to by U
 * comes from user requested SWI vectors
-L0E5E               equ       *         ; define assembler symbol L0E5E
+KrnJoin3            equ       *         ; define assembler symbol KrnJoin3
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; switch GIME shadow to user state
                     ldb       <D.TINIT  ; load B from <D.TINIT
@@ -1010,7 +1010,7 @@ L0E5E               equ       *         ; define assembler symbol L0E5E
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
 S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfdrv (task 1)
-                    bsr       L0E8D     ; copy over the DAT image
+                    bsr       KrnWeGoingBackSameTask ; copy over the DAT image
                   IFNE    H6309   ; begin conditional assembly for H6309
                     oim       #$01,<D.TINIT ; apply immediate bit operation #$01,<D.TINIT
                     lda       <D.TINIT  ; get copy of GIME Task side
@@ -1032,8 +1032,8 @@ S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfd
                     rti                 ; return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-L0E8D               cmpb      <D.Task1N ; are we going back to the same task
-                    beq       L0EA3     ; without the DAT image changing?
+KrnWeGoingBackSameTask cmpb      <D.Task1N ; are we going back to the same task
+                    beq       KrnReturn2 ; without the DAT image changing?
                     stb       <D.Task1N ; nope, save current task in map type 1
                   IFNE    mc09    ; begin conditional assembly for mc09
                     ldu       <D.TskIPt ; get task image pointer table
@@ -1046,15 +1046,15 @@ L0E8D               cmpb      <D.Task1N ; are we going back to the same task
 * Update 8 MMU mappings.
 * A = MMUADR value for 1st MMU register to update
 * U = address of DAT image to update into MMU
-L0E93               ldb       #8        ; number of MMU mappings to set
+KrnActualMMUBlock   ldb       #8        ; number of MMU mappings to set
                     pshs      b         ; squirrel it away
                     leau      1,u       ; point to actual MMU block for 1st mapping
 
-L0E9B               ldb       ,u++      ; get a bank, point to next bank
+KrnBank             ldb       ,u++      ; get a bank, point to next bank
                     std       >MMUADR   ; save it to MMU
                     inca                ; next mapsel value
                     dec       ,s        ; decrement ,s
-                    bne       L0E9B     ; no, keep going
+                    bne       KrnBank   ; no, keep going
                     leas      1,s       ; done. Tidy up the stack
                   ELSE
                     ldx       #DAT.Regs+8 ; get MMU start register for process's
@@ -1064,14 +1064,14 @@ L0E9B               ldb       ,u++      ; get a bank, point to next bank
 * Update 8 MMU mappings.
 * X = address of 1st DAT MMU register to update
 * U = address of DAT image to update into MMU
-L0E93               leau      1,u       ; point to actual MMU block
+KrnActualMMUBlock   leau      1,u       ; point to actual MMU block
                   IFNE    H6309   ; begin conditional assembly for H6309
                     lde       #4        ; get # banks/2 for task
                   ELSE
                     lda       #4        ; load A from #4
                     pshs      a         ; save a on the stack
                   ENDC
-L0E9B               lda       ,u++      ; get a bank
+KrnBank             lda       ,u++      ; get a bank
                     ldb       ,u++      ; and next one
                     std       ,x++      ; save it to MMU
                   IFNE    H6309   ; begin conditional assembly for H6309
@@ -1079,16 +1079,16 @@ L0E9B               lda       ,u++      ; get a bank
                   ELSE
                     dec       ,s        ; decrement ,s
                   ENDC
-                    bne       L0E9B     ; no, keep going
+                    bne       KrnBank   ; no, keep going
                   IFEQ    H6309   ; begin conditional assembly for H6309
                     leas      1,s       ; done. Tidy up the stack
                   ENDC
                   ENDC
-L0EA3               rts                 ; return
+KrnReturn2          rts                 ; return
 
 * Execute FIRQ vector (called from $FEF4)
 FIRQVCT             ldx       #D.FIRQ   ; get DP offset of vector
-                    bra       L0EB8     ; go execute it
+                    bra       KrnFasterClrXxxx ; go execute it
 
 * Execute IRQ vector (called from $FEF7)
 IRQVCT              orcc      #IntMasks ; disable IRQ's
@@ -1096,7 +1096,7 @@ IRQVCT              orcc      #IntMasks ; disable IRQ's
 
 * Execute interrupt vector, B=DP Vector offset
                   IFNE    mc09    ; begin conditional assembly for mc09
-L0EB8               lda       #$a0      ; [NAC HACK 2016Dec08] add equates..
+KrnFasterClrXxxx    lda       #$a0      ; [NAC HACK 2016Dec08] add equates..
                     sta       >MMUADR   ; force to System State (Task 0)
                     clra                ; clear A
                     tfr       a,dp      ; aSSUME: A=0 from earlier
@@ -1108,7 +1108,7 @@ MapT0               sta       >MMUADR   ; come here from elsewhere, too.
                     jmp       [,x]      ; execute it
                   ELSE
 * Execute interrupt vector, B=DP Vector offset
-L0EB8               clra                ; (faster than CLR >$xxxx)
+KrnFasterClrXxxx    clra                ; (faster than CLR >$xxxx)
                     sta       >DAT.Task ; force to Task 0 (system state)
                   IFNE    H6309   ; begin conditional assembly for H6309
                     tfr       0,dp      ; setup DP
@@ -1207,7 +1207,7 @@ Looper              lda       ,u+       ; load A from ,u+
                     bne       Looper    ; branch if zero is clear to Looper
                     puls      b         ; restore b from the stack
                   ENDC
-                    bra       L0EB8     ; and go from map type 1 to map type 0
+                    bra       KrnFasterClrXxxx ; and go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
 SWIVCT              ldx       #D.SWI    ; get DP offset of vector
@@ -1215,7 +1215,7 @@ SWIVCT              ldx       #D.SWI    ; get DP offset of vector
 
 * Execute NMI vector (called from $FEFD)
 NMIVCT              ldx       #D.NMI    ; get DP offset of vector
-                    bra       L0EB8     ; go execute it
+                    bra       KrnFasterClrXxxx ; go execute it
 
 * The end of the kernel module is here
                     emod
@@ -1244,17 +1244,17 @@ SWIStack
 * and get directed to here.  From here, the BRA takes CPU control to the
 * various handlers in the kernel.
                     bra       SWI3VCT   ; sWI3 vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       SWI2VCT   ; sWI2 vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       FIRQVCT   ; fIRQ vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       IRQVCT    ; iRQ vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       SWIVCT    ; sWI vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                     bra       NMIVCT    ; nMI vector comes here
-                    nop       ; no operation placeholder
+                    nop       ;         no operation placeholder
                   ENDC
 
 * The final byte (eg the NOP after bra NMIVCT) should be at offset $EFF

--- a/level2/modules/kernel/mc09krn.asm
+++ b/level2/modules/kernel/mc09krn.asm
@@ -20,84 +20,84 @@
 * F$SRqMem now properly scans the DAT images of the system to update
 * the D.SysMem map.
 
-               nam       krn
-               ttl       NitrOS-9 Level 2 Kernel
+                    nam       krn
+                    ttl       NitrOS-9 Level 2 Kernel
 
-               ifp1      
-               use       defsfile
-               endc      
+                  ifp1
+                    use       defsfile  ; include source file defsfile
+                  ENDC
 
 * defines for customizations
-Revision       set       9                   module revision
-Edition        set       19                  module Edition
-Where          equ       $F000               absolute address of where Kernel starts in memory
+Revision            set       9         ; module revision
+Edition             set       19        ; module Edition
+Where               equ       $F000     ; absolute address of where Kernel starts in memory
 
-               mod       eom,MName,Systm,ReEnt+Revision,entry,0
+                    mod       eom,MName,Systm,ReEnt+Revision,entry,0 ; define OS-9 module header
 
-MName          fcs       /Krn/
-               fcb       Edition
+MName               fcs       /Krn/
+                    fcb       Edition   ; define byte value(s) Edition
 
 
 
 * Might as well have this here as just past the end of Kernel...
-DisTable                 
-               fdb       L0CD2+Where         D.Clock absolute address at the start
-               fdb       XSWI3+Where         D.XSWI3
-               fdb       XSWI2+Where         D.XSWI2
-               fdb       D.Crash             D.XFIRQ crash on an FIRQ
-               fdb       XIRQ+Where          D.XIRQ
-               fdb       XSWI+Where          D.XSWI
-               fdb       D.Crash             D.XNMI crash on an NMI
-               fdb       $0055               D.ErrRst ??? Not used as far as I can tell
-               fdb       Sys.Vec+Where       Initial Kernel system call vector
-DisSize        equ       *-DisTable
+DisTable
+                    fdb       L0CD2+Where ; d.Clock absolute address at the start
+                    fdb       XSWI3+Where ; d.XSWI3
+                    fdb       XSWI2+Where ; d.XSWI2
+                    fdb       D.Crash   ; d.XFIRQ crash on an FIRQ
+                    fdb       XIRQ+Where ; d.XIRQ
+                    fdb       XSWI+Where ; d.XSWI
+                    fdb       D.Crash   ; d.XNMI crash on an NMI
+                    fdb       $0055     ; d.ErrRst ??? Not used as far as I can tell
+                    fdb       Sys.Vec+Where ; initial Kernel system call vector
+DisSize             equ       *-DisTable ; define assembler symbol DisSize
 * ^
 * Code using 'SubSiz', below, assumes that SubStrt follows on directly after
 * the end of DisTable. Therefore, DO NOT ADD ADD ANYTHING BETWEEN THESE 2 LABELS
 * v
-LowSub         equ       $0160               start of low memory subroutines
-SubStrt        equ       *
+LowSub              equ       $0160     ; start of low memory subroutines
+SubStrt             equ       *         ; define assembler symbol SubStrt
 * D.Flip0 - switch to system task 0
-R.Flip0        equ       *
-               ifne      H6309
-               aim       #$FE,<D.TINIT       map type 0
-               lde       <D.TINIT            another 2 bytes saved if GRFDRV does: tfr cc,e
-               ste       >DAT.Task           and we can use A here, instead of E
-               else      
-               pshs      a
-               lda       <D.TINIT            Get value from shadow
-               ifne      mc09
-               anda      #$BF                force TR=0
-               sta       <D.TINIT            Update shadow
-               sta       >MMUADR             Update MMU
-               else      
-               anda      #$FE                force TR=0
-               sta       <D.TINIT
-               sta       >DAT.Task
-               endc      
-               puls      a
-               endc      
-               clr       <D.SSTskN
-               tfr       x,s
-               tfr       a,cc
-               rts       
-SubSiz         equ       *-SubStrt
+R.Flip0             equ       *         ; define assembler symbol R.Flip0
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #$FE,<D.TINIT ; map type 0
+                    lde       <D.TINIT  ; another 2 bytes saved if GRFDRV does: tfr cc,e
+                    ste       >DAT.Task ; and we can use A here, instead of E
+                  ELSE
+                    pshs      a         ; save a on the stack
+                    lda       <D.TINIT  ; get value from shadow
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    anda      #$BF      ; force TR=0
+                    sta       <D.TINIT  ; update shadow
+                    sta       >MMUADR   ; update MMU
+                  ELSE
+                    anda      #$FE      ; force TR=0
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                    sta       >DAT.Task ; store A at >DAT.Task
+                  ENDC
+                    puls      a         ; restore a from the stack
+                  ENDC
+                    clr       <D.SSTskN ; clear <D.SSTskN
+                    tfr       x,s       ; transfer register value x,s
+                    tfr       a,cc      ; transfer register value a,cc
+                    rts                 ; return to caller
+SubSiz              equ       *-SubStrt ; define assembler symbol SubSiz
 * ^
 * Code around L0065, below, assumes that Vectors follows on directly after
 * the end of R.Flip0. Therefore, DO NOT ADD ADD ANYTHING BETWEEN THESE 2 LABELS
 * v
 * Interrupt service routine
-Vectors        jmp       [<-(D.SWI3-D.XSWI3),x] (-$10) (Jmp to 2ndary vector)
+Vectors             jmp       [<-(D.SWI3-D.XSWI3),x] ; (-$10) (Jmp to 2ndary vector)
 
-               ifne      mc09
-CPUVect        fdb       SWI3VCT+Where       SWI3  at $FFF2
-               fdb       SWI2VCT+Where       SWI2  at $FFF4
-               fdb       FIRQVCT+Where       FIRQ  at $FFF6
-               fdb       IRQVCT+Where        IRQ   at $FFF8
-               fdb       SWIVCT+Where        SWI   at $FFFA
-               fdb       NMIVCT+Where        NMI   at $FFFC
-               fdb       $0000+Where         RESET at $FFFE
-               endc      
+                  IFNE    mc09    ; begin conditional assembly for mc09
+CPUVect             fdb       SWI3VCT+Where ; sWI3  at $FFF2
+                    fdb       SWI2VCT+Where ; sWI2  at $FFF4
+                    fdb       FIRQVCT+Where ; fIRQ  at $FFF6
+                    fdb       IRQVCT+Where ; iRQ   at $FFF8
+                    fdb       SWIVCT+Where ; sWI   at $FFFA
+                    fdb       NMIVCT+Where ; nMI   at $FFFC
+                    fdb       $0000+Where ; rESET at $FFFE
+                  ENDC
 
 * [NAC HACK 2016Dec07] to do a real reset on Multicomp09 need first to
 * disable the MMU and re-enable the ROM. Maybe implement a little blob
@@ -105,30 +105,30 @@ CPUVect        fdb       SWI3VCT+Where       SWI3  at $FFF2
 
 * Initialize the system block (the lowest 8Kbytes of memory)
 * rel.asm has cleared the DP already, so start at address $100.
-entry          equ       *
-               ifne      H6309
-               ldq       #$01001f00          start address to clear & # bytes to clear
-               leay      <entry+2,pc         point to a 0
-               tfm       y,d+
-               std       <D.CCStk            set pointer to top of global memory to $2000
-               lda       #$01                set task user table to $0100
-               else      
-               ldx       #$100               start address
-               ldy       #$2000-$100         bytes to clear
-               clra      
-               clrb      
-L001C          std       ,x++                clear it 16-bits at a time
-               leay      -2,y
-               bne       L001C
-               stx       <D.CCStk            Set pointer to top of global memory to $2000
-               inca                          D = $0100
-               endc      
+entry               equ       *         ; define assembler symbol entry
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$01001f00 ; start address to clear & # bytes to clear
+                    leay      <entry+2,pc ; point to a 0
+                    tfm       y,d+      ; transfer memory block using y,d+
+                    std       <D.CCStk  ; set pointer to top of global memory to $2000
+                    lda       #$01      ; set task user table to $0100
+                  ELSE
+                    ldx       #$100     ; start address
+                    ldy       #$2000-$100 ; bytes to clear
+                    clra                ; clear A
+                    clrb                ; clear B
+L001C               std       ,x++      ; clear it 16-bits at a time
+                    leay      -2,y      ; compute -2,y into Y
+                    bne       L001C     ; branch if zero is clear to L001C
+                    stx       <D.CCStk  ; set pointer to top of global memory to $2000
+                    inca                ; D = $0100
+                  ENDC
 
 * Set up system variables in DP
-               std       <D.Tasks            set Task Structure pointer to $0100
-               addb      #$20
-               std       <D.TskIPt           set Task image table pointer to $0120
-               clrb      
+                    std       <D.Tasks  ; set Task Structure pointer to $0100
+                    addb      #$20      ; add #$20 to B
+                    std       <D.TskIPt ; set Task image table pointer to $0120
+                    clrb                ; clear B
 
 ********************************************************************
 * The memory block map is a data structure that is used to manage
@@ -146,152 +146,152 @@ L001C          std       ,x++                clear it 16-bits at a time
 * below, after the memory sizing.
 * See "Level 2 flags" in os9.d for other byte values.
 
-               inca                          set memory block map start pointer
-               std       <D.BlkMap           to $0200
+                    inca                ; set memory block map start pointer
+                    std       <D.BlkMap ; to $0200
 
-               inca                          set system service dispatch table pointer
-               std       <D.SysDis           to 0x300
-               inca                          set user dispatch table pointer to $0400
-               std       <D.UsrDis
-               inca                          set process descriptor block pointer to $0500
-               std       <D.PrcDBT
-               inca                          set system process descriptor pointer to $0600
-               std       <D.SysPrc
-               std       <D.Proc             set user process descriptor pointer to $0600
-               adda      #$02                set stack pointer to $0800
-               tfr       d,s
-               inca                          set system stack base pointer to $0900
-               std       <D.SysStk
-               std       <D.SysMem           set system memory map ptr $0900
-               inca                          set module directory start ptr to $0a00
-               std       <D.ModDir
-               std       <D.ModEnd           set module directory end ptr to $0a00
-               adda      #$06                set secondary module directory start to $1000
-               std       <D.ModDir+2
-               std       <D.ModDAT           set module directory DAT pointer to $1000
-               std       <D.CCMem            set pointer to beginning of global memory to $1000
+                    inca                ; set system service dispatch table pointer
+                    std       <D.SysDis ; to 0x300
+                    inca                ; set user dispatch table pointer to $0400
+                    std       <D.UsrDis ; store D at <D.UsrDis
+                    inca                ; set process descriptor block pointer to $0500
+                    std       <D.PrcDBT ; store D at <D.PrcDBT
+                    inca                ; set system process descriptor pointer to $0600
+                    std       <D.SysPrc ; store D at <D.SysPrc
+                    std       <D.Proc   ; set user process descriptor pointer to $0600
+                    adda      #$02      ; set stack pointer to $0800
+                    tfr       d,s       ; transfer register value d,s
+                    inca                ; set system stack base pointer to $0900
+                    std       <D.SysStk ; store D at <D.SysStk
+                    std       <D.SysMem ; set system memory map ptr $0900
+                    inca                ; set module directory start ptr to $0a00
+                    std       <D.ModDir ; store D at <D.ModDir
+                    std       <D.ModEnd ; set module directory end ptr to $0a00
+                    adda      #$06      ; set secondary module directory start to $1000
+                    std       <D.ModDir+2 ; store D at <D.ModDir+2
+                    std       <D.ModDAT ; set module directory DAT pointer to $1000
+                    std       <D.CCMem  ; set pointer to beginning of global memory to $1000
 * In following line, CRC=ON if it is STA <D.CRC, CRC=OFF if it is a STB <D.CRC
-               stb       <D.CRC              set CRC checking flag to off
+                    stb       <D.CRC    ; set CRC checking flag to off
 
 * Initialize interrupt vector tables in DP by moving pointer data down from DisTable
 
-               ifne      mc09
+                  IFNE    mc09    ; begin conditional assembly for mc09
 * Brett's ccbkrn identified this as a bug in the original code..
 * which has not been fixed. Should be easy to demonstrate which is
 * correct..
-               leay      DisTable,pcr        point to table of absolute vector addresses
-               else      
-               leay      <DisTable,pcr       point to table of absolute vector addresses
-               endc      
-               ldx       #D.Clock            where to put it in memory
-               ifne      H6309
-               ldf       #DisSize            size of the table - E=0 from TFM, above
-               tfm       y+,x+               move it over
-               else      
-               ldb       #DisSize
-l@                       
-               lda       ,y+                 load a byte from source
-               sta       ,x+                 store a byte to dest
-               decb                          bump counter
-               bne       l@                  loop if we're not done
-               endc      
+                    leay      DisTable,pcr ; point to table of absolute vector addresses
+                  ELSE
+                    leay      <DisTable,pcr ; point to table of absolute vector addresses
+                  ENDC
+                    ldx       #D.Clock  ; where to put it in memory
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #DisSize  ; size of the table - E=0 from TFM, above
+                    tfm       y+,x+     ; move it over
+                  ELSE
+                    ldb       #DisSize  ; load B from #DisSize
+l@
+                    lda       ,y+       ; load a byte from source
+                    sta       ,x+       ; store a byte to dest
+                    decb                ; bump counter
+                    bne       l@        ; loop if we're not done
+                  ENDC
 
 * Initialize D.Flip0 routine in low memory by copying lump of code down from R.Flip0.
 * ASSUME: Y left pointing to R.Flip0 by previous copy loop.
 
-               ldu       #LowSub             somewhere in block 0 that's never modified
-               stu       <D.Flip0            switch to system task 0
-               ifne      H6309
-               ldf       #SubSiz             size of it
-               tfm       y+,u+               copy it over
-               else      
-               ldb       #SubSiz
-Loop2          lda       ,y+                 load a byte from source
-               sta       ,u+                 and save to destination
-               decb                          bump counter
-               bne       Loop2               loop if not done
-               endc      
+                    ldu       #LowSub   ; somewhere in block 0 that's never modified
+                    stu       <D.Flip0  ; switch to system task 0
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #SubSiz   ; size of it
+                    tfm       y+,u+     ; copy it over
+                  ELSE
+                    ldb       #SubSiz   ; load B from #SubSiz
+Loop2               lda       ,y+       ; load a byte from source
+                    sta       ,u+       ; and save to destination
+                    decb                ; bump counter
+                    bne       Loop2     ; loop if not done
+                  ENDC
 
 * Initialize secondary interrupt vectors to all point to Vectors for now
 * ASSUME: Y left pointing to Vectors by previous copy loop
-               tfr       y,u                 move the pointer to a faster register
-L0065          stu       ,x++                Set all IRQ vectors to go to Vectors for now
-               cmpx      #D.NMI
-               bls       L0065
+                    tfr       y,u       ; move the pointer to a faster register
+L0065               stu       ,x++      ; set all IRQ vectors to go to Vectors for now
+                    cmpx      #D.NMI    ; compare X with #D.NMI
+                    bls       L0065     ; branch if unsigned result is lower or same to L0065
 
-               ifne      mc09
+                  IFNE    mc09    ; begin conditional assembly for mc09
 * Initialize CPU vectors
-               leay      CPUVect,pcr         Data source
-               ldx       #$FFF2              Data destination
-               ldb       #14                 7 vectors to copy
-L0067          lda       ,y+
-               sta       ,x+
-               decb      
-               bne       L0067
-               endc      
+                    leay      CPUVect,pcr ; data source
+                    ldx       #$FFF2    ; data destination
+                    ldb       #14       ; 7 vectors to copy
+L0067               lda       ,y+       ; load A from ,y+
+                    sta       ,x+       ; store A at ,x+
+                    decb                ; decrement B
+                    bne       L0067     ; branch if zero is clear to L0067
+                  ENDC
 
 * Initialize user interupt vectors
-               ldx       <D.XSWI2            Get SWI2 (os9 command) service routine pointer
-               stx       <D.UsrSvc           Save it as user service routine pointer
-               ldx       <D.XIRQ             Get IRQ service routine pointer
-               stx       <D.UsrIRQ           Save it as user IRQ routine pointer
+                    ldx       <D.XSWI2  ; get SWI2 (os9 command) service routine pointer
+                    stx       <D.UsrSvc ; save it as user service routine pointer
+                    ldx       <D.XIRQ   ; get IRQ service routine pointer
+                    stx       <D.UsrIRQ ; save it as user IRQ routine pointer
 
-               leax      >SysCall,pc         Setup System service routine entry vector
-               stx       <D.SysSvc
-               stx       <D.XSWI2
+                    leax      >SysCall,pc ; setup System service routine entry vector
+                    stx       <D.SysSvc ; store X at <D.SysSvc
+                    stx       <D.XSWI2  ; store X at <D.XSWI2
 
-               leax      >S.SysIRQ,pc        Setup system IRQ service vector
-               stx       <D.SysIRQ
-               stx       <D.XIRQ
+                    leax      >S.SysIRQ,pc ; setup system IRQ service vector
+                    stx       <D.SysIRQ ; store X at <D.SysIRQ
+                    stx       <D.XIRQ   ; store X at <D.XIRQ
 
-               leax      >S.SvcIRQ,pc        Setup in system IRQ service vector
-               stx       <D.SvcIRQ
-               leax      >S.Poll,pc          Setup interrupt polling vector
-               stx       <D.Poll             ORCC #$01;RTS
-               leax      >S.AltIRQ,pc        Setup alternate IRQ vector: pts to an RTS
-               stx       <D.AltIRQ
+                    leax      >S.SvcIRQ,pc ; setup in system IRQ service vector
+                    stx       <D.SvcIRQ ; store X at <D.SvcIRQ
+                    leax      >S.Poll,pc ; setup interrupt polling vector
+                    stx       <D.Poll   ; oRCC #$01;RTS
+                    leax      >S.AltIRQ,pc ; setup alternate IRQ vector: pts to an RTS
+                    stx       <D.AltIRQ ; store X at <D.AltIRQ
 
-               lda       #'K                 debug: signal that we are in Kernel
-               jsr       <D.BtBug
+                    lda       #'K       ; debug: signal that we are in Kernel
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
 
-               leax      >S.Flip1,pc         Setup change to task 1 vector
-               stx       <D.Flip1
+                    leax      >S.Flip1,pc ; setup change to task 1 vector
+                    stx       <D.Flip1  ; store X at <D.Flip1
 
 * Setup System calls
-               leay      >SysCalls,pc        load y with address of table, below
-               lbsr      SysSvc              copy table below into dispatch table
+                    leay      >SysCalls,pc ; load y with address of table, below
+                    lbsr      SysSvc    ; copy table below into dispatch table
 
 * Initialize system process descriptor
-               ldu       <D.PrcDBT           get process table pointer
-               ldx       <D.SysPrc           get system process pointer
+                    ldu       <D.PrcDBT ; get process table pointer
+                    ldx       <D.SysPrc ; get system process pointer
 
 * These overlap because it is quicker than trying to strip hi byte from X
-               stx       ,u                  save it as first process in table
-               stx       1,u                 save it as the second as well
-               ifne      H6309
-               oim       #$01,P$ID,x         Set process ID to 1 (inited to 0)
-               oim       #SysState,P$State,x Set to system state (inited to 0)
-               else      
-               ldd       #$01*256+SysState
-               sta       P$ID,x              set PID to 1
-               stb       P$State,x           set state to system (*NOT* zero )
-               endc      
-               clra                          set System task as task #0
-               sta       <D.SysTsk
-               sta       P$Task,x
-               coma                          Setup its priority & age ($FF)
-               sta       P$Prior,x
-               sta       P$Age,x
-               leax      <P$DATImg,x         point to DAT image
-               stx       <D.SysDAT           save it as a pointer in DP
+                    stx       ,u        ; save it as first process in table
+                    stx       1,u       ; save it as the second as well
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,P$ID,x ; set process ID to 1 (inited to 0)
+                    oim       #SysState,P$State,x ; set to system state (inited to 0)
+                  ELSE
+                    ldd       #$01*256+SysState ; load D from #$01*256+SysState
+                    sta       P$ID,x    ; set PID to 1
+                    stb       P$State,x ; set state to system (*NOT* zero )
+                  ENDC
+                    clra                ; set System task as task #0
+                    sta       <D.SysTsk ; store A at <D.SysTsk
+                    sta       P$Task,x  ; store A at P$Task,x
+                    coma                ; setup its priority & age ($FF)
+                    sta       P$Prior,x ; store A at P$Prior,x
+                    sta       P$Age,x   ; store A at P$Age,x
+                    leax      <P$DATImg,x ; point to DAT image
+                    stx       <D.SysDAT ; save it as a pointer in DP
 * actually, since block 0 is tfm'd to be zero, we can skip the next 2 lines
-               ifne      H6309
-               clrd      
-               else      
-               clra      
-               clrb      
-               endc      
-               std       ,x++                initialize 1st block to 0 (for this DP)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    clrd                ; clear D
+                  ELSE
+                    clra                ; clear A
+                    clrb                ; clear B
+                  ENDC
+                    std       ,x++      ; initialize 1st block to 0 (for this DP)
 
 ********************************************************************
 * The DAT image is a data structure that is used to indicate which
@@ -299,18 +299,18 @@ L0067          lda       ,y+
 
 * [NAC HACK 2016Dec06] future: I should be able to make this 7 if not 8..
 * DAT.BlCt-ROMCount-RAMCount = 8 - 1 - 1 = 6
-               lda       #$06                initialize the rest of the blocks to be free
-               ldu       #DAT.Free
-L00EF          stu       ,x++                store free "flag"
-               deca                          bump counter
-               bne       L00EF               loop if not done
+                    lda       #$06      ; initialize the rest of the blocks to be free
+                    ldu       #DAT.Free ; load U from #DAT.Free
+L00EF               stu       ,x++      ; store free "flag"
+                    deca                ; bump counter
+                    bne       L00EF     ; loop if not done
 
-               ldu       #KrnBlk             Block where the kernel will live
-               stu       ,x
+                    ldu       #KrnBlk   ; block where the kernel will live
+                    stu       ,x        ; store U at ,x
 
-               ldx       <D.Tasks            Point to task user table
-               inc       ,x                  mark first 2 in use (system & GrfDrv)
-               inc       1,x
+                    ldx       <D.Tasks  ; point to task user table
+                    inc       ,x        ; mark first 2 in use (system & GrfDrv)
+                    inc       1,x       ; increment 1,x
 
 ********************************************************************
 * The system memory map is a data structure that is used to manage
@@ -324,59 +324,59 @@ L00EF          stu       ,x++                store free "flag"
 
 * Update the system memory map to reserve the area used for
 * global memory.
-               ldx       <D.SysMem           Get system memory map pointer
-               ldb       <D.CCStk            Get MSB of top of CC memory
+                    ldx       <D.SysMem ; get system memory map pointer
+                    ldb       <D.CCStk  ; get MSB of top of CC memory
 * X indexes the system memory map.
 * B represents the number of 256-byte pages available.
 * Walk through the map changing the corresponding elements
 * from 0 (the initialisation value) to 1 (indicating 'used'). Higher
 * entries in the map remain as 0 (indicating 'unused').
-L0104          inc       ,x+                 Mark it as used
-               decb                          Done?
-               bne       L0104               No, go back till done
+L0104               inc       ,x+       ; mark it as used
+                    decb                ; done?
+                    bne       L0104     ; no, go back till done
 
 ********************************************************************
 * Deduce how many 8Kbyte blocks of physical memory are available and
 * update the memory block map end pointer (D.BlkMap+2) accordingly
-               ldx       <D.BlkMap           get ptr to 8k block map
-               inc       <KrnBlk,x           mark block holding kernel as used
-               ifne      mc09
-               inc       <$00,x              mark block $00 as used (global memory)
+                    ldx       <D.BlkMap ; get ptr to 8k block map
+                    inc       <KrnBlk,x ; mark block holding kernel as used
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    inc       <$00,x    ; mark block $00 as used (global memory)
 * For mc09 memory size is 512Kbyte or 1MByte. For now, hard-wire
 * the memory size to 512Kbyte.
-               ldd       #$0240
-               else      
+                    ldd       #$0240    ; load D from #$0240
+                  ELSE
 * This memory sizing routine uses location at X (D.BlkMap) as
 * a scratch location. At exit, it leaves this location at 1 which
 * has the (until now) undocumented side-effect of marking block 0
 * as used. It is essential that this is done because that block
 * does need to be reserved; it's used for global memory.
-               ifne      H6309
-               ldq       #$00080100          e=Marker, D=Block # to check
-L0111          asld                          get next block #
-               stb       >DAT.Regs+5         Map block into block 6 of my task
-               ste       >-$6000,x           save marker to that block
-               cmpe      ,x                  did it ghost to block 0?
-               bne       L0111               No, keep going till ghost is found
-               stb       <D.MemSz            Save # 8k mem blocks that exist
-               addr      x,d                 add number of blocks to block map start
-               else      
-               ldd       #$0008
-L0111          aslb      
-               rola      
-               stb       >DAT.Regs+5
-               pshs      a
-               lda       #$01
-               sta       >-$6000,x
-               cmpa      ,x
-               puls      a
-               bne       L0111
-               stb       <D.MemSz
-               pshs      x
-               addd      ,s++
-               endc      
-               endc      
-               std       <D.BlkMap+2         save memory block map end pointer
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldq       #$00080100 ; e=Marker, D=Block # to check
+L0111               asld                ; get next block #
+                    stb       >DAT.Regs+5 ; map block into block 6 of my task
+                    ste       >-$6000,x ; save marker to that block
+                    cmpe      ,x        ; did it ghost to block 0?
+                    bne       L0111     ; no, keep going till ghost is found
+                    stb       <D.MemSz  ; save # 8k mem blocks that exist
+                    addr      x,d       ; add number of blocks to block map start
+                  ELSE
+                    ldd       #$0008    ; load D from #$0008
+L0111               aslb                ; update processor state
+                    rola                ; shift or rotate and update condition codes
+                    stb       >DAT.Regs+5 ; store B at >DAT.Regs+5
+                    pshs      a         ; save a on the stack
+                    lda       #$01      ; load A from #$01
+                    sta       >-$6000,x ; store A at >-$6000,x
+                    cmpa      ,x        ; compare A with ,x
+                    puls      a         ; restore a from the stack
+                    bne       L0111     ; branch if zero is clear to L0111
+                    stb       <D.MemSz  ; store B at <D.MemSz
+                    pshs      x         ; save x on the stack
+                    addd      ,s++      ; add ,s++ to D
+                  ENDC
+                  ENDC
+                    std       <D.BlkMap+2 ; save memory block map end pointer
 
 ********************************************************************
 * Initial reservation of blocks in the memory block map. Code above
@@ -389,780 +389,780 @@ L0111          aslb
 * $0240 - 512k  ( 64, 8KByte blocks)
 * $0280 - 1024k (128, 8KByte blocks)
 * $0300 - 2048k (256, 8KByte blocks)
-               bitb      #%00110000          block above 128K-256K?
-               beq       L0170               yes, no need to mark block map
-               tstb                          2 meg?
-               beq       L0170               yes, skip this
+                    bitb      #%00110000 ; block above 128K-256K?
+                    beq       L0170     ; yes, no need to mark block map
+                    tstb                ; 2 meg?
+                    beq       L0170     ; yes, skip this
 * Mark blocks from 128k-256K to block $3F as NOT RAM
-               abx                           add maximum block number to block map start
-               leax      -1,x                Skip good blocks that are RAM
-               lda       #NotRAM             Not RAM flag
-               subb      #$3F                Calculate # blocks to mark as not RAM
-L0127          sta       ,x+                 Mark them all
-               decb      
-               bne       L0127
+                    abx                 ; add maximum block number to block map start
+                    leax      -1,x      ; skip good blocks that are RAM
+                    lda       #NotRAM   ; not RAM flag
+                    subb      #$3F      ; calculate # blocks to mark as not RAM
+L0127               sta       ,x+       ; mark them all
+                    decb                ; decrement B
+                    bne       L0127     ; branch if zero is clear to L0127
 
 * ASSUME: however we got here, B=0
-L0170          ldx       #Bt.Start           start address of the boot track in memory
-               lda       #18                 size of the boot track is $1800
+L0170               ldx       #Bt.Start ; start address of the boot track in memory
+                    lda       #18       ; size of the boot track is $1800
 
 * Verify the modules in the boot track and update/build a module index
-               lbsr      I.VBlock
-               bsr       L01D2               go mark system map
+                    lbsr      I.VBlock  ; call local routine I.VBlock
+                    bsr       L01D2     ; go mark system map
 
 * See if init module is in memory already
-L01B0          leax      <init,pc            point to 'Init' module name
-               bsr       link                try & link it
-               bcc       L01BF               no error, go on
-L01B8          os9       F$Boot              error linking init, try & load boot file
-               bcc       L01B0               got it, try init again
-               bra       L01CE               error, re-booting do D.Crash
+L01B0               leax      <init,pc  ; point to 'Init' module name
+                    bsr       link      ; try & link it
+                    bcc       L01BF     ; no error, go on
+L01B8               os9       F$Boot    ; error linking init, try & load boot file
+                    bcc       L01B0     ; got it, try init again
+                    bra       L01CE     ; error, re-booting do D.Crash
 
 * So far, so good. Save pointer to init module and execute krnp2
-L01BF          stu       <D.Init             Save init module pointer
-               lda       Feature1,u          Get feature byte #1 from init module
-               bita      #CRCOn              CRC feature on?
-               beq       ShowI               if not, continue
-               inc       <D.CRC              else inc. CRC flag
+L01BF               stu       <D.Init   ; save init module pointer
+                    lda       Feature1,u ; get feature byte #1 from init module
+                    bita      #CRCOn    ; cRC feature on?
+                    beq       ShowI     ; if not, continue
+                    inc       <D.CRC    ; else inc. CRC flag
 
-ShowI          lda       #'i                 debug: signal that we found the init module
-               jsr       <D.BtBug
+ShowI               lda       #'i       ; debug: signal that we found the init module
+                    jsr       <D.BtBug  ; call routine at <D.BtBug
 
-L01C1          leax      <krnp2,pc           Point to its name
-               bsr       link                Try to link it
-               bcc       L01D0               It worked, execute it
-               os9       F$Boot              It doesn't exist try re-booting
-               bcc       L01C1               No error's, let's try to link it again
-L01CE          jmp       <D.Crash            obviously can't do it, crash machine
-L01D0          jmp       ,y                  execute krnp2
+L01C1               leax      <krnp2,pc ; point to its name
+                    bsr       link      ; try to link it
+                    bcc       L01D0     ; it worked, execute it
+                    os9       F$Boot    ; it doesn't exist try re-booting
+                    bcc       L01C1     ; no error's, let's try to link it again
+L01CE               jmp       <D.Crash  ; obviously can't do it, crash machine
+L01D0               jmp       ,y        ; execute krnp2
 
 * Update the system memory map to reserve the area used by the kernel
-L01D2          ldx       <D.SysMem           Get system memory map pointer
-               ldd       #NotRAM*256+(Bt.Start/256) B = MSB of start of the boot
-               abx                           point to Bt.Start - start of boot track
-               comb                          we have $FF-$ED pages to mark as inUse
-               sta       b,x                 Mark I/O as not RAM
-L01DF          lda       #RAMinUse           get inUse flag
-L01E1          sta       ,x+                 mark this page
-               decb                          done?
-               bne       L01E1               no, keep going
-               ldx       <D.BlkMap           get pointer to start of block map
-               sta       <KrnBlk,x           mark kernel block as RAMinUse, instead of ModInBlk
-S.AltIRQ       rts                           return
+L01D2               ldx       <D.SysMem ; get system memory map pointer
+                    ldd       #NotRAM*256+(Bt.Start/256) ; B = MSB of start of the boot
+                    abx                 ; point to Bt.Start - start of boot track
+                    comb                ; we have $FF-$ED pages to mark as inUse
+                    sta       b,x       ; mark I/O as not RAM
+L01DF               lda       #RAMinUse ; get inUse flag
+L01E1               sta       ,x+       ; mark this page
+                    decb                ; done?
+                    bne       L01E1     ; no, keep going
+                    ldx       <D.BlkMap ; get pointer to start of block map
+                    sta       <KrnBlk,x ; mark kernel block as RAMinUse, instead of ModInBlk
+S.AltIRQ            rts                 ; return
 
 * Link module pointed to by X
-link           lda       #Systm              Attempt to link system module
-               os9       F$Link
-               rts       
+link                lda       #Systm    ; attempt to link system module
+                    os9       F$Link    ; call OS-9 service F$Link
+                    rts                 ; return to caller
 
-init           fcs       'Init'
-krnp2          fcs       'krnp2'
+init                fcs       'Init'
+krnp2               fcs       'krnp2'
 
 * Service vector call pointers
-SysCalls       fcb       F$Link
-               fdb       FLink-*-2
-               fcb       F$PrsNam
-               fdb       FPrsNam-*-2
-               fcb       F$CmpNam
-               fdb       FCmpNam-*-2
-               fcb       F$CmpNam+SysState
-               fdb       FSCmpNam-*-2
-               fcb       F$CRC
-               fdb       FCRC-*-2
-               fcb       F$SRqMem+SysState
-               fdb       FSRqMem-*-2
-               fcb       F$SRtMem+SysState
-               fdb       FSRtMem-*-2
-               fcb       F$AProc+SysState
-               fdb       FAProc-*-2
-               fcb       F$NProc+SysState
-               fdb       FNProc-*-2
-               fcb       F$VModul+SysState
-               fdb       FVModul-*-2
-               fcb       F$SSvc+SysState
-               fdb       FSSvc-*-2
-               fcb       F$SLink+SysState
-               fdb       FSLink-*-2
-               fcb       F$Boot+SysState
-               fdb       FBoot-*-2
-               fcb       F$BtMem+SysState
-               fdb       FSRqMem-*-2
-               ifne      H6309
-               fcb       F$CpyMem
-               fdb       FCpyMem-*-2
-               endc      
-               fcb       F$Move+SysState
-               fdb       FMove-*-2
-               fcb       F$AllImg+SysState
-               fdb       FAllImg-*-2
-               fcb       F$SetImg+SysState
-               fdb       FFreeLB-*-2
-               fcb       F$FreeLB+SysState
-               fdb       FSFreeLB-*-2
-               fcb       F$FreeHB+SysState
-               fdb       FFreeHB-*-2
-               fcb       F$AllTsk+SysState
-               fdb       FAllTsk-*-2
-               fcb       F$DelTsk+SysState
-               fdb       FDelTsk-*-2
-               fcb       F$SetTsk+SysState
-               fdb       FSetTsk-*-2
-               fcb       F$ResTsk+SysState
-               fdb       FResTsk-*-2
-               fcb       F$RelTsk+SysState
-               fdb       FRelTsk-*-2
-               fcb       F$DATLog+SysState
-               fdb       FDATLog-*-2
-               fcb       F$LDAXY+SysState
-               fdb       FLDAXY-*-2
-               fcb       F$LDDDXY+SysState
-               fdb       FLDDDXY-*-2
-               fcb       F$LDABX+SysState
-               fdb       FLDABX-*-2
-               fcb       F$STABX+SysState
-               fdb       FSTABX-*-2
-               fcb       F$ELink+SysState
-               fdb       FELink-*-2
-               fcb       F$FModul+SysState
-               fdb       FFModul-*-2
-               fcb       F$VBlock+SysState
-               fdb       FVBlock-*-2
-               ifne      H6309
-               fcb       F$DelRAM
-               fdb       FDelRAM-*-2
-               endc      
-               fcb       $80
+SysCalls            fcb       F$Link    ; define byte value(s) F$Link
+                    fdb       FLink-*-2 ; define word value(s) FLink-*-2
+                    fcb       F$PrsNam  ; define byte value(s) F$PrsNam
+                    fdb       FPrsNam-*-2 ; define word value(s) FPrsNam-*-2
+                    fcb       F$CmpNam  ; define byte value(s) F$CmpNam
+                    fdb       FCmpNam-*-2 ; define word value(s) FCmpNam-*-2
+                    fcb       F$CmpNam+SysState ; define byte value(s) F$CmpNam+SysState
+                    fdb       FSCmpNam-*-2 ; define word value(s) FSCmpNam-*-2
+                    fcb       F$CRC     ; define byte value(s) F$CRC
+                    fdb       FCRC-*-2  ; define word value(s) FCRC-*-2
+                    fcb       F$SRqMem+SysState ; define byte value(s) F$SRqMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                    fcb       F$SRtMem+SysState ; define byte value(s) F$SRtMem+SysState
+                    fdb       FSRtMem-*-2 ; define word value(s) FSRtMem-*-2
+                    fcb       F$AProc+SysState ; define byte value(s) F$AProc+SysState
+                    fdb       FAProc-*-2 ; define word value(s) FAProc-*-2
+                    fcb       F$NProc+SysState ; define byte value(s) F$NProc+SysState
+                    fdb       FNProc-*-2 ; define word value(s) FNProc-*-2
+                    fcb       F$VModul+SysState ; define byte value(s) F$VModul+SysState
+                    fdb       FVModul-*-2 ; define word value(s) FVModul-*-2
+                    fcb       F$SSvc+SysState ; define byte value(s) F$SSvc+SysState
+                    fdb       FSSvc-*-2 ; define word value(s) FSSvc-*-2
+                    fcb       F$SLink+SysState ; define byte value(s) F$SLink+SysState
+                    fdb       FSLink-*-2 ; define word value(s) FSLink-*-2
+                    fcb       F$Boot+SysState ; define byte value(s) F$Boot+SysState
+                    fdb       FBoot-*-2 ; define word value(s) FBoot-*-2
+                    fcb       F$BtMem+SysState ; define byte value(s) F$BtMem+SysState
+                    fdb       FSRqMem-*-2 ; define word value(s) FSRqMem-*-2
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    fcb       F$CpyMem  ; define byte value(s) F$CpyMem
+                    fdb       FCpyMem-*-2 ; define word value(s) FCpyMem-*-2
+                  ENDC
+                    fcb       F$Move+SysState ; define byte value(s) F$Move+SysState
+                    fdb       FMove-*-2 ; define word value(s) FMove-*-2
+                    fcb       F$AllImg+SysState ; define byte value(s) F$AllImg+SysState
+                    fdb       FAllImg-*-2 ; define word value(s) FAllImg-*-2
+                    fcb       F$SetImg+SysState ; define byte value(s) F$SetImg+SysState
+                    fdb       FFreeLB-*-2 ; define word value(s) FFreeLB-*-2
+                    fcb       F$FreeLB+SysState ; define byte value(s) F$FreeLB+SysState
+                    fdb       FSFreeLB-*-2 ; define word value(s) FSFreeLB-*-2
+                    fcb       F$FreeHB+SysState ; define byte value(s) F$FreeHB+SysState
+                    fdb       FFreeHB-*-2 ; define word value(s) FFreeHB-*-2
+                    fcb       F$AllTsk+SysState ; define byte value(s) F$AllTsk+SysState
+                    fdb       FAllTsk-*-2 ; define word value(s) FAllTsk-*-2
+                    fcb       F$DelTsk+SysState ; define byte value(s) F$DelTsk+SysState
+                    fdb       FDelTsk-*-2 ; define word value(s) FDelTsk-*-2
+                    fcb       F$SetTsk+SysState ; define byte value(s) F$SetTsk+SysState
+                    fdb       FSetTsk-*-2 ; define word value(s) FSetTsk-*-2
+                    fcb       F$ResTsk+SysState ; define byte value(s) F$ResTsk+SysState
+                    fdb       FResTsk-*-2 ; define word value(s) FResTsk-*-2
+                    fcb       F$RelTsk+SysState ; define byte value(s) F$RelTsk+SysState
+                    fdb       FRelTsk-*-2 ; define word value(s) FRelTsk-*-2
+                    fcb       F$DATLog+SysState ; define byte value(s) F$DATLog+SysState
+                    fdb       FDATLog-*-2 ; define word value(s) FDATLog-*-2
+                    fcb       F$LDAXY+SysState ; define byte value(s) F$LDAXY+SysState
+                    fdb       FLDAXY-*-2 ; define word value(s) FLDAXY-*-2
+                    fcb       F$LDDDXY+SysState ; define byte value(s) F$LDDDXY+SysState
+                    fdb       FLDDDXY-*-2 ; define word value(s) FLDDDXY-*-2
+                    fcb       F$LDABX+SysState ; define byte value(s) F$LDABX+SysState
+                    fdb       FLDABX-*-2 ; define word value(s) FLDABX-*-2
+                    fcb       F$STABX+SysState ; define byte value(s) F$STABX+SysState
+                    fdb       FSTABX-*-2 ; define word value(s) FSTABX-*-2
+                    fcb       F$ELink+SysState ; define byte value(s) F$ELink+SysState
+                    fdb       FELink-*-2 ; define word value(s) FELink-*-2
+                    fcb       F$FModul+SysState ; define byte value(s) F$FModul+SysState
+                    fdb       FFModul-*-2 ; define word value(s) FFModul-*-2
+                    fcb       F$VBlock+SysState ; define byte value(s) F$VBlock+SysState
+                    fdb       FVBlock-*-2 ; define word value(s) FVBlock-*-2
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    fcb       F$DelRAM  ; define byte value(s) F$DelRAM
+                    fdb       FDelRAM-*-2 ; define word value(s) FDelRAM-*-2
+                  ENDC
+                    fcb       $80       ; define byte value(s) $80
 
 * SWI3 vector entry
-XSWI3          lda       #P$SWI3             point to SWI3 vector
-               fcb       $8C                 skip 2 bytes
+XSWI3               lda       #P$SWI3   ; point to SWI3 vector
+                    fcb       $8C       ; skip 2 bytes
 
 * SWI vector entry
-XSWI           lda       #P$SWI              point to SWI vector
-               ldx       <D.Proc             get process pointer
-               ldu       a,x                 user defined SWI[x]?
-               beq       L028E               no, go get option byte
-GoUser         lbra      L0E5E               Yes, go call users's routine
+XSWI                lda       #P$SWI    ; point to SWI vector
+                    ldx       <D.Proc   ; get process pointer
+                    ldu       a,x       ; user defined SWI[x]?
+                    beq       L028E     ; no, go get option byte
+GoUser              lbra      L0E5E     ; yes, go call users's routine
 
 * SWI2 vector entry
-XSWI2          ldx       <D.Proc             get current process descriptor
-               ldu       P$SWI2,x            any SWI vector?
-               bne       GoUser              yes, go execute it
+XSWI2               ldx       <D.Proc   ; get current process descriptor
+                    ldu       P$SWI2,x  ; any SWI vector?
+                    bne       GoUser    ; yes, go execute it
 
 * Process software interupts from a user state
 * Entry: X=Process descriptor pointer of process that made system call
 *        U=Register stack pointer
-L028E          ldu       <D.SysSvc           set system call processor to system side
-               stu       <D.XSWI2
-               ldu       <D.SysIRQ           do the same thing for IRQ's
-               stu       <D.XIRQ
-               ifne      H6309
-               oim       #SysState,P$State,x mark process as in system state
-               else      
-               lda       P$State,x
-               ora       #SysState
-               sta       P$State,x
-               endc      
+L028E               ldu       <D.SysSvc ; set system call processor to system side
+                    stu       <D.XSWI2  ; store U at <D.XSWI2
+                    ldu       <D.SysIRQ ; do the same thing for IRQ's
+                    stu       <D.XIRQ   ; store U at <D.XIRQ
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #SysState,P$State,x ; mark process as in system state
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    ora       #SysState ; merge #SysState into A
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
 * copy register stack to process descriptor
-               sts       P$SP,x              save stack pointer
-               leas      (P$Stack-R$Size),x  point S to register stack destination
+                    sts       P$SP,x    ; save stack pointer
+                    leas      (P$Stack-R$Size),x ; point S to register stack destination
 
-               ifne      H6309
-               leau      R$Size-1,s          point to last byte of destination register stack
-               leay      -1,y                point to caller's register stack in $FEE1
-               ldw       #R$Size             size of the register stack
-               tfm       y-,u-
-               leau      ,s                  needed because the TFM is u-, not -u (post, not pre)
-               else      
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    leau      R$Size-1,s ; point to last byte of destination register stack
+                    leay      -1,y      ; point to caller's register stack in $FEE1
+                    ldw       #R$Size   ; size of the register stack
+                    tfm       y-,u-     ; transfer memory block using y-,u-
+                    leau      ,s        ; needed because the TFM is u-, not -u (post, not pre)
+                  ELSE
 * Note!  R$Size MUST BE an EVEN number of bytes for this to work!
-               leau      R$Size,s            point to last byte of destination register stack
-               lda       #R$Size/2
-Loop3          ldx       ,--y
-               stx       ,--u
-               deca      
-               bne       Loop3
-               endc      
-               andcc     #^IntMasks
+                    leau      R$Size,s  ; point to last byte of destination register stack
+                    lda       #R$Size/2 ; load A from #R$Size/2
+Loop3               ldx       ,--y      ; load X from ,--y
+                    stx       ,--u      ; store X at ,--u
+                    deca                ; decrement A
+                    bne       Loop3     ; branch if zero is clear to Loop3
+                  ENDC
+                    andcc     #^IntMasks ; clear condition-code bits using #^IntMasks
 * B=function code already from calling process: DON'T USE IT!
-               ldx       R$PC,u              get where PC was from process
-               leax      1,x                 move PC past option
-               stx       R$PC,u              save updated PC to process
+                    ldx       R$PC,u    ; get where PC was from process
+                    leax      1,x       ; move PC past option
+                    stx       R$PC,u    ; save updated PC to process
 * execute function call
-               ldy       <D.UsrDis           get user dispatch table pointer
-               lbsr      L033B               go execute option
-               ifne      H6309
-               aim       #^IntMasks,R$CC,u   Clear interrupt flags in caller's CC
-               else      
-               lda       R$CC,u
-               anda      #^IntMasks
-               sta       R$CC,u
-               endc      
-               ldx       <D.Proc             get current process ptr
-               ifne      H6309
-               aim       #^(SysState+TimOut),P$State,x Clear system & timeout flags
-               else      
-               lda       P$State,x
-               anda      #^(SysState+TimOut)
-               sta       P$State,x
-               endc      
+                    ldy       <D.UsrDis ; get user dispatch table pointer
+                    lbsr      L033B     ; go execute option
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^IntMasks,R$CC,u ; clear interrupt flags in caller's CC
+                  ELSE
+                    lda       R$CC,u    ; load A from R$CC,u
+                    anda      #^IntMasks ; mask A with #^IntMasks
+                    sta       R$CC,u    ; store A at R$CC,u
+                  ENDC
+                    ldx       <D.Proc   ; get current process ptr
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #^(SysState+TimOut),P$State,x ; clear system & timeout flags
+                  ELSE
+                    lda       P$State,x ; load A from P$State,x
+                    anda      #^(SysState+TimOut) ; mask A with #^(SysState+TimOut)
+                    sta       P$State,x ; store A at P$State,x
+                  ENDC
 
 * Check for image change now, which lets stuff like F$MapBlk and F$ClrBlk
 * do the short-circuit thing, too.  Adds about 20 cycles to each system call.
-               lbsr      TstImg              it doesn't hurt to call this twice
-               lda       P$State,x           get current state of the process
-               ora       <P$Signal,x         is there a pending signal?
-               sta       <D.Quick            save quick return flag
-               beq       AllClr              if nothing's have changed, do full checks
+                    lbsr      TstImg    ; it doesn't hurt to call this twice
+                    lda       P$State,x ; get current state of the process
+                    ora       <P$Signal,x ; is there a pending signal?
+                    sta       <D.Quick  ; save quick return flag
+                    beq       AllClr    ; if nothing's have changed, do full checks
 
-DoFull         bsr       L02DA               move the stack frame back to user state
-               lbra      L0D80               go back to the process
+DoFull              bsr       L02DA     ; move the stack frame back to user state
+                    lbra      L0D80     ; go back to the process
 
 * add ldu P$SP,x, etc...
-AllClr         equ       *
-               ifne      H6309
-               inc       <D.QCnt
-               aim       #$1F,<D.QCnt
-               beq       DoFull              every 32 system calls, do the full check
-               ldw       #R$Size             --- size of the register stack
-               ldy       #Where+SWIStack     --- to stack at top of memory
-               orcc      #IntMasks
-               tfm       u+,y+               --- move the stack to the top of memory
-               else      
-               lda       <D.QCnt
-               inca      
-               anda      #$1F
-               sta       <D.QCnt
-               beq       DoFull
-               ldb       #R$Size
-               ldy       #Where+SWIStack
-               orcc      #IntMasks
-Loop4          lda       ,u+
-               sta       ,y+
-               decb      
-               bne       Loop4
-               endc      
-               lbra      BackTo1             otherwise simply return to the user
+AllClr              equ       *         ; define assembler symbol AllClr
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    inc       <D.QCnt   ; increment <D.QCnt
+                    aim       #$1F,<D.QCnt ; apply immediate bit operation #$1F,<D.QCnt
+                    beq       DoFull    ; every 32 system calls, do the full check
+                    ldw       #R$Size   ; --- size of the register stack
+                    ldy       #Where+SWIStack ; --- to stack at top of memory
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+                    tfm       u+,y+     ; --- move the stack to the top of memory
+                  ELSE
+                    lda       <D.QCnt   ; load A from <D.QCnt
+                    inca                ; increment A
+                    anda      #$1F      ; mask A with #$1F
+                    sta       <D.QCnt   ; store A at <D.QCnt
+                    beq       DoFull    ; branch if zero is set to DoFull
+                    ldb       #R$Size   ; load B from #R$Size
+                    ldy       #Where+SWIStack ; load Y from #Where+SWIStack
+                    orcc      #IntMasks ; set condition-code bits using #IntMasks
+Loop4               lda       ,u+       ; load A from ,u+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Loop4     ; branch if zero is clear to Loop4
+                  ENDC
+                    lbra      BackTo1   ; otherwise simply return to the user
 
 * Copy register stack from user to system
 * Entry: U=Ptr to Register stack in process dsc
-L02CB          pshs      cc,x,y,u            preserve registers
-               ldb       P$Task,x            get task #
-               ldx       P$SP,x              get stack pointer
-               lbsr      L0BF3               calculate block offset (only affects A&X)
-               leax      -$6000,x            adjust pointer to where memory map will be
-               bra       L02E9               go copy it
+L02CB               pshs      cc,x,y,u  ; preserve registers
+                    ldb       P$Task,x  ; get task #
+                    ldx       P$SP,x    ; get stack pointer
+                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    leax      -$6000,x  ; adjust pointer to where memory map will be
+                    bra       L02E9     ; go copy it
 
 * Copy register stack from system to user
 * Entry: U=Ptr to Register stack in process dsc
-L02DA          pshs      cc,x,y,u            preserve registers
-               ldb       P$Task,x            get task # of destination
-               ldx       P$SP,x              get stack pointer
-               lbsr      L0BF3               calculate block offset (only affects A&X)
-               leax      -$6000,x            adjust pointer to where memory map will be
-               exg       x,y                 swap pointers & copy
+L02DA               pshs      cc,x,y,u  ; preserve registers
+                    ldb       P$Task,x  ; get task # of destination
+                    ldx       P$SP,x    ; get stack pointer
+                    lbsr      L0BF3     ; calculate block offset (only affects A&X)
+                    leax      -$6000,x  ; adjust pointer to where memory map will be
+                    exg       x,y       ; swap pointers & copy
 * Copy a register stack
 * Entry: X=Source
 *        Y=Destination
 *        A=Offset into DAT image of stack
 *        B=Task #
-L02E9          leau      a,u                 point to block # of where stack is
-               ifne      mc09
-               orcc      #IntMasks           shutdown interupts while we do this
+L02E9               leau      a,u       ; point to block # of where stack is
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    orcc      #IntMasks ; shutdown interupts while we do this
 
-               lda       #5
-               bsr       prepmmu             Select block 5
+                    lda       #5        ; load A from #5
+                    bsr       prepmmu   ; select block 5
 
-               lda       1,u                 get first block
-               ldb       3,u                 get a second just in case of overlap
+                    lda       1,u       ; get first block
+                    ldb       3,u       ; get a second just in case of overlap
 
-               sta       >MMUDAT             Set value for block 5
+                    sta       >MMUDAT   ; set value for block 5
 
-               lda       #6
-               bsr       prepmmu             Select block 6
+                    lda       #6        ; load A from #6
+                    bsr       prepmmu   ; select block 6
 
-               stb       >MMUDAT             Set value for block 6
+                    stb       >MMUDAT   ; set value for block 6
 
-               ldb       #R$Size
-Loop5          lda       ,x+
-               sta       ,y+
-               decb      
-               bne       Loop5
-               ldx       <D.SysDAT           remap the blocks we took out
+                    ldb       #R$Size   ; load B from #R$Size
+Loop5               lda       ,x+       ; load A from ,x+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Loop5     ; branch if zero is clear to Loop5
+                    ldx       <D.SysDAT ; remap the blocks we took out
 
-               lda       #5
-               bsr       prepmmu             Select block 5
+                    lda       #5        ; load A from #5
+                    bsr       prepmmu   ; select block 5
 
-               lda       $0B,x
-               ldb       $0D,x
+                    lda       $0B,x     ; load A from $0B,x
+                    ldb       $0D,x     ; load B from $0D,x
 
-               sta       >MMUDAT             Restore value for block 5
-               lda       #6
-               bsr       prepmmu             Select block 6
+                    sta       >MMUDAT   ; restore value for block 5
+                    lda       #6        ; load A from #6
+                    bsr       prepmmu   ; select block 6
 
-               stb       >MMUDAT             Restore value for block 6
-               else      
-               lda       1,u                 get first block
-               ldb       3,u                 get a second just in case of overlap
-               orcc      #IntMasks           shutdown interupts while we do this
-               std       >DAT.Regs+5         map blocks in
-               ifne      H6309
-               ldw       #R$Size             get size of register stack
-               tfm       x+,y+               copy it
-               else      
-               ldb       #R$Size
-Loop5          lda       ,x+
-               sta       ,y+
-               decb      
-               bne       Loop5
-               endc      
-               ldx       <D.SysDAT           remap the blocks we took out
-               lda       $0B,x
-               ldb       $0D,x
-               std       >DAT.Regs+5
-               endif     
-               puls      cc,x,y,u,pc         restore & return
+                    stb       >MMUDAT   ; restore value for block 6
+                  ELSE
+                    lda       1,u       ; get first block
+                    ldb       3,u       ; get a second just in case of overlap
+                    orcc      #IntMasks ; shutdown interupts while we do this
+                    std       >DAT.Regs+5 ; map blocks in
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get size of register stack
+                    tfm       x+,y+     ; copy it
+                  ELSE
+                    ldb       #R$Size   ; load B from #R$Size
+Loop5               lda       ,x+       ; load A from ,x+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Loop5     ; branch if zero is clear to Loop5
+                  ENDC
+                    ldx       <D.SysDAT ; remap the blocks we took out
+                    lda       $0B,x     ; load A from $0B,x
+                    ldb       $0D,x     ; load B from $0D,x
+                    std       >DAT.Regs+5 ; store D at >DAT.Regs+5
+                    endif
+                    puls      cc,x,y,u,pc ; restore & return
 
-               ifne      mc09
+                  IFNE    mc09    ; begin conditional assembly for mc09
 * A holds the MMU register we want to select. Merge in
 * the stored value and write the result to MMUADR. This is
 * a desperate attempt to save a few bytes..
-prepmmu                  
-               ora       <D.TINIT            Merge with current MMU mask
-               sta       >MMUADR             Select block
-               rts       
-               endif     
+prepmmu
+                    ora       <D.TINIT  ; merge with current MMU mask
+                    sta       >MMUADR   ; select block
+                    rts                 ; return to caller
+                    endif
 
 
 * Process software interupts from system state
 * Entry: U=Register stack pointer
-SysCall        leau      ,s                  get pointer to register stack
-               lda       <D.SSTskN           Get system task # (0=SYSTEM, 1=GRFDRV)
-               clr       <D.SSTskN           Force to System Process
-               pshs      a                   Save the system task number
-               lda       ,u                  Restore callers CC register (R$CC=$00)
-               tfr       a,cc                make it current
-               ldx       R$PC,u              Get my caller's PC register
-               leax      1,x                 move PC to next position
-               stx       R$PC,u              Save my caller's updated PC register
-               ldy       <D.SysDis           get system dispatch table pointer
-               bsr       L033B               execute system call
-               puls      a                   restore system state task number
-               lbra      L0E2B               return to process
+SysCall             leau      ,s        ; get pointer to register stack
+                    lda       <D.SSTskN ; get system task # (0=SYSTEM, 1=GRFDRV)
+                    clr       <D.SSTskN ; force to System Process
+                    pshs      a         ; save the system task number
+                    lda       ,u        ; restore callers CC register (R$CC=$00)
+                    tfr       a,cc      ; make it current
+                    ldx       R$PC,u    ; get my caller's PC register
+                    leax      1,x       ; move PC to next position
+                    stx       R$PC,u    ; save my caller's updated PC register
+                    ldy       <D.SysDis ; get system dispatch table pointer
+                    bsr       L033B     ; execute system call
+                    puls      a         ; restore system state task number
+                    lbra      L0E2B     ; return to process
 
 * Entry: X = system call vector to jump to
-Sys.Vec        jmp       ,x                  execute service call
+Sys.Vec             jmp       ,x        ; execute service call
 
 * Execute system call
 * Entry: B=Function call #
 *        Y=Function dispatch table pointer (D.SysDis or D.UsrDis)
-L033B                    
-               lslb                          is it a I/O call? (Also multiplys by 2 for offset)
-               bcc       L0345               no, go get normal vector
+L033B
+                    lslb                ; is it a I/O call? (Also multiplys by 2 for offset)
+                    bcc       L0345     ; no, go get normal vector
 * Execute I/O system calls
-               ldx       IOEntry,y           get IOMan vector
+                    ldx       IOEntry,y ; get IOMan vector
 * Execute the system call
-L034F          pshs      u                   preserve register stack pointer
-               jsr       [D.SysVec]          perform a vectored system call
-               puls      u                   restore pointer
-L0355          tfr       cc,a                move CC to A for stack update
-               bcc       L035B               go update it if no error from call
-               stb       R$B,u               save error code to caller's B
-L035B          ldb       R$CC,u              get callers CC, R$CC=$00
-               ifne      H6309
-               andd      #$2FD0              [A]=H,N,Z,V,C [B]=E,F,I
-               orr       b,a                 merge them together
-               else      
-               anda      #$2F                [A]=H,N,Z,V,C
-               andb      #$D0                [B]=E,F,I
-               pshs      b
-               ora       ,s+
-               endc      
-               sta       R$CC,u              return it to caller, R$CC=$00
-               rts       
+L034F               pshs      u         ; preserve register stack pointer
+                    jsr       [D.SysVec] ; perform a vectored system call
+                    puls      u         ; restore pointer
+L0355               tfr       cc,a      ; move CC to A for stack update
+                    bcc       L035B     ; go update it if no error from call
+                    stb       R$B,u     ; save error code to caller's B
+L035B               ldb       R$CC,u    ; get callers CC, R$CC=$00
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    andd      #$2FD0    ; [A]=H,N,Z,V,C [B]=E,F,I
+                    orr       b,a       merge them together
+                  ELSE
+                    anda      #$2F      ; [A]=H,N,Z,V,C
+                    andb      #$D0      ; [B]=E,F,I
+                    pshs      b         ; save b on the stack
+                    ora       ,s+       ; merge ,s+ into A
+                  ENDC
+                    sta       R$CC,u    ; return it to caller, R$CC=$00
+                    rts                 ; return to caller
 
 * Execute regular system calls
-L0345                    
-               clra                          clear MSB of offset
-               ldx       d,y                 get vector to call
-               bne       L034F               it's initialized, go execute it
-               comb                          set carry for error
-               ldb       #E$UnkSvc           get error code
-               bra       L0355               return with it
+L0345
+                    clra                ; clear MSB of offset
+                    ldx       d,y       ; get vector to call
+                    bne       L034F     ; it's initialized, go execute it
+                    comb                ; set carry for error
+                    ldb       #E$UnkSvc ; get error code
+                    bra       L0355     ; return with it
 
-               use       fssvc.asm
+                    use       fssvc.asm ; include source file fssvc.asm
 
-               use       flink.asm
+                    use       flink.asm ; include source file flink.asm
 
-               use       fvmodul.asm
+                    use       fvmodul.asm ; include source file fvmodul.asm
 
-               use       ffmodul.asm
+                    use       ffmodul.asm ; include source file ffmodul.asm
 
-               use       fprsnam.asm
+                    use       fprsnam.asm ; include source file fprsnam.asm
 
-               use       fcmpnam.asm
+                    use       fcmpnam.asm ; include source file fcmpnam.asm
 
-               use       fsrqmem.asm
+                    use       fsrqmem.asm ; include source file fsrqmem.asm
 
 *         use   fallram.asm
 
 
-               ifne      H6309
-               use       fdelram.asm
-               endc      
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    use       fdelram.asm ; include source file fdelram.asm
+                  ENDC
 
-               use       fallimg.asm
+                    use       fallimg.asm ; include source file fallimg.asm
 
-               use       ffreehb.asm
+                    use       ffreehb.asm ; include source file ffreehb.asm
 
-               use       fdatlog.asm
+                    use       fdatlog.asm ; include source file fdatlog.asm
 
-               use       fld.asm
+                    use       fld.asm   ; include source file fld.asm
 
-               ifne      H6309
-               use       fcpymem.asm
-               endc      
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    use       fcpymem.asm ; include source file fcpymem.asm
+                  ENDC
 
-               use       fmove.asm
+                    use       fmove.asm ; include source file fmove.asm
 
-               use       fldabx.asm
+                    use       fldabx.asm ; include source file fldabx.asm
 
-               use       falltsk.asm
+                    use       falltsk.asm ; include source file falltsk.asm
 
-               use       faproc.asm
+                    use       faproc.asm ; include source file faproc.asm
 
 * System IRQ service routine
-XIRQ           ldx       <D.Proc             get current process pointer
-               sts       P$SP,x              save the stack pointer
-               lds       <D.SysStk           get system stack pointer
-               ldd       <D.SysSvc           set system service routine to current
-               std       <D.XSWI2
-               ldd       <D.SysIRQ           set system IRQ routine to current
-               std       <D.XIRQ
-               jsr       [>D.SvcIRQ]         execute irq service
-               bcc       L0D5B
+XIRQ                ldx       <D.Proc   ; get current process pointer
+                    sts       P$SP,x    ; save the stack pointer
+                    lds       <D.SysStk ; get system stack pointer
+                    ldd       <D.SysSvc ; set system service routine to current
+                    std       <D.XSWI2  ; store D at <D.XSWI2
+                    ldd       <D.SysIRQ ; set system IRQ routine to current
+                    std       <D.XIRQ   ; store D at <D.XIRQ
+                    jsr       [>D.SvcIRQ] ; execute irq service
+                    bcc       L0D5B     ; branch if carry is clear to L0D5B
 
-               ldx       <D.Proc             get current process pointer
-               ldb       P$Task,x
-               ldx       P$SP,x              get it's stack pointer
+                    ldx       <D.Proc   ; get current process pointer
+                    ldb       P$Task,x  ; load B from P$Task,x
+                    ldx       P$SP,x    ; get it's stack pointer
 
-               pshs      u,d,cc              save some registers
-               leau      ,s                  point to a 'caller register stack'
-               lbsr      L0C40               do a LDB 0,X in task B
-               puls      u,d,cc              and now A ( R$A,U ) = the CC we want
+                    pshs      u,d,cc    ; save some registers
+                    leau      ,s        ; point to a 'caller register stack'
+                    lbsr      L0C40     ; do a LDB 0,X in task B
+                    puls      u,d,cc    ; and now A ( R$A,U ) = the CC we want
 
-               ora       #IntMasks           disable it's IRQ's
-               lbsr      L0C28               save it back
-L0D5B          orcc      #IntMasks           shut down IRQ's
-               ldx       <D.Proc             get current process pointer
-               tst       <D.QIRQ             was it a clock IRQ?
-               lbne      L0DF7               if not, do a quick return
+                    ora       #IntMasks ; disable it's IRQ's
+                    lbsr      L0C28     ; save it back
+L0D5B               orcc      #IntMasks ; shut down IRQ's
+                    ldx       <D.Proc   ; get current process pointer
+                    tst       <D.QIRQ   ; was it a clock IRQ?
+                    lbne      L0DF7     ; if not, do a quick return
 
-               lda       P$State,x           Get it's state
-               bita      #TimOut             Is it timed out?
-               bne       L0D7C               yes, wake it up
+                    lda       P$State,x ; get it's state
+                    bita      #TimOut   ; is it timed out?
+                    bne       L0D7C     ; yes, wake it up
 * Update active process queue
-               ldu       #(D.AProcQ-P$Queue) point to active process queue
-               ldb       #Suspend            get suspend flag
-L0D6A          ldu       P$Queue,u           get a active process pointer
-               beq       L0D78
-               bitb      P$State,u           is it suspended?
-               bne       L0D6A               yes, go to next one in chain
-               ldb       P$Prior,x           get current process priority
-               cmpb      P$Prior,u           do we bump this one?
-               blo       L0D7C
+                    ldu       #(D.AProcQ-P$Queue) ; point to active process queue
+                    ldb       #Suspend  ; get suspend flag
+L0D6A               ldu       P$Queue,u ; get a active process pointer
+                    beq       L0D78     ; branch if zero is set to L0D78
+                    bitb      P$State,u ; is it suspended?
+                    bne       L0D6A     ; yes, go to next one in chain
+                    ldb       P$Prior,x ; get current process priority
+                    cmpb      P$Prior,u ; do we bump this one?
+                    blo       L0D7C     ; branch if unsigned result is lower to L0D7C
 
-L0D78          ldu       P$SP,x
-               bra       L0DB9
+L0D78               ldu       P$SP,x    ; load U from P$SP,x
+                    bra       L0DB9     ; branch unconditionally to L0DB9
 
-L0D7C          anda      #^TimOut
-               sta       P$State,x
+L0D7C               anda      #^TimOut  ; mask A with #^TimOut
+                    sta       P$State,x ; store A at P$State,x
 
-L0D80          equ       *
-L0D83          bsr       L0D11               activate next process
+L0D80               equ       *         ; define assembler symbol L0D80
+L0D83               bsr       L0D11     ; activate next process
 
-               use       fnproc.asm
+                    use       fnproc.asm ; include source file fnproc.asm
 
 * The following routines must appear no earlier than $E00 when assembled, as
 * they have to always be in the vector RAM pages ($FE00-$FEFF)
 
-               ifne      mc09
+                  IFNE    mc09    ; begin conditional assembly for mc09
 * Copied nicer automatic padding from ccbkrn
 * CCB: this code (after pad) start assembling *before* 0xfe00, it's too big to
 * fit into the memory as stated above!!!!
 
-PAD            fill      $00,($0dfc-*)       fill memory to ensure the above happens
-               else      
-PAD            fill      $00,($0df1-*)       fill memory to ensure the above happens
-               endc      
+PAD                 fill      $00,($0dfc-*) ; fill memory to ensure the above happens
+                  ELSE
+PAD                 fill      $00,($0df1-*) ; fill memory to ensure the above happens
+                  ENDC
 
 
 * Default routine for D.SysIRQ
-S.SysIRQ                 
-               lda       <D.SSTskN           Get current task's GIME task # (0 or 1)
-               beq       FastIRQ             Use super-fast version for system state
-               clr       <D.SSTskN           Clear out memory copy (task 0)
-               jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
-               inc       <D.SSTskN           Save task # for system state
-               ifne      mc09
-               lda       #$40                mc09 MMU Task 1
-               ora       <D.TINIT            Merge task bit into Shadow version
-               sta       <D.TINIT            Update shadow
-               sta       >MMUADR             Save to MMU as well
-               else      
-               lda       #1                  Task 1
-               ora       <D.TINIT            Merge task bit into Shadow version
-               sta       <D.TINIT            Update shadow
-               sta       >DAT.Task           Save to GIME as well
-               endc      
-               bra       DoneIRQ             Check for error and exit
+S.SysIRQ
+                    lda       <D.SSTskN ; get current task's GIME task # (0 or 1)
+                    beq       FastIRQ   ; use super-fast version for system state
+                    clr       <D.SSTskN ; clear out memory copy (task 0)
+                    jsr       [>D.SvcIRQ] ; (Normally routine in Clock calling D.Poll)
+                    inc       <D.SSTskN ; save task # for system state
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    lda       #$40      ; mc09 MMU Task 1
+                    ora       <D.TINIT  ; merge task bit into Shadow version
+                    sta       <D.TINIT  ; update shadow
+                    sta       >MMUADR   ; save to MMU as well
+                  ELSE
+                    lda       #1        ; task 1
+                    ora       <D.TINIT  ; merge task bit into Shadow version
+                    sta       <D.TINIT  ; update shadow
+                    sta       >DAT.Task ; save to GIME as well
+                  ENDC
+                    bra       DoneIRQ   ; check for error and exit
 
-FastIRQ        jsr       [>D.SvcIRQ]         (Normally routine in Clock calling D.Poll)
-DoneIRQ        bcc       L0E28               No error on IRQ, exit
-               ifne      H6309
-               oim       #IntMasks,0,s       Setup RTI to shut interrupts off again
-               else      
-               lda       ,s
-               ora       #IntMasks
-               sta       ,s
-               endc      
-L0E28          rti       
+FastIRQ             jsr       [>D.SvcIRQ] ; (Normally routine in Clock calling D.Poll)
+DoneIRQ             bcc       L0E28     ; no error on IRQ, exit
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #IntMasks,0,s ; setup RTI to shut interrupts off again
+                  ELSE
+                    lda       ,s        ; load A from ,s
+                    ora       #IntMasks ; merge #IntMasks into A
+                    sta       ,s        ; store A at ,s
+                  ENDC
+L0E28               rti                 ; return from interrupt
 
 * return from a system call
-L0E29          clra                          Force System task # to 0 (non-GRDRV)
-L0E2B          ldx       <D.SysPrc           Get system process dsc. ptr
-               lbsr      TstImg              check image, and F$SetTsk (PRESERVES A)
-               orcc      #IntMasks           Shut interrupts off
-               sta       <D.SSTskN           Save task # for system state
-               beq       Fst2                If task 0, we're done
-               ifne      mc09
-               lda       #$40                [NAC HACK 2016Dec07] hope only 1 bit means anything..
-               ora       <D.TINIT            Merge task bit into Shadow version
-               sta       <D.TINIT            Update shadow
-               sta       >MMUADR             Save to MMU
-               else      
-               ora       <D.TINIT            Merge task bit into Shadow version
-               sta       <D.TINIT            Update shadow
-               sta       >DAT.Task           Save to GIME as well
-               endc      
-Fst2           leas      ,u                  Stack ptr=U & return
-               rti       
+L0E29               clra                ; force System task # to 0 (non-GRDRV)
+L0E2B               ldx       <D.SysPrc ; get system process dsc. ptr
+                    lbsr      TstImg    ; check image, and F$SetTsk (PRESERVES A)
+                    orcc      #IntMasks ; shut interrupts off
+                    sta       <D.SSTskN ; save task # for system state
+                    beq       Fst2      ; if task 0, we're done
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    lda       #$40      ; [NAC HACK 2016Dec07] hope only 1 bit means anything..
+                    ora       <D.TINIT  ; merge task bit into Shadow version
+                    sta       <D.TINIT  ; update shadow
+                    sta       >MMUADR   ; save to MMU
+                  ELSE
+                    ora       <D.TINIT  ; merge task bit into Shadow version
+                    sta       <D.TINIT  ; update shadow
+                    sta       >DAT.Task ; save to GIME as well
+                  ENDC
+Fst2                leas      ,u        ; stack ptr=U & return
+                    rti                 ; return from interrupt
 
 * Switch to new process, X=Process descriptor pointer, U=Stack pointer
-L0E4C          equ       *
-               ifne      H6309
-               oim       #$01,<D.TINIT       switch GIME shadow to user state
-               lda       <D.TINIT
-               else      
-               lda       <D.TINIT
-               ifne      mc09
-               ora       #$40
-               else      
-               ora       #$01
-               endc      
-               sta       <D.TINIT
-               endc      
-               ifne      mc09
-               sta       >MMUADR             save it to MMU
-               else      
-               sta       >DAT.Task           save it to GIME
-               endc      
-               leas      ,y                  point to new stack
-               tstb                          is the stack at SWISTACK?
-               bne       MyRTI               no, we're doing a system-state rti
+L0E4C               equ       *         ; define assembler symbol L0E4C
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch GIME shadow to user state
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                  ELSE
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    ora       #$40      ; merge #$40 into A
+                  ELSE
+                    ora       #$01      ; merge #$01 into A
+                  ENDC
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                  ENDC
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    sta       >MMUADR   ; save it to MMU
+                  ELSE
+                    sta       >DAT.Task ; save it to GIME
+                  ENDC
+                    leas      ,y        ; point to new stack
+                    tstb                ; is the stack at SWISTACK?
+                    bne       MyRTI     ; no, we're doing a system-state rti
 
-               ifne      H6309
-               ldf       #R$Size             E=0 from call to L0E8D before
-               ldu       #Where+SWIStack     point to the stack
-               tfm       u+,y+               move the stack from top of memory to user memory
-               else      
-               ldb       #R$Size
-               ldu       #Where+SWIStack     point to the stack
-RtiLoop        lda       ,u+
-               sta       ,y+
-               decb      
-               bne       RtiLoop
-               endc      
-MyRTI          rti                           return from IRQ
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldf       #R$Size   ; e=0 from call to L0E8D before
+                    ldu       #Where+SWIStack ; point to the stack
+                    tfm       u+,y+     ; move the stack from top of memory to user memory
+                  ELSE
+                    ldb       #R$Size   ; load B from #R$Size
+                    ldu       #Where+SWIStack ; point to the stack
+RtiLoop             lda       ,u+       ; load A from ,u+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       RtiLoop   ; branch if zero is clear to RtiLoop
+                  ENDC
+MyRTI               rti                 ; return from IRQ
 
 
 * Execute routine in task 1 pointed to by U
 * comes from user requested SWI vectors
-L0E5E          equ       *
-               ifne      H6309
-               oim       #$01,<D.TINIT       switch GIME shadow to user state
-               ldb       <D.TINIT
-               else      
-               ldb       <D.TINIT
-               ifne      mc09
-               orb       #$40
-               else      
-               orb       #$01
-               endc      
-               stb       <D.TINIT
-               endc      
-               ifne      mc09
-               stb       >MMUADR
-               else      
-               stb       >DAT.Task
-               endc      
-               jmp       ,u
+L0E5E               equ       *         ; define assembler symbol L0E5E
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; switch GIME shadow to user state
+                    ldb       <D.TINIT  ; load B from <D.TINIT
+                  ELSE
+                    ldb       <D.TINIT  ; load B from <D.TINIT
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    orb       #$40      ; merge #$40 into B
+                  ELSE
+                    orb       #$01      ; merge #$01 into B
+                  ENDC
+                    stb       <D.TINIT  ; store B at <D.TINIT
+                  ENDC
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    stb       >MMUADR   ; store B at >MMUADR
+                  ELSE
+                    stb       >DAT.Task ; store B at >DAT.Task
+                  ENDC
+                    jmp       ,u        ; transfer control to ,u
 
 * Flip to task 1 (used by GRF/WINDInt to switch to GRFDRV) (pointed to
 *  by <D.Flip1). All regs are already preserved on stack for the RTI
-S.Flip1        ldb       #2                  get Task image entry numberx2 for Grfdrv (task 1)
-               bsr       L0E8D               copy over the DAT image
-               ifne      H6309
-               oim       #$01,<D.TINIT
-               lda       <D.TINIT            get copy of GIME Task side
-               else      
-               lda       <D.TINIT
-               ifne      mc09
-               ora       #$40                force TR=1 in mc09 MMU
-               else      
-               ora       #$01                force TR=1
-               endc      
-               sta       <D.TINIT
-               endc      
-               ifne      mc09
-               sta       >MMUADR             save it to MMU register
-               else      
-               sta       >DAT.Task           save it to GIME register
-               endc      
-               inc       <D.SSTskN           increment system state task number
-               rti                           return
+S.Flip1             ldb       #2        ; get Task image entry numberx2 for Grfdrv (task 1)
+                    bsr       L0E8D     ; copy over the DAT image
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    oim       #$01,<D.TINIT ; apply immediate bit operation #$01,<D.TINIT
+                    lda       <D.TINIT  ; get copy of GIME Task side
+                  ELSE
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    ora       #$40      ; force TR=1 in mc09 MMU
+                  ELSE
+                    ora       #$01      ; force TR=1
+                  ENDC
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                  ENDC
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    sta       >MMUADR   ; save it to MMU register
+                  ELSE
+                    sta       >DAT.Task ; save it to GIME register
+                  ENDC
+                    inc       <D.SSTskN ; increment system state task number
+                    rti                 ; return
 
 * Setup MMU in task 1, B=Task # to swap to, shifted left 1 bit
-L0E8D          cmpb      <D.Task1N           are we going back to the same task
-               beq       L0EA3               without the DAT image changing?
-               stb       <D.Task1N           nope, save current task in map type 1
-               ifne      mc09
-               ldu       <D.TskIPt           get task image pointer table
-               ldu       b,u                 get address of DAT image
+L0E8D               cmpb      <D.Task1N ; are we going back to the same task
+                    beq       L0EA3     ; without the DAT image changing?
+                    stb       <D.Task1N ; nope, save current task in map type 1
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    ldu       <D.TskIPt ; get task image pointer table
+                    ldu       b,u       ; get address of DAT image
 
-               lda       <D.TINIT
-               adda      #8                  1st MMU value for process's mappings
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    adda      #8        ; 1st MMU value for process's mappings
 
 * COME HERE FROM FALLTSK
 * Update 8 MMU mappings.
 * A = MMUADR value for 1st MMU register to update
 * U = address of DAT image to update into MMU
-L0E93          ldb       #8                  number of MMU mappings to set
-               pshs      b                   squirrel it away
-               leau      1,u                 point to actual MMU block for 1st mapping
+L0E93               ldb       #8        ; number of MMU mappings to set
+                    pshs      b         ; squirrel it away
+                    leau      1,u       ; point to actual MMU block for 1st mapping
 
-L0E9B          ldb       ,u++                get a bank, point to next bank
-               std       >MMUADR             save it to MMU
-               inca                          next mapsel value
-               dec       ,s
-               bne       L0E9B               no, keep going
-               leas      1,s                 done. Tidy up the stack
-               else      
-               ldx       #DAT.Regs+8         get MMU start register for process's
-               ldu       <D.TskIPt           get task image pointer table
-               ldu       b,u                 get address of DAT image
+L0E9B               ldb       ,u++      ; get a bank, point to next bank
+                    std       >MMUADR   ; save it to MMU
+                    inca                ; next mapsel value
+                    dec       ,s        ; decrement ,s
+                    bne       L0E9B     ; no, keep going
+                    leas      1,s       ; done. Tidy up the stack
+                  ELSE
+                    ldx       #DAT.Regs+8 ; get MMU start register for process's
+                    ldu       <D.TskIPt ; get task image pointer table
+                    ldu       b,u       ; get address of DAT image
 * COME HERE FROM FALLTSK
 * Update 8 MMU mappings.
 * X = address of 1st DAT MMU register to update
 * U = address of DAT image to update into MMU
-L0E93          leau      1,u                 point to actual MMU block
-               ifne      H6309
-               lde       #4                  get # banks/2 for task
-               else      
-               lda       #4
-               pshs      a
-               endc      
-L0E9B          lda       ,u++                get a bank
-               ldb       ,u++                and next one
-               std       ,x++                Save it to MMU
-               ifne      H6309
-               dece                          done?
-               else      
-               dec       ,s
-               endc      
-               bne       L0E9B               no, keep going
-               ifeq      H6309
-               leas      1,s                 done. Tidy up the stack
-               endc      
-               endc      
-L0EA3          rts                           return
+L0E93               leau      1,u       ; point to actual MMU block
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    lde       #4        ; get # banks/2 for task
+                  ELSE
+                    lda       #4        ; load A from #4
+                    pshs      a         ; save a on the stack
+                  ENDC
+L0E9B               lda       ,u++      ; get a bank
+                    ldb       ,u++      ; and next one
+                    std       ,x++      ; save it to MMU
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    dece                ; done?
+                  ELSE
+                    dec       ,s        ; decrement ,s
+                  ENDC
+                    bne       L0E9B     ; no, keep going
+                  IFEQ    H6309   ; begin conditional assembly for H6309
+                    leas      1,s       ; done. Tidy up the stack
+                  ENDC
+                  ENDC
+L0EA3               rts                 ; return
 
 * Execute FIRQ vector (called from $FEF4)
-FIRQVCT        ldx       #D.FIRQ             get DP offset of vector
-               bra       L0EB8               go execute it
+FIRQVCT             ldx       #D.FIRQ   ; get DP offset of vector
+                    bra       L0EB8     ; go execute it
 
 * Execute IRQ vector (called from $FEF7)
-IRQVCT         orcc      #IntMasks           disable IRQ's
-               ldx       #D.IRQ              get DP offset of vector
+IRQVCT              orcc      #IntMasks ; disable IRQ's
+                    ldx       #D.IRQ    ; get DP offset of vector
 
 * Execute interrupt vector, B=DP Vector offset
-               ifne      mc09
-L0EB8          lda       #$a0                [NAC HACK 2016Dec08] add equates..
-               sta       >MMUADR             Force to System State (Task 0)
-               clra      
-               tfr       a,dp                ASSUME: A=0 from earlier
-MapGrf         equ       *                   come here from elsewhere, too.
-               lda       <D.TINIT
-               anda      #$BF                force TR=0 in mc09 MMU shadow
-               sta       <D.TINIT
-MapT0          sta       >MMUADR             come here from elsewhere, too.
-               jmp       [,x]                execute it
-               else      
+                  IFNE    mc09    ; begin conditional assembly for mc09
+L0EB8               lda       #$a0      ; [NAC HACK 2016Dec08] add equates..
+                    sta       >MMUADR   ; force to System State (Task 0)
+                    clra                ; clear A
+                    tfr       a,dp      ; aSSUME: A=0 from earlier
+MapGrf              equ       *         ; come here from elsewhere, too.
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    anda      #$BF      ; force TR=0 in mc09 MMU shadow
+                    sta       <D.TINIT  ; store A at <D.TINIT
+MapT0               sta       >MMUADR   ; come here from elsewhere, too.
+                    jmp       [,x]      ; execute it
+                  ELSE
 * Execute interrupt vector, B=DP Vector offset
-L0EB8          clra                          (faster than CLR >$xxxx)
-               sta       >DAT.Task           Force to Task 0 (system state)
-               ifne      H6309
-               tfr       0,dp                setup DP
-               else      
-               tfr       a,dp                ASSUME: A=0 from earlier
-               endc      
-MapGrf         equ       *                   come here from elsewhere, too.
-               ifne      H6309
-               aim       #$FE,<D.TINIT       switch GIME shadow to system state
-               lda       <D.TINIT            set GIME again just in case timer is used
-               else      
-               lda       <D.TINIT
-               anda      #$FE
-               sta       <D.TINIT
-               endc      
-MapT0          sta       >DAT.Task           come here from elsewhere, too.
-               jmp       [,x]                execute it
-               endc      
+L0EB8               clra                ; (faster than CLR >$xxxx)
+                    sta       >DAT.Task ; force to Task 0 (system state)
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,dp      ; setup DP
+                  ELSE
+                    tfr       a,dp      ; aSSUME: A=0 from earlier
+                  ENDC
+MapGrf              equ       *         ; come here from elsewhere, too.
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    aim       #$FE,<D.TINIT ; switch GIME shadow to system state
+                    lda       <D.TINIT  ; set GIME again just in case timer is used
+                  ELSE
+                    lda       <D.TINIT  ; load A from <D.TINIT
+                    anda      #$FE      ; mask A with #$FE
+                    sta       <D.TINIT  ; store A at <D.TINIT
+                  ENDC
+MapT0               sta       >DAT.Task ; come here from elsewhere, too.
+                    jmp       [,x]      ; execute it
+                  ENDC
 
 
 
 * Execute SWI3 vector (called from $FEEE)
-SWI3VCT        orcc      #IntMasks           disable IRQ's
-               ldx       #D.SWI3             get DP offset of vector
-               bra       SWICall             go execute it
+SWI3VCT             orcc      #IntMasks ; disable IRQ's
+                    ldx       #D.SWI3   ; get DP offset of vector
+                    bra       SWICall   ; go execute it
 
 * Execute SWI2 vector (called from $FEF1)
-SWI2VCT        orcc      #IntMasks           disasble IRQ's
-               ldx       #D.SWI2             get DP offset of vector
+SWI2VCT             orcc      #IntMasks ; disasble IRQ's
+                    ldx       #D.SWI2   ; get DP offset of vector
 
 * This routine is called from an SWI, SWI2, or SWI3
 * saves 1 cycle on system-system calls
 * saves about 200 cycles (calls to I.LDABX and L029E) on grfdrv-system,
 *  or user-system calls.
-SWICall        ldb       [R$PC,s]            get callcode of the system call
-               ifne      mc09
+SWICall             ldb       [R$PC,s]  ; get callcode of the system call
+                  IFNE    mc09    ; begin conditional assembly for mc09
 * [NAC HACK 2016Dec08] confused? it says, "go to map type 1" but
 * it is setting a 0.
-               lda       #$a0                [NAC HACK 2016Dec08] add equates..
-               sta       >MMUADR             Force to System State (Task 0)
-               clra      
-               else      
+                    lda       #$a0      ; [NAC HACK 2016Dec08] add equates..
+                    sta       >MMUADR   ; force to System State (Task 0)
+                    clra                ; clear A
+                  ELSE
 * NOTE: Alan DeKok claims that this is BAD.  It crashed Colin McKay's
 * CoCo 3.  Instead, we should do a clra/sta >DAT.Task.
 *         clr   >DAT.Task       go to map type 1
-               clra      
-               sta       >DAT.Task
-               endc      
+                    clra                ; clear A
+                    sta       >DAT.Task ; store A at >DAT.Task
+                  ENDC
 * set DP to zero
-               ifne      H6309
-               tfr       0,dp
-               else      
-               tfr       a,dp                ASSUME: A=0 from earlier
-               endc      
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    tfr       0,dp      ; transfer register value 0,dp
+                  ELSE
+                    tfr       a,dp      ; aSSUME: A=0 from earlier
+                  ENDC
 
 * These lines add a total of 81 addition cycles to each SWI(2,3) call,
 * and 36 bytes+12 for R$Size in the constant page at $FExx
@@ -1171,94 +1171,94 @@ SWICall        ldb       [R$PC,s]            get callcode of the system call
 * For processes that re-vector SWI, SWI3, it adds 81 cycles.  BUT SWI(3)
 * CANNOT be vectored to L0EBF cause the user SWI service routine has been
 * changed
-               lda       <D.TINIT            get map type flag
-               ifne      mc09
-               bita      #$40                check it without changing it in mc09 MMU
-               else      
-               bita      #$01                check it without changing it
-               endc      
+                    lda       <D.TINIT  ; get map type flag
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    bita      #$40      ; check it without changing it in mc09 MMU
+                  ELSE
+                    bita      #$01      ; check it without changing it
+                  ENDC
 
 * Change to LBEQ R.SysSvc to avoid JMP [,X]
 * and add R.SysSvc STA >DAT.Task ???
-               beq       MapT0               in map 0: restore hardware and do system service
-               tst       <D.SSTskN           get system state 0,1
-               bne       MapGrf              if in grfdrv, go to map 0 and do system service
+                    beq       MapT0     ; in map 0: restore hardware and do system service
+                    tst       <D.SSTskN ; get system state 0,1
+                    bne       MapGrf    ; if in grfdrv, go to map 0 and do system service
 
 * the preceding few lines are necessary, as all SWI's still pass thru
 * here before being vectored to the system service routine... which
 * doesn't copy the stack from user state.
-               ifne      mc09
-               sta       >MMUADR             go to map type X again to get user's stack
-               else      
-               sta       >DAT.Task           go to map type X again to get user's stack
-               endc      
+                  IFNE    mc09    ; begin conditional assembly for mc09
+                    sta       >MMUADR   ; go to map type X again to get user's stack
+                  ELSE
+                    sta       >DAT.Task ; go to map type X again to get user's stack
+                  ENDC
 * a byte less, a cycle more than ldy #$FEED-R$Size, or ldy #$F000+SWIStack
-               leay      <SWIStack,pc        where to put the register stack: to $FEDF
-               tfr       s,u                 get a copy of where the stack is
-               ifne      H6309
-               ldw       #R$Size             get the size of the stack
-               tfm       u+,y+               move the stack to the top of memory
-               else      
-               pshs      b
-               ldb       #R$Size
-Looper         lda       ,u+
-               sta       ,y+
-               decb      
-               bne       Looper
-               puls      b
-               endc      
-               bra       L0EB8               and go from map type 1 to map type 0
+                    leay      <SWIStack,pc ; where to put the register stack: to $FEDF
+                    tfr       s,u       ; get a copy of where the stack is
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    ldw       #R$Size   ; get the size of the stack
+                    tfm       u+,y+     ; move the stack to the top of memory
+                  ELSE
+                    pshs      b         ; save b on the stack
+                    ldb       #R$Size   ; load B from #R$Size
+Looper              lda       ,u+       ; load A from ,u+
+                    sta       ,y+       ; store A at ,y+
+                    decb                ; decrement B
+                    bne       Looper    ; branch if zero is clear to Looper
+                    puls      b         ; restore b from the stack
+                  ENDC
+                    bra       L0EB8     ; and go from map type 1 to map type 0
 
 * Execute SWI vector (called from $FEFA)
-SWIVCT         ldx       #D.SWI              get DP offset of vector
-               bra       SWICall             go execute it
+SWIVCT              ldx       #D.SWI    ; get DP offset of vector
+                    bra       SWICall   ; go execute it
 
 * Execute NMI vector (called from $FEFD)
-NMIVCT         ldx       #D.NMI              get DP offset of vector
-               bra       L0EB8               go execute it
+NMIVCT              ldx       #D.NMI    ; get DP offset of vector
+                    bra       L0EB8     ; go execute it
 
 * The end of the kernel module is here
-               emod      
-eom            equ       *
+                    emod
+eom                 equ       *         ; define assembler symbol eom
 
 * What follows after the kernel module is the register stack, starting
 * at $FEDD (6309) or $FEDF (6809).  This register stack area is used by
 * the kernel to save the caller's registers in the $FEXX area of memory
 * because it doesn't get "switched out" no matter the contents of the
 * MMU registers.
-SWIStack                 
-               fcc       /REGISTER STACK/    same # bytes as R$Size for 6809
-               ifne      H6309
-               fcc       /63/                if 6309, add two more bytes of space
-               endc      
+SWIStack
+                    fcc       /REGISTER STACK/    same # bytes as R$Size for 6809
+                  IFNE    H6309   ; begin conditional assembly for H6309
+                    fcc       /63/                if 6309, add two more bytes of space
+                  ENDC
 
-               fcb       $55                 D.ErrRst
+                    fcb       $55       ; d.ErrRst
 
-               ifne      mc09
+                  IFNE    mc09    ; begin conditional assembly for mc09
 * For Multicomp09, the processor vectors are in RAM so they can be loaded
 * with the service addresses directly, instead of requiring another indirection
 * The vectors are set up by a data table copy of CPUVect
-               else      
+                  ELSE
 * This list of addresses ends up at $FEEE after the kernel track is loaded
 * into memory.  All interrupts come through the 6809 vectors at $FFF0-$FFFE
 * and get directed to here.  From here, the BRA takes CPU control to the
 * various handlers in the kernel.
-               bra       SWI3VCT             SWI3 vector comes here
-               nop       
-               bra       SWI2VCT             SWI2 vector comes here
-               nop       
-               bra       FIRQVCT             FIRQ vector comes here
-               nop       
-               bra       IRQVCT              IRQ vector comes here
-               nop       
-               bra       SWIVCT              SWI vector comes here
-               nop       
-               bra       NMIVCT              NMI vector comes here
-               nop       
-               endc      
+                    bra       SWI3VCT   ; sWI3 vector comes here
+                    nop       ; no operation placeholder
+                    bra       SWI2VCT   ; sWI2 vector comes here
+                    nop       ; no operation placeholder
+                    bra       FIRQVCT   ; fIRQ vector comes here
+                    nop       ; no operation placeholder
+                    bra       IRQVCT    ; iRQ vector comes here
+                    nop       ; no operation placeholder
+                    bra       SWIVCT    ; sWI vector comes here
+                    nop       ; no operation placeholder
+                    bra       NMIVCT    ; nMI vector comes here
+                    nop       ; no operation placeholder
+                  ENDC
 
 * The final byte (eg the NOP after bra NMIVCT) should be at offset $EFF
 * and will end up at address $FEFF in physical memory. If any code above
 * is changed, you must inspect the listing and adjust the addresses at
 * the label PAD.
-               end       
+                    end


### PR DESCRIPTION
## Overview

Annotates the Level 1 and Level 2 kernel assembly sources with clearer inline comments and normalized comment formatting while preserving program behavior.

This also replaces confusing section markers that resembled conflict markers with `*[[[` / `*]]]`, renames mechanical disassembly-style labels to shorter descriptive names, and keeps labels short enough to preserve opcode-column alignment.

## Notable Changes

- Annotated and normalized inline comments in `level1/modules/kernel` and `level2/modules/kernel`.
- Replaced `*<<<<` / `*>>>>` marker comments with `*[[[` / `*]]]`.
- Removed code-side `Lxxxx` labels in favor of descriptive labels, then shortened long labels to fit the existing label column.
- Did not add missing history blocks.

## Verification

```sh
for d in level1/*/modules/kernel level2/*/modules/kernel; do
  [ -f "$d/makefile" ] || continue
  case "$d" in */dplus/*|*/mc09/*|*/mc09l2/*) continue;;
  esac
  NITROS9DIR=/Users/boisy/Projects/coco-shelf/nitros9 make -B -C "$d" all || exit 1
done
```

Verified output:

```text
compared=37 same=37 different=0 missing_baseline=0
```

Also checked:

```sh
git diff --check -- level1/modules/kernel level2/modules/kernel
rg -n '^[^*;]*\bL[0-9A-F]{4}\b' level1/modules/kernel level2/modules/kernel
rg -n '^[A-Za-z_.$][A-Za-z0-9_.$@]{20,}\s' level1/modules/kernel level2/modules/kernel
```

Verified output:

```text
no issues found
```
