### PR TITLE
Fix DoPoll carry leak masking IRQs after non-clock interrupt

### DIFF
--- a/level2/modules/clock.asm
+++ b/level2/modules/clock.asm
@@ -281,8 +281,8 @@ DoToggle
                orb       #GI.Toggl           --- ensure that 60Hz IRQ's are always enabled
                sta       >IRQEnR             Disable CART
                stb       >IRQEnR             Enable CART
-               clrb
                endc
+               clrb
                rts
 
 


### PR DESCRIPTION
## Summary

- When a non-clock IRQ fires, `SvcIRQ` sets `D.SvcIRQ = DoPoll` and chains to `S.SysIRQ`. `DoPoll` exits its polling loop with carry set (its normal "no more IRQs" exit) and falls through to `DoToggle`, returning to `DoneIRQ` with carry set.
- `DoneIRQ` (`krn.asm:1036`) treats carry set as an error and ORs `IntMasks` into the saved CC on the interrupt stack. The subsequent `RTI` returns the interrupted process with I=1 (interrupts masked).
- With the 6809 I bit set, the 60 Hz GIME clock IRQ cannot fire. `D.Tick` never decrements, and `D.Year`/`D.Month`/`D.Day`/`D.Hour`/`D.Min`/`D.Sec` stop updating. A spinlocking process (no OS9 calls) will freeze the clock globals indefinitely.
- Fix: move `clrb` in `DoToggle` (`clock.asm`) to after the `endc` so it executes unconditionally on all platforms. `clrb` clears carry as a side effect. On CoCo3 it was already inside the `ifne coco3` block and incidentally cleared carry; on Wildbits that block is skipped entirely, leaving carry set. Moving it outside the conditional fixes Wildbits without changing CoCo3 behavior.

## Test plan

- [ ] Build Level 2 for CoCo3 and confirm no assembly errors
- [ ] Build Level 2 for Wildbits and confirm no assembly errors
- [ ] Boot NitrOS-9 Level 2 on CoCo3 (real or emulated), perform disk I/O, and verify that `D.Sec`/`D.Min` continue advancing after the disk IRQ returns
- [ ] Run a tight busy-loop process alongside disk activity and confirm clock globals (`F$Time`) still update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)