### PR TITLE
Update CoCo 3 recipe contents

### DIFF
--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -76,7 +76,7 @@ BOOTMODS ?= krnp2 ioman init \
 	$(SCF) \
 	$(PIPE) \
 	$(CLOCK) \
-	sysgo_dd shell_21 \
+	sysgo_dd \
 	$(BOOTMODS_EXTRA)
 
 SHELLMODS = shellplus date deiniz echo iniz link load save unlink

--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -6,6 +6,7 @@ RECIPE ?= coco3
 -include recipe.mak
 vpath %.asm $(LEVEL1)/coco1/modules
 vpath %.asm $(LEVEL2)/sys
+vpath %.asm $(3RDPARTY)/packages/basic09
 vpath %.hp $(LEVEL2)/sys:$(LEVEL1)/sys
 
 ifeq ($(CPU),6309)
@@ -51,6 +52,7 @@ OS9FORMAT_CMD ?= $(OS9FORMAT_DS40)
 AFLAGS += -I.
 AFLAGS += -I$(L2MD)/kernel -I$(L2PMD)
 AFLAGS += -I$(L1MD)/kernel -I$(L1MD)
+AFLAGS += -I$(3RDPARTY)/packages/basic09 -I$(MODDIR)
 AFLAGS += $(AFLAGS_EXTRA)
 LFLAGS += -L $(LIBDIR) $(COCO3_LFLAG) -lnet -lalib
 LFLAGS += $(LFLAGS_EXTRA)
@@ -80,7 +82,7 @@ BOOTMODS ?= krnp2 ioman init \
 SHELLMODS = shellplus date deiniz echo iniz link load save unlink
 UTILPAK1 = attr build copy del deldir dir display list makdir mdir merge mfree procs rename tmode
 
-CMDS_BASE ?= $(sort $(filter-out shell_21 shellplus,$(STDCMDS)) dmem grfdrv mmap modpatch montype pmap proc reboot shell smap utilpak1 wcreate)
+CMDS_BASE ?= $(sort $(filter-out shell_21 shellplus,$(STDCMDS)) basic09 dmem gfx2 grfdrv inkey mmap modpatch montype pmap proc reboot runb shell smap syscall utilpak1 wcreate)
 CMDS = $(sort $(CMDS_BASE) $(CMDS_EXTRA))
 
 SYSDIR ?= .sys
@@ -146,6 +148,12 @@ $(MODDIR)/shell: $(addprefix $(MODDIR)/,$(SHELLMODS)) | $(MODDIR)
 
 $(MODDIR)/utilpak1: $(addprefix $(MODDIR)/,$(UTILPAK1)) | $(MODDIR)
 	$(MERGE) $(addprefix $(MODDIR)/,$(UTILPAK1)) >$@
+
+$(MODDIR)/coco3vtio.d: $(DEFSDIR)/cocovtio.d | $(MODDIR)
+	$(AS) $(AFLAGS) --preprocess -DLevel=2 -DCOCOVTIO.D=0 $< >$@
+
+$(MODDIR)/gfx2: gfx2.asm $(MODDIR)/coco3vtio.d | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DLevel=2
 
 # SYS files
 $(SYSDIR):

--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -5,6 +5,8 @@ include ../../rules.mak
 RECIPE ?= coco3
 -include recipe.mak
 vpath %.asm $(LEVEL1)/coco1/modules
+vpath %.asm $(LEVEL2)/sys
+vpath %.hp $(LEVEL2)/sys:$(LEVEL1)/sys
 
 ifeq ($(CPU),6309)
 AFLAGS += -DH6309=1
@@ -64,6 +66,8 @@ CLOCK ?= clock_60hz clock2_soft
 KERNEL_TRACK ?= $(REL) boot_1773_6ms krn
 KERNELFILE = kerneltrack
 STARTUP ?= $(NITROS9DIR)/level2/$(PORT)/startup
+TELNET_PORT ?= 6809
+HTTPD_PORT ?= 8809
 
 BOOTMODS ?= krnp2 ioman init \
 	$(RBF) \
@@ -76,9 +80,13 @@ BOOTMODS ?= krnp2 ioman init \
 SHELLMODS = shellplus date deiniz echo iniz link load save unlink
 UTILPAK1 = attr build copy del deldir dir display list makdir mdir merge mfree procs rename tmode
 
-CMDS_BASE ?= $(STDCMDS) grfdrv shell utilpak1
-CMDS += $(CMDS_BASE) \
-	$(CMDS_EXTRA)
+CMDS_BASE ?= $(sort $(filter-out shell_21 shellplus,$(STDCMDS)) dmem grfdrv mmap modpatch montype pmap proc reboot shell smap utilpak1 wcreate)
+CMDS = $(sort $(CMDS_BASE) $(CMDS_EXTRA))
+
+SYSDIR ?= .sys
+SYSBIN = ibmedcfont isolatin1font stdfonts stdpats_2 stdpats_4 stdpats_16 stdptrs
+SYSHELP = $(sort $(wildcard $(LEVEL1)/sys/*.hp) $(wildcard $(LEVEL2)/sys/*.hp))
+SYSTEXT = errmsg helpmsg inetd.conf motd password
 
 all: libs $(DSKIMAGE)
 
@@ -91,7 +99,8 @@ kernelfile: $(addprefix $(MODDIR)/,$(KERNEL_TRACK))
 bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(MERGE) $(addprefix $(MODDIR)/,$(BOOTMODS))>$@
 
-$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(DSK_EXTRA_DEPS)
+$(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) \
+	$(addprefix $(SYSDIR)/,$(SYSBIN) $(SYSTEXT)) $(STARTUP) $(DSK_EXTRA_DEPS)
 	$(RM) $@
 	$(OS9FORMAT_CMD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
 	$(OS9GEN) $@ -b=bootfile -t=$(KERNELFILE)
@@ -100,6 +109,10 @@ $(DSKIMAGE): kernelfile bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(DS
 	$(MAKDIR) $@,DEFS
 	$(OS9COPY) $(addprefix $(MODDIR)/,$(CMDS)) $@,CMDS
 	$(OS9ATTR_EXEC) $(foreach file,$(CMDS),$@,CMDS/$(file))
+	$(OS9COPY) $(addprefix $(SYSDIR)/,$(SYSBIN)) $@,SYS
+	$(OS9ATTR_TEXT) $(foreach file,$(SYSBIN),$@,SYS/$(file))
+	$(CPL) $(addprefix $(SYSDIR)/,$(SYSTEXT)) $@,SYS
+	$(OS9ATTR_TEXT) $(foreach file,$(SYSTEXT),$@,SYS/$(file))
 	$(CPL) $(STARTUP) $@,startup
 	$(OS9ATTR_TEXT) $@,startup
 	$(DSK_POST_COPY)
@@ -133,6 +146,30 @@ $(MODDIR)/shell: $(addprefix $(MODDIR)/,$(SHELLMODS)) | $(MODDIR)
 
 $(MODDIR)/utilpak1: $(addprefix $(MODDIR)/,$(UTILPAK1)) | $(MODDIR)
 	$(MERGE) $(addprefix $(MODDIR)/,$(UTILPAK1)) >$@
+
+# SYS files
+$(SYSDIR):
+	@mkdir -p $@
+
+$(SYSDIR)/%: %.asm | $(SYSDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+$(SYSDIR)/helpmsg: $(SYSHELP) | $(SYSDIR)
+	$(MERGE) $^ >$@
+
+$(SYSDIR)/errmsg: $(LEVEL1)/sys/errmsg | $(SYSDIR)
+	$(CP) $< $@
+
+$(SYSDIR)/password: $(LEVEL1)/sys/password | $(SYSDIR)
+	$(CP) $< $@
+
+$(SYSDIR)/motd: | $(SYSDIR)
+	@$(ECHO) > $@
+	@$(ECHO) "Welcome to NitrOS-9 Level $(LEVEL) $(NITROS9VER) !" >> $@
+	@$(ECHO) >> $@
+
+$(SYSDIR)/inetd.conf: $(LEVEL1)/sys/inetd.conf | $(SYSDIR)
+	@sed -e 's/%TELNET_PORT%/$(TELNET_PORT)/' -e 's/%HTTPD_PORT%/$(HTTPD_PORT)/' $< >$@
 
 # CoCo 3 kernel/booter variants
 $(MODDIR)/boot_1773_6ms: boot_1773.asm | $(MODDIR)
@@ -210,6 +247,6 @@ $(MODDIR)/n5_scdwv.dd: scdwvdesc.asm | $(MODDIR)
 
 clean:
 	$(RM) *.list *.map bootfile $(KERNELFILE) *.dsk buildinfo
-	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR)
+	-rm -rf $(OBJDIR) $(LIBDIR) $(MODDIR) $(SYSDIR)
 
 .PHONY: all clean libs

--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -82,7 +82,7 @@ BOOTMODS ?= krnp2 ioman init \
 SHELLMODS = shellplus date deiniz echo iniz link load save unlink
 UTILPAK1 = attr build copy del deldir dir display list makdir mdir merge mfree procs rename tmode
 
-CMDS_BASE ?= $(sort $(filter-out shell_21 shellplus,$(STDCMDS)) basic09 dmem gfx2 grfdrv inkey mmap modpatch montype pmap proc reboot runb shell smap syscall utilpak1 wcreate)
+CMDS_BASE ?= $(sort $(filter-out shell_21 shellplus,$(STDCMDS)) basic09 dmem gfx gfx2 grfdrv inkey mmap modpatch montype pmap proc reboot runb shell smap syscall utilpak1 wcreate)
 CMDS = $(sort $(CMDS_BASE) $(CMDS_EXTRA))
 
 SYSDIR ?= .sys

--- a/recipes/coco3/dw/recipe.mak
+++ b/recipes/coco3/dw/recipe.mak
@@ -13,4 +13,4 @@ SCF = scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb cowin.io \
 	n3_scdwv.dd n4_scdwv.dd n5_scdwv.dd
 CLOCK = clock_60hz clock2_dw
 
-CMDS_EXTRA += dw inetd telnet httpd
+CMDS_EXTRA += dw httpd inetd telnet

--- a/recipes/coco3/sierra/recipe.mak
+++ b/recipes/coco3/sierra/recipe.mak
@@ -11,50 +11,56 @@ SIERRA_DATA_FILES = $(notdir $(wildcard $(SIERRA_DIR)/logDir $(SIERRA_DIR)/objec
 	$(SIERRA_DIR)/words.tok $(SIERRA_DIR)/vol.*))
 
 ifeq ($(GAME),blackcauldron)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_40d.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_40d.txt
 else ifeq ($(GAME),christmas86)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC.txt
 else ifeq ($(GAME),goldrush)
-SIERRA_MEDIA = dw
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+SIERRA_DEFAULT_MEDIA = dw
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_dw.txt
 else ifeq ($(GAME),kingsquest1)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_80d.txt
 else ifeq ($(GAME),kingsquest2)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_80d.txt
 else ifeq ($(GAME),kingsquest3)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_80d.txt
 else ifeq ($(GAME),kingsquest4)
-SIERRA_MEDIA = dw
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+SIERRA_DEFAULT_MEDIA = dw
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_dw.txt
 else ifeq ($(GAME),leisuresuitlarry)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC.txt
 else ifeq ($(GAME),manhunter1)
-SIERRA_MEDIA = dw
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+SIERRA_DEFAULT_MEDIA = dw
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_dw.txt
 else ifeq ($(GAME),manhunter2)
-SIERRA_MEDIA = dw
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+SIERRA_DEFAULT_MEDIA = dw
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_dw.txt
 else ifeq ($(GAME),policequest1)
-SIERRA_MEDIA = dw
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+SIERRA_DEFAULT_MEDIA = dw
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_dw.txt
 else ifeq ($(GAME),spacequest0)
-SIERRA_MEDIA = dw
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_dw.txt
+SIERRA_DEFAULT_MEDIA = dw
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_dw.txt
 else ifeq ($(GAME),spacequest1)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_80d.txt
 else ifeq ($(GAME),spacequest2)
-SIERRA_MEDIA = 80d
-SIERRA_TOC_TXT = $(SIERRA_DIR)/tOC_80d.txt
+SIERRA_DEFAULT_MEDIA = 80d
+SIERRA_TOC_DEFAULT = $(SIERRA_DIR)/tOC_80d.txt
 else
 $(error Unsupported Sierra GAME "$(GAME)")
 endif
+
+# Override SIERRA_MEDIA on the command line to build a game with a different
+# supported disk backend, e.g. GAME=kingsquest3 SIERRA_MEDIA=dw.
+SIERRA_MEDIA ?= $(SIERRA_DEFAULT_MEDIA)
+SIERRA_TOC_DW = $(wildcard $(SIERRA_DIR)/tOC_dw.txt)
+SIERRA_TOC_TXT ?= $(if $(and $(filter dw,$(SIERRA_MEDIA)),$(SIERRA_TOC_DW)),$(SIERRA_TOC_DW),$(SIERRA_TOC_DEFAULT))
 
 ifeq ($(SIERRA_MEDIA),80d)
 OS9FORMAT_CMD = $(OS9FORMAT_DS80)


### PR DESCRIPTION
## Overview

Updates the shared CoCo 3 recipe logic so generated disks include the expected Level 2 `/SYS` font, pattern, help, and configuration files. SYS artifacts now build into a separate `SYSDIR` instead of `MODDIR`, while command and module artifacts remain under `MODDIR`.

The CoCo 3 command list also now includes the requested standalone diagnostic/system commands plus the Basic09 and graphics command set, excludes `shell_21` and `shellplus` from `/CMDS`, and sorts combined base plus recipe-specific command entries. The bootfile no longer includes `shell_21`; `/CMDS/shell` is still built by merging `shellplus` with its companion command modules.

Sierra game recipes now support overriding the selected media backend, so an 80-track default game can be built as DriveWire with `SIERRA_MEDIA=dw` when desired.

## Notable Changes

- Add SYS binary and text file generation/copy steps to `recipes/coco3/coco3.mak`.
- Build SYS files under `SYSDIR ?= .sys`, and clean that directory with the rest of the recipe artifacts.
- Use sorted wildcards for Level 1 and Level 2 `*.hp` files when building `helpmsg`.
- Add CoCo 3 `/CMDS` entries for `basic09`, `gfx`, `gfx2`, `inkey`, `runb`, and `syscall`.
- Build `gfx2` from the Basic09 package with a generated CoCo 3 VTIO include.
- Remove `shell_21` from the CoCo 3 bootfile while preserving the merged `/CMDS/shell`.
- Allow Sierra recipes to override `SIERRA_MEDIA`, preferring `tOC_dw.txt` for DriveWire when present.
- Sort DriveWire extras as `dw httpd inetd telnet`.
- Leave unrelated untracked Wildbits generated files unstaged.

## Verification

```sh
make -C recipes/coco3/40d l2_coco3.dsk
make -C recipes/coco3/40d -B -n bootfile | rg 'shell_21|\.mods/shell'\nmake -C recipes/coco3/40d -B -n .mods/shell | rg 'cat .*\.mods/shell|shellplus'\nmake -C recipes/coco3/40d -n l2_coco3.dsk | rg '(basic09|gfx|gfx2|syscall|inkey|runb|coco3vtio|os9 copy -o=0 .*CMDS)'\nmake -C recipes/coco3/sierra -n GAME=kingsquest3 l2_coco3_kingsquest3.dsk | rg 'boot_1773|rb1773|ddd0_80d|tOC_80d'\nmake -C recipes/coco3/sierra -n GAME=kingsquest3 SIERRA_MEDIA=dw l2_coco3_kingsquest3.dsk | rg 'boot_dw|rbdw|dwio|ddx0|tOC_dw'\nmake -C recipes/coco3/sierra -n GAME=spacequest1 SIERRA_MEDIA=dw l2_coco3_spacequest1.dsk | rg 'boot_dw|rbdw|dwio|ddx0|tOC_80d'\n```\n\nVerified output included:\n\n```text\nos9 copy -o=0 .sys/ibmedcfont .sys/isolatin1font .sys/stdfonts .sys/stdpats_2 .sys/stdpats_4 .sys/stdpats_16 .sys/stdptrs l2_coco3.dsk,SYS\nos9 copy -o=0 -l .sys/errmsg .sys/helpmsg .sys/inetd.conf .sys/motd .sys/password l2_coco3.dsk,SYS\nos9 copy -o=0 ... .mods/basic09 ... .mods/gfx .mods/gfx2 ... .mods/inkey ... .mods/runb ... .mods/shell ... .mods/syscall ... l2_coco3.dsk,CMDS\ncat .mods/shellplus .mods/date .mods/deiniz .mods/echo .mods/iniz .mods/link .mods/load .mods/save .mods/unlink >.mods/shell\ncat .mods/rel_32 .mods/boot_dw .mods/krn>kerneltrack\ncat .mods/krnp2 .mods/ioman .mods/init .mods/rbf.mn .mods/rbdw.dr .mods/dwio.sb .mods/ddx0.dd ... >bootfile\nos9 copy -o=0 -l .../kingsquest3/tOC_dw.txt l2_coco3_kingsquest3.dsk,tOC.txt\n```