### PR TITLE
Remove Deek from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @tlindner @strickyak @Deek @DrPitre @rlucente-retro @n6il @nitrobotics @jfed6000 @MatthewMassie
+* @tlindner @strickyak @DrPitre @rlucente-retro @n6il @nitrobotics @jfed6000 @MatthewMassie


### PR DESCRIPTION
## Overview

Removes `@Deek` from the repository-wide CODEOWNERS entry so they are no longer requested as a default code owner on all changes.

## Notable Changes

- Updated `.github/CODEOWNERS` to remove `@Deek` from the catch-all owner list.
- Left all other default code owners unchanged.

## Verification

```sh
git diff --cached -- .github/CODEOWNERS
rg -n "@Deek|Deek" .github/CODEOWNERS
```

Verified output:

```text
.github/CODEOWNERS | 2 +-
rg returned no matches in .github/CODEOWNERS
```