### PR TITLE
Fix an issue drawing menus in mode 5

### DIFF
--- a/level2/coco3/modules/cowin.asm
+++ b/level2/coco3/modules/cowin.asm
@@ -3027,8 +3027,7 @@ L0FFC               ldy       >WGlobal+g00BB      Get ptr to work window table
                     lda       Wt.Fore,y           Get current foreground color mask to preserve
                     sta       >GrfMem+gr00B5
                     ENDC
-*** IS THIS A BUG? A IS NOT USED BY GETCOLR - B IS. IT *RETURNS* A
-                    lda       #1                  ??? I THINK THIS SHOULD BE A LDB INSTEAD? LCB
+                    lda       #WColor1
                     lbsr      GetColr             convert it to mask
                     sta       Wt.Fore,y
                     lbsr      L1013               calculate X size
@@ -3492,9 +3491,14 @@ GetColr             pshs      b,x                 save color & table pointer
                     ldb       >WGlobal+g00BD      get screen type
                     leax      <ColrMsk-1,pc       point to color mask table (-1 since base 0)
                     ldb       b,x
+                    bmi       GetColr1Bit         special case for 1 bit
                     mul
-                    tfr       b,a
+GetColrCmn          tfr       b,a
                     puls      b,x,pc              restore & return
+GetColr1Bit         tsta
+                    bne       GetColrCmn
+                    clra
+                    puls      b,x,pc
 
 ColrMsk             fcb       $ff,$55,$55,$11
 


### PR DESCRIPTION
This PR fixes an issue drawing menu bars in mode 5, the 640x200 1-bit window.

Multi-Vue assumes at least 4 colors are available when drawing window chrome. Mode 5, however, only has two colors which results in menus being drawn incorrectly.

* This fix adds a special case in `GetColr` for Mode 5 to handle this issue.
* It also clarifies some code and removes a comment that asked a question whose answer was No, this is not a bug.

## Before Fix
<img width="637" height="508" alt="image" src="https://github.com/user-attachments/assets/b1b0cbf0-bfb2-49d3-8bd9-2e33f5ce431d" />


## After Fix
<img width="637" height="508" alt="FixedClock" src="https://github.com/user-attachments/assets/df43eb2e-d4c0-41dc-9b43-7d5aeceff322" />
