### PR TITLE
Fix nitrobotics CODEOWNERS spelling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @tlindner @strickyak @Deek @DrPitre @rlucente-retro @n6il @nitrorobotics @jfed6000 @MatthewMassie
+* @tlindner @strickyak @Deek @DrPitre @rlucente-retro @n6il @nitrobotics @jfed6000 @MatthewMassie


### PR DESCRIPTION
## Overview

Corrects the CODEOWNERS entry for the nitrobotics account so repository ownership requests point at the intended GitHub handle.

## Notable Changes

- Replaces `@nitrorobotics` with `@nitrobotics` in `.github/CODEOWNERS`.

## Verification

```sh
git diff origin/main..HEAD -- .github/CODEOWNERS
```

Verified output shows a single CODEOWNERS line change.