### PR TITLE
Add lwasm disassemblies of the OS-9 Microware C compiler, plus tooling

### DIFF
--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       4389
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.comp/
                     fcb       edition
 
-L0014               lda       ,y+
+copybytes           lda       ,y+
 L0016               sta       ,u+
 L0018               leax      -$01,x
-L001A               bne       L0014
+L001A               bne       copybytes
 L001C               rts
 
-start               pshs      y
+_start              pshs      y
 L001F               pshs      u
 L0021               clra
 L0022               clrb
@@ -37,12 +37,12 @@ L0030               pshs      x
 L0032               leay      LB358,pcr
 L0036               ldx       ,y++
 L0038               beq       L003E
-L003A               bsr       L0014
+L003A               bsr       copybytes
 L003C               ldu       $02,s
 L003E               leau      >$0078,u
 L0042               ldx       ,y++
 L0044               beq       L0049
-L0046               bsr       L0014
+L0046               bsr       copybytes
 L0048               clra
 L0049               cmpu      ,s
 L004C               beq       L0052
@@ -119,17 +119,17 @@ L00E0               leax      $0316,u
                     ldd       $0352,u
                     pshs      d
                     leay      ,u
-                    bsr       L00FA
-                    lbsr      L017C
+                    bsr       stkinit
+                    lbsr      main
                     clr       ,-s
                     clr       ,-s
-                    lbsr      LB34C
-L00FA               leax      $08A5,y
+                    lbsr      exit
+stkinit             leax      $08A5,y
                     stx       $0360,y
                     sts       $0354,y
                     sts       $0362,y
                     ldd       #$FF82
-L010F               leax      d,s
+stkcheck            leax      d,s
                     cmpx      $0362,y
                     bcc       L0121
                     cmpx      $0360,y
@@ -167,7 +167,7 @@ L016A               ldd       ,y++
                     leas      $04,s
                     rts
 
-L017C               pshs      u
+main                pshs      u
                     leax      L5DC9,pcr
                     pshs      x
                     lbsr      LB31C
@@ -229,7 +229,7 @@ L01E4               leau      $01,u
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L02F2
 L0215               leax      ,s
@@ -246,7 +246,7 @@ L0220               ldb       ,u
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L02F2
                     bra       L0257
@@ -322,14 +322,14 @@ L02CA               leax      $0253,y
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     bsr       L02F2
 L02F0               puls      pc,u
 L02F2               pshs      u
                     ldd       #$0001
                     pshs      d
-                    lbsr      LB34C
+                    lbsr      exit
                     leas      $02,s
                     puls      pc,u
 L0300               clrb
@@ -571,7 +571,7 @@ L054F               pshs      u
                     pshs      d
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
 L056A               pshs      u
@@ -787,7 +787,7 @@ L0781               fcb       $4F,$52,$54
                     fcb       $00
 L0785               pshs      u
 L0787               ldd       #$FFA2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L0899
                     std       $0C,s
@@ -912,7 +912,7 @@ L0895               leas      $0e,s
                     puls      pc,u
 L0899               pshs      u
                     ldd       #$FFA4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0C,s
                     ldu       #$0000
                     ldx       $003F
@@ -1307,7 +1307,7 @@ L0BF5               leas      $0C,s
                     puls      pc,u
 L0BF9               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldu       #$0000
                     bra       L0C08
@@ -1350,7 +1350,7 @@ L0C50               tfr       u,d
 
 L0C54               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
@@ -1385,7 +1385,7 @@ L0C9C               leas      $02,s
                     puls      pc,u
 L0CA0               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $003F
                     bra       L0CF9
 
@@ -1438,7 +1438,7 @@ L0CF9               cmpx      #$0041
                     puls      pc,u
 L0D26               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     lbra      L0E98
 
@@ -1662,7 +1662,7 @@ L0E98               cmpx      #$0050
                     puls      pc,u
 L0F4C               pshs      u
                     ldd       #$FFA2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     ldd       L001F
                     std       $04,s
@@ -1728,7 +1728,7 @@ L0F9D               ldd       $02,s
                     puls      pc,u
 L0FD8               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $000D
                     beq       L0FEC
                     ldu       $000D
@@ -1760,7 +1760,7 @@ L0FF8               ldd       $04,s
                     puls      pc,u
 L101A               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L110A,pcr
                     pshs      x
                     lbsr      L0450
@@ -1768,7 +1768,7 @@ L101A               pshs      u
 
 L102E               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       [$04,s]
                     ldx       $06,u
                     bra       L1081
@@ -1832,7 +1832,7 @@ L110A               fcc       /expression missing/
                     fcb       $00
 L111D               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0C,s
                     stu       -$02,s
@@ -1941,7 +1941,7 @@ L1204               tfr       u,d
                     puls      pc,u
 L120A               pshs      u
                     ldd       #$FFA8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0e,s
                     stu       -$02,s
@@ -2307,7 +2307,7 @@ L1524               leas      $0e,s
                     puls      pc,u
 L1528               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L156E
@@ -2335,7 +2335,7 @@ L156E               clra
                     puls      pc,u
 L1572               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L287A,pcr
                     pshs      x
                     lbsr      L0450
@@ -2343,7 +2343,7 @@ L1572               pshs      u
                     puls      pc,u
 L1587               pshs      u
                     ldd       #$FF9C
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$14,s
                     ldx       $18,s
                     ldu       $0a,x
@@ -3674,7 +3674,7 @@ L2170               ldd       $0C,s
                     puls      pc,u
 L2193               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -3694,7 +3694,7 @@ L21A9               leax      L294E,pcr
 L21BF               puls      pc,u
 L21C1               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     pshs      u
@@ -3745,7 +3745,7 @@ L2224               ldd       ,s
                     puls      pc,u
 L222C               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -4111,7 +4111,7 @@ L2540               ldd       $0a,s
 
 L2545               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
@@ -4170,7 +4170,7 @@ L25C5               leas      $04,s
                     puls      pc,u
 L25C9               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $08,s
                     pshs      d
                     ldd       $06,s
@@ -4244,7 +4244,7 @@ L2657               std       $12,u
                     puls      pc,u
 L2668               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -4290,7 +4290,7 @@ L26C1               leax      L2968,pcr
 
 L26D8               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0034
@@ -4308,7 +4308,7 @@ L26D8               pshs      u
 
 L2707               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       ,u
@@ -4391,7 +4391,7 @@ L27B6               leas      $02,s
 L27B8               puls      pc,u
 L27BA               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       ,u
                     cmpd      #$0004
@@ -4411,7 +4411,7 @@ L27E7               ldd       ,u
                     puls      pc,u
 L27EB               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       #$0006
                     pshs      d
@@ -4441,7 +4441,7 @@ L27EB               pshs      u
                     puls      pc,u
 L2832               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L2843
 
@@ -4460,7 +4460,7 @@ L2843               cmpx      #$0001
                     puls      pc,u
 L2861               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L29C4,pcr
                     pshs      x
                     ldd       $06,s
@@ -4508,7 +4508,7 @@ L29C4               fcc       /must be integral/
                     fcb       $00
 L29D5               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $003F
                     cmpd      #$0028
                     beq       L29ED
@@ -4581,7 +4581,7 @@ L2A48               cmpx      #$0013
                     beq       L2A21
                     cmpx      #$001A
                     beq       L2A26
-                    cmpx      #start
+                    cmpx      #_start
                     beq       L2A2C
                     cmpx      #$0015
                     beq       L2A32
@@ -4653,7 +4653,7 @@ L2B10               ldd       #$0028
                     puls      pc,u
 L2B1C               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     lbsr      L5F26
                     lbsr      L337E
@@ -4739,7 +4739,7 @@ L2BD2               ldd       $02,s
                     puls      pc,u
 L2BDF               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       $0033
                     std       $08,s
@@ -4816,7 +4816,7 @@ L2C52               ldd       $0035
                     puls      pc,u
 L2C8F               pshs      u
                     ldd       #$FFA8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L5F26
                     ldd       $0037
@@ -4981,7 +4981,7 @@ L2DCB               ldd       $0033
 
 L2DF6               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     lbsr      L5F26
                     clra
@@ -5033,7 +5033,7 @@ L2E5A               bsr       L2E9C
 
 L2E5E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     lbsr      L5F26
                     ldd       $0037
                     bne       L2E6F
@@ -5059,7 +5059,7 @@ L2E90               leas      $02,s
 
 L2E9C               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L3447,pcr
                     pshs      x
                     lbsr      L0450
@@ -5067,7 +5067,7 @@ L2EAD               leas      $02,s
                     puls      pc,u
 L2EB1               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       $0033
                     std       $08,s
@@ -5139,7 +5139,7 @@ L2F1C               lbsr      L5F26
                     puls      pc,u
 L2F5F               pshs      u
                     ldd       #$FFA6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     clra
                     clrb
@@ -5282,7 +5282,7 @@ L3094               leas      $0e,s
                     puls      pc,u
 L3098               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0028
@@ -5413,7 +5413,7 @@ L3197               clra
 
 L31B8               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     lbsr      L5F26
                     ldd       $0033
                     bne       L31D4
@@ -5441,7 +5441,7 @@ L31F1               ldd       #$0018
 
 L31F7               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     lbsr      L5F26
                     ldd       $0035
                     bne       L3213
@@ -5469,7 +5469,7 @@ L3230               ldd       #$0019
 
 L3235               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0034
@@ -5489,7 +5489,7 @@ L3255               lbsr      L32C2
                     pshs      d
                     ldd       $06,u
                     pshs      d
-                    ldd       #start
+                    ldd       #_start
                     pshs      d
                     lbsr      L4623
                     leas      $06,s
@@ -5497,12 +5497,12 @@ L3255               lbsr      L32C2
                     orb       #$02
                     std       $0a,u
 L3276               lbsr      L5F26
-L3279               ldd       #start
+L3279               ldd       #_start
 L327C               std       $002F
                     puls      pc,u
 L3280               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     bsr       L32C2
                     tfr       d,u
                     stu       -$02,s
@@ -5532,7 +5532,7 @@ L32BA               lbsr      L5F26
                     puls      pc,u
 L32C2               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $0041
                     ldd       ,u
                     cmpd      #$0009
@@ -5571,7 +5571,7 @@ L32F4               ldd       #$0009
 
 L3319               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     lbsr      L0785
@@ -5589,7 +5589,7 @@ L3319               pshs      u
 
 L3342               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L26D8
@@ -5618,7 +5618,7 @@ L336D               pshs      u
 
 L337E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       #$002D
                     pshs      d
@@ -5635,7 +5635,7 @@ L337E               pshs      u
 
 L33A5               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     clra
                     clrb
                     pshs      d
@@ -5658,7 +5658,7 @@ L33D3               tfr       u,d
                     puls      pc,u
 L33D7               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L33FF
@@ -5699,7 +5699,7 @@ L34AD               fcc       /condition needed/
                     fcb       $00
 L34BE               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L34D9
@@ -5711,7 +5711,7 @@ L34BE               pshs      u
                     puls      pc,u
 L34D9               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       $06,u
@@ -6107,7 +6107,7 @@ L3894               leas      $06,s
                     puls      pc,u
 L3898               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L38D5
@@ -6143,7 +6143,7 @@ L38D5               cmpx      #$0034
 L38E6               puls      pc,u
 L38E8               pshs      u
                     ldd       #$FFB2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $08,u
@@ -6212,7 +6212,7 @@ L3981               fcc       /longs/
                     fcb       $00
 L3987               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L39A2
@@ -6224,7 +6224,7 @@ L3987               pshs      u
                     puls      pc,u
 L39A2               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$08,s
                     ldd       ,u
@@ -6550,7 +6550,7 @@ L3CB0               fcc       /floats/
                     fcb       $00
 L3CB7               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldx       $0a,s
@@ -6700,7 +6700,7 @@ L3DEE               leas      $04,s
                     puls      pc,u
 L3DF2               pshs      u
                     ldd       #$FFA8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $06,s
                     leas      -$0C,s
                     ldd       $16,s
@@ -6914,7 +6914,7 @@ L3FCC               leas      $0C,s
                     puls      pc,u
 L3FD0               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L428F,pcr
                     pshs      x
                     lbsr      L5756
@@ -6927,7 +6927,7 @@ L3FD0               pshs      u
                     puls      pc,u
 L3FF1               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldd       #$0002
                     pshs      d
@@ -7132,7 +7132,7 @@ L419B               leas      $08,s
                     puls      pc,u
 L419F               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $08,s
@@ -7178,7 +7178,7 @@ L41FF               leas      $02,s
                     puls      pc,u
 L4203               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L4294,pcr
                     pshs      x
                     lbsr      L0450
@@ -7187,7 +7187,7 @@ L4203               pshs      u
                     puls      pc,u
 L421A               pshs      u
                     ldd       #$FFBC
-                    lbsr      L010F
+                    lbsr      stkcheck
 L4222               ldx       $003F
                     bra       L422D
 
@@ -7323,7 +7323,7 @@ L4371               leax      $0584,y
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     leax      $078a,y
                     pshs      x
@@ -7331,7 +7331,7 @@ L4371               leax      $0584,y
 L43B5               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L430E
 
@@ -7413,7 +7413,7 @@ L447A               ldd       $04,s
                     lbne      L430E
                     ldd       #$0001
                     pshs      d
-                    lbsr      LB34C
+                    lbsr      exit
                     leas      $02,s
                     lbra      L430E
 
@@ -7488,7 +7488,7 @@ L4509               pshs      u,d
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      LB34C
+                    lbsr      exit
                     leas      $02,s
 L4546               clra
                     clrb
@@ -7599,7 +7599,7 @@ L465E               ldd       $0e,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       $000F
                     subd      #$0002
@@ -7858,7 +7858,7 @@ L48AE               std       $06,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     lbra      L4C78
 
 L48C9               ldd       $10,s
@@ -7908,7 +7908,7 @@ L48E7               cmpx      #$007A
                     lbeq      L471D
                     cmpx      #$0044
                     lbeq      L4724
-                    cmpx      #start
+                    cmpx      #_start
                     lbeq      L472B
                     cmpx      #$007C
                     lbeq      L4751
@@ -8101,7 +8101,7 @@ L4B30               ldd       $10,s
 L4B47               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L4D75
 
@@ -8229,7 +8229,7 @@ L4C5D               ldd       $10,s
 L4C6F               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
 L4C78               leas      $08,s
                     lbra      L4D75
 
@@ -8335,7 +8335,7 @@ L4D5E               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
 L4D75               leas      $08,s
                     puls      pc,u
 L4D79               pshs      u
@@ -8557,7 +8557,7 @@ L4F9A               pshs      d
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L4FAD               cmpu      #$0005
@@ -9020,7 +9020,7 @@ L53CE               ldd       $04,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     ldd       $000F
                     addd      #$0002
@@ -9442,7 +9442,7 @@ L5794               pshs      u
                     pshs      d
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
 L57A1               leas      $04,s
                     puls      pc,u
 L57A5               pshs      u
@@ -9518,7 +9518,7 @@ L5832               pshs      u
 L583C               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L5849               pshs      u
@@ -9534,7 +9534,7 @@ L5849               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
                     bge       $58E8
@@ -9937,7 +9937,7 @@ L5BE5               leas      $02,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     bra       L5C2D
 
 L5C03               pshs      u
@@ -9976,7 +9976,7 @@ L5C34               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $0a,s
                     puls      pc,u
 L5C57               pshs      u
@@ -9997,7 +9997,7 @@ L5C6F               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       $06,s
                     pshs      d
@@ -10019,7 +10019,7 @@ L5C6F               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
 L5CB8               ldd       $0017
                     lbeq      L5DFF
@@ -10050,7 +10050,7 @@ L5CEB               pshs      u
 L5CF9               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
 L5D04               puls      pc,u
 L5D06               pshs      u
@@ -10066,7 +10066,7 @@ L5D06               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
 L5D28               puls      pc,u
 L5D2A               pshs      u
@@ -10773,7 +10773,7 @@ L6292               pshs      u
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
-                    ldd       #start
+                    ldd       #_start
                     pshs      d
                     leax      L6D56,pcr
                     pshs      x
@@ -11580,7 +11580,7 @@ L6A37               clra
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     bra       L6A99
 
@@ -11636,7 +11636,7 @@ L6AC1               pshs      u
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $04,s
 L6AD6               ldd       $04,s
                     cmpd      #$0020
@@ -11650,7 +11650,7 @@ L6AE6               ldd       $04,s
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     bra       L6B27
 
@@ -11670,7 +11670,7 @@ L6AFB               ldd       $0064
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $04,s
 L6B27               clra
                     clrb
@@ -11686,7 +11686,7 @@ L6B34               pshs      u
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L6B4B               pshs      u,d
@@ -11986,7 +11986,7 @@ L6E36               bhi       $6E45
                     tst       $0000
 L6E42               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L6EAC
@@ -12008,7 +12008,7 @@ L6E42               pshs      u
 
 L6E76               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L7E9C
@@ -12030,7 +12030,7 @@ L6EA8               std       $06,u
 L6EAA               puls      pc,u
 L6EAC               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       ,u
                     bra       L6ED7
@@ -12062,7 +12062,7 @@ L6ED7               cmpx      #$0008
 L6EEA               puls      pc,u
 L6EEC               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     lbra      L6F5F
@@ -12131,7 +12131,7 @@ L6F5F               cmpx      #$0037
 L6F81               puls      pc,u
 L6F83               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -12341,7 +12341,7 @@ L7176               tfr       u,d
                     puls      pc,u
 L717C               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -12689,7 +12689,7 @@ L7494               ldd       #$0070
 
 L749E               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       #$0000
                     bra       L74C2
 
@@ -12710,7 +12710,7 @@ L74C2               cmpu      #$000E
 
 L74CB               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       #$0001
@@ -12778,7 +12778,7 @@ L74CB               pshs      u
 
 L7567               pshs      u
                     ldd       #$FFAE
-L756C               lbsr      L010F
+L756C               lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -12834,7 +12834,7 @@ L75DF               leas      $06,s
                     puls      pc,u
 L75E3               pshs      u
                     ldd       #$FFB2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldd       $000F
                     std       ,s
@@ -12934,7 +12934,7 @@ L7680               ldx       $02,s
 
 L76BF               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $06,u
@@ -12977,7 +12977,7 @@ L7719               leas      $02,s
                     puls      pc,u
 L771D               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L774B
@@ -13003,7 +13003,7 @@ L774B               cmpx      #$0050
 
 L7759               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $12,x
                     cmpd      #$0002
@@ -13013,7 +13013,7 @@ L7759               pshs      u
 
 L7771               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L7790
@@ -13039,7 +13039,7 @@ L77A8               clra
 L77AA               puls      pc,u
 L77AC               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$80
@@ -13066,7 +13066,7 @@ L77AC               pshs      u
 L77E4               puls      pc,u
 L77E6               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -13232,7 +13232,7 @@ L792C               pshs      u
 
 L794A               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -13481,7 +13481,7 @@ L7B63               pshs      u
 
 L7B83               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$7f
@@ -13514,7 +13514,7 @@ L7BBC               ldd       #$0071
                     puls      pc,u
 L7BD2               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $0a,u
@@ -13664,7 +13664,7 @@ L7D15               leas      $04,s
                     puls      pc,u
 L7D19               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -13823,7 +13823,7 @@ L7E56               ldd       $0e,s
 
 L7E63               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     bsr       L7E9C
@@ -13847,7 +13847,7 @@ L7E95               ldd       #$0071
                     puls      pc,u
 L7E9C               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -14141,7 +14141,7 @@ L812E               leas      $08,s
                     puls      pc,u
 L8132               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$006F
                     beq       L814A
@@ -14168,7 +14168,7 @@ L8186               fcc       /x translate/
                     fcb       $00
 L8192               pshs      u
                     ldd       #$FFA2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$14,s
                     bra       L81AD
 
@@ -14470,7 +14470,7 @@ L843C               leas      $14,s
                     puls      pc,u
 L8441               pshs      u
                     ldd       #$FFA4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$12,s
                     lbsr      L8B51
                     std       $10,s
@@ -14622,7 +14622,7 @@ L857F               ldd       #$0028
 
 L8593               pshs      u
                     ldd       #$FF9E
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$12,s
                     lbsr      L8B51
                     std       $10,s
@@ -14890,7 +14890,7 @@ L87E1               leas      $12,s
                     puls      pc,u
 L87E6               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       ,u
                     cmpd      $06,s
@@ -14912,7 +14912,7 @@ L8816               clra
                     puls      pc,u
 L881A               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$0010
                     bne       L886B
@@ -14949,7 +14949,7 @@ L886B               ldd       $04,s
                     puls      pc,u
 L886F               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       #$0001
                     std       $0031
@@ -15105,7 +15105,7 @@ L89B0               lbsr      L5F26
                     puls      pc,u
 L89B7               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldd       $002B
                     std       $02,s
@@ -15229,7 +15229,7 @@ L8ABF               std       $000F
                     puls      pc,u
 L8AC5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     clra
                     clrb
@@ -15289,7 +15289,7 @@ L8B45               ldd       #$002E
 
 L8B51               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     lbsr      L0641
                     std       -$02,s
@@ -15327,7 +15327,7 @@ L8B9C               leas      $02,s
                     puls      pc,u
 L8BA0               pshs      u
                     ldd       #$FF98
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$1a,s
                     clra
                     clrb
@@ -15681,7 +15681,7 @@ L8EF0               leas      $1a,s
                     puls      pc,u
 L8EF5               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0C,s
                     clra
                     clrb
@@ -15832,7 +15832,7 @@ L9024               ldd       $0a,s
                     puls      pc,u
 L9035               pshs      u
                     ldd       #$FFBC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
@@ -15858,7 +15858,7 @@ L905D               ldd       ,s
 
 L906B               pshs      u
                     ldd       #$FFB2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       ,u
@@ -15926,7 +15926,7 @@ L90DD               std       $02,u
                     puls      pc,u
 L90F5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $08,s
                     leas      -$02,s
                     ldd       $06,s
@@ -15983,7 +15983,7 @@ L916A               ldd       $08,s
 
 L916F               pshs      u
                     ldd       #$FF74
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$40,s
                     ldu       [$44,s]
                     lbra      L922C
@@ -16070,13 +16070,13 @@ L922C               stu       -$02,s
                     puls      pc,u
 L923C               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L9375,pcr
                     bra       L9256
 
 L924A               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L938A,pcr
 L9256               pshs      x
                     lbsr      L0450
@@ -16120,7 +16120,7 @@ L938A               fcc       /identifier missing/
                     fcb       $00
 L939D               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
@@ -16326,7 +16326,7 @@ L9573               leas      $04,s
                     puls      pc,u
 L9577               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldd       $0a,x
@@ -16542,7 +16542,7 @@ L973E               ldd       $02,s
                     puls      pc,u
 L9754               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L9772
@@ -16563,7 +16563,7 @@ L9772               cmpx      #$0034
                     lbra      L998C
                     pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0034
@@ -16578,7 +16578,7 @@ L9772               cmpx      #$0034
 
 L97AE               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -16709,7 +16709,7 @@ L98ED               leas      $04,s
                     puls      pc,u
 L98F1               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L991B
 
@@ -16734,7 +16734,7 @@ L991B               cmpx      #$005A
                     puls      pc,u
 L9929               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L9947
 
@@ -16762,7 +16762,7 @@ L9947               cmpx      #$005A
                     puls      pc,u
 L9971               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -16863,7 +16863,7 @@ L9A1F               pshs      u
                     ldd       $06,s
                     bra       L9A45
 
-L9A34               pshs      u
+fprintf             pshs      u
                     ldd       $04,s
                     std       L0070
                     ldd       #$0001
@@ -16872,7 +16872,7 @@ L9A34               pshs      u
                     pshs      x
                     ldd       $08,s
 L9A45               pshs      d
-                    bsr       L9A6C
+                    bsr       doprnt
                     leas      $04,s
                     puls      pc,u
 L9A4D               pshs      u
@@ -16884,13 +16884,13 @@ L9A4D               pshs      u
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       L9A6C
+                    bsr       doprnt
                     leas      $04,s
                     clra
                     clrb
                     stb       [L0070,y]
                     puls      pc,u
-L9A6C               pshs      u
+doprnt              pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L9A84
@@ -19954,325 +19954,133 @@ LB347               bcs       LB33E
                     clrb
                     rts
 
-LB34C               lbsr      LB357
+exit                lbsr      LB357
                     lbsr      LA295
 LB352               ldd       $02,s
                     os9       F$Exit
 LB357               rts
 
-LB358               neg       $0003
-                    neg       $0002
-                    rora
-                    fcb       $02
-                    ldx       $0000
-                    fcb       $01
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $000C
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       L008C
+* ------------------------------------------------------------------
+* LB358 - cc1-style init image for the work block (see _start):
+* rts stub + count/block table + relocation dirs + module-name string.
+* ------------------------------------------------------------------
+LB358               fcb       $00,$03,$00,$02 init table / work-block image
+                    fcb       $46
+                    fcb       $02,$9E,$00,$01,$00,$02,$00,$00
+                    fcb       $00,$00,$00,$0C,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$8C
                     fcc       /cstr.XXXXX/
                     fcb       $00
                     fcc       /x expected/
+                    fcb       $00,$06,$83
+                    fcc       /XmXpXsXyX/
+                    fcb       $7F
+                    fcb       $58
+                    fcb       $84,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
                     fcb       $00
-                    ror       $0083
-                    aslb
-                    tst       -$08,u
-                    neg       $5873
-                    aslb
-                    rol       L587F
-                    aslb
-                    anda      #$00
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $006D
-                    nega
-                    rol       0,x
-                    neg       L0054
-                    fcc       |Ah-.BP0CESkkkkkkkkkk/(]x_d|
+                    fcb       $6D,$40,$69
+                    fcb       $00,$00
+                    fcc       |TAh-.BP0CESkkkkkkkkkk/(]x_d|
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj+f,Yj/
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj)X*D/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$09,$00,$00,$00,$0D,$0E
+                    fcb       $00,$00,$00,$0E,$0C,$01,$0E,$0F
+                    fcb       $0D,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$03,$00,$0A,$02,$0A
+                    fcb       $03,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$07
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$06,$00,$0E
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $81
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$00,$00,$84
+                    fcb       $48
+                    fcb       $00,$00,$00,$00,$00,$00,$87
+                    fcb       $7A
+                    fcb       $00,$00,$00,$00,$00,$00,$8A,$1C
+                    fcb       $40
+                    fcb       $00,$00,$00,$00,$00,$8E
+                    fcb       $43,$50
+                    fcb       $00,$00,$00,$00,$00,$91
+                    fcb       $74,$24
+                    fcb       $00,$00,$00,$00,$00,$94,$18,$96
+                    fcb       $80,$00,$00,$00,$00,$98
+                    fcb       $3E
+                    fcb       $BC
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$9B
+                    fcb       $6E,$6B,$28
+                    fcb       $00,$00,$00,$00,$9E,$15,$02,$F9
+                    fcb       $00,$00,$00,$00,$A2
+                    fcb       $2D,$78
+                    fcb       $EB,$C5,$AC
+                    fcb       $62
+                    fcb       $00,$C3
+                    fcb       $49
+                    fcb       $F2,$C9,$CD,$04
+                    fcb       $67,$4F
+                    fcb       $E4,$00,$02,$00,$04,$00,$08,$00
+                    fcb       $10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00,$80,$01,$00,$02,$00,$04,$00
+                    fcb       $08,$00,$10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$01,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$02,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
                     fcb       $00,$00,$00
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0009
-                    neg       $0000
-                    neg       $000D
-                    jmp       $0000
-                    neg       $0000
-                    jmp       $000C
-                    fcb       $01
-                    jmp       $000F
-                    tst       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0003
-                    neg       $000A
-                    fcb       $02
-                    dec       $0003
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    asr       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    ror       $0000
-                    jmp       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0081
-                    bra       LB4AB
-
-LB4AB               neg       $0000
-                    neg       $0000
-                    neg       L0084
-                    asla
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $87
-                    dec       >$0000
-                    neg       $0000
-                    neg       $0000
-                    ora       #$1C
-                    nega
-                    neg       $0000
-                    neg       $0000
-                    neg       L008E
-                    coma
-                    negb
-                    neg       $0000
-                    neg       $0000
-                    neg       $0091
-                    lsr       L2400
-                    neg       $0000
-                    neg       $0000
-                    anda      L0018
-                    lda       L0080
-                    neg       $0000
-                    neg       $0000
-                    eora      L003E
-                    cmpx      L2000
-                    neg       $0000
-                    neg       $009B
-                    jmp       $0b,s
-                    bvc       LB4ED
-LB4ED               neg       $0000
-                    neg       L009E
-                    fcb       $15,$02
-                    adcb      >$0000
-                    neg       $0000
-                    sbca      $0d,y
-                    asl       $EBC5
-                    cmpx      $02,s
-                    neg       $00C3
-                    rola
-                    sbcb      $C9CD
-                    lsr       $0067
-                    clra
-                    andb      0,x
-                    fcb       $02
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       $0020
-                    neg       $0040
-                    neg       L0080
-                    fcb       $01
-                    neg       $0002
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       $0020
-                    neg       $0040
-                    neg       $0027
-                    fcb       $10
-                    com       $00E8
-                    neg       $0064
-                    neg       $000A
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0006
-                    neg       L00B8
-                    neg       L00B6
-                    neg       L00B4
-                    neg       L00B2
-                    neg       L00B0
-                    neg       L00AE
-                    neg       $0003
-                    neg       L0094
-                    neg       L00AC
-                    neg       $0001
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$06
+                    fcb       $00,$B8,$00,$B6,$00,$B4,$00,$B2
+                    fcb       $00,$B0,$00,$AE,$00,$03,$00,$94
+                    fcb       $00,$AC,$00,$01
                     fcc       /c.comp/
                     fcb       $00
-
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -1,0 +1,21110 @@
+                    nam       c.comp
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $05
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       4389
+size                equ       .
+
+name                equ       *
+                    fcs       /c.comp/
+                    fcb       edition
+
+L0014               lda       ,y+
+L0016               sta       ,u+
+L0018               leax      -$01,x
+L001A               bne       L0014
+L001C               rts
+
+start               pshs      y
+L001F               pshs      u
+L0021               clra
+L0022               clrb
+L0023               sta       ,u+
+L0025               decb
+L0026               bne       L0023
+L0028               ldx       ,s
+L002A               leau      ,x
+L002C               leax      $08A5,x
+L0030               pshs      x
+L0032               leay      LB358,pcr
+L0036               ldx       ,y++
+L0038               beq       L003E
+L003A               bsr       L0014
+L003C               ldu       $02,s
+L003E               leau      >$0078,u
+L0042               ldx       ,y++
+L0044               beq       L0049
+L0046               bsr       L0014
+L0048               clra
+L0049               cmpu      ,s
+L004C               beq       L0052
+L004E               sta       ,u+
+L0050               bra       L0049
+
+L0052               ldu       $02,s
+L0054               ldd       ,y++
+L0056               beq       L005F
+L0058               leax      >$0000,pcr
+L005C               lbsr      L0162
+L005F               ldd       ,y++
+L0061               beq       L0068
+L0063               leax      ,u
+L0065               lbsr      L0162
+L0068               leas      $04,s
+L006A               puls      x
+L006C               stx       $0356,u
+L0070               sty       $0316,u
+L0075               ldd       #$0001
+L0078               std       $0352,u
+L007C               leay      $0318,u
+L0080               leax      ,s
+L0082               lda       ,x+
+L0084               ldb       $0353,u
+L0088               cmpb      #$1d
+                    beq       L00E0
+L008C               cmpa      #$0d
+L008E               beq       L00E0
+L0090               cmpa      #$20
+L0092               beq       L0098
+L0094               cmpa      #$2C
+L0096               bne       L009C
+L0098               lda       ,x+
+                    bra       L008C
+
+L009C               cmpa      #$22
+L009E               beq       L00A4
+L00A0               cmpa      #$27
+L00A2               bne       L00C2
+L00A4               stx       ,y++
+L00A6               inc       $0353,u
+                    pshs      a
+L00AC               lda       ,x+
+L00AE               cmpa      #$0d
+L00B0               beq       L00B6
+L00B2               cmpa      ,s
+L00B4               bne       L00AC
+L00B6               puls      b
+L00B8               clr       -$01,x
+                    cmpa      #$0d
+                    beq       L00E0
+                    lda       ,x+
+                    bra       L0084
+
+L00C2               leax      -$01,x
+                    stx       ,y++
+                    leax      $01,x
+L00C8               inc       $0353,u
+L00CC               cmpa      #$0d
+                    beq       L00DC
+                    cmpa      #$20
+                    beq       L00DC
+                    cmpa      #$2C
+                    beq       L00DC
+                    lda       ,x+
+                    bra       L00CC
+
+L00DC               clr       -$01,x
+                    bra       L0084
+
+L00E0               leax      $0316,u
+                    pshs      x
+                    ldd       $0352,u
+                    pshs      d
+                    leay      ,u
+                    bsr       L00FA
+                    lbsr      L017C
+                    clr       ,-s
+                    clr       ,-s
+                    lbsr      LB34C
+L00FA               leax      $08A5,y
+                    stx       $0360,y
+                    sts       $0354,y
+                    sts       $0362,y
+                    ldd       #$FF82
+L010F               leax      d,s
+                    cmpx      $0362,y
+                    bcc       L0121
+                    cmpx      $0360,y
+                    bcs       L013B
+                    stx       $0362,y
+L0121               fcb       $39
+L0122               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L013B               leax      L0122,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clr       ,-s
+                    lbsr      $B352
+                    ldd       $0354,y
+                    subd      $0362,y
+                    rts
+                    ldd       $0362,y
+                    subd      $0360,y
+                    rts
+
+L0162               pshs      x
+                    leax      d,y
+                    leax      d,x
+                    pshs      x
+L016A               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+                    std       ,x
+                    cmpy      ,s
+                    bne       L016A
+                    leas      $04,s
+                    rts
+
+L017C               pshs      u
+                    leax      L5DC9,pcr
+                    pshs      x
+                    lbsr      $B31C
+                    leas      $02,s
+                    leax      $0096,y
+                    pshs      x
+                    lbsr      $9FD7
+                    leas      $02,s
+                    leax      L0300,pcr
+                    pshs      x
+                    ldd       $0094,y
+                    pshs      d
+                    lbsr      $A5D9
+                    leas      $04,s
+                    lbsr      L6292
+                    leax      $0246,y
+                    stx       $0003
+                    leax      $0253,y
+                    stx       $0005
+                    lbra      L0295
+
+L01B7               ldx       $06,s
+                    leax      $02,x
+                    stx       $06,s
+                    ldu       ,x
+                    ldb       ,u
+                    cmpb      #$2d
+                    lbne      L0265
+                    lbra      L0257
+
+L01CA               ldb       ,u
+                    sex
+                    tfr       d,x
+                    lbra      L023B
+
+L01D2               ldd       #$0001
+                    std       $0015
+                    lbra      L0257
+
+L01DA               ldd       $0019
+                    addd      #$0001
+                    std       $0019
+                    lbra      L0257
+
+L01E4               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L0215
+                    leax      L0308,pcr
+                    pshs      x
+                    leau      $01,u
+                    pshs      u
+                    lbsr      L9F43
+                    leas      $04,s
+                    std       $0005
+                    bne       L0215
+                    pshs      u
+                    leax      $030A,pcr
+                    pshs      x
+                    leax      $0260,y
+                    pshs      x
+                    lbsr      L9A34
+                    leas      $06,s
+                    lbsr      L02F2
+L0215               leax      ,s
+                    bra       L0261
+
+L0219               ldd       #$0001
+                    std       $0017
+                    bra       L0257
+
+L0220               ldb       ,u
+                    sex
+                    pshs      d
+                    leax      L0319,pcr
+                    pshs      x
+                    leax      $0260,y
+                    pshs      x
+                    lbsr      L9A34
+                    leas      $06,s
+                    lbsr      L02F2
+                    bra       L0257
+
+L023B               cmpx      #$0073
+                    lbeq      L01D2
+                    cmpx      #$006E
+                    lbeq      L01DA
+                    cmpx      #$006F
+                    lbeq      L01E4
+                    cmpx      #$0070
+                    beq       L0219
+                    bra       L0220
+
+L0257               leau      $01,u
+                    ldb       ,u
+                    lbne      L01CA
+                    bra       L0295
+
+L0261               leas      ,x
+                    bra       L0295
+
+L0265               ldd       L0052
+                    bne       L0295
+                    ldd       L0052
+                    addd      #$0001
+                    std       L0052
+                    leax      $0246,y
+                    pshs      x
+                    leax      L032D,pcr
+                    pshs      x
+                    ldd       [$0a,s]
+                    pshs      d
+                    lbsr      L9F62
+                    leas      $06,s
+                    std       $0003
+                    bne       L0295
+                    leax      $032F,pcr
+                    pshs      x
+                    lbsr      L042D
+                    leas      $02,s
+L0295               ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    lbgt      L01B7
+                    lbsr      L42A6
+                    lbsr      $5F26
+                    bra       L02AB
+
+L02A8               lbsr      L8192
+L02AB               ldd       $003F
+                    cmpd      #$FFFF
+                    bne       L02A8
+                    lbsr      L5BC7
+                    ldx       $0005
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L02CA
+                    leax      $0345,pcr
+                    pshs      x
+                    lbsr      L042D
+                    leas      $02,s
+L02CA               leax      $0253,y
+                    pshs      x
+                    lbsr      $A2F8
+                    leas      $02,s
+                    ldd       $0009
+                    beq       L02F0
+                    ldd       $0009
+                    pshs      d
+                    leax      $0366,pcr
+                    pshs      x
+                    leax      $0260,y
+                    pshs      x
+                    lbsr      L9A34
+                    leas      $06,s
+                    bsr       L02F2
+L02F0               puls      pc,u
+L02F2               pshs      u
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      LB34C
+                    leas      $02,s
+                    puls      pc,u
+L0300               clrb
+                    lsr       -$0b,s
+                    tst       $0d,s
+                    rol       L5F00
+L0308               asr       >L0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L033B
+                    com       $0D00
+L0319               fcb       $75,$6e,$6b,$6e,$6f,$77,$6e,$20
+                    fcb       $66,$6C,$61,$67,$20,$3a,$20,$2d
+                    fcb       $25,$63,$0d,$00
+L032D               fcb       $72
+                    neg       L0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       $03A4
+
+L033B               jmp       -$10,s
+                    fcb       $75
+                    lsr       L2066
+                    rol       $0C,s
+                    fcb       $65
+                    neg       L0065
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       $03C3
+                    fcb       $72
+                    rol       -$0C,s
+                    rol       $0e,s
+                    asr       0,y
+                    fcb       $61
+                    com       $7365
+                    tst       $02,s
+                    inc       -$07,s
+                    bra       $03C0
+                    clr       $04,s
+                    fcb       $65
+                    bra       $03C8
+                    rol       $0C,s
+                    fcb       $65
+                    neg       L0065
+                    fcb       $72,$72,$6f,$72,$73,$20,$69,$6e
+                    fcb       $20,$63,$6f,$6d,$70,$69,$6C,$61
+                    fcb       $74,$69,$6f,$6e,$20,$3a,$20,$25
+                    fcb       $64,$0d,$00
+L0382               pshs      u
+                    ldu       $04,s
+                    leas      -$06,s
+                    ldd       L0023
+                    std       $02,s
+                    beq       L0397
+                    ldx       $02,s
+                    ldd       $10,x
+                    std       L0023
+                    bra       L03A3
+
+L0397               ldd       #$0012
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       $02,s
+L03A3               ldd       #$0012
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    stu       $08,s
+                    pshs      u
+                    bsr       L03FB
+                    leas      $06,s
+                    ldd       #$0009
+                    std       ,s
+                    bra       L03BF
+
+L03BB               clra
+                    clrb
+                    std       ,u++
+L03BF               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bne       L03BB
+                    ldd       $02,s
+                    ldx       $04,s
+                    std       $0e,x
+                    lbra      L05DB
+
+L03D4               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $0e,u
+                    std       ,s
+                    ldd       #$0012
+                    pshs      d
+                    pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L03FB
+                    leas      $06,s
+                    ldd       L0023
+                    ldx       ,s
+                    std       $10,x
+                    ldd       ,s
+                    std       L0023
+                    lbra      L05B5
+
+L03FB               pshs      u
+                    ldu       $04,s
+                    bra       L040B
+
+L0401               ldb       ,u+
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    stb       -$01,x
+L040B               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L0401
+                    puls      pc,u
+L0419               pshs      u
+                    leax      $0366,y
+                    pshs      x
+                    leax      L0725,pcr
+                    pshs      x
+                    lbsr      L054F
+                    lbra      L0594
+
+L042D               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L0450
+                    leas      $02,s
+                    leax      $0260,y
+                    pshs      x
+                    lbsr      $A2F8
+                    lbra      L0548
+
+L0443               pshs      u
+                    leax      L072B,pcr
+                    pshs      x
+                    bsr       L0450
+                    lbra      L05B5
+
+L0450               pshs      u
+                    ldd       L001F
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $0584,y
+                    pshs      x
+                    ldd       $0043
+                    bra       L04AD
+
+L0464               pshs      u
+                    leas      -$32,s
+                    leax      L073F,pcr
+                    pshs      x
+                    leax      $02,s
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+                    ldd       $38,s
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    lbsr      $A5F1
+                    leas      $04,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $38,s
+                    pshs      d
+                    bsr       L0498
+                    leas      $04,s
+                    leas      $32,s
+                    puls      pc,u
+L0498               pshs      u
+                    ldu       $04,s
+                    ldd       $0e,u
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    leax      $0584,y
+                    pshs      x
+                    ldd       $10,u
+L04AD               subd      ,s++
+                    pshs      d
+                    bsr       L04B6
+                    lbra      L05DB
+
+L04B6               pshs      u
+                    ldu       $04,s
+                    lbsr      L0419
+                    ldd       $08,s
+                    pshs      d
+                    leax      L0751,pcr
+                    pshs      x
+                    lbsr      L054F
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    leax      L075B,pcr
+                    pshs      x
+                    lbsr      L054F
+                    leas      $04,s
+                    ldd       $08,s
+                    cmpd      $0007
+                    bne       L04F1
+                    leax      $0584,y
+                    pshs      x
+                    lbsr      L056A
+                    leas      $02,s
+                    leax      ,s
+                    bra       L0508
+
+L04F1               ldd       $0007
+                    addd      #$FFFF
+                    cmpd      $08,s
+                    bne       L0528
+                    leax      $0684,y
+                    pshs      x
+                    lbsr      L056A
+                    leas      $02,s
+                    bra       L0518
+
+L0508               leas      ,x
+                    bra       L0518
+
+L050C               ldd       #$0020
+                    pshs      d
+                    lbsr      L0584
+                    leas      $02,s
+                    leau      -$01,u
+L0518               cmpu      #$0000
+                    bgt       L050C
+                    leax      L076B,pcr
+                    pshs      x
+                    bsr       L056A
+                    leas      $02,s
+L0528               ldd       $0009
+                    addd      #$0001
+                    std       $0009
+                    cmpd      #$001E
+                    ble       L054D
+                    leax      $0260,y
+                    pshs      x
+                    lbsr      $A2F8
+                    leas      $02,s
+                    leax      $076D,pcr
+                    pshs      x
+                    bsr       L056A
+L0548               leas      $02,s
+                    lbsr      L5DC9
+L054D               puls      pc,u
+L054F               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    leax      $0260,y
+                    pshs      x
+                    lbsr      L9A34
+                    leas      $08,s
+                    puls      pc,u
+L056A               pshs      u
+                    leax      $0260,y
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $9FB7
+                    leas      $04,s
+                    ldd       #$000D
+                    pshs      d
+                    bsr       L0584
+                    bra       L05B5
+
+L0584               pshs      u
+                    leax      $0260,y
+                    pshs      x
+                    ldb       $07,s
+                    sex
+                    pshs      d
+                    lbsr      $A1CD
+L0594               leas      $04,s
+                    puls      pc,u
+L0598               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L05B7
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L0598
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L0598
+                    leas      $02,s
+                    pshs      u
+                    bsr       L05B9
+L05B5               leas      $02,s
+L05B7               puls      pc,u
+L05B9               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L05C7
+                    ldd       $000D
+                    std       $0a,u
+                    stu       $000D
+L05C7               puls      pc,u
+L05C9               pshs      u
+                    ldd       #$0016
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L03FB
+L05DB               leas      $06,s
+                    puls      pc,u
+L05DF               pshs      u
+                    ldd       $003F
+                    cmpd      #$0033
+                    bne       L062D
+                    ldx       $0041
+                    cmpx      #$0001
+                    lbeq      L06FF
+                    cmpx      #$0002
+                    lbeq      L06FF
+                    cmpx      #$0007
+                    lbeq      L06FF
+                    cmpx      #$000A
+                    lbeq      L06FF
+                    cmpx      #$0008
+                    lbeq      L06FF
+                    cmpx      #$0004
+                    lbeq      L06FF
+                    cmpx      #$0003
+                    lbeq      L06FF
+                    cmpx      #$0006
+                    lbeq      L06FF
+                    cmpx      #$0005
+                    lbeq      L06FF
+                    lbra      L06CD
+
+L062D               ldd       $003F
+                    cmpd      #$0034
+                    lbne      L06CD
+                    ldx       $0041
+                    ldd       $08,x
+                    cmpd      #$001E
+                    bra       L0675
+
+L0641               pshs      u
+                    ldd       $003F
+                    cmpd      #$0033
+                    lbne      L06CD
+                    ldx       $0041
+                    cmpx      #$000E
+                    lbeq      L06FF
+                    cmpx      #$000D
+                    lbeq      L06FF
+                    cmpx      #$001E
+                    lbeq      L06FF
+                    cmpx      #$0010
+                    lbeq      L06FF
+                    cmpx      #$000F
+                    lbeq      L06FF
+                    cmpx      #$0021
+L0675               lbeq      L06FF
+                    lbra      L06CD
+
+L067C               pshs      u
+                    ldd       $04,s
+                    asra
+                    rorb
+                    asra
+                    rorb
+                    andb      #$F0
+                    bra       L0695
+
+L0688               pshs      u
+                    ldd       $04,s
+                    andb      #$F0
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      #$0010
+L0695               pshs      d
+                    ldd       $06,s
+                    clra
+                    andb      #$0f
+                    addd      ,s++
+                    puls      pc,u
+L06A0               pshs      u
+                    ldu       $04,s
+                    cmpu      #$004C
+                    blt       L06CD
+                    cmpu      #$0063
+                    bgt       L06CD
+                    ldd       #$0001
+                    bra       L06CF
+
+L06B5               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L06CD
+                    ldd       $02,u
+                    bra       L06CF
+
+L06C1               pshs      u
+                    ldd       $003F
+                    cmpd      $04,s
+                    bne       L06D1
+                    lbsr      $5F26
+L06CD               clra
+                    clrb
+L06CF               puls      pc,u
+L06D1               ldu       #$0000
+                    bra       L06E8
+
+L06D6               tfr       u,d
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    cmpd      $04,s
+                    beq       L06EE
+                    leau      $01,u
+L06E8               cmpu      #$0080
+                    blt       L06D6
+L06EE               tfr       u,d
+                    stb       $00A1,y
+                    leax      $00A1,y
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L06FF               ldd       #$0001
+                    puls      pc,u
+L0704               pshs      u
+                    bra       L070B
+
+L0708               lbsr      $5F26
+L070B               ldd       $003F
+                    cmpd      #$0028
+                    beq       L0723
+                    ldd       $003F
+                    cmpd      #$002A
+                    beq       L0723
+                    ldd       $003F
+                    cmpd      #$FFFF
+                    bne       L0708
+L0723               puls      pc,u
+L0725               bcs       L079A
+                    bra       L0763
+                    bra       L072B
+
+L072B               tst       -$0b,s
+                    inc       -$0C,s
+                    rol       -$10,s
+                    inc       $05,s
+                    bra       L0799
+                    fcb       $65
+                    ror       $09,s
+                    jmp       $09,s
+                    lsr       $696F
+                    jmp       0,x
+
+L073F               com       $0f,s
+                    tst       -$10,s
+                    rol       $0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L07AE
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       $077C
+                    bra       L0751
+
+L0751               inc       $09,s
+                    jmp       $05,s
+                    bra       $077C
+                    lsr       0,y
+                    bra       L075B
+
+L075B               bpl       L0787
+                    bpl       $0789
+                    bra       L0781
+                    bcs       $07D6
+L0763               bra       $0785
+                    bpl       $0791
+                    bpl       $0793
+                    tst       $0000
+L076B               fcb       $5e
+                    neg       $0074
+                    clr       $0f,s
+                    bra       $07DF
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       L07DC
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    com       L202D
+                    bra       L07C1
+                    fcb       $42
+L0781               clra
+                    fcb       $52
+                    lsrb
+                    neg       $0034
+                    nega
+L0787               ldd       #$FFA2
+                    lbsr      L010F
+                    leas      -$0e,s
+                    lbsr      L0899
+                    std       $0C,s
+                    lbne      L087E
+                    clra
+L0799               clrb
+L079A               lbra      L0895
+                    lbra      L087E
+
+L07A0               ldd       $003F
+                    std       $0a,s
+                    ldd       $0041
+                    std       $08,s
+                    std       ,s
+                    ldd       L001F
+                    std       $04,s
+L07AE               ldd       $0043
+                    std       $02,s
+                    lbsr      $5F26
+                    ldx       $0a,s
+                    bra       L07D2
+
+L07B9               ldd       $0a,s
+                    cmpd      #$00A0
+                    blt       L07C9
+L07C1               ldd       $0a,s
+                    cmpd      #$00A9
+                    ble       L07DE
+L07C9               ldd       $08,s
+                    addd      #$0001
+                    std       ,s
+                    bra       L07DE
+
+L07D2               cmpx      #$0064
+                    beq       L07DE
+                    cmpx      #$0078
+                    beq       L07DE
+L07DC               bra       L07B9
+
+L07DE               ldd       ,s
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    lbeq      L0873
+                    ldd       $0a,s
+                    cmpd      #$0064
+                    lbne      L0852
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L06C1
+                    std       ,s++
+                    bne       L0847
+                    ldd       $0043
+                    std       $02,s
+                    ldd       L001F
+                    std       $04,s
+                    ldd       #$0003
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    std       $06,s
+                    beq       L083C
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0003
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    bra       L0852
+
+L083C               leax      L109C,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L0847               pshs      u
+                    lbsr      L0598
+                    leas      $02,s
+                    leax      $0e,s
+                    bra       L0891
+
+L0852               ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $0C,s
+                    bra       L087E
+
+L0873               leax      L10B5,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L087E               lbsr      L0CA0
+                    std       -$02,s
+                    beq       L0893
+                    ldd       $12,s
+                    cmpd      $0041
+                    lble      L07A0
+                    bra       L0893
+
+L0891               leas      -$0e,x
+L0893               ldd       $0C,s
+L0895               leas      $0e,s
+                    puls      pc,u
+L0899               pshs      u
+                    ldd       #$FFA4
+                    lbsr      L010F
+                    leas      -$0C,s
+                    ldu       #$0000
+                    ldx       $003F
+                    lbra      L0A01
+
+L08AB               ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    ldd       $0041
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $003F
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    lbsr      $5F26
+                    lbra      L0A63
+
+L08D0               lbsr      $5F26
+                    lbsr      L05DF
+                    std       -$02,s
+                    beq       L08FE
+                    lbsr      L0F4C
+                    tfr       d,u
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    bsr       L0899
+                    std       $0a,u
+                    lbne      L0A63
+                    pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldu       #$0000
+                    lbra      L0A63
+
+L08FE               clra
+                    clrb
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L0934
+                    bra       L0911
+
+L090F               leas      -$0C,x
+L0911               lbsr      L101A
+                    ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+L0934               ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    lbra      L09FD
+
+L093F               ldd       $003F
+                    std       $08,s
+                    ldd       L001F
+                    std       $06,s
+                    ldd       $0043
+                    std       $04,s
+                    lbsr      $5F26
+                    lbsr      L0899
+                    std       $0a,s
+                    beq       L097A
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000E
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    lbra      L0A63
+
+L097A               leax      L10C6,pcr
+                    pshs      x
+                    lbsr      L0450
+                    lbra      L09FD
+
+L0986               ldd       L001F
+                    std       $06,s
+                    ldd       $0043
+                    std       $04,s
+                    lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$002D
+                    bne       L09C8
+                    lbsr      $5F26
+                    lbsr      L05DF
+                    std       -$02,s
+                    beq       L09AA
+                    lbsr      L0F4C
+                    std       $0a,s
+                    bra       L09BC
+
+L09AA               clra
+                    clrb
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    std       $0a,s
+                    bne       L09BC
+                    leax      $0C,s
+                    lbra      L090F
+
+L09BC               ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    bra       L09CD
+
+L09C8               lbsr      L0899
+                    std       $0a,s
+L09CD               ldd       $0a,s
+                    std       ,s
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L102E
+                    std       ,s
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L0598
+L09FD               leas      $02,s
+                    bra       L0A63
+
+L0A01               cmpx      #$0037
+                    lbeq      L08AB
+                    cmpx      #$0034
+                    lbeq      L08AB
+                    cmpx      #$004A
+                    lbeq      L08AB
+                    cmpx      #$004B
+                    lbeq      L08AB
+                    cmpx      #$0036
+                    lbeq      L08AB
+                    cmpx      #$002D
+                    lbeq      L08D0
+                    cmpx      #$0040
+                    lbeq      L093F
+                    cmpx      #$0043
+                    lbeq      L093F
+                    cmpx      #$0044
+                    lbeq      L093F
+                    cmpx      #$0042
+                    lbeq      L093F
+                    cmpx      #$003D
+                    lbeq      L093F
+                    cmpx      #$003C
+                    lbeq      L093F
+                    cmpx      #$0041
+                    lbeq      L093F
+                    cmpx      #$003B
+                    lbeq      L0986
+L0A63               cmpu      #$0000
+                    bne       L0A6E
+                    clra
+                    clrb
+                    lbra      L0BF5
+
+L0A6E               ldx       $003F
+                    lbra      L0B94
+
+L0A73               ldd       $0043
+                    std       $04,s
+                    ldd       L001F
+                    std       $06,s
+                    lbsr      $5F26
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000F
+                    pshs      d
+                    lbsr      L0BF9
+                    pshs      d
+                    pshs      u
+                    ldd       #$0065
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       #$002E
+                    lbra      L0B1A
+
+L0AA4               lbsr      $5F26
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    std       $0a,s
+                    bne       L0AD8
+                    lbsr      L101A
+                    ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $0a,s
+L0AD8               ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    ldd       #$000C
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0050
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    ldd       #$000F
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       #$0042
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       #$002C
+L0B1A               pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    lbra      L0A6E
+
+L0B24               ldd       $003F
+                    std       $08,s
+                    ldd       L001F
+                    std       $06,s
+                    ldd       $0043
+                    std       $04,s
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    lbsr      $5F26
+                    ldd       L0021
+                    addd      #$FFFF
+                    std       L0021
+                    ldd       $003F
+                    cmpd      #$0034
+                    beq       L0B4F
+                    lbsr      L924A
+                    lbra      L0BB0
+
+L0B4F               ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    ldd       $0041
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $003F
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $0a,s
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000F
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    lbsr      $5F26
+                    lbra      L0A6E
+
+L0B94               cmpx      #$002D
+                    lbeq      L0A73
+                    cmpx      #$002B
+                    lbeq      L0AA4
+                    cmpx      #$0045
+                    lbeq      L0B24
+                    cmpx      #$0046
+                    lbeq      L0B24
+L0BB0               ldx       $003F
+                    bra       L0BE9
+
+L0BB4               ldd       #$003E
+                    std       $003F
+                    leax      $0C,s
+                    bra       L0BC4
+
+L0BBD               ldd       #$003F
+                    std       $003F
+                    bra       L0BC6
+
+L0BC4               leas      -$0C,x
+L0BC6               ldd       $0043
+                    pshs      d
+                    ldd       L001F
+                    pshs      d
+                    ldd       #$000E
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $003F
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    lbsr      $5F26
+                    bra       L0BF3
+
+L0BE9               cmpx      #$003C
+                    beq       L0BB4
+                    cmpx      #$003D
+                    beq       L0BBD
+L0BF3               tfr       u,d
+L0BF5               leas      $0C,s
+                    puls      pc,u
+L0BF9               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    leas      -$02,s
+                    ldu       #$0000
+                    bra       L0C08
+
+L0C08               ldd       $003F
+                    cmpd      #$002E
+                    beq       L0C50
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    std       ,s
+                    beq       L0C43
+                    ldx       ,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000B
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       ,s
+                    ldu       ,s
+L0C43               ldd       $003F
+                    cmpd      #$0030
+                    bne       L0C50
+                    lbsr      $5F26
+                    bra       L0C08
+
+L0C50               tfr       u,d
+                    bra       L0C9C
+
+L0C54               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    leas      -$02,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $0785
+                    std       ,s
+                    lbsr      L111D
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0C80
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L0C80
+                    ldd       $08,u
+                    std       ,s
+                    bra       L0C8F
+
+L0C80               clra
+                    clrb
+                    std       ,s
+                    leax      L10D7,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L0C8F               stu       -$02,s
+                    beq       L0C9A
+                    pshs      u
+                    lbsr      L0598
+                    leas      $02,s
+L0C9A               ldd       ,s
+L0C9C               leas      $02,s
+                    puls      pc,u
+L0CA0               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldx       $003F
+                    bra       L0CF9
+
+L0CAC               ldd       #$0057
+                    std       $003F
+                    ldd       #$0008
+                    bra       L0CC8
+
+L0CB6               ldd       #$0052
+                    std       $003F
+                    ldd       #$000D
+                    bra       L0CC8
+
+L0CC0               ldd       #$0051
+                    std       $003F
+                    ldd       #$000C
+L0CC8               std       $0041
+L0CCA               ldd       #$0001
+                    puls      pc,u
+L0CCF               ldd       $003F
+                    cmpd      #$0047
+                    blt       L0CDF
+                    ldd       $003F
+                    cmpd      #$005F
+                    ble       L0CF3
+L0CDF               ldd       $003F
+                    cmpd      #$00A0
+                    lblt      L0E94
+                    ldd       $003F
+                    cmpd      #$00A9
+                    lbgt      L0E94
+L0CF3               ldd       #$0001
+                    lbra      L0E96
+
+L0CF9               cmpx      #$0041
+                    beq       L0CAC
+                    cmpx      #$0042
+                    beq       L0CB6
+                    cmpx      #$0043
+                    beq       L0CC0
+                    cmpx      #$0030
+                    beq       L0CCA
+                    cmpx      #$0078
+                    lbeq      L0CCA
+                    cmpx      #$0064
+                    lbeq      L0CCA
+                    cmpx      #$002F
+                    lbeq      L0E94
+                    bra       L0CCF
+                    puls      pc,u
+L0D26               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    ldx       $04,s
+                    lbra      L0E98
+
+L0D33               ldd       $06,s
+                    addd      $08,s
+                    puls      pc,u
+L0D39               ldd       $06,s
+                    subd      $08,s
+                    puls      pc,u
+L0D3F               ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      LAF4B
+                    puls      pc,u
+L0D4A               ldd       $08,s
+                    beq       L0D68
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      $AFFF
+                    bra       L0D66
+
+L0D59               ldd       $08,s
+                    beq       L0D68
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      $AFAC
+L0D66               puls      pc,u
+L0D68               lbsr      L1572
+                    lbra      L0E94
+
+L0D6E               ldd       $06,s
+                    anda      $08,s
+                    andb      $09,s
+                    puls      pc,u
+L0D76               ldd       $06,s
+                    ora       $08,s
+                    orb       $09,s
+                    puls      pc,u
+L0D7E               ldd       $06,s
+                    eora      $08,s
+                    eorb      $09,s
+                    puls      pc,u
+L0D86               ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      LB08C
+                    puls      pc,u
+L0D91               ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      LB069
+                    puls      pc,u
+L0D9C               ldd       $06,s
+                    cmpd      $08,s
+                    lbne      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0DAB               ldd       $06,s
+                    cmpd      $08,s
+                    lbeq      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0DBA               ldd       $06,s
+                    cmpd      $08,s
+                    lble      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0DC9               ldd       $06,s
+                    cmpd      $08,s
+                    lbge      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0DD8               ldd       $06,s
+                    cmpd      $08,s
+                    lblt      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0DE7               ldd       $06,s
+                    cmpd      $08,s
+                    lbgt      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0DF6               ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    puls      pc,u
+L0DFE               ldd       $06,s
+                    lbne      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0E0A               ldd       $06,s
+                    coma
+                    comb
+                    puls      pc,u
+L0E10               ldd       $06,s
+                    lbeq      L0E94
+                    ldd       $08,s
+                    lbeq      L0E94
+                    ldd       #$0001
+                    lbra      L0E96
+
+L0E22               ldd       $06,s
+                    bne       L0E2C
+                    ldd       $08,s
+                    lbeq      L0E94
+L0E2C               ldd       #$0001
+                    lbra      L0E96
+
+L0E32               leas      -$04,s
+                    ldd       $0C,s
+                    std       $02,s
+                    ldd       $0a,s
+                    std       ,s
+                    ldx       $08,s
+                    bra       L0E76
+
+L0E40               ldd       ,s
+                    cmpd      $02,s
+                    bhi       L0E70
+                    ldd       #$0001
+                    bra       L0E72
+
+L0E4C               ldd       ,s
+                    cmpd      $02,s
+                    bcc       L0E70
+                    ldd       #$0001
+                    bra       L0E72
+
+L0E58               ldd       ,s
+                    cmpd      $02,s
+                    bcs       L0E70
+                    ldd       #$0001
+                    bra       L0E72
+
+L0E64               ldd       ,s
+                    cmpd      $02,s
+                    bls       L0E70
+                    ldd       #$0001
+                    bra       L0E72
+
+L0E70               clra
+                    clrb
+L0E72               leas      $04,s
+                    puls      pc,u
+L0E76               cmpx      #$0060
+                    beq       L0E40
+                    cmpx      #$0061
+                    beq       L0E4C
+                    cmpx      #$0062
+                    beq       L0E58
+                    bra       L0E64
+                    leas      $04,s
+L0E89               leax      L10E9,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L0E94               clra
+                    clrb
+L0E96               puls      pc,u
+L0E98               cmpx      #$0050
+                    lbeq      L0D33
+                    cmpx      #$0051
+                    lbeq      L0D39
+                    cmpx      #$0052
+                    lbeq      L0D3F
+                    cmpx      #$0053
+                    lbeq      L0D4A
+                    cmpx      #$0054
+                    lbeq      L0D59
+                    cmpx      #$0057
+                    lbeq      L0D6E
+                    cmpx      #$0058
+                    lbeq      L0D76
+                    cmpx      #$0059
+                    lbeq      L0D7E
+                    cmpx      #$0056
+                    lbeq      L0D86
+                    cmpx      #$0055
+                    lbeq      L0D91
+                    cmpx      #$005A
+                    lbeq      L0D9C
+                    cmpx      #$005B
+                    lbeq      L0DAB
+                    cmpx      #$005F
+                    lbeq      L0DBA
+                    cmpx      #$005D
+                    lbeq      L0DC9
+                    cmpx      #$005E
+                    lbeq      L0DD8
+                    cmpx      #$005C
+                    lbeq      L0DE7
+                    cmpx      #$0043
+                    lbeq      L0DF6
+                    cmpx      #$0040
+                    lbeq      L0DFE
+                    cmpx      #$0044
+                    lbeq      L0E0A
+                    cmpx      #$0047
+                    lbeq      L0E10
+                    cmpx      #$0048
+                    lbeq      L0E22
+                    cmpx      #$0060
+                    lbeq      L0E32
+                    cmpx      #$0061
+                    lbeq      L0E32
+                    cmpx      #$0062
+                    lbeq      L0E32
+                    cmpx      #$0063
+                    lbeq      L0E32
+                    lbra      L0E89
+                    puls      pc,u
+L0F4C               pshs      u
+                    ldd       #$FFA2
+                    lbsr      L010F
+                    leas      -$0e,s
+                    ldd       L001F
+                    std       $04,s
+                    ldd       $0043
+                    std       $02,s
+                    leax      ,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    leax      $10,s
+                    pshs      x
+                    lbsr      L8BA0
+                    leas      $06,s
+                    std       $08,s
+                    pshs      d
+                    leax      $0C,s
+                    pshs      x
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      L8EF5
+                    leas      $06,s
+                    std       $08,s
+                    leax      >$0027,y
+                    pshs      x
+                    lbsr      L916F
+                    leas      $02,s
+                    ldd       $06,s
+                    beq       L0F9D
+                    leax      $10FB,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L0F9D               ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    bsr       L0FD8
+                    leas      $0C,s
+                    std       $06,s
+                    ldd       $08,s
+                    std       [$06,s]
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L906B
+                    leas      $06,s
+                    ldd       $06,s
+                    leas      $0e,s
+                    puls      pc,u
+L0FD8               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldd       $000D
+                    beq       L0FEC
+                    ldu       $000D
+                    ldd       $0a,u
+                    std       $000D
+                    bra       L0FF8
+
+L0FEC               ldd       #$0016
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    tfr       d,u
+L0FF8               ldd       $04,s
+                    std       $06,u
+                    ldd       $06,s
+                    std       $0a,u
+                    ldd       $08,s
+                    std       $0C,u
+                    ldd       $0a,s
+                    std       $08,u
+                    ldd       $0C,s
+                    std       $0e,u
+                    ldd       $0e,s
+                    std       $10,u
+                    clra
+                    clrb
+                    std       $14,u
+                    tfr       u,d
+                    puls      pc,u
+L101A               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      L110A,pcr
+                    pshs      x
+                    lbsr      L0450
+                    lbra      L107D
+
+L102E               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    ldu       [$04,s]
+                    ldx       $06,u
+                    bra       L1081
+
+L103D               pshs      u
+                    lbsr      L111D
+                    leas      $02,s
+                    std       [$04,s]
+                    tfr       d,u
+                    leax      ,s
+                    bra       L105D
+
+L104D               ldd       [$08,u]
+                    std       ,u
+                    pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldu       $08,u
+                    bra       L105F
+
+L105D               leas      ,x
+L105F               ldd       $04,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L90F5
+                    leas      $06,s
+                    puls      pc,u
+L1072               pshs      u
+                    ldd       #$000C
+                    addd      ,s++
+                    pshs      d
+                    bsr       L102E
+L107D               leas      $02,s
+                    puls      pc,u
+L1081               cmpx      #$0034
+                    beq       L104D
+                    cmpx      #$0020
+                    beq       L105F
+                    cmpx      #$0045
+                    beq       L1072
+                    cmpx      #$0046
+                    lbeq      L1072
+                    lbra      L103D
+                    puls      pc,u
+L109C               lsr       L6869
+                    fcb       $72
+                    lsr       0,y
+                    fcb       $65
+                    asl       $7072
+                    fcb       $65
+                    com       $7369
+                    clr       $0e,s
+                    bra       L111B
+                    rol       -$0d,s
+                    com       L696E
+                    asr       0,x
+L10B5               clr       -$10,s
+                    fcb       $65
+                    fcb       $72
+                    fcb       $61
+                    jmp       $04,s
+                    bra       $1123
+                    asl       L7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+L10C6               neg       L7269
+                    tst       $01,s
+                    fcb       $72
+                    rol       $2065
+                    asl       L7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+L10D7               com       $0f,s
+                    jmp       -$0d,s
+                    lsr       $616E
+                    lsr       $2072
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L10E9               com       $0f,s
+                    jmp       -$0d,s
+                    lsr       $616E
+                    lsr       $206F
+                    neg       $6572
+                    fcb       $61
+                    lsr       $6F72
+                    neg       $006E
+                    fcb       $61
+                    tst       $05,s
+                    bra       L116A
+                    jmp       0,y
+                    fcb       $61
+                    bra       $1169
+                    fcb       $61
+                    com       $7400
+L110A               fcb       $65
+                    asl       $7072
+                    fcb       $65
+                    com       $7369
+                    clr       $0e,s
+                    bra       $1183
+                    rol       -$0d,s
+                    com       L696E
+L111B               asr       0,x
+L111D               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$0C,s
+                    stu       -$02,s
+                    lbeq      L1204
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L111D
+                    leas      $02,s
+                    std       $0a,u
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L111D
+                    leas      $02,s
+                    std       $0C,u
+                    pshs      u
+                    lbsr      L1587
+                    leas      $02,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L1528
+                    std       ,s++
+                    beq       L115B
+                    leax      $0C,s
+                    lbra      L1202
+
+L115B               pshs      u
+                    lbsr      L120A
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       $0a,u
+                    std       $0a,s
+                    ldd       $0C,u
+L116A               std       $08,s
+                    ldd       $06,u
+                    std       $04,s
+                    cmpd      #$0064
+                    bne       L11B9
+                    ldx       $0a,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L11B9
+                    ldx       $0a,s
+                    ldd       $08,x
+                    beq       L1192
+                    ldx       $08,s
+                    ldd       $0a,x
+                    std       $02,s
+                    ldx       $08,s
+                    ldd       $0C,x
+                    bra       L119C
+
+L1192               ldx       $08,s
+                    ldd       $0C,x
+                    std       $02,s
+                    ldx       $08,s
+                    ldd       $0a,x
+L119C               pshs      d
+                    lbsr      L0598
+                    leas      $02,s
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    pshs      u
+                    bra       L11F9
+
+L11B9               ldd       $04,s
+                    cmpd      #$0042
+                    bne       L11CB
+                    ldx       $0a,s
+                    ldd       $06,x
+                    cmpd      #$0041
+                    beq       L11DD
+L11CB               ldd       $04,s
+                    cmpd      #$0041
+                    bne       L1204
+                    ldx       $0a,s
+                    ldd       $06,x
+                    cmpd      #$0042
+                    bne       L1204
+L11DD               ldx       $0a,s
+                    ldd       $0a,x
+                    std       $02,s
+                    ldd       ,u
+                    std       [$02,s]
+                    ldd       $02,u
+                    ldx       $02,s
+                    std       $02,x
+                    pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+L11F9               lbsr      L05B9
+                    leas      $02,s
+                    ldu       $02,s
+                    bra       L1204
+
+L1202               leas      -$0C,x
+L1204               tfr       u,d
+                    leas      $0C,s
+                    puls      pc,u
+L120A               pshs      u
+                    ldd       #$FFA8
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$0e,s
+                    stu       -$02,s
+                    bne       L121F
+                    clra
+                    clrb
+                    lbra      L1524
+
+L121F               ldd       $0a,u
+                    std       $0C,s
+                    ldd       $0C,u
+                    std       $0a,s
+                    ldd       $06,u
+                    std       $06,s
+                    pshs      d
+                    lbsr      L06A0
+                    std       ,s++
+                    bne       L1246
+                    ldd       $06,s
+                    cmpd      #$0047
+                    beq       L1246
+                    ldd       $06,s
+                    cmpd      #$0048
+                    lbne      L145D
+L1246               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1255
+                    ldd       #$0001
+                    bra       L1257
+
+L1255               clra
+                    clrb
+L1257               std       $02,s
+                    pshs      d
+                    ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L126A
+                    ldd       #$0001
+                    bra       L126C
+
+L126A               clra
+                    clrb
+L126C               std       $02,s
+                    anda      ,s+
+                    andb      ,s+
+                    std       -$02,s
+                    beq       L127B
+                    leax      $0e,s
+                    lbra      L146E
+
+L127B               ldd       $02,s
+                    beq       L12BB
+                    ldx       $06,s
+                    bra       L129A
+
+L1283               ldd       $0C,s
+                    std       $08,s
+                    ldd       $0a,s
+                    std       $0C,s
+                    std       $0a,u
+                    ldd       $08,s
+                    std       $0a,s
+                    std       $0C,u
+                    ldd       #$0001
+                    std       ,s
+                    bra       L12BB
+
+L129A               cmpx      #$0050
+                    beq       L1283
+                    cmpx      #$0052
+                    lbeq      L1283
+                    cmpx      #$0057
+                    lbeq      L1283
+                    cmpx      #$0058
+                    lbeq      L1283
+                    cmpx      #$0059
+                    lbeq      L1283
+L12BB               ldx       $06,s
+                    lbra      L1429
+
+L12C0               ldd       ,s
+                    lbeq      L1522
+                    ldx       $0a,s
+                    ldd       $08,x
+                    lbeq      L13EE
+                    lbra      L1522
+
+L12D1               ldd       ,s
+                    lbeq      L1522
+                    ldx       $0a,s
+                    ldd       $08,x
+                    lbeq      L13EE
+                    ldx       $0C,s
+                    ldx       $06,x
+                    lbra      L1338
+
+L12E6               ldx       $0C,s
+                    ldx       $0a,x
+                    ldd       $14,x
+                    leax      $14,x
+                    pshs      x,d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    addd      ,s++
+                    std       [,s++]
+                    bra       L12FE
+
+L12FC               leas      -$0e,x
+L12FE               ldd       $0C,s
+                    std       $08,s
+                    pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldu       $08,s
+                    lbra      L1522
+
+L1317               ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L1522
+                    ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $08,x
+                    leax      $08,x
+                    pshs      x,d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    addd      ,s++
+                    lbra      L13D1
+
+L1338               cmpx      #$0041
+                    lbeq      L12E6
+                    cmpx      #$0050
+                    beq       L1317
+                    lbra      L1522
+
+L1347               ldd       ,s
+                    beq       L1366
+                    ldx       $0a,s
+                    ldd       $08,x
+                    nega
+                    negb
+                    sbca      #$00
+                    ldx       $0a,s
+                    std       $08,x
+                    ldd       #$0050
+                    std       $06,u
+                    pshs      u
+                    lbsr      L120A
+                    leas      $02,s
+                    lbra      L1524
+
+L1366               ldd       $02,s
+                    lbeq      L1522
+                    ldx       $0C,s
+                    ldd       $08,x
+                    lbne      L1522
+                    ldd       #$0043
+                    std       $06,u
+                    ldd       $0a,s
+                    std       $0a,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    ldd       $0C,s
+                    lbra      L141F
+
+L1386               ldd       ,s
+                    lbeq      L1522
+                    ldx       $0a,s
+                    ldd       $08,x
+                    beq       L13A1
+                    lbra      L1522
+
+L1395               ldd       ,s
+                    lbeq      L1522
+                    ldx       $0a,s
+                    ldx       $08,x
+                    bra       L13D5
+
+L13A1               leax      $0e,s
+                    lbra      L1403
+
+L13A6               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0052
+                    lbne      L1522
+                    ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L1522
+                    ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $08,x
+                    leax      $08,x
+                    pshs      x,d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    lbsr      LAF4B
+L13D1               std       [,s++]
+                    bra       L13EE
+
+L13D5               stx       -$02,s
+                    beq       L13A1
+                    cmpx      #$0001
+                    beq       L13EE
+                    bra       L13A6
+
+L13E0               ldd       ,s
+                    beq       L13F3
+                    ldx       $0a,s
+                    ldd       $08,x
+                    cmpd      #$0001
+                    bne       L13F3
+L13EE               leax      $0e,s
+                    lbra      L12FC
+
+L13F3               ldd       $02,s
+                    lbeq      L1522
+                    ldx       $0C,s
+                    ldd       $08,x
+                    lbne      L1522
+                    bra       L1405
+
+L1403               leas      -$0e,x
+L1405               ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+L140C               std       $08,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    std       $0a,u
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldd       $0a,s
+L141F               pshs      d
+                    lbsr      L05B9
+L1424               leas      $02,s
+                    lbra      L1522
+
+L1429               cmpx      #$0058
+                    lbeq      L12C0
+                    cmpx      #$0059
+                    lbeq      L12C0
+                    cmpx      #$0050
+                    lbeq      L12D1
+                    cmpx      #$0051
+                    lbeq      L1347
+                    cmpx      #$0057
+                    lbeq      L1386
+                    cmpx      #$0052
+                    lbeq      L1395
+                    cmpx      #$0053
+                    lbeq      L13E0
+                    lbra      L1522
+
+L145D               ldx       $06,s
+                    lbra      L150D
+
+L1462               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1492
+                    bra       L1470
+
+L146E               leas      -$0e,x
+L1470               ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $12,u
+                    ldx       $0a,s
+                    ldd       $08,x
+                    pshs      d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L0D26
+                    leas      $06,s
+                    lbra      L140C
+
+L1492               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L14E1
+                    leas      -$02,s
+                    ldx       $0e,s
+                    ldd       $08,x
+                    std       ,s
+                    bne       L14B2
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       ,s
+L14B2               ldx       $08,s
+                    bra       L14CF
+
+L14B6               ldx       ,s
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      LAE9F
+                    bra       L14CA
+
+L14C1               ldx       ,s
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      LAEB3
+L14CA               lbsr      LAEDF
+                    bra       L14D9
+
+L14CF               cmpx      #$0043
+                    beq       L14B6
+                    cmpx      #$0044
+                    beq       L14C1
+L14D9               ldd       ,s
+                    ldx       $0e,s
+                    std       $08,x
+                    bra       L1501
+
+L14E1               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$004B
+                    bne       L1522
+                    leas      -$02,s
+                    ldx       $0e,s
+                    ldd       $08,x
+                    std       ,s
+                    beq       L1501
+                    ldx       ,s
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      $A74C
+                    lbsr      $AE34
+L1501               pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldu       $0e,s
+                    lbra      L1424
+
+L150D               cmpx      #$0040
+                    lbeq      L1462
+                    cmpx      #$0044
+                    lbeq      L1462
+                    cmpx      #$0043
+                    lbeq      L1462
+L1522               tfr       u,d
+L1524               leas      $0e,s
+                    puls      pc,u
+L1528               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L156E
+                    ldx       $06,u
+                    bra       L153F
+
+L153A               ldd       #$0001
+                    puls      pc,u
+L153F               cmpx      #$0076
+                    beq       L153A
+                    cmpx      #$006F
+                    lbeq      L153A
+                    cmpx      #$0036
+                    lbeq      L153A
+                    cmpx      #$004A
+                    lbeq      L153A
+                    cmpx      #$004B
+                    lbeq      L153A
+                    cmpx      #$0034
+                    lbeq      L153A
+                    cmpx      #$0037
+                    lbeq      L153A
+L156E               clra
+                    clrb
+                    puls      pc,u
+L1572               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      L287A,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    puls      pc,u
+L1587               pshs      u
+                    ldd       #$FF9C
+                    lbsr      L010F
+                    leas      -$14,s
+                    ldx       $18,s
+                    ldu       $0a,x
+                    ldx       $18,s
+                    ldd       $0C,x
+                    std       $12,s
+                    ldd       #$0002
+                    std       $0a,s
+                    std       $08,s
+                    clra
+                    clrb
+                    std       $06,s
+                    ldd       #$0001
+                    std       $0C,s
+                    ldx       $18,s
+                    ldd       $06,x
+                    std       $0e,s
+                    tfr       d,x
+                    lbra      L204E
+
+L15BB               ldx       $18,s
+                    ldd       $08,x
+                    std       $10,s
+                    ldx       $10,s
+                    ldd       $08,x
+                    cmpd      #$001E
+                    bne       L15EB
+                    leax      L2889,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L27EB
+                    leas      $02,s
+                    lbra      L2170
+
+L15EB               ldd       [$10,s]
+                    std       $0C,s
+                    ldx       $10,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$0f
+                    cmpd      #$000A
+                    bne       L162C
+                    leas      -$02,s
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       ,s
+                    ldd       $0e,s
+                    andb      #$F0
+                    addd      [,s]
+                    std       [$12,s]
+                    std       $0e,s
+                    ldx       ,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    lbsr      L906B
+                    leas      $06,s
+                    leas      $02,s
+L162C               ldx       $10,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L164B
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    lbne      L16AE
+L164B               ldu       $18,s
+                    ldd       $0a,s
+                    std       $02,u
+                    ldx       $18,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $1a,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       #$0041
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $18,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L1699
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L06B5
+                    leas      $02,s
+                    std       $06,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    bra       L169B
+
+L1699               ldd       $0C,s
+L169B               std       ,u
+                    pshs      d
+                    lbsr      L0688
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       #$0001
+                    std       $12,u
+                    bra       L16D5
+
+L16AE               ldx       $10,s
+                    ldd       $08,x
+                    std       $04,s
+                    tfr       d,x
+                    bra       L16C9
+
+L16B9               ldd       $04,s
+                    ldx       $18,s
+                    std       $06,x
+                    clra
+                    clrb
+                    ldx       $18,s
+                    std       $08,x
+                    bra       L16D5
+
+L16C9               cmpx      #$0076
+                    beq       L16B9
+                    cmpx      #$006F
+                    lbeq      L16B9
+L16D5               ldd       #$0001
+                    bra       L16DC
+
+L16DA               clra
+                    clrb
+L16DC               std       $08,s
+                    lbra      L2170
+
+L16E1               ldd       #$0008
+                    std       $0C,s
+                    ldd       #$0001
+                    std       $08,s
+                    ldd       #$0004
+                    lbra      L1846
+
+L16F1               ldd       #$0006
+                    std       $0C,s
+                    ldd       #$0001
+                    std       $08,s
+                    ldd       #$0008
+                    lbra      L1846
+
+L1701               ldd       #$0012
+                    std       $0C,s
+                    ldd       #$0001
+                    lbra      L1846
+
+L170C               pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldd       [$18,s]
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L172C
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L1747
+L172C               leax      $28A2,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0688
+                    leas      $02,s
+                    std       $0C,s
+L1747               ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1760
+                    ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    bra       L176D
+
+L1760               ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    std       $0C,s
+L176D               ldx       $18,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldx       $18,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    stu       $18,s
+                    lbra      L2170
+
+L178B               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L2668
+                    leas      $04,s
+                    ldd       $06,u
+                    cmpd      #$0076
+                    beq       L17A7
+                    ldd       $06,u
+                    cmpd      #$006F
+                    bne       L17BE
+L17A7               leax      L28AE,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L27EB
+                    leas      $02,s
+L17BE               ldd       $12,u
+                    std       $08,s
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L0688
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       $04,u
+                    std       $06,s
+                    lbra      L2170
+
+L17D9               ldd       $04,u
+                    std       $06,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L181D
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L183F
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L067C
+                    std       ,s
+                    lbsr      L0688
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    stu       $18,s
+                    bra       L183F
+
+L181D               leax      L28C1,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L27EB
+                    leas      $02,s
+                    ldd       #$0011
+                    std       ,u
+                    ldd       #$0001
+                    std       $0C,s
+                    clra
+                    clrb
+                    std       $06,s
+L183F               ldd       $12,u
+                    std       $08,s
+                    ldd       $02,u
+L1846               std       $0a,s
+                    lbra      L2170
+
+L184B               leax      ,s
+                    pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    ldd       $16,s
+                    pshs      d
+                    lbsr      L2707
+                    leas      $06,s
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L2668
+                    leas      $04,s
+                    ldx       $12,s
+                    ldd       $08,x
+                    bne       L189F
+                    ldd       ,s
+                    bne       L189F
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    stu       $18,s
+                    ldx       $18,s
+                    ldd       $12,x
+                    std       $08,s
+                    lbra      L1902
+
+L189F               ldd       $12,u
+                    std       $08,s
+                    ldd       $06,u
+                    cmpd      #$0042
+                    bne       L18C4
+                    ldd       $0a,u
+                    std       $10,s
+                    pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldu       $10,s
+                    tfr       u,d
+                    ldx       $18,s
+                    std       $0a,x
+                    bra       L18F7
+
+L18C4               ldd       ,u
+                    std       $04,s
+                    ldd       $10,u
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       #$0041
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    ldx       $18,s
+                    std       $0a,x
+                    tfr       d,u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0688
+                    leas      $02,s
+                    std       ,u
+L18F7               ldd       $08,s
+                    std       $12,u
+                    leax      $14,s
+                    lbra      L1960
+
+L1902               lbra      L2170
+
+L1905               leax      ,s
+                    pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    ldd       $16,s
+                    pshs      d
+                    lbsr      L2707
+                    leas      $06,s
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       ,u
+                    std       $04,s
+                    cmpd      #$0001
+                    beq       L1959
+                    ldd       $04,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L193A
+                    ldd       #$0001
+                    bra       L193C
+
+L193A               clra
+                    clrb
+L193C               bne       L1959
+                    leax      L28D2,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $12,u
+L1959               ldd       $12,u
+                    std       $08,s
+                    bra       L1963
+
+L1960               leas      -$14,x
+L1963               ldd       #$0050
+                    ldx       $18,s
+                    std       $06,x
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L120A
+                    leas      $02,s
+                    std       $18,s
+                    ldd       ,s
+                    bne       L19C0
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0688
+                    leas      $02,s
+                    std       [$18,s]
+                    ldd       $08,s
+                    ldx       $18,s
+                    std       $12,x
+                    ldd       $0a,s
+                    ldx       $18,s
+                    std       $02,x
+                    ldx       $18,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $1a,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $20,s
+                    pshs      d
+                    ldd       #$0042
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $18,s
+L19C0               lbra      L2170
+
+L19C3               ldd       ,u
+                    std       $0C,s
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L19FF
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L19FF
+                    ldd       $0a,u
+                    ldx       $18,s
+                    std       $0a,x
+                    std       $10,s
+                    pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldd       [$10,s]
+L19F5               pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    lbra      L1A63
+
+L19FF               ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L1A0E
+                    ldd       $0C,s
+                    bra       L19F5
+
+L1A0E               ldd       $0C,s
+                    bne       L1A51
+                    ldd       $08,u
+                    std       $10,s
+                    ldd       #$0031
+                    std       [$10,s]
+                    ldd       #$0002
+                    ldx       $10,s
+                    std       $02,x
+                    clra
+                    clrb
+                    ldx       $10,s
+                    std       $04,x
+                    ldd       #$000E
+                    ldx       $10,s
+                    std       $08,x
+                    clra
+                    clrb
+                    ldx       $10,s
+                    std       $0C,x
+                    ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L03FB
+                    leas      $06,s
+                    ldd       #$0001
+                    bra       L1A63
+
+L1A51               leax      L28EE,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$0f
+L1A63               std       $0C,s
+                    ldd       $04,u
+                    std       $06,s
+                    ldd       $02,u
+                    std       $0a,s
+L1A6D               pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L27BA
+                    leas      $02,s
+                    ldx       ,u
+                    bra       L1A92
+
+L1A7F               ldd       #$0001
+                    bra       L1A87
+
+L1A84               ldd       #$0006
+L1A87               pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    bra       L1A9C
+
+L1A92               cmpx      #$0002
+                    beq       L1A7F
+                    cmpx      #$0005
+                    beq       L1A84
+L1A9C               lbra      L2170
+
+L1A9F               ldx       $12,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldd       [$12,s]
+                    std       $0C,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    lbra      L2170
+
+L1AB5               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1AC7
+                    pshs      u
+                    lbsr      L21C1
+                    leas      $02,s
+L1AC7               ldd       #$0001
+                    lbra      L2012
+
+L1ACD               pshs      u
+                    lbsr      L21C1
+                    leas      $02,s
+                    lbra      L2012
+
+L1AD7               pshs      u
+                    lbsr      L21C1
+                    leas      $02,s
+                    std       $0C,s
+                    cmpd      #$0006
+                    lbne      L1BC8
+                    pshs      u
+                    lbsr      L2861
+                    leas      $02,s
+                    pshs      u
+                    lbra      L1BC3
+
+L1AF4               clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L2668
+                    leas      $04,s
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    beq       L1B25
+                    ldd       $04,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L067C
+                    std       ,s
+                    lbsr      L90F5
+                    leas      $06,s
+                    bra       L1B28
+
+L1B25               ldd       #$0001
+L1B28               ldx       $18,s
+                    std       $08,x
+                    ldd       $12,u
+                    std       $08,s
+                    ldd       $06,u
+                    cmpd      #$0042
+                    lbne      L1CAC
+                    ldd       $08,s
+                    addd      #$0001
+                    lbra      L1CAA
+
+L1B44               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1B56
+                    pshs      u
+                    lbsr      L21C1
+                    leas      $02,s
+L1B56               ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbeq      L1BC8
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L21C1
+                    bra       L1BC6
+
+L1B6E               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2545
+                    leas      $04,s
+                    std       $0C,s
+                    cmpd      #$0006
+                    bne       L1B87
+                    leax      $14,s
+                    bra       L1BAB
+
+L1B87               lbra      L2170
+
+L1B8A               pshs      u
+                    lbsr      L21C1
+                    leas      $02,s
+                    std       $0C,s
+                    cmpd      #$0006
+                    beq       L1BAE
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L21C1
+                    leas      $02,s
+                    cmpd      #$0006
+                    bne       L1BCB
+                    bra       L1BAE
+
+L1BAB               leas      -$14,x
+L1BAE               leax      L28FD,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       $18,s
+                    pshs      d
+L1BC3               lbsr      L27EB
+L1BC6               leas      $02,s
+L1BC8               lbra      L2170
+
+L1BCB               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L222C
+                    lbra      L1C54
+
+L1BDB               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1BF2
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1C04
+L1BF2               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2545
+                    leas      $04,s
+                    cmpd      #$0007
+                    bne       L1C0E
+L1C04               ldd       $0e,s
+                    addd      #$0004
+                    ldx       $18,s
+                    std       $06,x
+L1C0E               lbra      L2170
+
+L1C11               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C4A
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C2D
+                    ldd       #$0001
+                    bra       L1C2F
+
+L1C2D               clra
+                    clrb
+L1C2F               bne       L1C56
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L21C1
+                    leas      $02,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L222C
+                    bra       L1C54
+
+L1C4A               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2545
+L1C54               leas      $04,s
+L1C56               lbra      L2170
+
+L1C59               ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C78
+                    leas      -$02,s
+                    stu       ,s
+                    ldu       $14,s
+                    ldd       ,s
+                    std       $14,s
+                    leas      $02,s
+                    ldx       $18,s
+                    stu       $0a,x
+L1C78               ldd       $02,u
+                    std       $0a,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C93
+                    ldd       $04,u
+                    std       $06,s
+                    leax      $14,s
+                    lbra      L1D92
+
+L1C93               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2545
+                    leas      $04,s
+                    std       $0C,s
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+L1CAA               std       $08,s
+L1CAC               lbra      L2170
+
+L1CAF               ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+                    std       $08,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L2006
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       $04,u
+                    std       $06,s
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L1D95
+                    ldd       $08,s
+                    ldx       $18,s
+                    std       $12,x
+                    ldd       $0C,s
+                    cmpd      [$12,s]
+                    bne       L1CF9
+                    ldd       $0a,s
+                    ldx       $12,s
+                    cmpd      $02,x
+                    beq       L1D0C
+L1CF9               leax      L2913,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    lbra      L1D83
+
+L1D0C               ldd       $0C,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L90F5
+                    leas      $06,s
+                    std       $0a,s
+                    cmpd      #$0001
+                    lbeq      L1D83
+                    ldd       #$0002
+                    std       $08,s
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $10,s
+                    ldx       $18,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $1a,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    ldd       $20,s
+                    pshs      d
+                    ldd       #$0053
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $18,s
+L1D83               ldd       #$0002
+                    std       $0a,s
+                    clra
+                    clrb
+                    std       $06,s
+                    ldd       #$0001
+                    lbra      L2012
+
+L1D92               leas      -$14,x
+L1D95               ldd       $12,s
+                    pshs      d
+                    lbsr      L21C1
+                    leas      $02,s
+                    ldd       [$12,s]
+                    pshs      d
+                    lbsr      L2832
+                    std       ,s++
+                    bne       L1DBF
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L2861
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L27EB
+                    leas      $02,s
+L1DBF               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L222C
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L25C9
+                    leas      $08,s
+                    ldx       $18,s
+                    std       $0C,x
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+                    std       $08,s
+                    lbra      L2170
+
+L1DF9               clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L2668
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L27BA
+                    leas      $02,s
+                    std       $02,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1E3F
+                    ldd       $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1E3F
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L2832
+                    std       ,s++
+                    lbeq      L1EBF
+L1E3F               ldd       $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1E62
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1E62
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L2832
+                    std       ,s++
+                    lbeq      L1EBF
+L1E62               ldd       $0C,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L222C
+                    leas      $04,s
+                    leax      $14,s
+                    lbra      L1F54
+
+L1E76               leas      -$14,x
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L2668
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L21C1
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L27BA
+                    leas      $02,s
+                    std       $02,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1ED3
+                    ldx       $0e,s
+                    bra       L1EC5
+
+L1EAB               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L222C
+                    leas      $04,s
+                    leax      $14,s
+                    bra       L1EF5
+
+L1EBF               leax      $14,s
+                    lbra      L1F6B
+
+L1EC5               cmpx      #$00A1
+                    beq       L1EAB
+                    cmpx      #$00A0
+                    lbeq      L1EAB
+                    bra       L1EBF
+
+L1ED3               ldx       $0e,s
+                    lbra      L1F45
+
+L1ED8               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L1EE5
+                    ldd       #$0006
+                    bra       L1EE7
+
+L1EE5               ldd       $0C,s
+L1EE7               pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L222C
+                    leas      $04,s
+                    bra       L1EF8
+
+L1EF5               leas      -$14,x
+L1EF8               ldd       $0e,s
+                    addd      #$FFB0
+                    ldx       $18,s
+                    std       $06,x
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L1587
+                    leas      $02,s
+                    std       $18,s
+                    ldd       $0C,s
+                    cmpd      #$0002
+                    bne       L1F2F
+                    ldd       $0a,u
+                    ldx       $18,s
+                    std       $0a,x
+                    pshs      u
+                    lbsr      L05B9
+                    leas      $02,s
+                    ldx       $18,s
+                    ldu       $0a,x
+                    ldd       #$0001
+                    std       $0C,s
+L1F2F               ldd       $0e,s
+                    addd      #$FFB0
+                    ldx       $18,s
+                    cmpd      $06,x
+                    bne       L1F57
+                    ldd       $0e,s
+                    ldx       $18,s
+                    std       $06,x
+                    bra       L1F57
+
+L1F45               cmpx      #$00A6
+                    beq       L1EF8
+                    cmpx      #$00A5
+                    lbeq      L1EF8
+                    lbra      L1ED8
+
+L1F54               leas      -$14,x
+L1F57               ldd       $02,u
+                    std       $0a,s
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+                    std       $08,s
+                    ldd       $04,u
+                    lbra      L2028
+
+L1F6B               leas      -$14,x
+                    leax      $2924,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    lbra      L2049
+
+L1F7F               ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1FDE
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       $12,u
+                    std       $08,s
+                    ldd       $02,u
+                    std       $06,s
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1FD1
+                    ldd       $0C,s
+                    cmpd      [$12,s]
+                    bne       L1FB7
+                    ldd       $02,u
+                    ldx       $12,s
+                    cmpd      $02,x
+                    beq       L1FCA
+L1FB7               leax      $2932,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    lbra      L2170
+
+L1FCA               clra
+                    clrb
+                    std       $06,s
+                    lbra      L2170
+
+L1FD1               ldd       $12,s
+                    pshs      d
+L1FD6               lbsr      L2193
+                    leas      $02,s
+                    lbra      L2170
+
+L1FDE               ldd       [$12,s]
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L2006
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $12,x
+                    std       $08,s
+                    ldx       $12,s
+                    ldd       $04,x
+L2000               std       $06,s
+                    pshs      u
+                    bra       L1FD6
+
+L2006               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2545
+                    leas      $04,s
+L2012               std       $0C,s
+                    lbra      L2170
+
+L2017               ldd       [$12,s]
+                    std       $0C,s
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $04,x
+L2028               std       $06,s
+L202A               lbra      L2170
+
+L202D               ldd       $0e,s
+                    cmpd      #$00A0
+                    blt       L203B
+                    leax      $14,s
+                    lbra      L1E76
+
+L203B               leax      $2943,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0464
+L2049               leas      $04,s
+                    lbra      L2170
+
+L204E               cmpx      #$0034
+                    lbeq      L15BB
+                    cmpx      #$0036
+                    lbeq      L16DA
+                    cmpx      #$004A
+L205F               lbeq      L16E1
+                    cmpx      #$004B
+L2066               lbeq      L16F1
+                    cmpx      #$0037
+                    lbeq      L1701
+                    cmpx      #$0020
+L2074               lbeq      L170C
+L2078               cmpx      #$0041
+                    lbeq      L178B
+                    cmpx      #$0042
+                    lbeq      L17D9
+                    cmpx      #$0045
+                    lbeq      L184B
+                    cmpx      #$0046
+                    lbeq      L1905
+                    cmpx      #$0065
+                    lbeq      L19C3
+                    cmpx      #$000B
+                    lbeq      L1A6D
+                    cmpx      #$0030
+                    lbeq      L1A9F
+                    cmpx      #$0040
+                    lbeq      L1AB5
+                    cmpx      #$0043
+                    lbeq      L1ACD
+                    cmpx      #$0044
+                    lbeq      L1AD7
+                    cmpx      #$003C
+                    lbeq      L1AF4
+                    cmpx      #$003E
+                    lbeq      L1AF4
+                    cmpx      #$003D
+                    lbeq      L1AF4
+                    cmpx      #$003F
+                    lbeq      L1AF4
+                    cmpx      #$0047
+                    lbeq      L1B44
+                    cmpx      #$0048
+                    lbeq      L1B44
+                    cmpx      #$0053
+                    lbeq      L2006
+                    cmpx      #$0052
+                    lbeq      L2006
+                    cmpx      #$0057
+                    lbeq      L1B6E
+                    cmpx      #$0058
+                    lbeq      L1B6E
+                    cmpx      #$0059
+                    lbeq      L1B6E
+                    cmpx      #$0054
+                    lbeq      L1B6E
+                    cmpx      #$0056
+                    lbeq      L1B8A
+                    cmpx      #$0055
+                    lbeq      L1B8A
+                    cmpx      #$005D
+                    lbeq      L1BDB
+                    cmpx      #$005F
+                    lbeq      L1BDB
+                    cmpx      #$005C
+                    lbeq      L1BDB
+                    cmpx      #$005E
+                    lbeq      L1BDB
+                    cmpx      #$005A
+                    lbeq      L1C11
+                    cmpx      #$005B
+                    lbeq      L1C11
+                    cmpx      #$0050
+                    lbeq      L1C59
+                    cmpx      #$0051
+                    lbeq      L1CAF
+                    cmpx      #$0078
+                    lbeq      L1DF9
+                    cmpx      #$002F
+                    lbeq      L1F7F
+                    cmpx      #$0064
+                    lbeq      L2017
+                    lbra      L202D
+
+L2170               ldd       $0C,s
+                    std       [$18,s]
+                    ldd       $0a,s
+                    ldx       $18,s
+                    std       $02,x
+                    ldd       $08,s
+                    ldx       $18,s
+                    std       $12,x
+                    ldd       $06,s
+                    ldx       $18,s
+                    std       $04,x
+                    ldd       $18,s
+                    leas      $14,s
+                    puls      pc,u
+L2193               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L21A9
+                    ldd       $08,u
+                    beq       L21BF
+L21A9               leax      $294E,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+L21BF               puls      pc,u
+L21C1               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldd       ,u
+                    std       ,s
+                    tfr       d,x
+                    bra       L2204
+
+L21DC               ldd       #$0001
+                    bra       L21E4
+
+L21E1               ldd       #$0006
+L21E4               std       ,s
+                    pshs      d
+                    pshs      u
+                    bsr       L222C
+                    leas      $04,s
+                    bra       L2224
+
+L21F0               leax      $295D,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    ldd       #$0001
+                    std       ,s
+                    bra       L2224
+
+L2204               cmpx      #$0002
+                    beq       L21DC
+                    cmpx      #$0005
+                    beq       L21E1
+                    cmpx      #$0006
+                    beq       L2224
+                    cmpx      #$0008
+                    beq       L2224
+                    cmpx      #$0001
+                    beq       L2224
+                    cmpx      #$0007
+                    beq       L2224
+                    bra       L21F0
+
+L2224               ldd       ,s
+                    std       ,u
+                    leas      $02,s
+                    puls      pc,u
+L222C               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       ,u
+                    lbra      L24DB
+
+L2241               ldx       $0a,s
+                    bra       L2277
+
+L2245               ldd       #$0085
+                    bra       L2258
+
+L224A               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    bsr       L222C
+                    leas      $04,s
+                    ldd       #$0083
+L2258               std       ,s
+                    lbra      L2508
+
+L225D               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    lbra      L2508
+
+L2277               cmpx      #$0001
+                    beq       L2245
+                    cmpx      #$0007
+                    lbeq      L2245
+                    cmpx      #$0008
+                    beq       L224A
+                    cmpx      #$0006
+                    beq       L225D
+                    cmpx      #$0005
+                    lbeq      L225D
+                    lbra      L2508
+
+L2297               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L2508
+L22A4               ldx       $0a,s
+                    lbra      L233C
+
+L22A9               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L22E4
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       $02,s
+                    ldd       $08,u
+                    ldx       $02,s
+                    std       $02,x
+                    bge       L22CA
+                    ldd       #$FFFF
+                    bra       L22CC
+
+L22CA               clra
+                    clrb
+L22CC               std       [$02,s]
+                    ldd       $02,s
+                    std       $08,u
+                    bra       L22D7
+
+L22D5               leas      -$04,x
+L22D7               ldd       #$004A
+                    std       $06,u
+                    ldd       #$0004
+L22DF               std       $02,u
+                    lbra      L2508
+
+L22E4               ldd       #$0083
+                    bra       L2337
+
+L22E9               ldd       #$0001
+                    std       $0a,s
+                    lbra      L2508
+
+L22F1               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    ldd       #$008D
+                    bra       L2337
+
+L2302               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L2334
+                    ldd       #$0008
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       $02,s
+                    ldx       $02,s
+                    pshs      x
+                    ldd       $08,u
+                    lbsr      $A791
+                    lbsr      $AE34
+                    bra       L2326
+
+L2324               leas      -$04,x
+L2326               ldd       $02,s
+                    std       $08,u
+                    ldd       #$004B
+                    std       $06,u
+                    ldd       #$0008
+                    bra       L22DF
+
+L2334               ldd       #$008E
+L2337               std       ,s
+                    lbra      L2508
+
+L233C               cmpx      #$0008
+                    lbeq      L22A9
+                    cmpx      #$0002
+                    lbeq      L22E9
+                    cmpx      #$0005
+                    beq       L22F1
+                    cmpx      #$0006
+                    beq       L2302
+                    lbra      L2508
+
+L2357               ldx       $0a,s
+                    bra       L2381
+
+L235B               ldd       #$0086
+                    bra       L2374
+
+L2360               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    ldd       #$008D
+                    bra       L2374
+
+L2371               ldd       #$0092
+L2374               std       ,s
+                    lbra      L2508
+
+L2379               ldd       #$0001
+                    std       $0a,s
+                    lbra      L2508
+
+L2381               cmpx      #$0008
+                    beq       L235B
+                    cmpx      #$0005
+                    beq       L2360
+                    cmpx      #$0006
+                    beq       L2371
+                    cmpx      #$0002
+                    beq       L2379
+                    lbra      L2508
+
+L2398               ldx       $0a,s
+                    lbra      L2410
+
+L239D               ldd       $0a,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L2508
+L23AA               ldd       $06,u
+                    cmpd      #$004A
+                    bne       L23CD
+                    ldd       $08,u
+                    std       $02,s
+                    ldx       $02,s
+                    ldd       $02,x
+                    std       $08,u
+                    bra       L23C0
+
+L23BE               leas      -$04,x
+L23C0               ldd       #$0036
+                    std       $06,u
+                    ldd       #$0002
+                    std       $02,u
+                    lbra      L2508
+
+L23CD               ldd       #$0084
+                    bra       L240B
+
+L23D2               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    ldd       #$008D
+                    bra       L240B
+
+L23E3               ldd       $06,u
+                    cmpd      #$004A
+                    bne       L2408
+                    ldd       #$0008
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       $02,s
+                    ldx       $02,s
+                    pshs      x
+                    ldx       $08,u
+                    lbsr      LA780
+L2400               lbsr      $AE34
+                    leax      $04,s
+                    lbra      L2324
+
+L2408               ldd       #$0090
+L240B               std       ,s
+                    lbra      L2508
+
+L2410               cmpx      #$0001
+                    lbeq      L23AA
+                    cmpx      #$0007
+                    lbeq      L23AA
+                    cmpx      #$0002
+                    lbeq      L23AA
+                    cmpx      #$0005
+                    beq       L23D2
+                    cmpx      #$0006
+                    beq       L23E3
+                    lbra      L239D
+
+L2432               ldx       $0a,s
+                    bra       L2458
+
+L2436               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    lbra      L2508
+
+L2450               ldd       #$008C
+                    std       ,s
+                    lbra      L2508
+
+L2458               cmpx      #$0008
+                    beq       L2436
+                    cmpx      #$0007
+                    lbeq      L2436
+                    cmpx      #$0002
+                    lbeq      L2436
+                    cmpx      #$0001
+                    lbeq      L2436
+                    cmpx      #$0006
+                    beq       L2450
+                    lbra      L2508
+
+L247A               ldx       $0a,s
+                    bra       L24BC
+
+L247E               ldd       $06,u
+                    cmpd      #$004B
+                    bne       L2492
+                    ldx       $08,u
+                    lbsr      $A77B
+                    std       $08,u
+                    leax      $04,s
+                    lbra      L23BE
+
+L2492               ldd       #$008F
+                    bra       L24B8
+
+L2497               ldd       $06,u
+                    cmpd      #$004B
+                    bne       L24B0
+                    ldx       $08,u
+                    pshs      x
+                    ldx       $08,u
+                    lbsr      $A775
+                    lbsr      LAEDF
+                    leax      $04,s
+                    lbra      L22D5
+
+L24B0               ldd       #$0091
+                    bra       L24B8
+
+L24B5               ldd       #$008D
+L24B8               std       ,s
+                    bra       L2508
+
+L24BC               cmpx      #$0002
+                    beq       L247E
+                    cmpx      #$0007
+                    lbeq      L247E
+                    cmpx      #$0001
+                    lbeq      L247E
+                    cmpx      #$0008
+                    beq       L2497
+                    cmpx      #$0005
+                    beq       L24B5
+                    bra       L2508
+
+L24DB               cmpx      #$0002
+                    lbeq      L2241
+                    cmpx      #$0001
+                    lbeq      L22A4
+                    cmpx      #$0007
+                    lbeq      L2357
+                    cmpx      #$0008
+                    lbeq      L2398
+                    cmpx      #$0005
+                    lbeq      L2432
+                    cmpx      #$0006
+                    lbeq      L247A
+                    lbra      L2297
+
+L2508               ldd       ,s
+                    beq       L2540
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    std       $02,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L05C9
+                    leas      $04,s
+                    ldd       ,s
+                    std       $06,u
+                    ldd       $02,s
+                    std       $0a,u
+                    clra
+                    clrb
+                    std       $0C,u
+L2540               ldd       $0a,s
+                    lbra      L25BE
+
+L2545               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      L21C1
+                    leas      $02,s
+                    std       $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L21C1
+                    leas      $02,s
+L2563               std       ,s
+                    ldd       $02,s
+                    cmpd      #$0006
+                    bne       L2572
+                    ldd       #$0006
+                    bra       L258A
+
+L2572               ldd       ,s
+                    cmpd      #$0006
+                    bne       L257F
+                    ldd       #$0006
+                    bra       L259D
+
+L257F               ldd       $02,s
+                    cmpd      #$0008
+                    bne       L2592
+                    ldd       #$0008
+L258A               pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    bra       L25A1
+
+L2592               ldd       ,s
+                    cmpd      #$0008
+                    bne       L25A8
+                    ldd       #$0008
+L259D               pshs      d
+                    pshs      u
+L25A1               lbsr      L222C
+                    leas      $04,s
+                    bra       L25C5
+
+L25A8               ldd       $02,s
+                    cmpd      #$0007
+                    beq       L25B8
+                    ldd       ,s
+                    cmpd      #$0007
+                    bne       L25C2
+L25B8               ldd       #$0007
+                    std       [$0a,s]
+L25BE               std       ,u
+                    bra       L25C5
+
+L25C2               ldd       #$0001
+L25C5               leas      $04,s
+                    puls      pc,u
+L25C9               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L067C
+                    std       ,s
+                    lbsr      L90F5
+                    leas      $06,s
+                    std       $04,s
+                    cmpd      #$0001
+                    bne       L25F3
+                    ldd       $0a,s
+                    puls      pc,u
+L25F3               ldx       $0a,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $0C,s
+                    ldd       $0e,x
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       #$0001
+                    std       ,u
+                    ldx       $0a,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $0C,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0052
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    pshs      d
+                    lbsr      L120A
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L2654
+                    clra
+                    clrb
+                    bra       L2657
+
+L2654               ldd       #$0002
+L2657               std       $12,u
+                    ldd       #$0001
+                    std       ,u
+                    ldd       #$0002
+                    std       $02,u
+                    tfr       u,d
+                    puls      pc,u
+L2668               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    std       ,s
+                    tfr       d,x
+                    cmpx      #$0076
+                    lbeq      L27B6
+                    cmpx      #$006F
+                    lbeq      L27B6
+                    cmpx      #$0042
+                    lbeq      L27B6
+                    ldd       ,s
+                    cmpd      #$0034
+                    bne       L26C1
+                    pshs      u
+                    bsr       L26D8
+                    leas      $02,s
+                    ldd       $08,s
+                    lbne      L27B6
+                    ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L26B3
+                    ldd       #$0001
+                    bra       L26B5
+
+L26B3               clra
+                    clrb
+L26B5               bne       L26C1
+                    ldd       ,u
+                    cmpd      #$0004
+                    lbne      L27B6
+L26C1               leax      $2968,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L27EB
+                    leas      $02,s
+                    lbra      L27B6
+
+L26D8               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       $06,u
+                    cmpd      #$0034
+                    lbne      L27B8
+                    ldd       ,u
+                    lbne      L27B8
+                    leax      L2978,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L27EB
+                    lbra      L27B6
+
+L2707               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       ,u
+                    std       [$08,s]
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L2746
+                    ldd       #$0001
+                    std       [$0a,s]
+                    ldd       $0a,u
+                    std       ,s
+                    ldd       $04,u
+                    ldx       ,s
+                    std       $04,x
+                    pshs      u
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L05C9
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    bra       L274B
+
+L2746               clra
+                    clrb
+                    std       [$0a,s]
+L274B               pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0034
+                    bne       L278B
+                    ldd       $08,u
+                    std       ,s
+                    ldx       ,s
+                    ldd       $08,x
+                    cmpd      #$0011
+                    beq       L276C
+                    leax      $02,s
+                    bra       L2789
+
+L276C               ldd       #$0036
+                    std       $06,u
+                    ldx       ,s
+                    ldd       $06,x
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $12,u
+                    ldd       #$0001
+                    std       ,u
+                    ldx       ,s
+                    ldd       $02,x
+                    bra       L27B6
+                    bra       L278B
+
+L2789               leas      -$02,x
+L278B               leax      $298C,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L27EB
+                    leas      $02,s
+                    ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $12,u
+                    ldd       #$0001
+                    std       [$08,s]
+                    ldd       #$0002
+L27B6               leas      $02,s
+L27B8               puls      pc,u
+L27BA               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       ,u
+                    cmpd      #$0004
+                    beq       L27D4
+                    ldd       ,u
+                    cmpd      #$0003
+                    bne       L27E7
+L27D4               leax      L29A3,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0498
+                    leas      $04,s
+                    pshs      u
+                    bsr       L27EB
+                    leas      $02,s
+L27E7               ldd       ,u
+                    puls      pc,u
+L27EB               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    leax      >$0078,y
+                    pshs      x
+                    lbsr      L03FB
+                    leas      $06,s
+                    ldd       #$0001
+                    std       $12,u
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L0598
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L0598
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $0C,u
+                    std       $0a,u
+                    ldd       #$0034
+                    std       $06,u
+                    leax      >$0078,y
+                    stx       $08,u
+                    puls      pc,u
+L2832               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldx       $04,s
+                    bra       L2843
+
+L283E               ldd       #$0001
+                    puls      pc,u
+L2843               cmpx      #$0001
+                    beq       L283E
+                    cmpx      #$0002
+                    lbeq      L283E
+                    cmpx      #$0008
+                    lbeq      L283E
+                    cmpx      #$0007
+                    lbeq      L283E
+                    clra
+                    clrb
+                    puls      pc,u
+L2861               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    leax      L29C4,pcr
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L0498
+                    leas      $04,s
+                    puls      pc,u
+L287A               lsr       $09,s
+                    ror       $6964
+                    fcb       $65
+                    bra       L28E4
+                    rol       $207A
+                    fcb       $65
+                    fcb       $72
+                    clr       0,x
+L2889               lsr       $7970
+                    fcb       $65
+                    lsr       $05,s
+                    ror       0,y
+                    blt       $28B3
+                    jmp       $0f,s
+                    lsr       $2061
+                    bra       L2910
+                    fcb       $61
+                    fcb       $72
+                    rol       $01,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       L0063
+                    fcb       $61
+                    jmp       $0e,s
+                    clr       -$0C,s
+                    bra       L290D
+                    fcb       $61
+                    com       $7400
+L28AE               com       $01,s
+                    jmp       $07,y
+                    lsr       L2074
+                    fcb       $61
+                    fcb       $6b
+                    fcb       $65
+                    bra       $291B
+                    lsr       $04,s
+                    fcb       $72
+                    fcb       $65
+                    com       $7300
+L28C1               neg       L6F69
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $293C
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L28D2               neg       L6F69
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $294A
+                    fcb       $72
+                    bra       L2947
+                    jmp       -$0C,s
+                    fcb       $65
+                    asr       $05,s
+                    fcb       $72
+L28E4               bra       $2958
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L28EE               jmp       $0f,s
+                    lsr       $2061
+                    bra       L295B
+                    fcb       $75
+                    jmp       $03,s
+                    lsr       $696F
+                    jmp       0,x
+L28FD               fcb       $62
+                    clr       -$0C,s
+                    asl       0,y
+                    tst       -$0b,s
+                    com       $7420
+                    fcb       $62
+                    fcb       $65
+                    bra       $2974
+                    jmp       -$0C,s
+L290D               fcb       $65
+                    asr       -$0e,s
+L2910               fcb       $61
+                    inc       0,x
+L2913               neg       L6F69
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L2989
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       L6368
+                    neg       $0074
+                    rol       L7065
+                    bra       L2997
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       L6368
+                    neg       L0070
+                    clr       $09,s
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $29A8
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       L6368
+                    neg       $0074
+                    rol       L7065
+L2947               bra       L29AC
+                    asl       $05,s
+                    com       $0b,s
+                    neg       $0073
+                    asl       $0f,s
+                    fcb       $75
+                    inc       $04,s
+                    bra       $29B8
+                    fcb       $65
+                    bra       L29A7
+                    fcb       $55
+                    inca
+L295B               inca
+                    neg       $0074
+                    rol       L7065
+                    bra       $29C8
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L006C
+                    ror       $616C
+                    fcb       $75
+                    fcb       $65
+                    bra       $29E2
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L2978               fcb       $75
+                    jmp       $04,s
+                    fcb       $65
+                    com       $0C,s
+                    fcb       $61
+                    fcb       $72
+                    fcb       $65
+                    lsr       0,y
+                    ror       L6172
+                    rol       $01,s
+                    fcb       $62
+L2989               inc       $05,s
+                    neg       $0073
+                    lsr       L7275
+                    com       -$0C,s
+                    bra       $2A01
+                    fcb       $65
+                    tst       $02,s
+L2997               fcb       $65
+                    fcb       $72
+                    bra       $2A0D
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L29A3               com       L7472
+                    fcb       $75
+L29A7               com       -$0C,s
+                    fcb       $75
+                    fcb       $72
+                    fcb       $65
+L29AC               bra       $2A1D
+                    fcb       $72
+                    bra       L2A26
+                    jmp       $09,s
+                    clr       $0e,s
+                    bra       $2A20
+                    jmp       $01,s
+                    neg       $7072
+                    clr       -$10,s
+                    fcb       $72
+                    rol       $01,s
+                    lsr       L6500
+L29C4               tst       -$0b,s
+                    com       $7420
+                    fcb       $62
+                    fcb       $65
+                    bra       L2A36
+                    jmp       -$0C,s
+                    fcb       $65
+                    asr       -$0e,s
+                    fcb       $61
+                    inc       0,x
+L29D5               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldd       $003F
+                    cmpd      #$0028
+                    beq       L29ED
+                    clra
+                    clrb
+                    std       $002F
+                    bra       L29ED
+
+L29EB               leas      ,x
+L29ED               ldx       $003F
+                    lbra      L2AEC
+
+L29F2               ldx       $0041
+                    bra       L2A48
+
+L29F6               lbsr      L2B1C
+                    puls      pc,u
+L29FB               lbsr      L2BDF
+                    puls      pc,u
+L2A00               lbsr      L3098
+                    lbra      L2B10
+
+L2A06               lbsr      L2DF6
+                    puls      pc,u
+L2A0B               lbsr      L2C8F
+                    puls      pc,u
+L2A10               lbsr      L31B8
+                    lbra      L2B10
+
+L2A16               lbsr      L31F7
+                    lbra      L2B10
+
+L2A1C               lbsr      L2E5E
+                    puls      pc,u
+L2A21               lbsr      L2F5F
+                    puls      pc,u
+L2A26               lbsr      L2EB1
+                    lbra      L2B10
+
+L2A2C               lbsr      L3235
+                    lbra      L2B10
+
+L2A32               leax      L3401,pcr
+L2A36               pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbsr      $5F26
+                    lbra      L2A9C
+
+L2A43               leax      ,s
+                    lbra      L2AA5
+
+L2A48               cmpx      #$0013
+                    beq       L29F6
+                    cmpx      #$0014
+                    beq       L29FB
+                    cmpx      #$0012
+                    beq       L2A00
+                    cmpx      #$0017
+                    beq       L2A06
+                    cmpx      #$0016
+                    beq       L2A0B
+                    cmpx      #$0018
+                    beq       L2A10
+                    cmpx      #$0019
+                    beq       L2A16
+                    cmpx      #$001B
+                    beq       L2A1C
+                    cmpx      #$001C
+                    beq       L2A21
+                    cmpx      #$001A
+                    beq       L2A26
+                    cmpx      #start
+                    beq       L2A2C
+                    cmpx      #$0015
+                    beq       L2A32
+                    bra       L2A43
+
+L2A86               lbsr      L89B7
+                    lbsr      $5F26
+                    puls      pc,u
+L2A8E               puls      pc,u
+L2A90               lbsr      L42B9
+                    ldb       $0045
+                    cmpb      #$3a
+                    bne       L2AA1
+                    lbsr      L3280
+L2A9C               leax      ,s
+                    lbra      L29EB
+
+L2AA1               leax      ,s
+                    bra       L2ACD
+
+L2AA5               leas      ,x
+L2AA7               lbsr      L0641
+                    std       -$02,s
+                    bne       L2AB5
+                    lbsr      L05DF
+                    std       -$02,s
+                    beq       L2ACF
+L2AB5               leax      L3414,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L2AC0               lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0028
+                    bne       L2AC0
+                    bra       L2B10
+
+L2ACD               leas      ,x
+L2ACF               clra
+                    clrb
+                    pshs      d
+                    lbsr      L3319
+                    std       ,s++
+                    bne       L2B10
+                    leax      L3428,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbsr      L0704
+                    puls      pc,u
+                    bra       L2B10
+
+L2AEC               cmpx      #$0028
+                    beq       L2B10
+                    cmpx      #$0033
+                    lbeq      L29F2
+                    cmpx      #$0029
+                    lbeq      L2A86
+                    cmpx      #$FFFF
+                    lbeq      L2A8E
+                    cmpx      #$0034
+                    lbeq      L2A90
+L2B0D               lbra      L2AA7
+
+L2B10               ldd       #$0028
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    puls      pc,u
+L2B1C               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    leas      -$06,s
+                    lbsr      $5F26
+                    lbsr      L337E
+                    std       ,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    tfr       d,u
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    ldd       $003F
+                    cmpd      #$0028
+                    bne       L2B6B
+                    lbsr      $5F26
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L33D7
+                    leas      $08,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    stu       $02,s
+                    bra       L2B8D
+
+L2B6B               ldd       #$0001
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L33D7
+                    leas      $08,s
+                    pshs      u
+                    lbsr      L57B2
+                    leas      $02,s
+                    lbsr      L29D5
+                    ldd       $04,s
+                    std       $02,s
+L2B8D               ldd       $003F
+                    cmpd      #$0033
+                    bne       L2BD2
+                    ldd       $0041
+                    cmpd      #$0015
+                    bne       L2BD2
+                    lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0028
+                    beq       L2BD2
+                    cmpu      $02,s
+                    beq       L2BCF
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+L2BCF               lbsr      L29D5
+L2BD2               ldd       $02,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    leas      $06,s
+                    puls      pc,u
+L2BDF               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L010F
+                    leas      -$0a,s
+                    ldd       $0033
+                    std       $08,s
+                    ldd       $0035
+                    std       $06,s
+                    ldd       $0786,y
+                    std       $04,s
+                    ldd       $0788,y
+                    std       $02,s
+                    lbsr      $5F26
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0033
+                    ldd       $000F
+                    std       $0788,y
+                    std       $0786,y
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0035
+                    lbsr      L337E
+                    std       ,s
+                    ldd       $003F
+                    cmpd      #$0028
+                    bne       L2C2D
+                    ldu       $0035
+                    bra       L2C52
+
+L2C2D               clra
+                    clrb
+                    pshs      d
+                    ldd       $0035
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L57B2
+                    leas      $02,s
+                    lbsr      L29D5
+L2C52               ldd       $0035
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0033
+                    pshs      d
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L33D7
+                    leas      $08,s
+                    ldd       $0033
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $08,s
+                    std       $0033
+                    ldd       $06,s
+                    std       $0035
+                    ldd       $04,s
+                    std       $0786,y
+                    ldd       $02,s
+                    std       $0788,y
+                    leas      $0a,s
+                    puls      pc,u
+L2C8F               pshs      u
+                    ldd       #$FFA8
+                    lbsr      L010F
+                    leas      -$0e,s
+                    lbsr      $5F26
+                    ldd       $0037
+                    addd      #$0001
+                    std       $0037
+                    ldd       $003B
+                    std       ,s
+                    ldd       $0039
+                    std       $0a,s
+                    clra
+                    clrb
+                    std       $0039
+                    ldd       $0033
+                    std       $0C,s
+                    ldd       $0784,y
+                    std       $08,s
+                    ldd       $0786,y
+                    std       $02,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0033
+                    ldd       $000F
+                    std       $0786,y
+                    clra
+                    clrb
+                    std       $0784,y
+                    ldd       #$002D
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      $0785
+                    std       ,s
+                    lbsr      L111D
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L2D43
+                    pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldx       ,u
+                    bra       L2D1B
+
+L2CFD               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    bra       L2D33
+
+L2D0B               pshs      u
+                    lbsr      L2861
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L27EB
+                    leas      $02,s
+                    bra       L2D33
+
+L2D1B               cmpx      #$0002
+                    beq       L2CFD
+                    cmpx      #$0008
+                    lbeq      L2CFD
+                    cmpx      #$0001
+                    beq       L2D33
+                    cmpx      #$0007
+                    beq       L2D33
+                    bra       L2D0B
+
+L2D33               pshs      u
+                    lbsr      L6E76
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L0598
+                    leas      $02,s
+                    bra       L2D46
+
+L2D43               lbsr      L101A
+L2D46               ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $08,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    lbsr      L29D5
+                    ldd       $002F
+                    bne       L2D82
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0033
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L2D82               ldd       $06,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldu       $0039
+                    bra       L2DAD
+
+L2D8F               ldd       ,u
+                    std       $04,s
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $04,u
+                    pshs      d
+                    ldd       #$007D
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       L0025
+                    std       ,u
+                    stu       L0025
+                    ldu       $04,s
+L2DAD               stu       -$02,s
+                    bne       L2D8F
+                    ldd       $0784,y
+                    beq       L2DCB
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0784,y
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L2DCB               ldd       $0033
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $0a,s
+                    std       $0039
+                    ldd       $08,s
+                    std       $0784,y
+                    ldd       $0037
+                    addd      #$FFFF
+                    std       $0037
+                    ldd       ,s
+                    std       $003B
+                    ldd       $0C,s
+                    std       $0033
+                    ldd       $02,s
+                    std       $0786,y
+                    lbra      L3094
+
+L2DF6               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    leas      -$02,s
+L2E00               lbsr      $5F26
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0C54
+                    leas      $02,s
+                    std       ,s
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    ldd       $0037
+                    beq       L2E5A
+                    ldu       L0025
+                    beq       L2E26
+                    ldd       ,u
+                    std       L0025
+                    bra       L2E32
+
+L2E26               ldd       #$0006
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    tfr       d,u
+L2E32               ldd       $0039
+                    beq       L2E3C
+                    stu       [$003B,y]
+                    bra       L2E3E
+
+L2E3C               stu       $0039
+L2E3E               stu       $003B
+                    clra
+                    clrb
+                    std       ,u
+                    ldd       ,s
+                    std       $02,u
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,u
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    bra       L2EAD
+
+L2E5A               bsr       L2E9C
+                    bra       L2EAD
+
+L2E5E               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    lbsr      $5F26
+                    ldd       $0037
+                    bne       L2E6F
+                    bsr       L2E9C
+L2E6F               ldd       $0784,y
+                    beq       L2E80
+L2E75               leax      $3435,pcr
+                    pshs      x
+                    lbsr      L0450
+                    bra       L2E90
+
+L2E80               ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0784,y
+                    pshs      d
+                    lbsr      L57B2
+L2E90               leas      $02,s
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L06C1
+                    bra       L2EAD
+
+L2E9C               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      $3447,pcr
+                    pshs      x
+                    lbsr      L0450
+L2EAD               leas      $02,s
+                    puls      pc,u
+L2EB1               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L010F
+                    leas      -$0a,s
+                    ldd       $0033
+                    std       $08,s
+                    ldd       $0035
+                    std       $06,s
+                    ldd       $0788,y
+                    std       ,s
+                    ldd       $0786,y
+                    std       $02,s
+                    ldd       $000F
+                    std       $0788,y
+                    std       $0786,y
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0035
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0033
+                    lbsr      $5F26
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    lbsr      L29D5
+                    ldd       $003F
+                    cmpd      #$0033
+                    bne       L2F11
+                    ldd       $0041
+                    cmpd      #$0014
+                    beq       L2F1C
+L2F11               leax      $345B,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L2F1C               lbsr      $5F26
+                    ldd       $0035
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0033
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L337E
+                    pshs      d
+                    lbsr      L33D7
+                    leas      $08,s
+                    ldd       $0033
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $08,s
+                    std       $0033
+                    ldd       $06,s
+                    std       $0035
+                    ldd       $02,s
+                    std       $0786,y
+                    ldd       ,s
+                    std       $0788,y
+                    leas      $0a,s
+                    puls      pc,u
+L2F5F               pshs      u
+                    ldd       #$FFA6
+                    lbsr      L010F
+                    leas      -$0e,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldu       $0033
+                    ldd       $0035
+                    std       $0C,s
+                    ldd       $0786,y
+                    std       $06,s
+                    ldd       $0788,y
+                    std       $04,s
+                    ldd       $000F
+                    std       $0786,y
+                    std       $0788,y
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0a,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0033
+                    lbsr      $5F26
+                    ldd       #$002D
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L3319
+                    leas      $02,s
+                    ldd       #$0028
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    ldd       $003F
+                    cmpd      #$0028
+                    beq       L2FE5
+                    lbsr      L33A5
+                    std       $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0a,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L2FE5               ldd       #$0028
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      $0785
+                    std       ,s
+                    lbsr      L111D
+                    leas      $02,s
+                    std       ,s
+                    beq       L3013
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    bra       L3015
+
+L3013               ldd       $0a,s
+L3015               std       $0035
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    lbsr      L29D5
+                    ldd       ,s
+                    beq       L3043
+                    ldd       $0035
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L3342
+                    leas      $02,s
+L3043               ldd       $02,s
+                    beq       L3067
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0033
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L33D7
+                    leas      $08,s
+                    bra       L3079
+
+L3067               clra
+                    clrb
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L3079               ldd       $0033
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    stu       $0033
+                    ldd       $0C,s
+                    std       $0035
+                    ldd       $06,s
+                    std       $0786,y
+                    ldd       $04,s
+                    std       $0788,y
+L3094               leas      $0e,s
+                    puls      pc,u
+L3098               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0028
+                    lbeq      L3197
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    lbeq      L3197
+                    pshs      u
+                    lbsr      L111D
+                    leas      $02,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L27BA
+                    leas      $02,s
+                    ldd       $002D
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L30E5
+                    ldd       #$0001
+                    bra       L30E7
+
+L30E5               ldd       $002D
+L30E7               pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+                    ldx       $002D
+                    lbra      L3179
+
+L30F5               pshs      u
+                    lbsr      L34BE
+                    leas      $02,s
+                    leax      ,s
+                    bra       L3109
+
+L3100               pshs      u
+                    lbsr      $3987
+                    leas      $02,s
+                    bra       L310B
+
+L3109               leas      ,x
+L310B               ldd       $06,u
+                    cmpd      #$0080
+                    lbeq      L3190
+                    ldd       #$0080
+                    pshs      d
+                    ldd       #$006F
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       #$006F
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldx       $002D
+                    bra       L3162
+
+L313C               ldd       $002D
+                    pshs      d
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L3190
+
+L3151               ldd       #$0089
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L3190
+
+L3162               cmpx      #$0005
+                    beq       L313C
+                    cmpx      #$0006
+                    lbeq      L313C
+                    bra       L3151
+
+L3170               pshs      u
+                    lbsr      L6E42
+                    leas      $02,s
+                    bra       L3190
+
+L3179               cmpx      #$0008
+                    lbeq      L30F5
+                    cmpx      #$0005
+                    lbeq      L3100
+                    cmpx      #$0006
+                    lbeq      L3100
+                    bra       L3170
+
+L3190               pshs      u
+                    lbsr      L0598
+                    leas      $02,s
+L3197               clra
+                    clrb
+                    pshs      d
+                    lbsr      L57E3
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0012
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       #$0012
+                    lbra      L327C
+
+L31B8               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    lbsr      $5F26
+                    ldd       $0033
+                    bne       L31D4
+                    leax      L346A,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L31F1
+
+L31D4               ldd       $0786,y
+                    pshs      d
+                    lbsr      L57E3
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0033
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L31F1               ldd       #$0018
+                    lbra      L327C
+
+L31F7               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    lbsr      $5F26
+                    ldd       $0035
+                    bne       L3213
+                    leax      $3476,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L3230
+
+L3213               ldd       $0788,y
+                    pshs      d
+                    lbsr      L57E3
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0035
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L3230               ldd       #$0019
+                    bra       L327C
+
+L3235               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0034
+                    beq       L3255
+                    leax      $3485,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L3279
+
+L3255               lbsr      L32C2
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L3276
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #start
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       $0a,u
+                    orb       #$02
+                    std       $0a,u
+L3276               lbsr      $5F26
+L3279               ldd       #start
+L327C               std       $002F
+                    puls      pc,u
+L3280               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    bsr       L32C2
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L32BA
+                    ldd       $08,u
+                    cmpd      #$000F
+                    bne       L329D
+                    lbsr      L0443
+                    bra       L32BA
+
+L329D               ldd       #$000F
+                    std       $08,u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$0009
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       $0a,u
+                    orb       #$01
+                    std       $0a,u
+L32BA               lbsr      $5F26
+                    lbsr      $5F26
+                    puls      pc,u
+L32C2               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldu       $0041
+                    ldd       ,u
+                    cmpd      #$0009
+                    lbeq      L33D3
+                    ldd       ,u
+                    beq       L32F4
+                    ldd       $0C,u
+                    beq       L32ED
+                    leax      L3494,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    clra
+                    clrb
+                    puls      pc,u
+L32ED               pshs      u
+                    lbsr      L0382
+                    leas      $02,s
+L32F4               ldd       #$0009
+                    std       ,u
+                    ldd       #$000D
+                    std       $08,u
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $0a,u
+                    ldd       $0031
+                    std       $0C,u
+                    ldd       $0029
+                    std       $10,u
+                    stu       $0029
+                    lbra      L33D3
+
+L3319               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    lbeq      L33D3
+                    pshs      u
+                    lbsr      L111D
+                    std       ,s
+                    bsr       L3342
+                    leas      $02,s
+                    tfr       d,u
+                    lbra      L33D3
+
+L3342               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldu       $04,s
+                    pshs      u
+                    lbsr      L26D8
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L3363
+
+L3357               ldd       #$003C
+                    bra       L335F
+
+L335C               ldd       #$003D
+L335F               std       $06,u
+                    bra       L336D
+
+L3363               cmpx      #$003E
+                    beq       L3357
+                    cmpx      #$003F
+                    beq       L335C
+L336D               pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L0598
+                    lbra      L33D1
+
+L337E               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    leas      -$02,s
+                    ldd       #$002D
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    bsr       L33A5
+                    std       ,s
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    ldd       ,s
+                    lbra      L33FD
+
+L33A5               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      $0785
+                    std       ,s
+                    lbsr      L111D
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L33C8
+                    pshs      u
+                    lbsr      L26D8
+                    bra       L33D1
+
+L33C8               leax      $34AD,pcr
+                    pshs      x
+                    lbsr      L0450
+L33D1               leas      $02,s
+L33D3               tfr       u,d
+                    puls      pc,u
+L33D7               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L33FF
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L939D
+                    leas      $08,s
+                    pshs      u
+                    lbsr      L0598
+L33FD               leas      $02,s
+L33FF               puls      pc,u
+L3401               jmp       $0f,s
+                    bra       $342C
+                    rol       $06,s
+                    beq       $3429
+                    ror       $0f,s
+                    fcb       $72
+                    bra       $3435
+                    fcb       $65
+                    inc       -$0d,s
+                    fcb       $65
+                    beq       L3414
+L3414               rol       $0C,s
+                    inc       $05,s
+                    asr       $01,s
+                    inc       0,y
+                    lsr       $05,s
+                    com       $0C,s
+                    fcb       $61
+                    fcb       $72
+                    fcb       $61
+                    lsr       $696F
+                    jmp       0,x
+
+L3428               com       L796E
+                    lsr       $6178
+                    bra       L3495
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $006D
+                    fcb       $75
+                    inc       -$0C,s
+                    rol       -$10,s
+                    inc       $05,s
+                    bra       $34A3
+                    fcb       $65
+                    ror       $01,s
+                    fcb       $75
+                    inc       -$0C,s
+                    com       >$006E
+                    clr       0,y
+                    com       $7769
+                    lsr       L6368
+                    bra       $34C5
+                    lsr       L6174
+                    fcb       $65
+                    tst       $05,s
+                    jmp       -$0C,s
+                    neg       $0077
+                    asl       $09,s
+                    inc       $05,s
+                    bra       $34C7
+                    asl       L7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+L346A               fcb       $62
+                    fcb       $72
+                    fcb       $65
+                    fcb       $61
+                    fcb       $6b
+                    bra       $34D6
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L0063
+                    clr       $0e,s
+                    lsr       L696E
+                    fcb       $75
+                    fcb       $65
+                    bra       L34E5
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L006C
+                    fcb       $61
+                    fcb       $62
+                    fcb       $65
+                    inc       0,y
+                    fcb       $72
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L3494               fcb       $61
+L3495               inc       -$0e,s
+                    fcb       $65
+                    fcb       $61
+                    lsr       -$07,s
+                    bra       L34FE
+                    bra       L350B
+                    clr       $03,s
+                    fcb       $61
+                    inc       0,y
+                    ror       L6172
+                    rol       $01,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       L0063
+                    clr       $0e,s
+                    lsr       $09,s
+                    lsr       $696F
+                    jmp       0,y
+                    jmp       $05,s
+                    fcb       $65
+                    lsr       $05,s
+                    lsr       0,x
+L34BE               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L34D9
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L3898
+                    leas      $02,s
+                    puls      pc,u
+L34D9               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$06,s
+L34E5               ldd       $06,u
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L379C
+
+L34EE               pshs      u
+                    lbsr      L7BD2
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L77AC
+                    leas      $02,s
+                    ldx       $06,u
+L34FE               bra       L351A
+
+L3500               ldd       $08,u
+                    lbeq      L3894
+                    pshs      u
+                    ldd       #$0077
+L350B               pshs      d
+                    ldd       #$007B
+L3510               pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    lbra      L3773
+
+L351A               cmpx      #$0093
+                    beq       L3500
+                    cmpx      #$0094
+                    lbeq      L3500
+                    cmpx      #$0095
+                    lbeq      L3500
+                    lbra      L3894
+
+L3530               ldd       $0a,u
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       #$0086
+                    lbra      L36F5
+
+L353F               ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0091
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    lbra      L3701
+
+L355E               ldd       $0a,u
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       #$0083
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L357A
+
+L3578               leas      -$06,x
+L357A               ldd       #$0080
+                    std       $06,u
+                    lbra      L3894
+
+L3582               ldd       $08,u
+                    pshs      d
+                    ldd       #$004A
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L35BB
+
+L3597               leax      L34BE,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L7567
+                    bra       L35B9
+
+L35A4               ldd       $0a,u
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+L35B9               leas      $04,s
+L35BB               leax      $06,s
+                    lbra      L3771
+
+L35C0               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0080
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $02,s
+                    cmpd      #$003E
+                    bne       L361B
+                    ldd       #$003F
+                    lbra      L36F5
+
+L361B               ldd       #$003E
+                    lbra      L36F5
+
+L3621               pshs      u
+                    lbsr      L75E3
+                    leas      $02,s
+                    lbra      L3701
+
+L362B               ldx       $0a,u
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L3645
+                    leas      -$02,s
+                    ldd       $0a,u
+                    std       ,s
+                    ldd       $0C,u
+                    std       $0a,u
+                    ldd       ,s
+                    std       $0C,u
+                    leas      $02,s
+L3645               ldx       $0C,u
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L3696
+                    ldx       $0C,u
+                    ldd       $08,x
+                    std       $04,s
+                    ldd       [$04,s]
+                    bne       L3696
+                    ldx       $04,s
+                    ldd       $02,x
+                    pshs      d
+                    lbsr      L749E
+                    leas      $02,s
+                    std       ,s
+                    beq       L3696
+                    ldd       $0C,u
+                    std       $04,s
+                    ldd       ,s
+                    ldx       $04,s
+                    std       $08,x
+                    ldd       #$0036
+                    ldx       $04,s
+                    std       $06,x
+                    ldd       #$0001
+                    std       [$04,s]
+                    ldd       $02,s
+                    cmpd      #$0052
+                    bne       L368D
+                    ldd       #$0056
+                    bra       L3690
+
+L368D               ldd       #$0055
+L3690               std       $02,s
+                    leax      $06,s
+                    bra       L36D0
+
+L3696               ldd       $0a,u
+                    std       $04,s
+                    ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L36AF
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L38E8
+                    leas      $02,s
+                    bra       L36C7
+
+L36AF               ldd       $04,s
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+L36C7               ldd       $0C,u
+                    pshs      d
+                    lbsr      L34BE
+                    bra       L36F1
+
+L36D0               leas      -$06,x
+L36D2               ldd       $0a,u
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L6E42
+L36F1               leas      $02,s
+                    ldd       $02,s
+L36F5               pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+L3701               leax      $06,s
+                    lbra      L3578
+
+L3706               ldd       $0a,u
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    leax      $06,s
+                    bra       L375E
+
+L372B               leas      -$06,x
+                    ldd       $0a,u
+                    std       $04,s
+                    pshs      d
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $02,s
+                    addd      #$FFB0
+                    std       $06,u
+                    ldd       #$0093
+                    ldx       $04,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L34D9
+                    leas      $02,s
+                    bra       L3760
+
+L375E               leas      -$06,x
+L3760               ldd       #$0089
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L3773
+
+L3771               leas      -$06,x
+L3773               ldd       #$0093
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L3894
+
+L377F               ldd       $02,s
+                    cmpd      #$00A0
+                    blt       L378C
+                    leax      $06,s
+                    lbra      L372B
+
+L378C               leax      L3981,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0464
+                    leas      $04,s
+                    lbra      L3894
+
+L379C               cmpx      #$0080
+                    lbeq      L3894
+                    cmpx      #$0093
+                    lbeq      L3894
+                    cmpx      #$0094
+                    lbeq      L3894
+                    cmpx      #$0095
+                    lbeq      L3894
+                    cmpx      #$0034
+                    lbeq      L3894
+                    cmpx      #$0042
+                    lbeq      L34EE
+                    cmpx      #$0086
+                    lbeq      L3530
+                    cmpx      #$0091
+                    lbeq      L353F
+                    cmpx      #$0083
+                    lbeq      L355E
+                    cmpx      #$004A
+                    lbeq      L3582
+                    cmpx      #$0064
+                    lbeq      L3597
+                    cmpx      #$003C
+                    lbeq      L35A4
+                    cmpx      #$003D
+                    lbeq      L35A4
+                    cmpx      #$0044
+                    lbeq      L35A4
+                    cmpx      #$0043
+                    lbeq      L35A4
+                    cmpx      #$003E
+                    lbeq      L35C0
+                    cmpx      #$003F
+                    lbeq      L35C0
+                    cmpx      #$0065
+                    lbeq      L3621
+                    cmpx      #$0052
+                    lbeq      L362B
+                    cmpx      #$0053
+                    lbeq      L3696
+                    cmpx      #$005A
+                    lbeq      L3696
+                    cmpx      #$005B
+                    lbeq      L3696
+                    cmpx      #$005E
+                    lbeq      L3696
+                    cmpx      #$005C
+                    lbeq      L3696
+                    cmpx      #$005F
+                    lbeq      L3696
+                    cmpx      #$005D
+                    lbeq      L3696
+                    cmpx      #$0050
+                    lbeq      L3696
+                    cmpx      #$0051
+                    lbeq      L3696
+                    cmpx      #$0054
+                    lbeq      L3696
+                    cmpx      #$0057
+                    lbeq      L3696
+                    cmpx      #$0058
+                    lbeq      L3696
+                    cmpx      #$0059
+                    lbeq      L3696
+                    cmpx      #$0056
+                    lbeq      L36D2
+                    cmpx      #$0055
+                    lbeq      L36D2
+                    cmpx      #$0078
+                    lbeq      L3706
+                    lbra      L377F
+
+L3894               leas      $06,s
+                    puls      pc,u
+L3898               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldx       $04,s
+                    ldx       $06,x
+                    bra       L38D5
+
+L38A6               ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L38E6
+
+L38C0               ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L38E6
+
+L38D5               cmpx      #$0034
+                    beq       L38A6
+                    cmpx      #$0094
+                    beq       L38C0
+                    cmpx      #$0095
+                    lbeq      L38C0
+L38E6               puls      pc,u
+L38E8               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $08,u
+                    std       ,s
+                    ldx       ,s
+                    lda       ,x
+                    ora       $01,x
+                    ora       $02,x
+                    ora       $03,x
+                    beq       L3947
+                    ldx       ,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       [,s]
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L396E
+
+L3947               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+L396E               ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    leas      $02,s
+                    puls      pc,u
+L3981               inc       $0f,s
+                    jmp       $07,s
+                    com       >$0034
+                    nega
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L39A2
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L3898
+                    leas      $02,s
+                    puls      pc,u
+L39A2               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$08,s
+                    ldd       ,u
+                    std       $02,s
+                    ldd       $06,u
+                    std       $06,s
+                    tfr       d,x
+                    lbra      L3BD7
+
+L39BB               pshs      u
+                    lbsr      L34D9
+                    leas      $02,s
+                    lbra      L3CAC
+
+L39C5               ldd       $0a,u
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    bra       L39D2
+
+L39D0               leas      -$08,x
+L39D2               ldd       $06,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L39E4
+
+L39E2               leas      -$08,x
+L39E4               ldd       #$0080
+                    std       $06,u
+                    lbra      L3CAC
+
+L39EC               ldd       $0a,u
+                    pshs      d
+                    lbsr      L34BE
+                    bra       L39FC
+
+L39F5               ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+L39FC               leas      $02,s
+                    leax      $08,s
+                    bra       L39D0
+
+L3A02               ldd       $08,u
+                    pshs      d
+                    ldd       #$004B
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    lbra      L3BAE
+
+L3A18               leax      $3987,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L7567
+                    leas      $04,s
+                    bra       L3A42
+
+L3A27               ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L3A42               leax      $08,s
+                    lbra      L3BAC
+
+L3A47               ldd       #$0080
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $08,s
+                    cmpd      #$003E
+                    bne       L3AA9
+                    ldd       #$003F
+                    bra       L3AAC
+
+L3AA9               ldd       #$003E
+L3AAC               pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L3AF2
+
+L3ABA               pshs      u
+                    lbsr      L75E3
+                    leas      $02,s
+                    bra       L3AF2
+
+L3AC3               ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+L3AF2               leax      $08,s
+                    lbra      L39E2
+
+L3AF7               ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    leax      $08,s
+                    lbra      L3B95
+
+L3B1D               leas      -$08,x
+                    ldd       $0a,u
+                    std       $04,s
+                    ldd       $02,s
+                    cmpd      #$0005
+                    bne       L3B4F
+                    ldx       $04,s
+                    ldd       $0a,x
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       #$008C
+                    pshs      d
+                    ldd       #$0087
+                    bra       L3B60
+
+L3B4F               ldd       $04,s
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+L3B60               pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $06,s
+                    addd      #$FFB0
+                    std       $06,u
+                    ldd       #$0093
+                    ldx       $04,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L39A2
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0005
+                    bne       L3B97
+                    ldd       #$008D
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L3B97
+
+L3B95               leas      -$08,x
+L3B97               ldd       $02,s
+                    pshs      d
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L3BAE
+
+L3BAC               leas      -$08,x
+L3BAE               ldd       #$0093
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L3CAC
+
+L3BBA               ldd       $06,s
+                    cmpd      #$00A0
+                    blt       L3BC7
+                    leax      $08,s
+                    lbra      L3B1D
+
+L3BC7               leax      L3CB0,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0464
+                    leas      $04,s
+                    lbra      L3CAC
+
+L3BD7               cmpx      #$0080
+                    lbeq      L3CAC
+                    cmpx      #$0093
+                    lbeq      L3CAC
+                    cmpx      #$0094
+                    lbeq      L3CAC
+                    cmpx      #$0095
+                    lbeq      L3CAC
+                    cmpx      #$0034
+                    lbeq      L3CAC
+                    cmpx      #$0042
+                    lbeq      L39BB
+                    cmpx      #$0092
+                    lbeq      L39C5
+                    cmpx      #$008E
+                    lbeq      L39C5
+                    cmpx      #$0090
+                    lbeq      L39EC
+                    cmpx      #$008D
+                    lbeq      L39F5
+                    cmpx      #$008C
+                    lbeq      L39F5
+                    cmpx      #$004B
+                    lbeq      L3A02
+                    cmpx      #$0064
+                    lbeq      L3A18
+                    cmpx      #$003C
+                    lbeq      L3A27
+                    cmpx      #$003D
+                    lbeq      L3A27
+                    cmpx      #$0043
+                    lbeq      L3A27
+                    cmpx      #$003E
+                    lbeq      L3A47
+                    cmpx      #$003F
+                    lbeq      L3A47
+                    cmpx      #$0065
+                    lbeq      L3ABA
+                    cmpx      #$005A
+                    lbeq      L3AC3
+                    cmpx      #$005B
+                    lbeq      L3AC3
+                    cmpx      #$005E
+                    lbeq      L3AC3
+                    cmpx      #$005C
+                    lbeq      L3AC3
+                    cmpx      #$005F
+                    lbeq      L3AC3
+                    cmpx      #$005D
+                    lbeq      L3AC3
+                    cmpx      #$0050
+                    lbeq      L3AC3
+                    cmpx      #$0051
+                    lbeq      L3AC3
+                    cmpx      #$0052
+                    lbeq      L3AC3
+                    cmpx      #$0053
+                    lbeq      L3AC3
+                    cmpx      #$0078
+                    lbeq      L3AF7
+                    lbra      L3BBA
+
+L3CAC               leas      $08,s
+                    puls      pc,u
+L3CB0               ror       $0C,s
+                    clr       $01,s
+                    lsr       $7300
+L3CB7               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldx       $0a,s
+                    bra       L3CDD
+
+L3CC7               lbsr      L4203
+                    lbra      L3DEE
+
+L3CCD               ldd       #$0001
+                    bra       L3CD4
+
+L3CD2               clra
+                    clrb
+L3CD4               pshs      d
+                    lbsr      L5D4E
+                    leas      $02,s
+                    bra       L3CFE
+
+L3CDD               cmpx      #$001E
+                    beq       L3CC7
+                    cmpx      #$000E
+                    lbeq      L3CC7
+                    cmpx      #$0022
+                    lbeq      L3CC7
+                    cmpx      #$0021
+                    beq       L3CCD
+                    cmpx      #$0023
+                    lbeq      L3CCD
+                    bra       L3CD2
+
+L3CFE               ldd       $0031
+                    bne       L3D30
+                    leax      $14,u
+                    stx       $02,s
+                    ldd       $0a,s
+                    cmpd      #$000F
+                    beq       L3D1C
+                    ldd       $0a,s
+                    cmpd      #$0023
+                    beq       L3D1C
+                    ldd       #$0001
+                    bra       L3D23
+
+L3D1C               ldd       #$000C
+                    std       $08,u
+                    clra
+                    clrb
+L3D23               pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L5815
+                    leas      $04,s
+                    bra       L3D3C
+
+L3D30               ldd       $06,u
+                    pshs      d
+                    lbsr      L57C3
+                    leas      $02,s
+                    lbsr      L577A
+L3D3C               ldd       $0C,s
+                    cmpd      #$0022
+                    bne       L3D90
+                    ldd       #$0001
+                    std       L0056
+                    lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0037
+                    bne       L3D89
+                    ldd       $04,u
+                    std       $02,s
+                    ldd       [$02,s]
+                    bne       L3D64
+                    ldd       $0060
+                    std       [$02,s]
+                    bra       L3D81
+
+L3D64               ldd       [$02,s]
+                    subd      $0060
+                    std       ,s
+                    blt       L3D76
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L6B34
+                    bra       L3D7F
+
+L3D76               leax      L4244,pcr
+                    pshs      x
+                    lbsr      L0450
+L3D7F               leas      $02,s
+L3D81               lbsr      $5F26
+                    leax      $04,s
+                    lbra      L3DE5
+
+L3D89               ldd       #$0002
+                    std       L0056
+                    bra       L3D98
+
+L3D90               ldd       #$0002
+                    std       L0056
+                    lbsr      $5F26
+L3D98               ldd       $0C,s
+                    cmpd      #$0004
+                    bne       L3DB5
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0a,u
+L3DA6               pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    bsr       L3DF2
+                    leas      $08,s
+                    bra       L3DE7
+
+L3DB5               ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L3DC8
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $04,u
+                    bra       L3DA6
+
+L3DC8               ldd       #$0001
+                    pshs      d
+                    ldd       $04,u
+                    pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    bsr       L3DF2
+                    leas      $08,s
+                    std       -$02,s
+                    bne       L3DE7
+                    lbsr      L421A
+                    bra       L3DE7
+
+L3DE5               leas      -$04,x
+L3DE7               lbsr      L5D64
+                    clra
+                    clrb
+                    std       L0056
+L3DEE               leas      $04,s
+                    puls      pc,u
+L3DF2               pshs      u
+                    ldd       #$FFA8
+                    lbsr      L010F
+                    ldu       $06,s
+                    leas      -$0C,s
+                    ldd       $16,s
+                    bne       L3E0F
+                    ldd       #$0029
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    bra       L3E25
+
+L3E0F               ldd       $003F
+                    cmpd      #$0029
+                    bne       L3E21
+                    ldd       #$0001
+                    std       $0a,s
+                    lbsr      $5F26
+                    bra       L3E25
+
+L3E21               clra
+                    clrb
+                    std       $0a,s
+L3E25               ldd       $10,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    lbne      L3F13
+                    ldd       [$14,s]
+                    std       $02,s
+                    bne       L3E3F
+                    ldd       #$FFFF
+                    std       $02,s
+L3E3F               ldd       $10,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    std       $08,s
+                    cmpd      #$0004
+                    bne       L3E55
+                    ldd       $0a,u
+                    bra       L3E5A
+
+L3E55               ldx       $14,s
+                    ldd       $02,x
+L3E5A               std       $04,s
+                    clra
+                    clrb
+                    std       $06,s
+                    bra       L3E98
+
+L3E62               ldd       $16,s
+                    addd      #$0001
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L3DF2
+                    leas      $08,s
+                    std       -$02,s
+                    lbeq      L3FCA
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    cmpd      $02,s
+                    bcc       L3EA0
+                    ldd       $003F
+                    cmpd      #$0030
+                    bne       L3EA0
+                    lbsr      $5F26
+                    bra       L3E98
+
+L3E98               ldd       $003F
+                    cmpd      #$002A
+                    bne       L3E62
+L3EA0               ldd       $02,s
+                    cmpd      #$FFFF
+                    bne       L3EAF
+                    ldd       $06,s
+                    std       [$14,s]
+                    bra       L3EDE
+
+L3EAF               ldd       $06,s
+                    cmpd      $02,s
+                    bcc       L3EDE
+                    ldx       $14,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L90F5
+                    leas      $06,s
+                    pshs      d
+                    ldd       $04,s
+                    subd      $08,s
+                    lbsr      LAF4B
+                    pshs      d
+                    lbsr      L3FD0
+                    leas      $02,s
+                    bra       L3EDE
+
+L3EDC               leas      -$0C,x
+L3EDE               ldd       $16,s
+                    beq       L3EE9
+                    ldd       $0a,s
+                    lbeq      L3FB7
+L3EE9               ldd       $003F
+                    cmpd      #$0030
+                    bne       L3EF4
+                    lbsr      $5F26
+L3EF4               ldd       $003F
+                    cmpd      #$002A
+                    bne       L3F02
+                    lbsr      $5F26
+                    lbra      L3FB7
+
+L3F02               leax      L424D,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbsr      L421A
+                    lbra      L3FB7
+
+L3F13               ldd       $10,s
+                    cmpd      #$0004
+                    lbne      L3F9E
+                    ldd       $14,s
+                    std       ,s
+                    bne       L3F6C
+                    leax      $425F,pcr
+                    lbra      L3FC0
+
+L3F2C               ldx       ,s
+                    ldu       $02,x
+                    ldd       $16,s
+                    addd      #$0001
+                    pshs      d
+                    ldd       ,u
+                    cmpd      #$0004
+                    bne       L3F44
+                    ldd       $0a,u
+                    bra       L3F46
+
+L3F44               ldd       $04,u
+L3F46               pshs      d
+                    pshs      u
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L3DF2
+                    leas      $08,s
+                    std       -$02,s
+                    lbeq      L3FCA
+                    ldd       [,s]
+                    std       ,s
+                    beq       L3F95
+                    ldd       $003F
+                    cmpd      #$0030
+                    bne       L3F95
+                    lbsr      $5F26
+                    bra       L3F6C
+
+L3F6C               ldd       $003F
+                    cmpd      #$002A
+                    bne       L3F2C
+                    bra       L3F95
+
+L3F76               ldx       ,s
+                    ldu       $02,x
+                    ldd       $04,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L90F5
+                    leas      $06,s
+                    pshs      d
+                    bsr       L3FD0
+                    leas      $02,s
+                    ldd       [,s]
+                    std       ,s
+L3F95               ldd       ,s
+                    bne       L3F76
+                    leax      $0C,s
+                    lbra      L3EDC
+
+L3F9E               ldd       $10,s
+                    pshs      d
+                    bsr       L3FF1
+                    std       ,s++
+                    beq       L3FBC
+                    ldd       $0a,s
+                    beq       L3FB7
+                    ldd       #$002A
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+L3FB7               ldd       #$0001
+                    bra       L3FCC
+
+L3FBC               leax      L4272,pcr
+L3FC0               pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbsr      L421A
+L3FCA               clra
+                    clrb
+L3FCC               leas      $0C,s
+                    puls      pc,u
+L3FD0               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      L428F,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    lbsr      L577A
+                    puls      pc,u
+L3FF1               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    leas      -$08,s
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      $0785
+                    std       ,s
+                    lbsr      L111D
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L4015
+                    clra
+                    clrb
+                    lbra      L419B
+
+L4015               clra
+                    clrb
+                    std       $04,s
+                    ldd       #$0001
+                    std       $02,s
+                    ldd       ,u
+                    std       ,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L4054
+                    ldx       ,s
+                    bra       L4043
+
+L4031               ldd       #$0001
+                    bra       L407D
+
+L4036               ldd       ,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L4086
+                    bra       L406A
+
+L4043               cmpx      #$0008
+                    beq       L4031
+                    cmpx      #$0001
+                    beq       L4086
+                    cmpx      #$0007
+                    beq       L4086
+                    bra       L4036
+
+L4054               ldd       ,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L406E
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L2832
+                    std       ,s++
+                    bne       L4086
+L406A               leax      $08,s
+                    bra       L40A6
+
+L406E               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L407B
+                    ldd       #$0006
+                    bra       L407D
+
+L407B               ldd       $0C,s
+L407D               pshs      d
+                    pshs      u
+                    lbsr      L222C
+                    leas      $04,s
+L4086               ldd       $06,u
+                    cmpd      #$0050
+                    beq       L4096
+                    ldd       $06,u
+                    cmpd      #$0051
+                    bne       L40DF
+L4096               ldd       $0C,u
+                    std       $06,s
+                    tfr       d,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    beq       L40B1
+                    bra       L40A8
+
+L40A6               leas      -$08,x
+L40A8               clra
+                    clrb
+                    std       $02,s
+                    leax      $08,s
+                    lbra      L4190
+
+L40B1               ldd       $06,u
+                    cmpd      #$0051
+                    bne       L40C3
+                    ldx       $06,s
+                    ldd       $08,x
+                    nega
+                    negb
+                    sbca      #$00
+                    bra       L40C7
+
+L40C3               ldx       $06,s
+                    ldd       $08,x
+L40C7               std       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L0598
+                    leas      $02,s
+                    stu       $06,s
+                    ldu       $0a,u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+L40DF               ldd       $06,u
+                    cmpd      #$0041
+                    lbne      L4143
+                    ldd       $0a,u
+                    std       $06,s
+                    tfr       d,x
+                    ldx       $08,x
+                    ldx       $08,x
+                    bra       L4120
+
+L40F5               clra
+                    clrb
+                    std       $02,s
+                    lbra      L4192
+
+L40FC               lbsr      L5D32
+                    ldd       #$0001
+                    std       $005A
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    lbsr      L5474
+                    leas      $06,s
+                    clra
+                    clrb
+                    std       $005A
+                    lbsr      L577A
+                    lbra      L4192
+
+L4120               cmpx      #$000F
+                    beq       L40FC
+                    cmpx      #$000E
+                    lbeq      L40FC
+                    cmpx      #$000C
+                    lbeq      L40FC
+                    cmpx      #$0021
+                    lbeq      L40FC
+                    cmpx      #$0022
+                    lbeq      L40FC
+                    bra       L40F5
+
+L4143               ldx       $06,u
+                    bra       L4177
+
+L4147               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L415B
+                    ldx       $08,u
+                    pshs      x
+                    ldx       $08,u
+                    lbsr      $A7AE
+                    lbsr      LAE24
+L415B               ldd       $0C,s
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    bsr       L419F
+                    leas      $04,s
+                    bra       L4192
+
+L4169               lbsr      L5D32
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    bra       L4192
+
+L4177               cmpx      #$004B
+                    beq       L4147
+                    cmpx      #$0036
+                    beq       L415B
+                    cmpx      #$004A
+                    lbeq      L415B
+                    cmpx      #$0037
+                    beq       L4169
+                    lbra      L40F5
+
+L4190               leas      -$08,x
+L4192               pshs      u
+                    lbsr      L0598
+                    leas      $02,s
+                    ldd       $02,s
+L419B               leas      $08,s
+                    puls      pc,u
+L419F               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldx       $08,s
+                    bra       L41CF
+
+L41AF               lbsr      L5D2A
+                    pshs      u
+                    lbsr      L57A5
+                    leas      $02,s
+                    lbsr      L577A
+                    bra       L41FF
+
+L41BE               ldd       #$0001
+                    bra       L41CB
+
+L41C3               ldd       #$0002
+                    bra       L41CB
+
+L41C8               ldd       #$0004
+L41CB               std       ,s
+                    bra       L41F4
+
+L41CF               cmpx      #$0002
+                    beq       L41AF
+                    cmpx      #$0001
+                    beq       L41BE
+                    cmpx      #$0007
+                    lbeq      L41BE
+                    cmpx      #$0008
+                    beq       L41C3
+                    cmpx      #$0005
+                    lbeq      L41C3
+                    cmpx      #$0006
+                    beq       L41C8
+                    lbra      L41BE
+
+L41F4               ldd       ,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L5170
+                    leas      $04,s
+L41FF               leas      $02,s
+                    puls      pc,u
+L4203               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      $4294,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bsr       L421A
+                    puls      pc,u
+L421A               pshs      u
+                    ldd       #$FFBC
+                    lbsr      L010F
+L4222               ldx       $003F
+                    bra       L422D
+
+L4226               puls      pc,u
+L4228               lbsr      $5F26
+                    bra       L4222
+
+L422D               cmpx      #$0030
+                    beq       L4226
+                    cmpx      #$0028
+                    lbeq      L4226
+                    cmpx      #$FFFF
+                    lbeq      L4226
+                    bra       L4228
+                    puls      pc,u
+L4244               lsr       $6F6F
+                    bra       $42B5
+                    clr       $0e,s
+                    asr       0,x
+L424D               lsr       $6F6F
+                    bra       L42BF
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       $42BC
+                    inc       $05,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    com       >L0075
+                    jmp       $09,s
+                    clr       $0e,s
+                    com       $206E
+                    clr       -$0C,s
+                    bra       $42CC
+                    inc       $0C,s
+                    clr       -$09,s
+                    fcb       $65
+                    lsr       0,x
+L4272               com       $0f,s
+                    jmp       -$0d,s
+                    lsr       $616E
+                    lsr       $2065
+                    asl       $7072
+                    fcb       $65
+                    com       $7369
+                    clr       $0e,s
+                    bra       L42F9
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L428F               fcb       $72
+                    dec       $6220
+                    neg       L0063
+                    fcb       $61
+                    jmp       $0e,s
+                    clr       -$0C,s
+                    bra       $4305
+                    jmp       $09,s
+                    lsr       $6961
+                    inc       $09,s
+                    dec       L6500
+L42A6               pshs      u
+                    leax      $0584,y
+                    stx       $004A
+                    clra
+                    clrb
+                    stb       $0584,y
+                    ldd       #$0020
+                    bra       L42DF
+
+L42B9               pshs      u
+                    bra       L42BF
+
+L42BD               bsr       L42CF
+L42BF               ldb       $0045
+                    cmpb      #$20
+                    beq       L42BD
+                    ldb       $0045
+                    cmpb      #$09
+                    lbeq      L42BD
+                    puls      pc,u
+L42CF               pshs      u
+                    ldx       $004A
+                    leax      $01,x
+                    stx       $004A
+                    ldb       -$01,x
+                    stb       $0045
+                    bne       L42E1
+                    bsr       L42E3
+L42DF               stb       $0045
+L42E1               puls      pc,u
+L42E3               pshs      u
+                    leas      -$08,s
+                    ldd       L0058
+                    bne       L42F9
+                    ldd       #$0001
+                    std       L0058
+                    leax      L459E,pcr
+                    stx       $004A
+                    lbra      L44CC
+
+L42F9               clra
+                    clrb
+                    std       L0058
+                    leax      $0584,y
+                    pshs      x
+                    leax      $0684,y
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+L430E               lbsr      L4509
+                    std       $004A
+                    lbeq      L4403
+                    ldb       [$004A,y]
+                    cmpb      #$23
+                    lbne      L44C5
+                    ldx       $004A
+                    ldb       $01,x
+                    sex
+                    std       $04,s
+                    lbsr      L4509
+                    std       -$02,s
+                    lbeq      L4403
+                    ldx       $04,s
+                    lbra      L4491
+
+L4336               leax      $0584,y
+                    pshs      x
+                    lbsr      L44D3
+                    leas      $02,s
+                    std       $0007
+                    bra       L430E
+
+L4345               lbsr      L5D40
+L4348               leax      $0584,y
+                    pshs      x
+                    leax      $459F,pcr
+                    bra       L43B5
+
+L4354               leax      $0584,y
+                    pshs      x
+                    leax      $0366,y
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+L4365               lbsr      L4509
+                    std       -$02,s
+                    lbne      L430E
+                    lbra      L4403
+
+L4371               leax      $0584,y
+                    pshs      x
+                    leax      $078a,y
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+                    lbsr      L4509
+                    std       -$02,s
+                    lbeq      L4403
+                    leax      $0584,y
+                    pshs      x
+                    lbsr      L44D3
+                    std       ,s
+                    leax      $078a,y
+                    pshs      x
+                    leax      L45A3,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $08,s
+                    leax      $078a,y
+                    pshs      x
+                    leax      L45B9,pcr
+L43B5               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    lbra      L430E
+
+L43C3               leax      $0584,y
+                    pshs      x
+                    leax      $078a,y
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+                    lbsr      L4509
+                    std       -$02,s
+                    beq       L4403
+                    leax      $0584,y
+                    pshs      x
+                    lbsr      L44D3
+                    leas      $02,s
+                    std       $06,s
+                    lbsr      L4509
+                    std       -$02,s
+                    beq       L4403
+                    leax      $0584,y
+                    pshs      x
+                    lbsr      L44D3
+                    leas      $02,s
+                    std       $02,s
+                    lbsr      L4509
+                    std       -$02,s
+                    bne       L4409
+L4403               ldd       #$FFFF
+                    lbra      L44CF
+
+L4409               ldd       $06,s
+                    beq       L4424
+                    ldd       $06,s
+                    pshs      d
+                    leax      $0366,y
+                    pshs      x
+                    leax      L45C2,pcr
+                    pshs      x
+                    lbsr      L9A1F
+                    leas      $06,s
+                    bra       L442F
+
+L4424               leax      $45D0,pcr
+                    pshs      x
+                    lbsr      L9A1F
+                    leas      $02,s
+L442F               leax      $0584,y
+                    pshs      x
+                    leax      L45DC,pcr
+                    pshs      x
+                    lbsr      L9A1F
+                    leas      $04,s
+                    ldb       $078a,y
+                    beq       L447A
+                    leax      $078a,y
+                    pshs      x
+                    lbsr      $9F95
+                    leas      $02,s
+                    bra       L4463
+
+L4453               leax      $0253,y
+                    pshs      x
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      $A1CD
+                    leas      $04,s
+L4463               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L4453
+                    leax      $45EA,pcr
+                    pshs      x
+                    lbsr      $9F95
+                    leas      $02,s
+L447A               ldd       $04,s
+                    cmpd      #$0031
+                    lbne      L430E
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      LB34C
+                    leas      $02,s
+                    lbra      L430E
+
+L4491               cmpx      #$0035
+                    lbeq      L4336
+                    cmpx      #$0036
+                    lbeq      L4345
+                    cmpx      #$0032
+                    lbeq      L4348
+                    cmpx      #$0037
+                    lbeq      L4354
+                    cmpx      #$0050
+                    lbeq      L4371
+                    cmpx      #$0030
+                    lbeq      L43C3
+                    cmpx      #$0031
+                    lbeq      L43C3
+                    lbra      L430E
+
+L44C5               ldd       $0007
+                    addd      #$0001
+                    std       $0007
+L44CC               ldd       #$0020
+L44CF               leas      $08,s
+                    puls      pc,u
+L44D3               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L44F0
+
+L44DD               ldd       ,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      LAF4B
+                    pshs      d
+                    ldd       $04,s
+                    addd      #$FFD0
+                    addd      ,s++
+L44F0               std       ,s
+                    ldb       ,u+
+                    sex
+                    std       $02,s
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L44DD
+                    ldd       ,s
+                    leas      $04,s
+                    puls      pc,u
+L4509               pshs      u,d
+                    leau      $0584,y
+                    ldd       $0003
+                    pshs      d
+                    lbsr      $A3E4
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    lbne      L4579
+                    ldx       $0003
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L4546
+                    leax      $0260,y
+                    pshs      x
+                    leax      $45EC,pcr
+                    pshs      x
+                    lbsr      $9FB7
+                    leas      $04,s
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      LB34C
+                    leas      $02,s
+L4546               clra
+                    clrb
+                    bra       L459A
+
+L454A               ldx       ,s
+                    bra       L456B
+
+L454E               clra
+                    clrb
+                    stb       ,u
+                    leax      $0584,y
+                    tfr       x,d
+                    bra       L459A
+
+L455A               ldd       ,s
+                    stb       ,u+
+                    ldd       $0003
+                    pshs      d
+                    lbsr      $A3E4
+                    leas      $02,s
+                    std       ,s
+                    bra       L4579
+
+L456B               cmpx      #$000D
+                    beq       L454E
+                    cmpx      #$FFFF
+                    lbeq      L454E
+                    bra       L455A
+
+L4579               cmpu      $00AC,y
+                    bne       L454A
+                    ldd       $0007
+                    addd      #$0001
+                    std       $0007
+                    std       L001F
+                    leax      $0584,y
+                    stx       $0043
+                    leax      >L460F,pcr
+                    pshs      x
+                    lbsr      L042D
+                    leas      $02,s
+L459A               leas      $02,s
+                    puls      pc,u
+L459E               neg       L0025
+                    com       $0D00
+L45A3               bra       $4615
+                    fcb       $73,$65,$63,$74,$20,$25,$73,$2C
+                    fcb       $30,$2C,$30,$2C,$25,$64,$2C,$30
+                    fcb       $2C,$30,$0d,$00
+L45B9               bra       $4629
+                    fcb       $61
+                    tst       0,y
+                    bcs       $4633
+                    tst       $0000
+L45C2               bcs       $4637
+                    bra       L4600
+                    bra       L4634
+                    rol       $0e,s
+                    fcb       $65
+                    bra       L45F2
+                    lsr       0,y
+                    neg       L0061
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    bra       L4614
+                    bra       L45DC
+
+L45DC               bpl       L4608
+                    bpl       L460A
+                    bra       L4607
+                    com       L202A
+                    bpl       L4611
+                    bpl       L45F6
+                    neg       $005E
+                    neg       L0049
+                    fcb       $4e,$50,$55,$54,$20
+L45F2               fcb       $46,$49,$4C,$45
+L45F6               fcb       $20,$45,$52,$52,$4f,$52,$20,$3a
+                    fcb       $20,$54
+L4600               fcb       $45,$4d,$50,$4f,$52,$41,$52
+L4607               fcb       $59
+L4608               fcb       $20,$46
+L460A               fcb       $49,$4C,$45,$0d,$00
+L460F               rol       $0e,s
+L4611               neg       $7574
+L4614               bra       $4682
+                    rol       $0e,s
+                    fcb       $65
+                    bra       $468F
+                    clr       $0f,s
+                    bra       L468B
+                    clr       $0e,s
+                    asr       0,x
+L4623               pshs      u
+                    ldu       $0a,s
+                    leas      -$08,s
+                    ldd       $0C,s
+                    cmpd      #$0088
+                    bne       L4641
+                    ldd       $10,s
+L4634               pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L4D79
+                    lbra      L4B9E
+
+L4641               ldd       $0C,s
+                    cmpd      #$0087
+                    bne       L4659
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L4F62
+                    lbra      L4B9E
+
+L4659               ldx       $0C,s
+                    lbra      L48E7
+
+L465E               ldd       $0e,s
+                    pshs      d
+                    lbsr      L4D27
+                    std       ,s
+                    leax      L5898,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    ldd       $000F
+                    subd      #$0002
+                    std       $000F
+                    cmpd      $001B
+                    lbge      L4D75
+                    ldd       $000F
+                    std       $001B
+                    lbra      L4D75
+
+L468B               ldd       $10,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0081
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       $0e,s
+                    std       $10,s
+                    ldd       #$005A
+                    std       $0e,s
+L46AE               leax      $58A2,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L56D0
+                    std       ,s
+                    lbra      L479F
+
+L46C5               ldd       $0017
+                    beq       L46CC
+                    lbsr      L5CEB
+L46CC               leax      $58A5,pcr
+                    lbra      L4840
+
+L46D3               pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L5244
+                    leas      $06,s
+                    lbra      L4D75
+
+L46E7               leax      $58B0,pcr
+                    bra       L4715
+
+L46ED               leax      $58B7,pcr
+                    bra       L4715
+
+L46F3               leax      $58BE,pcr
+                    bra       L4715
+
+L46F9               leax      $58C4,pcr
+                    bra       L4715
+
+L46FF               leax      L58CA,pcr
+                    bra       L4715
+
+L4705               leax      L58D0,pcr
+                    bra       L4715
+
+L470B               leax      $58D6,pcr
+                    bra       L4715
+
+L4711               leax      L58DD,pcr
+L4715               pshs      x
+                    lbsr      L51F1
+                    lbra      L4B24
+
+L471D               leax      L58E3,pcr
+                    lbra      L4840
+
+L4724               leax      L58F7,pcr
+                    lbra      L4840
+
+L472B               leax      $5902,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $000F
+                    nega
+                    negb
+                    sbca      #$00
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       $00B0,y
+                    pshs      d
+                    lbsr      L5794
+                    leas      $02,s
+                    lbsr      L577A
+L4751               ldd       $00B4,y
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $0e,s
+                    bra       L47A7
+
+L4760               ldd       $00B4,y
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $10,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    leax      L5908,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $000F
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    leax      L590E,pcr
+                    pshs      x
+L479F               lbsr      L5794
+                    leas      $02,s
+                    ldd       $10,s
+L47A7               pshs      d
+                    lbsr      L57B2
+                    lbra      L4B24
+
+L47AF               ldd       #$0004
+                    std       $0013
+                    ldx       $10,s
+                    ldd       $06,x
+                    cmpd      #$0034
+                    bne       L47E4
+                    ldx       $10,s
+                    ldd       $08,x
+                    std       $04,s
+                    beq       L47E4
+                    ldd       $00B2,y
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    addd      #$0014
+                    pshs      d
+                    lbsr      L5815
+                    lbra      L4B9E
+
+L47E4               leax      L5912,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L5474
+                    leas      $06,s
+                    lbra      L4877
+
+L4805               leax      L5917,pcr
+                    bra       L4840
+
+L480B               leax      $591B,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       #$0002
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0064
+                    pshs      d
+                    lbsr      L5429
+                    lbra      L4C78
+
+L4830               leax      L591E,pcr
+                    bra       L4840
+
+L4836               leax      $5929,pcr
+                    bra       L4840
+
+L483C               leax      $5934,pcr
+L4840               pshs      x
+                    lbra      L4B21
+
+L4845               leax      $593F,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    leax      $08,s
+                    bra       L4861
+
+L4854               leax      L5944,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    bra       L4863
+
+L4861               leas      -$08,x
+L4863               ldd       $0e,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       $00B0,y
+                    pshs      d
+                    lbsr      L5794
+                    leas      $02,s
+L4877               lbsr      L577A
+                    lbra      L4D75
+
+L487D               leax      L5949,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldx       $0e,s
+                    bra       L48DA
+
+L488C               ldx       $10,s
+                    ldd       $06,x
+                    std       $06,s
+                    cmpd      #$0094
+                    bne       L489E
+                    ldd       #$0079
+                    bra       L48AE
+
+L489E               ldd       $06,s
+                    cmpd      #$0095
+                    bne       L48AB
+                    ldd       #$0075
+                    bra       L48AE
+
+L48AB               ldd       #$0078
+L48AE               std       $06,s
+                    pshs      d
+                    ldx       $12,s
+                    ldd       $08,x
+                    pshs      d
+                    leax      L594F,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    lbra      L4C78
+
+L48C9               ldd       $10,s
+                    pshs      d
+                    lbsr      L4D27
+                    std       ,s
+                    leax      $5956,pcr
+                    lbra      L4B47
+
+L48DA               cmpx      #$0077
+                    beq       L488C
+                    cmpx      #$0070
+                    beq       L48C9
+                    lbra      L4D75
+
+L48E7               cmpx      #$007A
+                    lbeq      L465E
+                    cmpx      #$007D
+                    lbeq      L468B
+                    cmpx      #$0082
+                    lbeq      L46AE
+                    cmpx      #$0012
+                    lbeq      L46C5
+                    cmpx      #$0057
+                    lbeq      L46D3
+                    cmpx      #$0058
+                    lbeq      L46D3
+                    cmpx      #$0059
+                    lbeq      L46D3
+                    cmpx      #$0052
+                    lbeq      L46E7
+                    cmpx      #$004E
+                    lbeq      L46ED
+                    cmpx      #$0053
+                    lbeq      L46F3
+                    cmpx      #$0056
+                    lbeq      L46F9
+                    cmpx      #$0055
+                    lbeq      L46FF
+                    cmpx      #$004D
+                    lbeq      L4705
+                    cmpx      #$004C
+                    lbeq      L470B
+                    cmpx      #$0054
+                    lbeq      L4711
+                    cmpx      #$0043
+                    lbeq      L471D
+                    cmpx      #$0044
+                    lbeq      L4724
+                    cmpx      #start
+                    lbeq      L472B
+                    cmpx      #$007C
+                    lbeq      L4751
+                    cmpx      #$0009
+                    lbeq      L4760
+                    cmpx      #$0065
+                    lbeq      L47AF
+                    cmpx      #$0085
+                    lbeq      L4805
+                    cmpx      #$0084
+                    lbeq      L480B
+                    cmpx      #$0098
+                    lbeq      L4830
+                    cmpx      #$0096
+                    lbeq      L4836
+                    cmpx      #$0097
+                    lbeq      L483C
+                    cmpx      #$0076
+                    lbeq      L4845
+                    cmpx      #$006F
+                    lbeq      L4854
+                    cmpx      #$007B
+                    lbeq      L487D
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L4D27
+                    leas      $02,s
+                    std       $06,s
+                    ldd       $10,s
+                    cmpd      #$0077
+                    lbne      L4A40
+                    ldd       $06,u
+                    cmpd      #$0085
+                    bne       L4A23
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldx       $0C,s
+                    bra       L4A05
+
+L49EC               leax      $595C,pcr
+                    bra       L49FC
+
+L49F2               leax      $5960,pcr
+                    bra       L49FC
+
+L49F8               leax      L5968,pcr
+L49FC               pshs      x
+                    lbsr      L576F
+                    leas      $02,s
+                    bra       L4A1B
+
+L4A05               cmpx      #$0075
+                    beq       L49EC
+                    cmpx      #$004F
+                    beq       L49F2
+                    cmpx      #$0050
+                    lbeq      L49F2
+                    cmpx      #$0051
+                    beq       L49F8
+L4A1B               ldd       #$0070
+                    std       $06,u
+                    lbra      L4D75
+
+L4A23               ldd       ,u
+                    cmpd      #$0002
+                    bne       L4A40
+                    ldd       $0C,s
+                    cmpd      #$007F
+                    beq       L4A40
+                    ldd       $06,s
+                    cmpd      #$0078
+                    beq       L4A40
+                    ldd       #$0062
+                    std       $06,s
+L4A40               ldx       $0C,s
+                    lbra      L4CE6
+
+L4A45               ldd       $10,s
+                    cmpd      #$0077
+                    lbne      L4B04
+                    ldd       $08,u
+                    std       ,s
+                    ldd       $06,u
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L4AE0
+
+L4A5D               ldd       $0e,s
+                    cmpd      #$0070
+                    beq       L4A82
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L5832
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L4D27
+                    std       ,s
+                    ldd       $02,s
+                    pshs      d
+                    leax      L5970,pcr
+                    lbra      L4C6F
+
+L4A82               ldd       #$0064
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4D27
+                    std       ,s
+                    lbsr      L4D5E
+                    leas      $04,s
+                    ldd       ,s
+                    lbeq      L4D75
+                    ldd       ,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0050
+                    pshs      d
+                    lbsr      L4623
+                    lbra      L4C78
+
+L4AB4               ldd       $0e,s
+                    cmpd      #$0070
+                    lbeq      L4D75
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0064
+                    lbra      L4B99
+
+L4AC8               ldd       $08,u
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L5849
+                    lbra      L4B9E
+
+L4AD6               ldd       #$0036
+                    std       $10,s
+                    ldu       ,s
+                    bra       L4B04
+
+L4AE0               cmpx      #$0071
+                    lbeq      L4A5D
+                    cmpx      #$0076
+                    lbeq      L4A5D
+                    cmpx      #$006F
+                    lbeq      L4A5D
+                    cmpx      #$0070
+                    beq       L4AB4
+                    cmpx      #$0037
+                    beq       L4AC8
+                    cmpx      #$0036
+                    beq       L4AD6
+L4B04               ldd       $0e,s
+                    cmpd      #$0070
+                    bne       L4B29
+                    ldd       $10,s
+                    cmpd      #$0036
+                    bne       L4B29
+                    cmpu      #$0000
+                    bne       L4B29
+                    leax      $5977,pcr
+                    pshs      x
+L4B21               lbsr      L576F
+L4B24               leas      $02,s
+                    lbra      L4D75
+
+L4B29               leax      $5982,pcr
+                    lbra      L4BAD
+
+L4B30               ldd       $10,s
+                    cmpd      #$0036
+                    bne       L4B55
+                    cmpu      #$0000
+                    bne       L4B55
+                    ldd       $06,s
+                    pshs      d
+                    leax      L5985,pcr
+L4B47               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    lbra      L4D75
+
+L4B55               leax      L5991,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $06,s
+                    cmpd      #$0062
+                    bne       L4BB4
+                    ldd       #$0064
+                    std       $06,s
+                    bra       L4BB4
+
+L4B6F               ldd       $10,s
+                    cmpd      #$0077
+                    bne       L4BA3
+                    ldd       $06,u
+                    std       $02,s
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    beq       L4BA3
+                    ldd       $02,s
+                    cmpd      $0e,s
+                    lbeq      L4D75
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L4D27
+                    std       ,s
+                    ldd       $08,s
+L4B99               pshs      d
+                    lbsr      L4D5E
+L4B9E               leas      $04,s
+                    lbra      L4D75
+
+L4BA3               leax      $5995,pcr
+                    bra       L4BAD
+
+L4BA9               leax      $5998,pcr
+L4BAD               pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+L4BB4               leax      $08,s
+                    bra       L4BC9
+
+L4BB8               ldd       #$0043
+                    pshs      d
+                    lbsr      L4623
+                    leas      $02,s
+L4BC2               leax      $599C,pcr
+                    lbra      L4C42
+
+L4BC9               leas      -$08,x
+                    lbra      L4C49
+
+L4BCE               ldd       $10,s
+                    cmpd      #$0077
+                    lbne      L4C3E
+                    ldx       $08,u
+                    ldd       $08,x
+                    std       $02,s
+                    tfr       d,x
+                    bra       L4C2B
+
+L4BE3               ldd       $06,s
+                    pshs      d
+                    lbsr      L5832
+                    leas      $02,s
+                    ldd       #$003E
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0023
+                    bne       L4C09
+                    ldx       $08,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L57C3
+                    bra       L4C13
+
+L4C09               ldd       $08,u
+                    addd      #$0014
+                    pshs      d
+                    lbsr      L57D6
+L4C13               leas      $02,s
+                    ldd       $14,u
+                    pshs      d
+                    lbsr      L5453
+                    leas      $02,s
+                    ldd       $00AE,y
+                    pshs      d
+                    lbsr      L5794
+                    lbra      L4CB6
+
+L4C2B               cmpx      #$0021
+                    beq       L4BE3
+                    cmpx      #$0022
+                    lbeq      L4BE3
+                    cmpx      #$0023
+                    lbeq      L4BE3
+L4C3E               leax      $59A0,pcr
+L4C42               pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+L4C49               clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L5429
+                    bra       L4C78
+
+L4C5D               ldd       $10,s
+                    pshs      d
+                    lbsr      L4D27
+                    std       ,s
+                    ldd       $08,s
+                    pshs      d
+                    leax      $59A4,pcr
+L4C6F               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+L4C78               leas      $08,s
+                    lbra      L4D75
+
+L4C7D               ldd       $06,s
+                    pshs      d
+                    lbsr      L5832
+                    leas      $02,s
+                    ldx       $10,s
+                    bra       L4CCC
+
+L4C8B               leax      $59B0,pcr
+                    pshs      x
+                    lbsr      L5794
+                    leas      $02,s
+                    leax      $08,s
+                    bra       L4CAD
+
+L4C9A               pshs      u
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    bra       L4CAF
+
+L4CAD               leas      -$08,x
+L4CAF               ldd       $06,s
+                    pshs      d
+                    lbsr      L5785
+L4CB6               leas      $02,s
+                    lbsr      L577A
+                    lbra      L4D75
+
+L4CBE               leax      L59B3,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbra      L4D75
+
+L4CCC               cmpx      #$0070
+                    beq       L4C8B
+                    cmpx      #$0036
+                    beq       L4C9A
+                    bra       L4CBE
+
+L4CD8               ldd       $00B8,y
+                    pshs      d
+                    lbsr      L0450
+                    leas      $02,s
+                    lbra      L4D75
+
+L4CE6               cmpx      #$0075
+                    lbeq      L4A45
+                    cmpx      #$0081
+                    lbeq      L4B30
+                    cmpx      #$0079
+                    lbeq      L4B6F
+                    cmpx      #$0051
+                    lbeq      L4BA9
+                    cmpx      #$004F
+                    lbeq      L4BB8
+                    cmpx      #$0050
+                    lbeq      L4BC2
+                    cmpx      #$007F
+                    lbeq      L4BCE
+                    cmpx      #$0073
+                    lbeq      L4C5D
+                    cmpx      #$0074
+                    lbeq      L4C7D
+                    bra       L4CD8
+
+L4D27               pshs      u
+                    ldx       $04,s
+                    bra       L4D46
+
+L4D2D               ldd       #$0064
+                    puls      pc,u
+L4D32               ldd       #$0078
+                    puls      pc,u
+L4D37               ldd       #$0079
+                    puls      pc,u
+L4D3C               ldd       #$0075
+                    puls      pc,u
+L4D41               ldd       #$0020
+                    puls      pc,u
+L4D46               cmpx      #$0070
+                    beq       L4D2D
+                    cmpx      #$0071
+                    beq       L4D32
+                    cmpx      #$0076
+                    beq       L4D37
+                    cmpx      #$006F
+                    beq       L4D3C
+                    bra       L4D41
+                    puls      pc,u
+L4D5E               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      L59BB,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+L4D75               leas      $08,s
+                    puls      pc,u
+L4D79               pshs      u
+                    ldx       $04,s
+                    lbra      L4E99
+
+L4D80               ldd       #$0002
+                    pshs      d
+                    ldd       #$0093
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0093
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    lbra      L4F75
+
+L4DD0               leax      L59C7,pcr
+                    pshs      x
+                    lbsr      L576F
+                    lbra      L5470
+
+L4DDC               leax      $59EA,pcr
+                    bra       L4E1C
+
+L4DE2               leax      $59F1,pcr
+                    bra       L4E2F
+
+L4DE8               leax      $59F7,pcr
+                    bra       L4E2F
+
+L4DEE               leax      $59FD,pcr
+                    bra       L4E2F
+
+L4DF4               leax      L5A03,pcr
+                    bra       L4E2F
+
+L4DFA               leax      $5A09,pcr
+                    bra       L4E2F
+
+L4E00               leax      $5A0F,pcr
+                    bra       L4E2F
+
+L4E06               leax      $5A15,pcr
+                    bra       L4E2F
+
+L4E0C               leax      $5A1A,pcr
+                    bra       L4E2F
+
+L4E12               leax      $5A20,pcr
+                    bra       L4E1C
+
+L4E18               leax      $5A26,pcr
+L4E1C               pshs      x
+                    lbsr      L520E
+                    leas      $02,s
+                    ldd       $000F
+                    subd      #$0002
+                    lbra      L5229
+
+L4E2B               leax      $5A2C,pcr
+L4E2F               pshs      x
+                    lbsr      L520E
+                    lbra      L5470
+
+L4E37               leax      $5A33,pcr
+                    bra       L4E59
+
+L4E3D               leax      L5A39,pcr
+                    bra       L4E59
+
+L4E43               leax      L5A41,pcr
+                    bra       L4E59
+
+L4E49               leax      $5A48,pcr
+                    bra       L4E59
+
+L4E4F               leax      $5A4F,pcr
+                    bra       L4E59
+
+L4E55               leax      $5A55,pcr
+L4E59               pshs      x
+                    lbsr      L520E
+                    leas      $02,s
+                    ldd       $000F
+                    subd      #$0004
+                    lbra      L5229
+
+L4E68               ldd       #$0002
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      L4F72
+
+L4E74               leax      L5A5B,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    ldd       $00B8,y
+                    pshs      d
+                    lbsr      L5794
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    lbsr      L577A
+                    lbra      L4F60
+
+L4E99               cmpx      #$006E
+                    lbeq      L4D80
+                    cmpx      #$008B
+                    lbeq      L4DD0
+                    cmpx      #$0089
+                    lbeq      L4DDC
+                    cmpx      #$0050
+                    lbeq      L4DE2
+                    cmpx      #$0051
+                    lbeq      L4DE8
+                    cmpx      #$0052
+                    lbeq      L4DEE
+                    cmpx      #$0053
+                    lbeq      L4DF4
+                    cmpx      #$0054
+                    lbeq      L4DFA
+                    cmpx      #$0057
+                    lbeq      L4E00
+                    cmpx      #$0058
+                    lbeq      L4E06
+                    cmpx      #$0059
+                    lbeq      L4E0C
+                    cmpx      #$0056
+                    lbeq      L4E12
+                    cmpx      #$0055
+                    lbeq      L4E18
+                    cmpx      #$005A
+                    lbeq      L4E2B
+                    cmpx      #$005B
+                    lbeq      L4E2B
+                    cmpx      #$005E
+                    lbeq      L4E2B
+                    cmpx      #$005C
+                    lbeq      L4E2B
+                    cmpx      #$005F
+                    lbeq      L4E2B
+                    cmpx      #$005D
+                    lbeq      L4E2B
+                    cmpx      #$0043
+                    lbeq      L4E37
+                    cmpx      #$0044
+                    lbeq      L4E3D
+                    cmpx      #$0083
+                    lbeq      L4E43
+                    cmpx      #$0086
+                    lbeq      L4E49
+                    cmpx      #$003C
+                    lbeq      L4E4F
+                    cmpx      #$003E
+                    lbeq      L4E4F
+                    cmpx      #$003D
+                    lbeq      L4E55
+                    cmpx      #$003F
+                    lbeq      L4E55
+                    cmpx      #$004A
+                    lbeq      L4E68
+                    lbra      L4E74
+
+L4F60               puls      pc,u
+L4F62               pshs      u
+                    ldu       $06,s
+                    ldx       $04,s
+                    lbra      L5075
+
+L4F6B               ldd       #$0004
+                    pshs      d
+                    pshs      u
+L4F72               lbsr      L5130
+L4F75               leas      $04,s
+                    puls      pc,u
+L4F79               leax      $5A6A,pcr
+                    pshs      x
+                    lbsr      L522D
+                    leas      $02,s
+                    ldd       $000F
+                    subd      #$0008
+                    lbra      L5229
+
+L4F8C               cmpu      #$0005
+                    bne       L4F97
+                    ldd       #$0033
+                    bra       L4F9A
+
+L4F97               ldd       #$0037
+L4F9A               pshs      d
+                    leax      $5A72,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    puls      pc,u
+L4FAD               cmpu      #$0005
+                    bne       L4FB9
+                    leax      L5A7D,pcr
+                    bra       L4FBD
+
+L4FB9               leax      $5A84,pcr
+L4FBD               tfr       x,d
+                    pshs      d
+                    lbsr      L522D
+                    lbra      L5205
+
+L4FC7               leax      $5A8B,pcr
+                    bra       L4FE3
+
+L4FCD               leax      $5A91,pcr
+                    bra       L4FE3
+
+L4FD3               leax      $5A97,pcr
+                    bra       L4FE3
+
+L4FD9               leax      L5A9D,pcr
+                    bra       L4FE3
+
+L4FDF               leax      $5AA3,pcr
+L4FE3               pshs      x
+                    lbsr      L522D
+                    leas      $02,s
+                    ldd       $000F
+                    addd      #$0008
+                    lbra      L5229
+
+L4FF2               leax      $5AAA,pcr
+                    bra       L5048
+
+L4FF8               cmpu      #$0005
+                    bne       L5004
+                    leax      L5AB0,pcr
+                    bra       L501A
+
+L5004               leax      $5AB6,pcr
+                    bra       L501A
+
+L500A               cmpu      #$0005
+                    bne       L5016
+                    leax      $5ABC,pcr
+                    bra       L501A
+
+L5016               leax      L5AC2,pcr
+L501A               tfr       x,d
+                    pshs      d
+                    bra       L504A
+
+L5020               leax      L5AC8,pcr
+                    bra       L5048
+
+L5026               leax      $5ACE,pcr
+                    bra       L5048
+
+L502C               leax      $5AD4,pcr
+                    bra       L5048
+
+L5032               leax      $5ADA,pcr
+                    bra       L5048
+
+L5038               leax      $5AE0,pcr
+                    bra       L5048
+
+L503E               leax      $5AE6,pcr
+                    bra       L5048
+
+L5044               leax      $5AEC,pcr
+L5048               pshs      x
+L504A               lbsr      L522D
+                    lbra      L5470
+
+L5050               leax      $5AF2,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    ldd       $00B8,y
+                    pshs      d
+                    lbsr      L5794
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    lbsr      L577A
+                    lbra      L512E
+
+L5075               cmpx      #$004B
+                    lbeq      L4F6B
+                    cmpx      #$006E
+                    lbeq      L4F79
+                    cmpx      #$008B
+                    lbeq      L4F8C
+                    cmpx      #$0089
+                    lbeq      L4FAD
+                    cmpx      #$0050
+                    lbeq      L4FC7
+                    cmpx      #$0051
+                    lbeq      L4FCD
+                    cmpx      #$0052
+                    lbeq      L4FD3
+                    cmpx      #$0053
+                    lbeq      L4FD9
+                    cmpx      #$005A
+                    lbeq      L4FDF
+                    cmpx      #$005B
+                    lbeq      L4FDF
+                    cmpx      #$005E
+                    lbeq      L4FDF
+                    cmpx      #$005C
+                    lbeq      L4FDF
+                    cmpx      #$005F
+                    lbeq      L4FDF
+                    cmpx      #$005D
+                    lbeq      L4FDF
+                    cmpx      #$0043
+                    lbeq      L4FF2
+                    cmpx      #$003C
+                    lbeq      L4FF8
+                    cmpx      #$003E
+                    lbeq      L4FF8
+                    cmpx      #$003D
+                    lbeq      L500A
+                    cmpx      #$003F
+                    lbeq      L500A
+                    cmpx      #$008D
+                    lbeq      L5020
+                    cmpx      #$008C
+                    lbeq      L5026
+                    cmpx      #$0090
+                    lbeq      L502C
+                    cmpx      #$008E
+                    lbeq      L5032
+                    cmpx      #$0092
+                    lbeq      L5038
+                    cmpx      #$0091
+                    lbeq      L503E
+                    cmpx      #$008F
+                    lbeq      L5044
+                    lbra      L5050
+
+L512E               puls      pc,u
+L5130               pshs      u,d
+                    leax      L5B02,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       ,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L5170
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L57C3
+                    leas      $02,s
+                    leax      $5B07,pcr
+                    pshs      x
+                    lbsr      L576F
+                    leas      $02,s
+                    lbra      L5470
+
+L5170               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    lbsr      L5D32
+                    ldd       $08,s
+                    cmpd      #$0001
+                    bne       L518B
+                    pshs      u
+                    lbsr      L57A5
+L5186               leas      $02,s
+                    lbra      L51EB
+
+L518B               cmpu      #$0000
+                    bne       L51BC
+                    ldd       #$0001
+                    std       ,s
+                    bra       L51A3
+
+L5198               leax      $5B0E,pcr
+                    pshs      x
+                    lbsr      L5794
+                    leas      $02,s
+L51A3               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      $08,s
+                    blt       L5198
+                    ldd       #$0030
+                    pshs      d
+                    lbsr      L5785
+                    bra       L5186
+
+L51BC               clra
+                    clrb
+                    bra       L51E2
+
+L51C0               ldd       ,u++
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       $08,s
+                    addd      #$FFFF
+                    cmpd      ,s
+                    beq       L51DD
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+L51DD               ldd       ,s
+                    addd      #$0001
+L51E2               std       ,s
+                    ldd       ,s
+                    cmpd      $08,s
+                    blt       L51C0
+L51EB               lbsr      L577A
+                    lbra      L5470
+
+L51F1               pshs      u
+                    ldd       $00B2,y
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L576F
+L5205               leas      $02,s
+                    ldd       $000F
+                    addd      #$0002
+                    bra       L5229
+
+L520E               pshs      u
+                    ldd       $00B2,y
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L576F
+                    leas      $02,s
+                    ldd       $000F
+                    addd      #$0004
+L5229               std       $000F
+                    puls      pc,u
+L522D               pshs      u
+                    ldd       $00B2,y
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L576F
+                    lbra      L5470
+
+L5244               pshs      u
+                    ldu       $04,s
+                    leas      -$06,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       $0C,s
+                    cmpd      #$0077
+                    bne       L5274
+                    ldd       [$0e,s]
+                    cmpd      #$0002
+                    bne       L5264
+                    ldd       #$0001
+                    bra       L5266
+
+L5264               clra
+                    clrb
+L5266               std       $02,s
+                    ldx       $0e,s
+                    ldd       $06,x
+                    std       $0C,s
+                    ldx       $0e,s
+                    ldd       $08,x
+                    std       $0e,s
+L5274               leax      ,u
+                    bra       L528C
+
+L5278               leax      L5B11,pcr
+                    bra       L5288
+
+L527E               leax      $5B15,pcr
+                    bra       L5288
+
+L5284               leax      $5B18,pcr
+L5288               stx       $04,s
+                    bra       L529B
+
+L528C               cmpx      #$0057
+                    beq       L5278
+                    cmpx      #$0058
+                    beq       L527E
+                    cmpx      #$0059
+                    beq       L5284
+L529B               ldx       $0C,s
+                    lbra      L53FB
+
+L52A0               ldd       $02,s
+                    beq       L52C2
+                    cmpu      #$0057
+                    bne       L52B5
+                    ldd       $00B6,y
+                    pshs      d
+                    lbsr      L576F
+                    leas      $02,s
+L52B5               ldd       $04,s
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    clra
+                    clrb
+                    bra       L52EF
+
+L52C2               ldd       $04,s
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       #$0061
+                    pshs      d
+                    lbsr      L5429
+                    leas      $08,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       #$0001
+L52EF               pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       #$0062
+                    pshs      d
+                    lbsr      L5429
+                    leas      $08,s
+                    lbra      L5425
+
+L5308               ldd       $0e,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      LB069
+                    clra
+                    std       ,s
+                    tfr       d,x
+                    bra       L5362
+
+L5319               cmpu      #$0057
+                    bne       L536D
+                    ldd       $00B6,y
+                    pshs      d
+                    bra       L5339
+
+L5327               cmpu      #$0057
+                    beq       L536D
+                    cmpu      #$0059
+                    bne       L5340
+                    leax      $5B1C,pcr
+                    pshs      x
+L5339               lbsr      L576F
+                    leas      $02,s
+                    bra       L536D
+
+L5340               ldd       $04,s
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0061
+                    pshs      d
+                    lbsr      L5429
+                    leas      $08,s
+                    bra       L536D
+
+L5362               stx       -$02,s
+                    beq       L5319
+                    cmpx      #$00FF
+                    beq       L5327
+                    bra       L5340
+
+L536D               ldd       $0e,s
+                    clra
+                    std       ,s
+                    tfr       d,x
+                    bra       L53C3
+
+L5376               cmpu      #$0057
+                    lbne      L5425
+                    leax      $5B21,pcr
+                    bra       L5396
+
+L5384               cmpu      #$0057
+                    lbeq      L5425
+                    cmpu      #$0059
+                    bne       L53A0
+                    leax      $5B26,pcr
+L5396               pshs      x
+                    lbsr      L576F
+                    leas      $02,s
+                    lbra      L5425
+
+L53A0               ldd       $04,s
+                    pshs      d
+                    lbsr      L5756
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0062
+                    pshs      d
+                    lbsr      L5429
+                    leas      $08,s
+                    lbra      L5425
+
+L53C3               stx       -$02,s
+                    beq       L5376
+                    cmpx      #$00FF
+                    beq       L5384
+                    bra       L53A0
+
+L53CE               ldd       $04,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $5B2B,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $08,s
+                    ldd       $000F
+                    addd      #$0002
+                    std       $000F
+                    bra       L5425
+
+L53EE               leax      $5B3E,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L5425
+
+L53FB               cmpx      #$0034
+                    lbeq      L52A0
+                    cmpx      #$0094
+                    lbeq      L52A0
+                    cmpx      #$0095
+                    lbeq      L52A0
+                    cmpx      #$0093
+                    lbeq      L52A0
+                    cmpx      #$0036
+                    lbeq      L5308
+                    cmpx      #$006E
+                    beq       L53CE
+                    bra       L53EE
+
+L5425               leas      $06,s
+                    puls      pc,u
+L5429               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    bsr       L5474
+                    leas      $06,s
+                    lbsr      L577A
+                    puls      pc,u
+L5453               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L5472
+                    cmpu      #$0000
+                    ble       L546B
+                    ldd       #$002B
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+L546B               pshs      u
+                    lbsr      L57A5
+L5470               leas      $02,s
+L5472               puls      pc,u
+L5474               pshs      u,x,d
+                    ldd       $08,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L5489
+                    ldd       #$005B
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+L5489               ldd       $08,s
+                    anda      #$7f
+                    tfr       d,x
+                    lbra      L5680
+
+L5492               ldu       $0a,s
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L54B3
+                    ldd       #$0023
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    bra       L54C0
+
+L54B3               ldd       $0C,s
+                    addd      $14,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+L54C0               pshs      d
+                    bsr       L5474
+                    leas      $06,s
+                    lbra      L57A1
+
+L54C9               ldd       #$0023
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    ldd       $0a,s
+                    lbra      L5605
+
+L54D8               leax      $5B4F,pcr
+                    pshs      x
+                    lbsr      L5794
+                    leas      $02,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L5453
+                    leas      $02,s
+                    ldd       $00AE,y
+                    pshs      d
+                    lbsr      L5794
+                    lbra      L567C
+
+L54F8               ldu       $0a,s
+                    lbeq      L5603
+                    ldd       $08,u
+                    std       ,s
+                    tfr       d,x
+                    lbra      L55D0
+
+L5507               ldd       $06,u
+                    subd      $000F
+                    addd      $0C,s
+                    std       $0a,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       $00B0,y
+                    lbra      L55C1
+
+L551D               ldd       $005A
+                    bne       L5539
+                    ldd       $08,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L552F
+                    ldd       #$003E
+                    bra       L5532
+
+L552F               ldd       #$003C
+L5532               pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+L5539               ldd       $06,u
+                    pshs      d
+                    lbsr      L57C3
+                    leas      $02,s
+                    leax      $04,s
+                    bra       L5572
+
+L5546               ldd       $005A
+                    bne       L5562
+                    ldd       $08,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L5558
+                    ldd       #$003E
+                    bra       L555B
+
+L5558               ldd       #$003C
+L555B               pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+L5562               pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    lbsr      L57D6
+                    leas      $02,s
+                    bra       L5574
+
+L5572               leas      -$04,x
+L5574               ldd       $0C,s
+                    pshs      d
+                    lbsr      L5453
+                    leas      $02,s
+                    ldd       $08,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L55AA
+                    ldd       $005A
+                    lbne      L56B8
+                    ldd       ,s
+                    cmpd      #$0021
+                    lbeq      L56B8
+                    ldd       ,s
+                    cmpd      #$0022
+                    lbeq      L56B8
+                    ldd       ,s
+                    cmpd      #$0023
+                    lbeq      L56B8
+L55AA               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L55BD
+                    leax      $5B56,pcr
+                    pshs      x
+                    bra       L55C3
+
+L55BD               ldd       $00AE,y
+L55C1               pshs      d
+L55C3               lbsr      L5794
+                    lbra      L567C
+
+L55C9               leax      $5B5B,pcr
+                    lbra      L5677
+
+L55D0               cmpx      #$000D
+                    lbeq      L5507
+                    cmpx      #$0023
+                    lbeq      L551D
+                    cmpx      #$000F
+                    lbeq      L5539
+                    cmpx      #$0021
+                    lbeq      L5546
+                    cmpx      #$0022
+                    lbeq      L5546
+                    cmpx      #$000E
+                    lbeq      L5562
+                    cmpx      #$000C
+                    lbeq      L5562
+                    bra       L55C9
+
+L5603               ldd       $0C,s
+L5605               pshs      d
+                    lbsr      L57A5
+                    lbra      L567C
+
+L560D               ldd       $0a,s
+                    addd      $0C,s
+                    std       $0a,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    ldd       $08,s
+                    anda      #$7f
+                    tfr       d,x
+                    bra       L5643
+
+L562C               ldd       #$0078
+                    bra       L5639
+
+L5631               ldd       #$0079
+                    bra       L5639
+
+L5636               ldd       #$0075
+L5639               pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    lbra      L56B8
+
+L5643               cmpx      #$0093
+                    beq       L562C
+                    cmpx      #$0094
+                    beq       L5631
+                    cmpx      #$0095
+                    beq       L5636
+                    bra       L56B8
+
+L5654               ldd       $00B0,y
+                    pshs      d
+                    lbsr      L5794
+                    leas      $02,s
+                    leax      $5B69,pcr
+                    pshs      x
+                    lbsr      L5794
+                    leas      $02,s
+                    ldd       $000F
+                    addd      #$0002
+                    std       $000F
+                    bra       L56B8
+
+L5673               leax      L5B6C,pcr
+L5677               pshs      x
+                    lbsr      L0450
+L567C               leas      $02,s
+                    bra       L56B8
+
+L5680               cmpx      #$0077
+                    lbeq      L5492
+                    cmpx      #$0036
+                    lbeq      L54C9
+                    cmpx      #$0080
+                    lbeq      L54D8
+                    cmpx      #$0034
+                    lbeq      L54F8
+                    cmpx      #$0093
+                    lbeq      L560D
+                    cmpx      #$0094
+                    lbeq      L560D
+                    cmpx      #$0095
+                    lbeq      L560D
+                    cmpx      #$006E
+                    beq       L5654
+                    bra       L5673
+
+L56B8               ldd       $08,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    lbeq      L57A1
+                    ldd       #$005D
+                    pshs      d
+                    lbsr      L5785
+                    leas      $02,s
+                    lbra      L57A1
+
+L56D0               pshs      u
+                    ldx       $04,s
+                    bra       L571F
+
+L56D6               leax      $5B78,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L56E1               leax      $5B7F,pcr
+                    bra       L571B
+
+L56E7               leax      L5B83,pcr
+                    bra       L571B
+
+L56ED               leax      L5B87,pcr
+                    bra       L571B
+
+L56F3               leax      L5B8B,pcr
+                    bra       L571B
+
+L56F9               leax      L5B8F,pcr
+                    bra       L571B
+
+L56FF               leax      L5B93,pcr
+                    bra       L571B
+
+L5705               leax      L5B97,pcr
+                    bra       L571B
+
+L570B               leax      L5B9B,pcr
+                    bra       L571B
+
+L5711               leax      L5B9F,pcr
+                    bra       L571B
+
+L5717               leax      L5BA3,pcr
+L571B               tfr       x,d
+                    puls      pc,u
+L571F               cmpx      #$005A
+                    beq       L56E1
+                    cmpx      #$005B
+                    beq       L56E7
+                    cmpx      #$005C
+                    beq       L56ED
+                    cmpx      #$005D
+                    beq       L56F3
+                    cmpx      #$005E
+                    beq       L56F9
+                    cmpx      #$005F
+                    beq       L56FF
+                    cmpx      #$0060
+                    beq       L5705
+                    cmpx      #$0061
+                    beq       L570B
+                    cmpx      #$0062
+                    beq       L5711
+                    cmpx      #$0063
+                    beq       L5717
+                    lbra      L56D6
+                    puls      pc,u
+L5756               pshs      u
+                    ldd       $0005
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      $A1CD
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L5794
+                    lbra      L5811
+
+L576F               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L5756
+                    lbra      L582B
+
+L577A               pshs      u
+                    ldd       $0005
+                    pshs      d
+                    ldd       #$000D
+                    bra       L578D
+
+L5785               pshs      u
+                    ldd       $0005
+                    pshs      d
+                    ldd       $06,s
+L578D               pshs      d
+                    lbsr      $A1CD
+                    bra       L57A1
+
+L5794               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+L57A1               leas      $04,s
+                    puls      pc,u
+L57A5               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      L5BA7,pcr
+                    lbra      L583C
+
+L57B2               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L57C3
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $002F
+                    lbra      L582D
+
+L57C3               pshs      u
+                    ldd       #$005F
+                    pshs      d
+                    bsr       L5785
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L57A5
+                    bra       L5811
+
+L57D6               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      $5BAA,pcr
+                    lbra      L583C
+
+L57E3               pshs      u,d
+                    ldd       $06,s
+                    subd      $000F
+                    std       ,s
+                    beq       L580F
+                    leax      $5BAF,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L57A5
+                    leas      $02,s
+                    ldd       $00B0,y
+                    pshs      d
+                    lbsr      L5794
+                    leas      $02,s
+                    lbsr      L577A
+L580F               ldd       $06,s
+L5811               leas      $02,s
+                    puls      pc,u
+L5815               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L57D6
+                    leas      $02,s
+                    ldd       $06,s
+                    beq       L582D
+                    ldd       #$003A
+                    pshs      d
+                    lbsr      L5785
+L582B               leas      $02,s
+L582D               lbsr      L577A
+                    puls      pc,u
+L5832               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      L5BB5,pcr
+L583C               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    puls      pc,u
+L5849               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L5832
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$005F
+                    pshs      d
+                    leax      L5BBD,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $08,s
+                    puls      pc,u
+                    bge       $58E8
+                    neg       L002C
+                    com       >L006C
+                    fcb       $62
+                    com       L7220
+                    neg       L006C
+                    fcb       $62
+                    fcb       $72
+                    fcb       $61
+                    bra       L587F
+
+L587F               com       $0C,s
+                    fcb       $72
+                    fcb       $61
+                    neg       L0075
+                    jmp       $0b,s
+                    jmp       $0f,s
+                    asr       L6E20
+                    clr       -$10,s
+                    fcb       $65
+                    fcb       $72
+                    fcb       $61
+                    lsr       $6F72
+                    bra       L58D0
+                    bra       L5898
+
+L5898               bra       L590A
+                    com       L6873
+                    bra       $58C4
+                    com       $0d,x
+                    neg       L006C
+                    fcb       $62
+                    neg       L0070
+                    fcb       $75
+                    inc       -$0d,s
+                    bra       $5920
+                    bge       $591D
+                    com       $0d,x
+                    neg       L0063
+                    com       $0d,s
+                    fcb       $75
+                    inc       -$0C,s
+                    neg       L0063
+                    com       -$0b,s
+                    lsr       $09,s
+                    ror       >L0063
+                    com       $04,s
+                    rol       -$0a,s
+                    neg       L0063
+                    com       $01,s
+                    com       $6C00
+L58CA               com       $03,s
+                    fcb       $61
+                    com       L7200
+L58D0               com       $03,s
+                    inc       -$0d,s
+                    fcb       $72
+                    neg       L0063
+                    com       -$0b,s
+                    tst       $0f,s
+                    lsr       0,x
+L58DD               com       $03,s
+                    tst       $0f,s
+                    lsr       0,x
+L58E3               jmp       $05,s
+                    asr       $01,s
+                    tst       $0020
+                    jmp       $05,s
+                    asr       $02,s
+                    tst       $0020
+                    com       $6263
+                    fcb       $61
+                    bra       $5918
+                    leax      0,x
+L58F7               com       $0f,s
+                    tst       $01,s
+                    tst       $0020
+                    com       $0f,s
+                    tst       $02,s
+                    neg       L006C
+                    fcb       $65
+                    fcb       $61
+                    asl       L2000
+L5908               inc       $05,s
+L590A               fcb       $61
+                    com       L2000
+L590E               bge       $5988
+                    tst       $0000
+L5912               dec       -$0d,s
+                    fcb       $72
+                    bra       L5917
+
+L5917               com       $6578
+                    neg       L006C
+                    lsr       0,x
+L591E               fcb       $61
+                    com       L6C62
+                    tst       $0020
+                    fcb       $72
+                    clr       $0C,s
+                    fcb       $61
+                    neg       L0061
+                    com       L7261
+                    tst       $0020
+                    fcb       $72
+                    clr       -$0e,s
+                    fcb       $62
+                    neg       L006C
+                    com       L7261
+                    tst       $0020
+                    fcb       $72
+                    clr       -$0e,s
+                    fcb       $62
+                    neg       L006C
+                    lsr       -$07,s
+                    bra       L5944
+
+L5944               inc       $04,s
+                    fcb       $75
+                    bra       L5949
+
+L5949               inc       $05,s
+                    fcb       $61
+                    asl       L2000
+L594F               bcs       L59B5
+                    bge       L5978
+                    com       $0d,x
+                    neg       $0064
+                    bge       $597E
+                    com       $0d,x
+                    neg       $0073
+                    fcb       $65
+                    asl       >L0061
+                    lsr       $03,s
+                    fcb       $61
+                    bra       $5989
+                    leax      0,x
+L5968               com       $6263
+                    fcb       $61
+                    bra       L5991
+                    leax      0,x
+L5970               bcs       $59D6
+                    bge       L5999
+                    com       $0d,x
+                    neg       L0063
+L5978               inc       -$0e,s
+                    fcb       $61
+                    tst       $0020
+                    com       $0C,s
+                    fcb       $72
+                    fcb       $62
+                    neg       L006C
+                    lsr       0,x
+L5985               bra       L59FA
+                    lsr       L2563
+                    bra       L59B9
+                    leas      $0C,y
+                    com       $0D00
+L5991               com       $0d,s
+                    neg       >$0073
+                    lsr       >$0073
+L5999               fcb       $75
+                    fcb       $62
+                    neg       L0061
+                    lsr       $04,s
+                    neg       L006C
+                    fcb       $65
+                    fcb       $61
+                    neg       $0020
+                    fcb       $65
+                    asl       $6720
+                    bcs       L5A0E
+                    bge       L59D2
+                    com       $0d,x
+                    neg       $0064
+                    bge       L59B3
+L59B3               inca
+                    fcb       $45
+L59B5               fcb       $41
+                    bra       L5A19
+                    fcb       $72
+L59B9               asr       0,x
+L59BB               bra       L5A31
+                    ror       -$0e,s
+                    bra       $59E6
+                    com       $0C,y
+                    bcs       $5A28
+                    tst       $0000
+L59C7               inc       $04,s
+                    fcb       $61
+                    bra       L59FC
+                    bge       $5A46
+                    tst       $0020
+                    clr       -$0e,s
+L59D2               fcb       $61
+                    bra       L5A06
+                    bge       $5A4F
+                    tst       $0020
+                    clr       -$0e,s
+                    fcb       $61
+                    bra       L5A10
+                    bge       L5A58
+                    tst       $0020
+                    clr       -$0e,s
+                    fcb       $61
+                    bra       $5A1A
+                    bge       $5A61
+                    neg       L005F
+                    inc       $0d,s
+                    clr       -$0a,s
+                    fcb       $65
+                    neg       L005F
+                    inc       $01,s
+                    lsr       $04,s
+                    neg       L005F
+                    inc       -$0d,s
+L59FA               fcb       $75
+                    fcb       $62
+L59FC               neg       L005F
+                    inc       $0d,s
+                    fcb       $75
+                    inc       0,x
+L5A03               clrb
+                    inc       $04,s
+L5A06               rol       -$0a,s
+                    neg       L005F
+                    inc       $0d,s
+                    clr       $04,s
+L5A0E               neg       L005F
+L5A10               inc       $01,s
+                    jmp       $04,s
+                    neg       L005F
+                    inc       $0f,s
+                    fcb       $72
+L5A19               neg       L005F
+                    inc       -$08,s
+                    clr       -$0e,s
+                    neg       L005F
+                    inc       -$0d,s
+                    asl       $0C,s
+                    neg       L005F
+                    inc       -$0d,s
+                    asl       -$0e,s
+                    neg       L005F
+                    inc       $03,s
+                    tst       -$10,s
+L5A31               fcb       $72
+                    neg       L005F
+                    inc       $0e,s
+                    fcb       $65
+                    asr       0,x
+L5A39               clrb
+                    inc       $03,s
+                    clr       $0d,s
+                    neg       $6C00
+L5A41               clrb
+                    inc       $09,s
+                    lsr       $6F6C
+                    neg       L005F
+                    inc       -$0b,s
+                    lsr       $6F6C
+                    neg       L005F
+                    inc       $09,s
+                    jmp       $03,s
+                    neg       L005F
+                    inc       $04,s
+L5A58               fcb       $65
+                    com       0,x
+L5A5B               com       $0f,s
+                    lsr       $07,s
+                    fcb       $65
+                    jmp       0,y
+                    blt       $5A84
+                    inc       $0f,s
+                    jmp       $07,s
+                    com       >L005F
+                    lsr       -$0d,s
+                    lsr       L6163
+                    fcb       $6b
+                    neg       $0020
+                    inc       $04,s
+                    fcb       $61
+                    bra       L5A9D
+                    com       $0C,y
+                    asl       $0D00
+L5A7D               clrb
+                    ror       $0d,s
+                    clr       -$0a,s
+                    fcb       $65
+                    neg       L005F
+                    lsr       $0d,s
+                    clr       -$0a,s
+                    fcb       $65
+                    neg       L005F
+                    lsr       $01,s
+                    lsr       $04,s
+                    neg       L005F
+                    lsr       -$0d,s
+                    fcb       $75
+                    fcb       $62
+                    neg       L005F
+                    lsr       $0d,s
+                    fcb       $75
+                    inc       0,x
+L5A9D               clrb
+                    lsr       $04,s
+                    rol       -$0a,s
+                    neg       L005F
+                    lsr       $03,s
+                    tst       -$10,s
+                    fcb       $72
+                    neg       L005F
+                    lsr       $0e,s
+                    fcb       $65
+                    asr       0,x
+L5AB0               clrb
+                    ror       $09,s
+                    jmp       $03,s
+                    neg       L005F
+                    lsr       $09,s
+                    jmp       $03,s
+                    neg       L005F
+                    ror       $04,s
+                    fcb       $65
+                    com       0,x
+L5AC2               clrb
+                    lsr       $04,s
+                    fcb       $65
+                    com       0,x
+L5AC8               clrb
+                    lsr       -$0C,s
+                    clr       $06,s
+                    neg       L005F
+                    ror       -$0C,s
+                    clr       $04,s
+                    neg       L005F
+                    inc       -$0C,s
+                    clr       $04,s
+                    neg       L005F
+                    rol       -$0C,s
+                    clr       $04,s
+                    neg       L005F
+                    fcb       $75
+                    lsr       $6F64
+                    neg       L005F
+                    lsr       -$0C,s
+                    clr       $0C,s
+                    neg       L005F
+                    lsr       -$0C,s
+                    clr       $09,s
+                    neg       L0063
+                    clr       $04,s
+                    asr       $05,s
+                    jmp       0,y
+                    blt       L5B1B
+                    ror       $0C,s
+                    clr       $01,s
+                    lsr       $7300
+L5B02               fcb       $62
+                    com       L7220
+                    neg       L0070
+                    fcb       $75
+                    inc       -$0d,s
+                    bra       L5B85
+                    neg       L0030
+                    bge       L5B11
+L5B11               fcb       $61
+                    jmp       $04,s
+                    neg       $006F
+                    fcb       $72
+                    neg       L0065
+                    clr       -$0e,s
+L5B1B               neg       L0063
+                    clr       $0d,s
+                    fcb       $61
+                    neg       L0063
+                    inc       -$0e,s
+                    fcb       $62
+                    neg       L0063
+                    clr       $0d,s
+                    fcb       $62
+                    neg       $0020
+                    bcs       L5BA1
+                    fcb       $61
+                    bra       $5B5D
+                    com       L2B0D
+                    bra       $5B5B
+                    com       $6220
+                    bge       $5BAE
+                    bmi       $5B4A
+                    neg       L0063
+                    clr       $0d,s
+                    neg       L696C
+                    fcb       $65
+                    fcb       $72
+                    bra       $5BBC
+                    fcb       $72
+                    clr       -$0b,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       L005F
+                    ror       $0C,s
+                    fcb       $61
+                    com       $03,s
+                    neg       L002C
+                    neg       L6372
+                    neg       $0073
+                    lsr       $6F72
+                    fcb       $61
+                    asr       $05,s
+                    bra       L5BC9
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $002B
+                    bmi       L5B6C
+L5B6C               lsr       $05,s
+                    fcb       $72
+                    fcb       $65
+                    ror       $05,s
+                    fcb       $72
+                    fcb       $65
+                    jmp       $03,s
+                    fcb       $65
+                    neg       $0072
+                    fcb       $65
+                    inc       0,y
+                    clr       -$10,s
+                    neg       L0065
+                    fcb       $71
+                    bra       L5B83
+
+L5B83               jmp       $05,s
+
+L5B85               bra       L5B87
+
+L5B87               inc       $05,s
+                    bra       L5B8B
+
+L5B8B               inc       -$0C,s
+                    bra       L5B8F
+
+L5B8F               asr       $05,s
+                    bra       L5B93
+
+L5B93               asr       -$0C,s
+                    bra       L5B97
+
+L5B97               inc       -$0d,s
+                    bra       L5B9B
+
+L5B9B               inc       $0f,s
+                    bra       L5B9F
+
+L5B9F               asl       -$0d,s
+L5BA1               bra       L5BA3
+
+L5BA3               asl       $09,s
+                    bra       L5BA7
+
+L5BA7               bcs       $5C0D
+                    neg       L0025
+                    bgt       L5BE5
+                    com       >L006C
+                    fcb       $65
+                    fcb       $61
+                    com       L2000
+L5BB5               bra       L5C23
+                    fcb       $65
+                    fcb       $61
+                    bcs       L5C1E
+                    bra       L5BBD
+
+L5BBD               bcs       $5C22
+                    bcs       L5C25
+                    bge       $5C33
+                    com       -$0e,s
+                    tst       $0000
+L5BC7               pshs      u
+L5BC9               lbsr      L5D72
+                    lbsr      L5D64
+                    ldd       $0009
+                    lbeq      L5DFF
+                    leax      L5E01,pcr
+                    lbra      L5D6A
+
+L5BDC               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L5D4E
+L5BE5               leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57C3
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    leax      $5E14,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    bra       L5C2D
+
+L5C03               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L5D4E
+                    leas      $02,s
+                    ldd       #$003A
+                    bra       L5C21
+
+L5C13               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L5D4E
+                    leas      $02,s
+L5C1E               ldd       #$0020
+L5C21               pshs      d
+L5C23               ldd       $08,s
+L5C25               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L5C34
+L5C2D               leas      $06,s
+                    lbsr      L5D64
+                    puls      pc,u
+L5C34               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldb       $0b,s
+                    sex
+                    pshs      d
+                    ldd       $08,s
+                    addd      #$0014
+                    pshs      d
+                    leax      $5E1D,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $0a,s
+                    puls      pc,u
+L5C57               pshs      u
+                    ldd       $06,s
+                    std       $005E
+                    pshs      d
+                    lbsr      L57C3
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    leax      $5E2C,pcr
+                    lbra      L5CF9
+
+L5C6F               pshs      u
+                    ldu       $04,s
+                    pshs      u
+                    leax      L5E40,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L5815
+                    leas      $04,s
+                    leax      L5E4B,pcr
+                    pshs      x
+                    lbsr      L576F
+                    leas      $02,s
+                    ldd       $0015
+                    bne       L5CB8
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       L005C
+                    pshs      d
+                    leax      $5E52,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+L5CB8               ldd       $0017
+                    lbeq      L5DFF
+                    leax      L5E6D,pcr
+                    pshs      x
+                    lbsr      L5756
+                    leas      $02,s
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L57C3
+                    leas      $02,s
+                    leax      L5E73,pcr
+                    pshs      x
+                    lbsr      L5794
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L57D6
+                    leas      $02,s
+                    leax      L5E87,pcr
+                    lbra      L5D46
+
+L5CEB               pshs      u
+                    ldd       $0017
+                    beq       L5D04
+                    ldd       $005E
+                    pshs      d
+                    leax      L5EAB,pcr
+L5CF9               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+L5D04               puls      pc,u
+L5D06               pshs      u
+                    ldd       $0015
+                    bne       L5D28
+                    ldd       $001B
+                    subd      $0013
+                    addd      #$FFC0
+                    pshs      d
+                    ldd       L005C
+                    pshs      d
+                    leax      L5EE9,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $08,s
+L5D28               puls      pc,u
+L5D2A               pshs      u
+                    leax      L5EF6,pcr
+                    bra       L5D38
+
+L5D32               pshs      u
+                    leax      L5EFB,pcr
+L5D38               pshs      x
+                    lbsr      L5756
+                    lbra      L5DFD
+
+L5D40               pshs      u
+                    leax      L5F00,pcr
+L5D46               pshs      x
+                    lbsr      L5794
+                    lbra      L5DFD
+
+L5D4E               pshs      u
+                    ldd       $04,s
+                    beq       L5D5A
+                    leax      $5F03,pcr
+                    bra       L5D5E
+
+L5D5A               leax      $5F0C,pcr
+L5D5E               tfr       x,d
+                    pshs      d
+                    bra       L5D6C
+
+L5D64               pshs      u
+                    leax      $5F12,pcr
+L5D6A               pshs      x
+L5D6C               lbsr      L576F
+                    lbra      L5DFD
+
+L5D72               pshs      u
+                    ldd       L004C
+                    lbeq      L5DFF
+                    ldd       L004C
+                    pshs      d
+                    lbsr      $A14D
+                    leas      $02,s
+                    bra       L5D90
+
+L5D85               ldd       $0005
+                    pshs      d
+                    pshs      u
+                    lbsr      $A1CD
+                    leas      $04,s
+L5D90               ldd       L004C
+                    pshs      d
+                    lbsr      $A3E4
+                    leas      $02,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L5D85
+                    ldx       L004C
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L5DB5
+                    leax      $5F1A,pcr
+                    pshs      x
+                    lbsr      L042D
+                    leas      $02,s
+L5DB5               ldd       L004C
+                    pshs      d
+                    lbsr      $A2BE
+                    leas      $02,s
+                    leax      $0096,y
+                    pshs      x
+                    lbsr      $B17D
+                    bra       L5DFD
+
+L5DC9               pshs      u,d
+                    ldd       $0364,y
+                    beq       L5DD7
+                    ldd       $0364,y
+                    bra       L5DDA
+
+L5DD7               ldd       #$0001
+L5DDA               std       ,s
+                    ldd       L004C
+                    beq       L5DF4
+                    ldd       L004C
+                    pshs      d
+                    lbsr      $A2BE
+                    leas      $02,s
+                    leax      $0096,y
+                    pshs      x
+                    lbsr      $B17D
+                    leas      $02,s
+L5DF4               ldd       ,s
+                    pshs      d
+                    lbsr      $B352
+                    leas      $02,s
+L5DFD               leas      $02,s
+L5DFF               puls      pc,u
+L5E01               ror       $01,s
+                    rol       $0C,s
+                    bra       $5E7A
+                    clr       -$0b,s
+                    fcb       $72
+                    com       $05,s
+                    bra       L5E73
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    com       >$0020
+                    fcb       $72
+                    tst       $02,s
+                    bra       $5E3F
+                    lsr       $0d,x
+                    neg       L0025
+                    bgt       $5E58
+                    com       L2563
+                    bra       L5E97
+                    tst       $02,s
+                    bra       L5E4E
+                    lsr       $0d,x
+                    neg       $0020
+                    ror       $03,s
+                    com       0,y
+                    bhi       $5E58
+                    bgt       L5E6D
+                    com       $220D
+                    bra       L5EA0
+                    com       $02,s
+                    bra       $5E6E
+                    tst       $0000
+L5E40               bra       L5EB6
+                    lsr       $6C20
+                    bcs       L5E75
+                    fcb       $38
+                    com       $0D00
+L5E4B               neg       L7368
+L5E4E               com       $2075
+                    neg       $0020
+                    inc       $04,s
+                    lsr       0,y
+                    bls       $5EB8
+                    bcs       $5EBF
+                    tst       $0020
+                    inc       $02,s
+                    com       L7220
+                    clrb
+                    com       L746B
+                    com       $08,s
+                    fcb       $65
+                    com       $0b,s
+                    tst       $0000
+L5E6D               inc       $05,s
+                    fcb       $61
+                    asl       L2000
+L5E73               bge       $5EE5
+L5E75               com       -$0e,s
+                    tst       $0020
+                    neg       L7368
+                    com       L2078
+                    tst       $0020
+                    inc       $05,s
+                    fcb       $61
+                    asl       L2000
+L5E87               bge       L5EF9
+                    com       -$0e,s
+                    tst       $0020
+                    neg       L7368
+                    com       L2078
+                    tst       $0020
+                    inc       $02,s
+L5E97               com       L7220
+                    clrb
+                    neg       L726F
+                    ror       $0d,x
+L5EA0               bra       $5F0E
+                    fcb       $65
+                    fcb       $61
+                    com       $2034
+                    bge       L5F1C
+                    tst       $0000
+L5EAB               bra       $5F1D
+                    com       L6873
+                    bra       $5F16
+                    tst       $0020
+                    inc       $05,s
+L5EB6               fcb       $61
+                    asl       L205F
+                    bcs       $5F20
+                    bge       L5F2E
+                    com       -$0e,s
+                    tst       $0020
+                    neg       L7368
+                    com       L2078
+                    tst       $0020
+                    inc       $02,s
+                    com       L7220
+                    clrb
+                    fcb       $65
+                    neg       L726F
+                    ror       $0d,x
+                    bra       $5F44
+                    fcb       $65
+                    fcb       $61
+                    com       $2032
+                    bge       L5F52
+                    tst       $0020
+                    neg       L756C
+                    com       $2064
+                    tst       $0000
+L5EE9               clrb
+                    bcs       $5F50
+                    bra       $5F53
+                    fcb       $71
+                    fcb       $75
+                    bra       $5F17
+                    lsr       $0d,x
+                    tst       $0000
+L5EF6               ror       $03,s
+                    fcb       $62
+L5EF9               bra       L5EFB
+
+L5EFB               ror       $04,s
+                    fcb       $62
+                    bra       L5F00
+
+L5F00               bpl       $5F22
+                    neg       $0076
+                    com       L6563
+                    lsr       $2064
+                    neg       >$0076
+                    com       L6563
+                    lsr       >L0065
+                    jmp       $04,s
+                    com       L6563
+                    lsr       >$0064
+                    fcb       $75
+L5F1C               tst       -$10,s
+                    com       L7472
+                    rol       $0e,s
+                    asr       -$0d,s
+                    neg       $0034
+                    nega
+                    leas      -$15,s
+                    lbsr      L42B9
+L5F2E               ldb       $0045
+                    sex
+                    cmpd      #$FFFF
+                    bne       L5F41
+                    ldd       #$FFFF
+                    std       $003F
+                    leas      $15,s
+                    puls      pc,u
+L5F41               ldd       $004A
+                    addd      #$FFFF
+                    std       $0043
+                    ldd       $0007
+                    std       L001F
+                    bra       L5F60
+
+L5F4E               leax      L6CDE,pcr
+L5F52               pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbsr      L42CF
+                    ldd       $004A
+                    std       $0043
+L5F60               ldb       $0045
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    std       $003F
+                    beq       L5F4E
+                    ldb       $0045
+                    sex
+                    leax      $013a,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    std       $0041
+                    ldx       $003F
+                    lbra      L626E
+
+L5F83               leax      $0a,s
+                    pshs      x
+                    lbsr      L64B7
+                    leas      $02,s
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      L652E
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       ,u
+                    std       $003F
+                    cmpd      #$0033
+                    bne       L5FBA
+                    ldd       $08,u
+                    std       $0041
+                    cmpd      #$003B
+                    lbne      L628D
+                    ldd       #$003B
+                    std       $003F
+                    ldd       #$000E
+                    std       $0041
+                    lbra      L628D
+
+L5FBA               ldd       #$0034
+                    std       $003F
+                    stu       $0041
+                    lbra      L628D
+
+L5FC4               leax      ,s
+                    pshs      x
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L6654
+                    leas      $04,s
+                    std       $13,s
+                    bra       L5FDA
+
+L5FD7               leas      -$15,x
+L5FDA               leax      ,s
+                    stx       $08,s
+                    ldx       $13,s
+                    bra       L6038
+
+L5FE3               ldd       [$08,s]
+                    bra       L602E
+
+L5FE8               ldd       #$0004
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    tfr       d,u
+                    leax      ,u
+                    pshs      x
+                    ldx       $0a,s
+                    lbsr      LAEDF
+                    stu       $0041
+                    ldd       #$004A
+                    bra       L6033
+
+L6004               ldd       #$0008
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    tfr       d,u
+                    leax      ,u
+                    pshs      x
+                    ldx       $0a,s
+                    lbsr      $AE34
+                    stu       $0041
+                    ldd       #$004B
+                    bra       L6033
+
+L6020               leax      $6CEC,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    ldd       #$0001
+L602E               std       $0041
+                    ldd       #$0036
+L6033               std       $003F
+                    lbra      L628D
+
+L6038               cmpx      #$0001
+                    beq       L5FE3
+                    cmpx      #$0008
+                    beq       L5FE8
+                    cmpx      #$0006
+                    beq       L6004
+                    bra       L6020
+
+L6049               lbsr      L69C3
+                    ldd       #$0036
+                    bra       L6057
+
+L6051               lbsr      L69F3
+                    ldd       #$0037
+L6057               std       $003F
+                    lbra      L628D
+
+L605C               lbsr      L42CF
+                    ldx       $003F
+                    lbra      L6211
+
+L6064               ldb       $0045
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    lbne      L628D
+                    leax      ,s
+                    pshs      x
+                    ldd       #$0006
+                    pshs      d
+                    lbsr      L6654
+                    leas      $04,s
+                    std       $13,s
+                    leax      $15,s
+                    lbra      L5FD7
+
+L608C               ldb       $0045
+                    sex
+                    tfr       d,x
+                    bra       L60AB
+
+L6093               ldd       #$0047
+                    std       $003F
+                    lbsr      L42CF
+                    ldd       #$0005
+                    bra       L60EA
+
+L60A0               ldd       #$00A7
+                    std       $003F
+                    ldd       #$0002
+                    lbra      L61F7
+
+L60AB               cmpx      #$0026
+                    beq       L6093
+                    cmpx      #$003D
+                    beq       L60A0
+                    lbra      L628D
+
+L60B8               ldb       $0045
+                    cmpb      #$3d
+                    lbne      L628D
+                    ldd       #$005A
+                    std       $003F
+                    ldd       #$0009
+                    lbra      L61F7
+
+L60CB               ldb       $0045
+                    sex
+                    tfr       d,x
+                    bra       L60EF
+
+L60D2               ldd       #$0048
+                    std       $003F
+                    lbsr      L42CF
+                    ldd       #$0004
+                    bra       L60EA
+
+L60DF               ldd       #$00A8
+L60E2               std       $003F
+                    lbsr      L42CF
+                    ldd       #$0002
+L60EA               std       $0041
+                    lbra      L628D
+
+L60EF               cmpx      #$007C
+                    beq       L60D2
+                    cmpx      #$003D
+                    beq       L60DF
+                    lbra      L628D
+
+L60FC               ldb       $0045
+                    cmpb      #$3d
+                    lbne      L628D
+                    ldd       #$005B
+                    std       $003F
+                    lbsr      L42CF
+                    ldd       #$0009
+                    bra       L60EA
+
+L6111               ldb       $0045
+                    cmpb      #$3d
+                    lbne      L628D
+                    ldd       #$00A2
+                    bra       L60E2
+
+L611E               ldb       $0045
+                    cmpb      #$3d
+                    lbne      L628D
+                    ldd       $003F
+                    addd      #$0050
+                    lbra      L60E2
+
+L612E               ldb       $0045
+                    sex
+                    tfr       d,x
+                    bra       L6160
+
+L6135               ldd       #$0056
+                    std       $003F
+                    ldd       #$000B
+                    std       $0041
+                    lbsr      L42CF
+                    ldb       $0045
+                    cmpb      #$3d
+                    lbne      L628D
+                    ldd       #$00A6
+                    std       $003F
+                    ldd       #$0002
+                    lbra      L61F7
+
+L6155               ldd       #$005C
+                    std       $003F
+                    ldd       #$000A
+                    lbra      L61F7
+
+L6160               cmpx      #$003C
+L6163               beq       L6135
+                    cmpx      #$003D
+                    beq       L6155
+                    lbra      L628D
+
+L616D               ldb       $0045
+                    sex
+                    tfr       d,x
+L6172               bra       L619F
+
+L6174               ldd       #$0055
+                    std       $003F
+                    ldd       #$000B
+                    std       $0041
+                    lbsr      L42CF
+                    ldb       $0045
+                    cmpb      #$3d
+                    lbne      L628D
+                    ldd       #$00A5
+                    std       $003F
+                    ldd       #$0002
+                    lbra      L61F7
+
+L6194               ldd       #$005E
+                    std       $003F
+                    ldd       #$000A
+                    lbra      L61F7
+
+L619F               cmpx      #$003E
+                    beq       L6174
+                    cmpx      #$003D
+                    beq       L6194
+                    lbra      L628D
+
+L61AC               ldb       $0045
+                    sex
+                    tfr       d,x
+                    bra       L61C7
+
+L61B3               ldd       #$003C
+                    std       $003F
+                    ldd       #$000E
+                    bra       L61F7
+
+L61BD               ldd       #$00A0
+                    std       $003F
+                    ldd       #$0002
+                    bra       L61F7
+
+L61C7               cmpx      #$002B
+                    beq       L61B3
+                    cmpx      #$003D
+                    beq       L61BD
+                    lbra      L628D
+
+L61D4               ldb       $0045
+                    sex
+                    tfr       d,x
+                    bra       L61FF
+
+L61DB               ldd       #$003D
+                    std       $003F
+                    ldd       #$000E
+                    bra       L61F7
+
+L61E5               ldd       #$00A1
+                    std       $003F
+                    ldd       #$0002
+                    bra       L61F7
+
+L61EF               ldd       #$0046
+                    std       $003F
+                    ldd       #$000F
+L61F7               std       $0041
+                    lbsr      L42CF
+                    lbra      L628D
+
+L61FF               cmpx      #$002D
+                    beq       L61DB
+                    cmpx      #$003D
+                    beq       L61E5
+                    cmpx      #$003E
+                    beq       L61EF
+                    lbra      L628D
+
+L6211               cmpx      #$0045
+                    lbeq      L6064
+                    cmpx      #$0041
+                    lbeq      L608C
+                    cmpx      #$0078
+                    lbeq      L60B8
+                    cmpx      #$0058
+                    lbeq      L60CB
+                    cmpx      #$0040
+                    lbeq      L60FC
+                    cmpx      #$0042
+                    lbeq      L6111
+                    cmpx      #$0053
+                    lbeq      L611E
+                    cmpx      #$0054
+                    lbeq      L611E
+                    cmpx      #$0059
+                    lbeq      L611E
+                    cmpx      #$005D
+                    lbeq      L612E
+                    cmpx      #$005F
+                    lbeq      L616D
+                    cmpx      #$0050
+                    lbeq      L61AC
+                    cmpx      #$0043
+                    lbeq      L61D4
+                    bra       L628D
+
+L626E               cmpx      #$006A
+                    lbeq      L5F83
+                    cmpx      #$006B
+                    lbeq      L5FC4
+                    cmpx      #$0068
+                    lbeq      L6049
+                    cmpx      #$0069
+                    lbeq      L6051
+                    lbra      L605C
+
+L628D               leas      $15,s
+                    puls      pc,u
+L6292               pshs      u
+                    ldd       #$0006
+                    pshs      d
+                    leax      $6CFE,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0005
+                    pshs      d
+                    leax      $6D05,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$001E
+                    pshs      d
+                    leax      $6D0B,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$000F
+                    pshs      d
+                    leax      L6D13,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$003B
+                    pshs      d
+                    leax      $6D1A,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0001
+                    pshs      d
+                    leax      $6D21,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0001
+                    std       L0021
+                    ldd       #$0001
+                    pshs      d
+                    leax      $6D25,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0005
+                    pshs      d
+                    leax      $6D29,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       L0021
+                    ldd       #$0002
+                    pshs      d
+                    leax      $6D2F,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$000A
+                    pshs      d
+                    leax      $6D34,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$000D
+                    pshs      d
+                    leax      $6D3A,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$000E
+                    pshs      d
+                    leax      L6D3F,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0021
+                    pshs      d
+                    leax      L6D46,pcr
+                    pshs      x
+L6368               lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0010
+                    pshs      d
+L6372               leax      $6D4D,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #start
+                    pshs      d
+                    leax      $6D56,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0012
+                    pshs      d
+                    leax      L6D5B,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0013
+                    pshs      d
+                    leax      L6D62,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0014
+                    pshs      d
+                    leax      $6D65,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0015
+                    pshs      d
+                    leax      $6D6B,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0016
+                    pshs      d
+                    leax      $6D70,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0017
+                    pshs      d
+                    leax      $6D77,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0018
+                    pshs      d
+                    leax      L6D7C,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0019
+                    pshs      d
+                    leax      $6D82,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$001A
+                    pshs      d
+                    leax      $6D8B,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$001B
+                    pshs      d
+                    leax      L6D8E,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$001C
+                    pshs      d
+                    leax      $6D96,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0004
+                    pshs      d
+                    leax      $6D9A,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0003
+                    pshs      d
+                    leax      $6DA1,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0007
+                    pshs      d
+                    leax      $6DA7,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    ldd       #$0008
+                    pshs      d
+                    leax      L6DB0,pcr
+                    pshs      x
+                    lbsr      L65D0
+                    leas      $04,s
+                    leax      $6DB5,pcr
+                    pshs      x
+                    lbsr      L652E
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       #$0001
+                    std       ,u
+                    ldd       #$000E
+                    std       $08,u
+                    ldd       #$0002
+                    std       $02,u
+                    leax      $6DBB,pcr
+                    pshs      x
+                    lbsr      L652E
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       #$0038
+                    std       ,u
+                    ldd       #$000C
+                    std       $08,u
+                    ldd       #$0004
+                    std       $02,u
+                    puls      pc,u
+L64B7               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       #$0001
+                    bra       L64CE
+
+L64C2               ldb       $0045
+                    stb       ,u+
+                    lbsr      L42CF
+                    ldd       ,s
+                    addd      #$0001
+L64CE               std       ,s
+                    ldb       $0045
+                    sex
+                    pshs      d
+                    bsr       L6507
+                    std       ,s++
+                    beq       L64E3
+                    ldd       ,s
+                    cmpd      #$0008
+                    ble       L64C2
+L64E3               ldd       ,s
+                    cmpd      #$0002
+                    bne       L64F0
+                    ldd       #$005F
+                    stb       ,u+
+L64F0               clra
+                    clrb
+                    stb       ,u
+                    bra       L64F9
+
+L64F6               lbsr      L42CF
+L64F9               ldb       $0045
+                    sex
+                    pshs      d
+                    bsr       L6507
+L6500               std       ,s++
+                    bne       L64F6
+                    lbra      L6650
+
+L6507               pshs      u
+                    ldd       $04,s
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6a
+                    beq       L6525
+                    ldd       $04,s
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    bne       L652A
+L6525               ldd       #$0001
+                    bra       L652C
+
+L652A               clra
+                    clrb
+L652C               puls      pc,u
+L652E               pshs      u,y,x,d
+                    ldd       L0021
+                    beq       L653A
+                    leax      $0484,y
+                    bra       L653E
+
+L653A               leax      $0384,y
+L653E               tfr       x,d
+                    std       $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L6602
+                    leas      $02,s
+                    aslb
+                    rola
+                    addd      $02,s
+                    std       $04,s
+                    ldu       [$04,s]
+                    bra       L6583
+
+L6556               ldb       $14,u
+                    sex
+                    pshs      d
+                    ldb       [$0C,s]
+                    sex
+                    cmpd      ,s++
+L6563               bne       L6580
+L6565               ldd       #$0008
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      $A68C
+                    leas      $06,s
+                    std       -$02,s
+                    beq       L65CA
+L6580               ldu       $12,u
+L6583               stu       -$02,s
+                    bne       L6556
+                    ldu       $0062
+                    beq       L6592
+                    ldd       $12,u
+                    std       $0062
+                    bra       L659E
+
+L6592               ldd       #$001C
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    tfr       d,u
+L659E               ldd       #$0008
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $A64F
+                    leas      $06,s
+                    clra
+                    clrb
+                    std       ,u
+                    clra
+                    clrb
+                    std       $08,u
+                    ldd       [$04,s]
+                    std       $12,u
+                    stu       [$04,s]
+                    ldd       $04,s
+                    std       $0e,u
+L65CA               tfr       u,d
+                    leas      $06,s
+                    puls      pc,u
+L65D0               pshs      u
+                    leas      -$09,s
+                    ldd       #$0008
+                    pshs      d
+                    ldd       $0f,s
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      $A64F
+                    leas      $06,s
+                    clra
+                    clrb
+                    stb       $08,s
+                    leax      ,s
+                    pshs      x
+                    lbsr      L652E
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       #$0033
+                    std       ,u
+                    ldd       $0f,s
+                    std       $08,u
+                    leas      $09,s
+                    puls      pc,u
+L6602               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L6610
+
+L660C               ldd       $02,s
+                    addd      ,s
+L6610               std       $02,s
+                    ldb       ,u+
+                    sex
+                    std       ,s
+                    bne       L660C
+                    ldd       $02,s
+                    clra
+                    andb      #$7f
+                    leas      $04,s
+                    puls      pc,u
+L6622               pshs      u,d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $B253
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L6640
+                    leax      $6DC1,pcr
+                    pshs      x
+                    lbsr      L042D
+                    leas      $02,s
+L6640               ldd       L0046
+                    bne       L6648
+                    ldd       ,s
+                    std       L0046
+L6648               ldd       ,s
+                    addd      $06,s
+                    std       L0048
+                    ldd       ,s
+L6650               leas      $02,s
+                    puls      pc,u
+L6654               pshs      u
+                    ldu       $06,s
+                    leas      -$10,s
+                    clra
+                    clrb
+                    std       $02,s
+                    leax      $08,s
+                    pshs      x
+                    bsr       L666C
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L666C               puls      x
+                    lbsr      $AE34
+                    leax      $08,s
+                    stx       ,s
+                    ldd       $14,s
+                    cmpd      #$0006
+                    bne       L6684
+                    leax      $10,s
+                    lbra      L67BF
+
+L6684               ldb       $0045
+                    cmpb      #$30
+                    lbne      L6791
+                    leas      -$06,s
+                    lbsr      L42CF
+                    ldb       $0045
+                    cmpb      #$2e
+                    bne       L66A0
+                    lbsr      L42CF
+                    leax      $16,s
+                    lbra      L67BF
+
+L66A0               leax      $02,s
+                    pshs      x
+                    bsr       L66AA
+                    neg       $0000
+                    neg       $0000
+L66AA               puls      x
+                    lbsr      LAEDF
+                    ldb       $0045
+                    cmpb      #$78
+                    beq       L66BD
+                    ldb       $0045
+                    cmpb      #$58
+                    lbne      L6733
+L66BD               leas      -$02,s
+                    bra       L66F6
+
+L66C1               leax      $04,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    ldd       #$0004
+                    lbsr      LAEF5
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $06,s
+                    cmpd      #$0041
+                    blt       L66E4
+                    ldd       #$0037
+                    bra       L66E7
+
+L66E4               ldd       #$0030
+L66E7               pshs      d
+                    ldd       $08,s
+                    subd      ,s++
+                    lbsr      LAEC6
+                    lbsr      LAE51
+                    lbsr      LAEDF
+L66F6               lbsr      L42CF
+                    ldb       $0045
+                    sex
+                    pshs      d
+                    lbsr      L6CB1
+                    leas      $02,s
+                    std       ,s
+                    bne       L66C1
+                    leas      $02,s
+                    bra       L673F
+
+L670B               leax      $02,s
+                    pshs      x
+                    leax      $04,s
+                    pshs      x
+                    ldd       #$0003
+                    lbsr      LAEF5
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldb       $0045
+                    sex
+                    addd      #$FFD0
+                    lbsr      LAEC6
+                    lbsr      LAE51
+                    lbsr      LAEDF
+                    lbsr      L42CF
+L6733               ldb       $0045
+                    sex
+                    pshs      d
+                    lbsr      L6C9E
+                    std       ,s++
+                    bne       L670B
+L673F               leax      $02,s
+                    stx       ,s
+                    ldb       $0045
+                    cmpb      #$4C
+                    beq       L674F
+                    ldb       $0045
+                    cmpb      #$6C
+                    bne       L6757
+L674F               lbsr      L42CF
+                    leax      $16,s
+                    bra       L6766
+
+L6757               ldd       [,s]
+                    bne       L6769
+                    ldd       $04,s
+                    std       ,u
+                    ldd       #$0001
+                    bra       L6775
+                    bra       L6769
+
+L6766               leas      -$16,x
+L6769               leax      ,u
+                    pshs      x
+                    leax      $04,s
+                    lbsr      LAEDF
+                    ldd       #$0008
+L6775               leas      $16,s
+                    puls      pc,u
+                    bra       L6791
+
+L677C               ldb       $0045
+                    sex
+                    pshs      d
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      L9990
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L67D5
+                    lbsr      L42CF
+L6791               ldb       $0045
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L677C
+                    ldb       $0045
+                    cmpb      #$2e
+                    beq       L67B4
+                    ldb       $0045
+                    cmpb      #$65
+                    beq       L67B4
+                    ldb       $0045
+                    cmpb      #$45
+                    lbne      L68BB
+L67B4               ldb       $0045
+                    cmpb      #$2e
+                    bne       L67F4
+                    lbsr      L42CF
+                    bra       L67E5
+
+L67BF               leas      -$10,x
+                    bra       L67E5
+
+L67C3               ldb       $0045
+                    sex
+                    pshs      d
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      L9990
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L67DB
+L67D5               lbsr      L42CF
+                    lbra      L68CB
+
+L67DB               lbsr      L42CF
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+L67E5               ldb       $0045
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L67C3
+L67F4               ldd       #$00B8
+                    ldx       ,s
+                    stb       $07,x
+                    leax      $08,s
+                    pshs      x
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      $A731
+                    leas      $02,s
+                    lbsr      $AE34
+                    ldb       $0045
+                    cmpb      #$45
+                    beq       L6819
+                    ldb       $0045
+                    cmpb      #$65
+                    lbne      L6887
+L6819               ldd       #$0001
+                    std       $04,s
+                    lbsr      L42CF
+                    ldb       $0045
+                    cmpb      #$2b
+                    bne       L682C
+                    lbsr      L42CF
+                    bra       L6839
+
+L682C               ldb       $0045
+                    cmpb      #$2d
+                    bne       L6839
+                    lbsr      L42CF
+                    clra
+                    clrb
+                    std       $04,s
+L6839               clra
+                    clrb
+                    std       $06,s
+                    bra       L6858
+
+L683F               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      LAF4B
+                    pshs      d
+                    ldb       $0045
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    lbsr      L42CF
+L6858               ldb       $0045
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L683F
+                    ldd       $06,s
+L6869               cmpd      #$0028
+                    lbge      L68CB
+                    ldd       $02,s
+L6873               pshs      d
+                    ldd       $06,s
+                    beq       L6881
+                    ldd       $08,s
+                    nega
+                    negb
+                    sbca      #$00
+                    bra       L6883
+
+L6881               ldd       $08,s
+L6883               addd      ,s++
+                    std       $02,s
+L6887               ldd       $02,s
+                    bge       L6898
+                    ldd       $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $02,s
+                    ldd       #$0001
+                    bra       L689A
+
+L6898               clra
+                    clrb
+L689A               std       $04,s
+                    leax      ,u
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $0e,s
+                    lbsr      LAE0D
+                    lbsr      L6926
+                    leas      $0C,s
+                    lbsr      $AE34
+                    ldd       #$0006
+                    lbra      L6921
+
+L68BB               ldb       [,s]
+                    bne       L68CB
+                    ldx       ,s
+                    ldb       $01,x
+                    bne       L68CB
+                    ldx       ,s
+                    ldb       $02,x
+                    beq       L68D0
+L68CB               clra
+                    clrb
+                    lbra      L6921
+
+L68D0               ldb       $0045
+                    cmpb      #$6C
+                    beq       L68DC
+                    ldb       $0045
+                    cmpb      #$4C
+                    bne       L68FB
+L68DC               leas      -$02,s
+                    lbsr      L42CF
+                    bra       L68E6
+
+L68E3               leas      -$12,x
+L68E6               ldd       $02,s
+                    addd      #$0003
+                    std       ,s
+                    leax      ,u
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      LAEDF
+                    ldd       #$0008
+                    bra       L691C
+
+L68FB               ldx       ,s
+                    ldb       $03,x
+                    bne       L6907
+                    ldx       ,s
+                    ldb       $04,x
+                    beq       L690C
+L6907               leax      $10,s
+                    bra       L68E3
+
+L690C               leas      -$02,s
+                    ldd       $02,s
+                    addd      #$0005
+                    std       ,s
+                    ldd       [,s]
+                    std       ,u
+                    ldd       #$0001
+L691C               leas      $12,s
+                    puls      pc,u
+L6921               leas      $10,s
+                    puls      pc,u
+L6926               pshs      u
+                    ldd       $0C,s
+                    cmpd      #$0009
+                    ble       L6955
+                    leax      $04,s
+                    pshs      x
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $AFFF
+                    addd      #$0009
+                    pshs      d
+                    leax      $0a,s
+                    lbsr      LAE0D
+                    bsr       L6970
+                    leas      $0C,s
+                    lbsr      $AE34
+L6955               ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $AFAC
+L6963               pshs      d
+                    leax      $08,s
+                    lbsr      LAE0D
+                    bsr       L6970
+L696C               leas      $0C,s
+L696E               puls      pc,u
+L6970               pshs      u
+                    ldd       $0C,s
+L6974               beq       L69B6
+                    leas      -$02,s
+                    leax      $01BA,y
+                    stx       ,s
+                    ldd       ,s
+                    pshs      d
+                    ldd       $10,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      ,s++
+                    std       ,s
+                    ldd       $10,s
+                    beq       L69A0
+                    leax      $06,s
+                    lbsr      LAE0D
+                    ldx       $08,s
+                    lbsr      $A765
+                    bra       L69AA
+
+L69A0               leax      $06,s
+                    lbsr      LAE0D
+                    ldx       $08,s
+                    lbsr      $A76D
+L69AA               leau      $0358,y
+                    pshs      u
+                    lbsr      $AE34
+                    lbra      L6C9A
+
+L69B6               leax      $04,s
+                    leau      $0358,y
+                    pshs      u
+                    lbsr      $AE34
+                    puls      pc,u
+L69C3               pshs      u
+                    lbsr      L42CF
+                    ldb       $0045
+                    cmpb      #$5C
+                    bne       L69D5
+                    lbsr      L6B4B
+                    std       $0041
+                    bra       L69DD
+
+L69D5               ldb       $0045
+                    sex
+                    std       $0041
+                    lbsr      L42CF
+L69DD               ldb       $0045
+                    cmpb      #$27
+                    lbeq      L6ABC
+                    leax      $6DCF,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbra      L6ABF
+
+L69F3               pshs      u
+                    ldx       L0056
+                    bra       L6A27
+
+L69F9               ldd       L004C
+                    bne       L6A1D
+                    leax      $6DEF,pcr
+                    pshs      x
+                    leax      $0096,y
+                    pshs      x
+                    lbsr      L9F43
+                    leas      $04,s
+                    std       L004C
+                    bne       L6A1D
+                    leax      L6DF2,pcr
+                    pshs      x
+                    lbsr      L042D
+                    leas      $02,s
+L6A1D               ldd       L004C
+                    bra       L6A23
+
+L6A21               ldd       $0005
+L6A23               std       $0064
+                    bra       L6A37
+
+L6A27               stx       -$02,s
+                    beq       L69F9
+                    cmpx      #$0002
+                    lbeq      L69F9
+                    cmpx      #$0001
+                    beq       L6A21
+L6A37               clra
+                    clrb
+                    std       $0060
+                    ldd       L0056
+                    cmpd      #$0001
+                    lbeq      L6A99
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $0041
+                    pshs      d
+                    ldd       #$005F
+                    pshs      d
+                    leax      $6E0A,pcr
+                    pshs      x
+                    ldd       $0064
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $08,s
+                    bra       L6A99
+
+L6A66               leax      $0584,y
+                    pshs      x
+                    ldd       $004A
+                    subd      ,s++
+                    bne       L6A7F
+                    leax      L6E0F,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L6AA2
+
+L6A7F               ldb       $0045
+                    cmpb      #$5C
+                    bne       L6A90
+                    lbsr      L6B4B
+                    pshs      d
+                    bsr       L6AC1
+                    leas      $02,s
+                    bra       L6A9C
+
+L6A90               ldb       $0045
+                    sex
+                    pshs      d
+                    bsr       L6AC1
+                    leas      $02,s
+L6A99               lbsr      L42CF
+L6A9C               ldb       $0045
+                    cmpb      #$22
+                    bne       L6A66
+L6AA2               clra
+                    clrb
+                    pshs      d
+                    bsr       L6AC1
+                    leas      $02,s
+                    ldd       $0064
+                    pshs      d
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      $A1CD
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $003D
+L6ABC               lbsr      L42CF
+L6ABF               puls      pc,u
+L6AC1               pshs      u
+                    ldd       $003D
+                    bne       L6AD6
+                    leax      $6E23,pcr
+                    pshs      x
+                    ldd       $0064
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $04,s
+L6AD6               ldd       $04,s
+                    cmpd      #$0020
+                    blt       L6AE6
+                    ldd       $04,s
+                    cmpd      #$0022
+                    bne       L6AFB
+L6AE6               ldd       $04,s
+                    pshs      d
+                    leax      L6E2A,pcr
+                    pshs      x
+                    ldd       $0064
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    bra       L6B27
+
+L6AFB               ldd       $0064
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $A1CD
+                    leas      $04,s
+                    ldd       $003D
+                    addd      #$0001
+                    std       $003D
+                    subd      #$0001
+                    cmpd      #$004B
+                    blt       L6B2B
+                    leax      L6E36,pcr
+                    pshs      x
+                    ldd       $0064
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $04,s
+L6B27               clra
+                    clrb
+                    std       $003D
+L6B2B               ldd       $0060
+                    addd      #$0001
+                    std       $0060
+                    puls      pc,u
+L6B34               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      $6E39,pcr
+                    pshs      x
+                    ldd       $0064
+                    pshs      d
+                    lbsr      L9A34
+                    leas      $06,s
+                    puls      pc,u
+L6B4B               pshs      u,d
+                    lbsr      L42CF
+                    ldb       $0045
+                    sex
+                    tfr       d,u
+                    lbsr      L42CF
+                    leax      ,u
+                    bra       L6B86
+
+L6B5C               ldd       #$000A
+                    lbra      L6C9A
+
+L6B62               ldd       #$0009
+                    lbra      L6C9A
+
+L6B68               ldd       #$0008
+                    lbra      L6C9A
+
+L6B6E               ldd       #$000B
+                    lbra      L6C9A
+
+L6B74               ldd       #$000D
+                    lbra      L6C9A
+
+L6B7A               ldd       #$000C
+                    lbra      L6C9A
+
+L6B80               ldd       #$0020
+                    lbra      L6C9A
+
+L6B86               cmpx      #$006E
+                    beq       L6B74
+                    cmpx      #$006C
+                    beq       L6B5C
+                    cmpx      #$0074
+                    beq       L6B62
+                    cmpx      #$0062
+                    beq       L6B68
+                    cmpx      #$0076
+                    beq       L6B6E
+                    cmpx      #$0072
+                    lbeq      L6B74
+                    cmpx      #$0066
+                    beq       L6B7A
+                    cmpx      #$000D
+                    beq       L6B80
+                    cmpu      #$0078
+                    lbne      L6C0C
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       $02,s
+                    tfr       d,u
+                    bra       L6BE9
+
+L6BC2               tfr       u,d
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0041
+                    bge       L6BDD
+                    ldd       $02,s
+                    addd      #$FFD0
+                    bra       L6BE2
+
+L6BDD               ldd       $02,s
+                    addd      #$FFC9
+L6BE2               addd      ,s++
+                    tfr       d,u
+                    lbsr      L42CF
+L6BE9               ldb       $0045
+                    sex
+                    pshs      d
+                    lbsr      L6CB1
+                    leas      $02,s
+                    std       ,s
+                    beq       L6C07
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+                    subd      #$0001
+                    cmpd      #$0002
+                    blt       L6BC2
+L6C07               leas      $02,s
+                    lbra      L6C98
+
+L6C0C               cmpu      #$0064
+                    bne       L6C54
+                    clra
+                    clrb
+                    std       ,s
+                    tfr       d,u
+                    bra       L6C31
+
+L6C1A               pshs      u
+                    ldd       #$000A
+                    lbsr      LAF4B
+                    pshs      d
+                    ldb       $0045
+                    sex
+                    addd      ,s++
+                    addd      #$FFD0
+                    tfr       d,u
+                    lbsr      L42CF
+L6C31               ldb       $0045
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    lbne      L6C98
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0003
+                    blt       L6C1A
+                    bra       L6C98
+
+L6C54               pshs      u
+                    lbsr      L6C9E
+                    std       ,s++
+                    beq       L6C98
+                    leau      -$30,u
+                    clra
+                    clrb
+L6C62               std       ,s
+                    bra       L6C7D
+
+L6C66               tfr       u,d
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    pshs      d
+                    ldb       $0045
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    tfr       d,u
+                    lbsr      L42CF
+L6C7D               ldb       $0045
+                    sex
+                    pshs      d
+                    bsr       L6C9E
+                    std       ,s++
+                    beq       L6C98
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0003
+                    blt       L6C66
+L6C98               tfr       u,d
+L6C9A               leas      $02,s
+                    puls      pc,u
+L6C9E               pshs      u
+                    ldb       $05,s
+                    cmpb      #$37
+                    bgt       L6CDA
+                    ldb       $05,s
+                    cmpb      #$30
+                    blt       L6CDA
+                    ldd       #$0001
+                    bra       L6CDC
+
+L6CB1               pshs      u
+                    ldb       $05,s
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L6CD5
+                    ldb       $05,s
+                    clra
+                    andb      #$5f
+                    stb       $05,s
+                    cmpd      #$0041
+                    blt       L6CDA
+                    ldb       $05,s
+                    cmpb      #$46
+                    bgt       L6CDA
+L6CD5               ldb       $05,s
+                    sex
+                    bra       L6CDC
+
+L6CDA               clra
+                    clrb
+L6CDC               puls      pc,u
+L6CDE               fcb       $62
+                    fcb       $61
+                    lsr       0,y
+                    com       $08,s
+                    fcb       $61
+                    fcb       $72
+                    fcb       $61
+                    com       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    neg       L0063
+                    clr       $0e,s
+                    com       $7461
+                    jmp       -$0C,s
+                    bra       $6D65
+                    ror       $6572
+                    ror       $0C,s
+                    clr       -$09,s
+                    neg       $0064
+                    clr       -$0b,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       $0066
+                    inc       $0f,s
+                    fcb       $61
+                    lsr       >$0074
+                    rol       L7065
+                    lsr       $05,s
+                    ror       0,x
+L6D13               com       $7461
+                    lsr       L6963
+                    neg       $0073
+                    rol       -$06,s
+                    fcb       $65
+                    clr       $06,s
+                    neg       $0069
+                    jmp       -$0C,s
+                    neg       $0069
+                    jmp       -$0C,s
+                    neg       $0066
+                    inc       $0f,s
+                    fcb       $61
+                    lsr       >L0063
+                    asl       $01,s
+                    fcb       $72
+                    neg       $0073
+                    asl       $0f,s
+                    fcb       $72
+                    lsr       >L0061
+                    fcb       $75
+                    lsr       L6F00
+L6D3F               fcb       $65
+                    asl       $7465
+                    fcb       $72
+                    jmp       0,x
+
+L6D46               lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+                    neg       $0072
+                    fcb       $65
+                    asr       $09,s
+                    com       $7465
+                    fcb       $72
+                    neg       $0067
+                    clr       -$0C,s
+                    clr       0,x
+L6D5B               fcb       $72
+                    fcb       $65
+                    lsr       $7572
+                    jmp       0,x
+
+L6D62               rol       $06,s
+                    neg       $0077
+                    asl       $09,s
+                    inc       $05,s
+                    neg       L0065
+                    inc       -$0d,s
+                    fcb       $65
+                    neg       $0073
+                    asr       L6974
+                    com       $08,s
+                    neg       L0063
+                    fcb       $61
+                    com       L6500
+L6D7C               fcb       $62
+                    fcb       $72
+                    fcb       $65
+                    fcb       $61
+                    fcb       $6b
+                    neg       L0063
+                    clr       $0e,s
+                    lsr       L696E
+                    fcb       $75
+                    fcb       $65
+                    neg       $0064
+                    clr       0,x
+L6D8E               lsr       $05,s
+                    ror       $01,s
+                    fcb       $75
+                    inc       -$0C,s
+                    neg       $0066
+                    clr       -$0e,s
+                    neg       $0073
+                    lsr       L7275
+                    com       -$0C,s
+                    neg       L0075
+                    jmp       $09,s
+                    clr       $0e,s
+                    neg       L0075
+                    jmp       -$0d,s
+                    rol       $07,s
+                    jmp       $05,s
+                    lsr       0,x
+L6DB0               inc       $0f,s
+                    jmp       $07,s
+                    neg       L0065
+                    fcb       $72
+                    fcb       $72
+                    jmp       $0f,s
+                    neg       L006C
+                    com       L6565
+                    fcb       $6b
+                    neg       $006F
+                    fcb       $75
+                    lsr       $206F
+                    ror       0,y
+                    tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       >L0075
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    tst       $09,s
+                    jmp       $01,s
+                    lsr       $6564
+                    bra       L6E40
+                    asl       $01,s
+                    fcb       $72
+                    fcb       $61
+                    com       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L6E4A
+                    clr       $0e,s
+                    com       $7461
+                    jmp       -$0C,s
+                    neg       $0077
+                    bmi       L6DF2
+L6DF2               com       $01,s
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L6E71
+                    lsr       L7269
+                    jmp       $07,s
+                    com       L2066
+                    rol       $0C,s
+                    fcb       $65
+                    neg       L0025
+                    com       $05,y
+                    lsr       0,x
+L6E0F               fcb       $75
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    tst       $09,s
+                    jmp       $01,s
+                    lsr       $6564
+                    bra       $6E90
+                    lsr       L7269
+L6E20               jmp       $07,s
+                    neg       $0020
+                    ror       $03,s
+                    com       0,y
+                    bhi       L6E2A
+L6E2A               bhi       $6E39
+                    bra       L6E94
+                    com       $02,s
+                    bra       $6E56
+                    bcs       L6EAC
+                    tst       $0000
+L6E36               bhi       $6E45
+                    neg       $0020
+                    fcb       $72
+                    dec       $6220
+                    bcs       $6EA4
+L6E40               tst       $0000
+L6E42               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+L6E4A               ldu       $04,s
+                    pshs      u
+                    lbsr      L6EAC
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0070
+                    beq       L6EAA
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+L6E71               ldd       #$0070
+L6E74               bra       L6EA8
+
+L6E76               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    pshs      u
+                    lbsr      L7E9C
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0071
+                    beq       L6EAA
+                    pshs      u
+                    ldd       #$0077
+L6E94               pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0071
+L6EA8               std       $06,u
+L6EAA               puls      pc,u
+L6EAC               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldx       ,u
+                    bra       L6ED7
+
+L6EBA               pshs      u
+                    lbsr      L34BE
+                    bra       L6ED3
+
+L6EC1               pshs      u
+                    lbsr      $3987
+                    bra       L6ED3
+
+L6EC8               pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    pshs      u
+                    bsr       L6EEC
+L6ED3               leas      $02,s
+                    bra       L6EEA
+
+L6ED7               cmpx      #$0008
+                    beq       L6EBA
+                    cmpx      #$0005
+                    beq       L6EC1
+                    cmpx      #$0006
+                    lbeq      L6EC1
+                    bra       L6EC8
+
+L6EEA               puls      pc,u
+L6EEC               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldx       $06,u
+                    lbra      L6F5F
+
+L6EFB               pshs      u
+                    ldd       #$0077
+L6F00               pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0071
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L6F81
+
+L6F1D               ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    clra
+                    clrb
+                    std       $08,u
+                    ldd       #$0071
+                    bra       L6F5B
+
+L6F3E               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L6F58
+                    leas      ,x
+L6F58               ldd       #$0070
+L6F5B               std       $06,u
+                    bra       L6F81
+
+L6F5F               cmpx      #$0037
+                    lbeq      L6EFB
+                    cmpx      #$0041
+L6F69               beq       L6F1D
+                    cmpx      #$0071
+                    beq       L6F81
+                    cmpx      #$0070
+                    beq       L6F81
+                    cmpx      #$006F
+                    beq       L6F81
+                    cmpx      #$0076
+                    beq       L6F81
+                    bra       L6F3E
+
+L6F81               puls      pc,u
+L6F83               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    std       ,s
+                    cmpd      #$0030
+                    bne       L6FCC
+                    leas      -$02,s
+                    ldd       $0C,u
+                    std       ,s
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L6F83
+                    std       ,s
+                    lbsr      L0598
+                    leas      $02,s
+                    pshs      u
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L05C9
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L05B9
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    leas      $02,s
+                    lbra      L7176
+
+L6FCC               ldd       ,u
+                    cmpd      #$0008
+                    bne       L6FDE
+                    pshs      u
+                    lbsr      L34D9
+                    leas      $02,s
+                    lbra      L7176
+
+L6FDE               ldd       ,u
+                    cmpd      #$0005
+                    beq       L6FEE
+                    ldd       ,u
+                    cmpd      #$0006
+                    bne       L6FF8
+L6FEE               pshs      u
+                    lbsr      L39A2
+                    leas      $02,s
+                    lbra      L7176
+
+L6FF8               ldd       ,s
+                    pshs      d
+                    lbsr      L06A0
+                    std       ,s++
+                    beq       L7011
+                    pshs      u
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L717C
+                    leas      $04,s
+                    lbra      L7176
+
+L7011               ldx       ,s
+                    lbra      L70DD
+
+L7016               pshs      u
+                    lbsr      L77E6
+                    lbra      L70A6
+
+L701E               ldd       $0a,u
+                    pshs      d
+                    lbsr      L6F83
+                    lbra      L70A6
+
+L7028               ldd       $0a,u
+                    pshs      d
+                    lbsr      L34D9
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0084
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L708D
+
+L7046               ldd       $0a,u
+                    pshs      d
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       #$008F
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    bra       L708B
+
+L705E               pshs      u
+                    lbsr      L7BD2
+                    bra       L70A6
+
+L7065               pshs      u
+                    lbsr      L74CB
+                    bra       L70A6
+
+L706C               ldd       $0a,u
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4623
+                    leas      $02,s
+                    bra       L708D
+
+L7080               leax      L6E42,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L7567
+L708B               leas      $04,s
+L708D               ldd       #$0070
+                    std       $06,u
+                    lbra      L7176
+
+L7095               ldd       #$0070
+                    pshs      d
+                    pshs      u
+                    lbsr      L7D19
+                    bra       L70D8
+
+L70A1               pshs      u
+                    lbsr      L75E3
+L70A6               leas      $02,s
+                    lbra      L7176
+
+L70AB               ldd       ,s
+                    cmpd      #$00A0
+                    blt       L70BE
+                    ldd       ,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L794A
+                    bra       L70D8
+
+L70BE               leax      L8153,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0464
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    leax      L815F,pcr
+                    pshs      x
+                    lbsr      L9A1F
+L70D8               leas      $04,s
+                    lbra      L7176
+
+L70DD               cmpx      #$0037
+                    lbeq      L7176
+                    cmpx      #$0034
+                    lbeq      L7176
+                    cmpx      #$0076
+                    lbeq      L7176
+                    cmpx      #$006F
+                    lbeq      L7176
+                    cmpx      #$0041
+                    beq       L7176
+                    cmpx      #$0036
+                    beq       L7176
+                    cmpx      #$0078
+                    lbeq      L7016
+                    cmpx      #$0085
+                    lbeq      L701E
+                    cmpx      #$0084
+                    lbeq      L7028
+                    cmpx      #$008F
+                    lbeq      L7046
+                    cmpx      #$0042
+                    lbeq      L705E
+                    cmpx      #$0040
+                    lbeq      L7065
+                    cmpx      #$0047
+                    lbeq      L7065
+                    cmpx      #$0048
+                    lbeq      L7065
+                    cmpx      #$0044
+                    lbeq      L706C
+                    cmpx      #$0043
+                    lbeq      L706C
+                    cmpx      #$0064
+                    lbeq      L7080
+                    cmpx      #$003C
+                    lbeq      L7095
+                    cmpx      #$003E
+                    lbeq      L7095
+                    cmpx      #$003D
+                    lbeq      L7095
+                    cmpx      #$003F
+                    lbeq      L7095
+                    cmpx      #$0065
+                    lbeq      L70A1
+                    lbra      L70AB
+
+L7176               tfr       u,d
+                    leas      $02,s
+                    puls      pc,u
+L717C               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    leas      -$06,s
+                    ldx       $0C,s
+                    ldu       $0a,x
+                    ldx       $0C,s
+                    ldd       $0C,x
+                    std       $04,s
+                    ldd       ,u
+                    cmpd      #$0007
+                    bne       L71BE
+                    ldx       $0a,s
+                    bra       L71AD
+
+L719C               ldd       #$004E
+                    bra       L71A9
+
+L71A1               ldd       #$004C
+                    bra       L71A9
+
+L71A6               ldd       #$004D
+L71A9               std       $0a,s
+                    bra       L71F2
+
+L71AD               cmpx      #$0053
+                    beq       L719C
+                    cmpx      #$0054
+                    beq       L71A1
+                    cmpx      #$0055
+                    beq       L71A6
+                    bra       L71F2
+
+L71BE               ldx       $0a,s
+                    bra       L71E6
+
+L71C2               ldd       $06,u
+                    cmpd      #$0041
+                    bne       L71F2
+                    ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    beq       L71F2
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L7E9C
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $0066
+                    lbra      L75DF
+                    bra       L71F2
+
+L71E6               cmpx      #$0050
+                    beq       L71C2
+                    cmpx      #$0051
+                    lbeq      L71C2
+L71F2               ldx       $0a,s
+                    lbra      L73E6
+
+L71F7               ldd       $04,s
+                    pshs      d
+                    lbsr      L9754
+                    std       ,s++
+L7200               bne       L7229
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L6EAC
+                    leas      $02,s
+                    ldx       $04,s
+                    ldd       $06,x
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       #$006E
+                    ldx       $04,s
+L7220               std       $06,x
+                    pshs      u
+                    lbsr      L6E42
+                    bra       L7237
+
+L7229               pshs      u
+                    lbsr      L6E42
+L722E               leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L6F83
+L7237               leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0051
+                    lbra      L72E2
+
+L724D               pshs      u
+                    lbsr      L9754
+                    std       ,s++
+                    beq       L7261
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L9754
+                    std       ,s++
+                    beq       L7269
+L7261               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L7275
+L7269               leas      -$02,s
+                    stu       ,s
+                    ldu       $06,s
+L726F               ldd       ,s
+                    std       $06,s
+                    leas      $02,s
+L7275               ldd       $06,u
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    beq       L72A0
+                    ldd       $06,u
+L7282               pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       #$006E
+                    ldx       $04,s
+                    std       $06,x
+                    bra       L72D1
+
+L72A0               pshs      u
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L9754
+                    std       ,s++
+                    bne       L72B7
+                    ldd       #$0070
+                    bra       L7282
+
+L72B7               ldd       $04,s
+                    pshs      d
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldd       $0a,s
+                    cmpd      #$0050
+                    beq       L72D1
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L77AC
+                    leas      $02,s
+L72D1               ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $10,s
+L72E2               pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    lbra      L748C
+
+L72EC               ldd       $0C,s
+                    pshs      d
+                    lbsr      L74CB
+                    lbra      L73CF
+
+L72F6               ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L735A
+                    ldx       $04,s
+                    ldd       $08,x
+                    std       ,s
+                    bra       L730C
+
+L730A               leas      -$06,x
+L730C               ldd       ,s
+                    cmpd      #$0004
+                    bhi       L735A
+                    pshs      u
+                    lbsr      L6E42
+L7319               leas      $02,s
+                    bra       L7344
+
+L731D               ldx       $0a,s
+                    bra       L7335
+
+L7321               ldd       #$0098
+                    bra       L732E
+
+L7326               ldd       #$0096
+                    bra       L732E
+
+L732B               ldd       #$0097
+L732E               pshs      d
+                    lbsr      L4623
+                    bra       L7319
+
+L7335               cmpx      #$0056
+                    beq       L7321
+                    cmpx      #$0055
+                    beq       L7326
+                    cmpx      #$004D
+                    beq       L732B
+L7344               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bne       L731D
+                    ldd       #$0001
+                    std       $0066
+                    leax      $06,s
+                    lbra      L7492
+
+L735A               leax      $06,s
+                    bra       L73A8
+
+L735E               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L7372
+                    leas      -$02,s
+L7368               stu       ,s
+                    ldu       $06,s
+                    ldd       ,s
+                    std       $06,s
+                    leas      $02,s
+L7372               ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L73AA
+                    ldx       $04,s
+                    ldd       $08,x
+                    pshs      d
+                    lbsr      L749E
+                    leas      $02,s
+                    std       ,s
+                    beq       L73AA
+                    ldd       ,s
+                    ldx       $04,s
+                    std       $08,x
+                    ldd       $0a,s
+                    cmpd      #$0052
+                    bne       L739E
+                    ldd       #$0056
+                    bra       L73A1
+
+L739E               ldd       #$004D
+L73A1               std       $0a,s
+                    leax      $06,s
+                    lbra      L730A
+
+L73A8               leas      -$06,x
+L73AA               pshs      u
+                    lbsr      L6EAC
+                    leas      $02,s
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4623
+L73CF               leas      $02,s
+                    lbra      L748C
+
+L73D4               leax      L8163,pcr
+                    pshs      x
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L0464
+                    leas      $04,s
+                    lbra      L748C
+
+L73E6               cmpx      #$0051
+                    lbeq      L71F7
+                    cmpx      #$0057
+                    lbeq      L724D
+                    cmpx      #$0058
+                    lbeq      L724D
+                    cmpx      #$0059
+                    lbeq      L724D
+                    cmpx      #$0050
+                    lbeq      L724D
+                    cmpx      #$005A
+                    lbeq      L72EC
+                    cmpx      #$005B
+                    lbeq      L72EC
+                    cmpx      #$005F
+                    lbeq      L72EC
+                    cmpx      #$005D
+                    lbeq      L72EC
+                    cmpx      #$005C
+                    lbeq      L72EC
+                    cmpx      #$005E
+                    lbeq      L72EC
+                    cmpx      #$0063
+                    lbeq      L72EC
+                    cmpx      #$0061
+                    lbeq      L72EC
+                    cmpx      #$0060
+                    lbeq      L72EC
+                    cmpx      #$0062
+                    lbeq      L72EC
+                    cmpx      #$004D
+                    lbeq      L72F6
+                    cmpx      #$0055
+                    lbeq      L72F6
+                    cmpx      #$0056
+                    lbeq      L72F6
+                    cmpx      #$0052
+                    lbeq      L735E
+L746B               cmpx      #$004E
+                    lbeq      L7372
+L7472               cmpx      #$0053
+                    lbeq      L73AA
+                    cmpx      #$004C
+                    lbeq      L73AA
+                    cmpx      #$0054
+                    lbeq      L73AA
+                    lbra      L73D4
+                    leas      -$06,x
+L748C               clra
+                    clrb
+                    std       $0066
+                    bra       L7494
+
+L7492               leas      -$06,x
+L7494               ldd       #$0070
+                    ldx       $0C,s
+                    std       $06,x
+                    lbra      L75DF
+
+L749E               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldu       #$0000
+                    bra       L74C2
+
+L74AB               tfr       u,d
+                    leau      $01,u
+                    aslb
+                    rola
+                    leax      $0222,y
+                    leax      d,x
+                    ldd       ,x
+                    cmpd      $04,s
+                    bne       L74C2
+                    tfr       u,d
+                    puls      pc,u
+L74C2               cmpu      #$000E
+                    blt       L74AB
+                    lbra      L77A8
+
+L74CB               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $02,s
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L939D
+                    leas      $08,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       #$0070
+                    std       $06,u
+                    lbra      L7D15
+
+L7567               pshs      u
+                    ldd       #$FFAE
+L756C               lbsr      L010F
+                    ldu       $04,s
+                    leas      -$06,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $02,s
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $08,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L939D
+                    leas      $08,s
+                    ldu       $0C,u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    jsr       [$0e,s]
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    jsr       [$0e,s]
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L57B2
+                    leas      $02,s
+L75DF               leas      $06,s
+                    puls      pc,u
+L75E3               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L010F
+                    leas      -$04,s
+                    ldd       $000F
+                    std       ,s
+                    ldd       $08,s
+                    std       $02,s
+                    lbra      L7680
+
+L75F8               ldx       $02,s
+                    ldu       $0a,x
+                    ldd       ,u
+                    cmpd      #$0008
+                    bne       L7627
+                    ldd       $06,u
+                    cmpd      #$004A
+                    bne       L7616
+                    pshs      u
+                    lbsr      L38E8
+                    leas      $02,s
+                    lbra      L7680
+
+L7616               pshs      u
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0088
+                    bra       L7679
+
+L7627               ldd       ,u
+                    cmpd      #$0005
+                    beq       L7637
+                    ldd       ,u
+                    cmpd      #$0006
+                    bne       L7648
+L7637               pshs      u
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0087
+                    bra       L7679
+
+L7648               pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L765C
+
+L7653               pshs      u
+                    lbsr      L6EEC
+                    leas      $02,s
+                    bra       L7672
+
+L765C               cmpx      #$0070
+                    beq       L7672
+                    cmpx      #$0071
+                    beq       L7672
+                    cmpx      #$006F
+                    beq       L7672
+                    cmpx      #$0076
+                    beq       L7672
+                    bra       L7653
+
+L7672               ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+L7679               pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+L7680               ldx       $02,s
+                    ldd       $0C,x
+                    std       $02,s
+                    lbne      L75F8
+                    ldx       $08,s
+                    ldd       $0a,x
+                    pshs      d
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldx       $08,s
+                    ldd       $0a,x
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0065
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L57E3
+                    leas      $02,s
+                    std       $000F
+                    ldd       #$0070
+                    ldx       $08,s
+                    std       $06,x
+                    lbra      L7D15
+
+L76BF               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldx       $06,u
+                    bra       L7704
+
+L76CF               ldd       $0a,u
+                    std       ,s
+                    tfr       d,x
+                    ldx       $06,x
+                    bra       L76E8
+
+L76D9               ldd       #$0001
+                    bra       L7719
+
+L76DE               ldd       ,s
+                    pshs      d
+                    bsr       L771D
+                    leas      $02,s
+                    bra       L7719
+
+L76E8               cmpx      #$0036
+                    beq       L76D9
+                    cmpx      #$0034
+                    lbeq      L76D9
+                    cmpx      #$0076
+                    lbeq      L76D9
+                    cmpx      #$006F
+                    lbeq      L76D9
+                    bra       L76DE
+
+L7704               cmpx      #$0034
+                    lbeq      L76D9
+                    cmpx      #$0036
+                    lbeq      L76D9
+                    cmpx      #$0042
+                    beq       L76CF
+                    clra
+                    clrb
+L7719               leas      $02,s
+                    puls      pc,u
+L771D               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldx       $06,u
+                    bra       L774B
+
+L772B               ldx       $0a,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    lbeq      L77A8
+                    ldx       $0C,u
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L77A8
+                    bra       L7789
+                    lbra      L77A8
+
+L774B               cmpx      #$0050
+                    beq       L772B
+                    cmpx      #$0051
+                    lbeq      L772B
+                    bra       L77A8
+
+L7759               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldx       $04,s
+                    ldd       $12,x
+                    cmpd      #$0002
+                    bge       L77A8
+                    ldd       #$0001
+                    bra       L77AA
+
+L7771               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldx       $06,u
+                    bra       L7790
+
+L777F               ldx       $0a,u
+                    ldd       $06,x
+                    cmpd      #$0041
+                    bne       L77A8
+L7789               ldd       #$0001
+                    puls      pc,u
+                    bra       L77A8
+
+L7790               cmpx      #$0050
+                    beq       L777F
+                    cmpx      #$0051
+                    lbeq      L777F
+                    cmpx      #$0037
+                    beq       L7789
+                    cmpx      #$0041
+                    lbeq      L7789
+L77A8               clra
+                    clrb
+L77AA               puls      pc,u
+L77AC               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L77E4
+                    ldd       $06,u
+                    anda      #$7f
+                    std       $06,u
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0093
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+L77E4               puls      pc,u
+L77E6               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    leas      -$04,s
+                    ldx       $08,s
+                    ldd       $0C,x
+                    std       ,s
+                    ldx       $08,s
+                    ldu       $0a,x
+                    ldd       $06,u
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    lbeq      L787C
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L771D
+                    std       ,s++
+                    beq       L781B
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L7E9C
+                    bra       L7822
+
+L781B               ldd       ,s
+                    pshs      d
+                    lbsr      L6F83
+L7822               leas      $02,s
+                    ldx       ,s
+                    ldx       $06,x
+                    bra       L7870
+
+L782A               ldx       ,s
+                    ldd       $0a,x
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$007F
+                    bra       L7866
+
+L783E               ldd       ,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+L7856               ldd       ,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$0075
+L7866               pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    lbra      L7A13
+
+L7870               cmpx      #$0041
+                    beq       L782A
+                    cmpx      #$0085
+                    beq       L783E
+                    bra       L7856
+
+L787C               pshs      u
+                    lbsr      L76BF
+                    std       ,s++
+                    beq       L78B4
+                    ldd       ,u
+                    cmpd      #$0002
+                    beq       L78B4
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L771D
+                    std       ,s++
+                    bne       L78A3
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L7771
+                    std       ,s++
+                    beq       L78B4
+L78A3               pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L7E63
+                    lbra      L792A
+
+L78B4               ldx       ,s
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    beq       L78DB
+                    pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldd       ,u
+                    cmpd      #$0002
+                    lbne      L792C
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L6E42
+                    bra       L792A
+
+L78DB               pshs      u
+                    lbsr      L7759
+                    std       ,s++
+                    beq       L78F4
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L6F83
+                    bra       L792A
+
+L78F4               pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L76BF
+                    std       ,s++
+                    bne       L7923
+                    ldd       $06,u
+                    anda      #$7f
+                    tfr       d,x
+                    bra       L7917
+
+L790E               pshs      u
+                    lbsr      L7B83
+                    leas      $02,s
+                    bra       L7923
+
+L7917               cmpx      #$0095
+                    beq       L7923
+                    cmpx      #$0094
+                    beq       L7923
+                    bra       L790E
+
+L7923               ldd       ,s
+                    pshs      d
+                    lbsr      L6EAC
+L792A               leas      $02,s
+L792C               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldx       $04,s
+                    ldd       $06,x
+                    pshs      d
+                    ldd       #$0079
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldx       ,s
+                    ldd       $06,x
+                    lbra      L7A15
+
+L794A               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    leas      -$04,s
+                    ldx       $08,s
+                    ldd       $0C,x
+                    std       $02,s
+                    ldx       $08,s
+                    ldu       $0a,x
+                    pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldd       $0a,s
+                    addd      #$FFB0
+                    std       $0a,s
+                    ldd       ,u
+L796E               cmpd      #$0007
+                    bne       L7998
+                    ldx       $0a,s
+                    bra       L7989
+
+L7978               ldd       #$004E
+                    bra       L7985
+
+L797D               ldd       #$004D
+                    bra       L7985
+
+L7982               ldd       #$004C
+L7985               std       $0a,s
+                    bra       L7998
+
+L7989               cmpx      #$0053
+                    beq       L7978
+                    cmpx      #$0055
+                    beq       L797D
+                    cmpx      #$0054
+                    beq       L7982
+L7998               ldd       $06,u
+                    anda      #$7f
+                    std       ,s
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    lbeq      L7A6E
+                    ldx       $0a,s
+                    lbra      L7A49
+
+L79AE               ldx       $02,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L79E5
+                    ldd       $0a,s
+                    cmpd      #$0050
+                    bne       L79C6
+                    ldx       $02,s
+                    ldd       $08,x
+                    bra       L79CE
+
+L79C6               ldx       $02,s
+                    ldd       $08,x
+                    nega
+                    negb
+                    sbca      #$00
+L79CE               pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0074
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L7A13
+
+L79E5               ldd       $02,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       $0a,s
+                    cmpd      #$0051
+                    bne       L7A00
+                    ldd       #$0043
+                    pshs      d
+                    lbsr      L4623
+                    leas      $02,s
+L7A00               ldd       #$0070
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0074
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L7A13               ldd       $06,u
+L7A15               ldx       $08,s
+                    std       $06,x
+                    clra
+                    clrb
+                    ldx       $08,s
+                    std       $08,x
+                    lbra      L7D15
+
+L7A22               leax      $04,s
+                    bra       L7A6C
+
+L7A26               ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4623
+                    leas      $02,s
+                    lbra      L7B63
+
+L7A49               cmpx      #$0050
+                    lbeq      L79AE
+                    cmpx      #$0051
+                    lbeq      L79AE
+                    cmpx      #$0057
+                    beq       L7A22
+                    cmpx      #$0058
+                    lbeq      L7A22
+                    cmpx      #$0059
+                    lbeq      L7A22
+                    bra       L7A26
+
+L7A6C               leas      -$04,x
+L7A6E               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       ,u
+                    cmpd      #$0002
+                    bne       L7A96
+                    ldd       #$0085
+                    pshs      d
+                    lbsr      L4623
+                    leas      $02,s
+L7A96               ldx       $0a,s
+                    lbra      L7B3D
+
+L7A9B               ldd       $02,s
+                    pshs      d
+                    lbsr      L76BF
+                    std       ,s++
+                    beq       L7AEC
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldx       $0a,s
+                    bra       L7ABE
+
+L7AB3               ldd       $02,s
+                    pshs      d
+                    lbsr      L77AC
+                    leas      $02,s
+                    bra       L7AD1
+
+L7ABE               cmpx      #$0057
+                    beq       L7AB3
+                    cmpx      #$0058
+                    lbeq      L7AB3
+                    cmpx      #$0059
+                    lbeq      L7AB3
+L7AD1               ldd       $02,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    lbra      L7B63
+
+L7AEC               ldd       ,s
+                    cmpd      #$0094
+                    beq       L7B03
+                    ldd       ,s
+                    cmpd      #$0095
+                    beq       L7B03
+                    pshs      u
+                    lbsr      L7B83
+                    leas      $02,s
+L7B03               ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       $0a,s
+                    cmpd      #$0051
+                    bne       L7B28
+                    ldd       #$004F
+                    std       $0a,s
+L7B28               ldd       #$006E
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L7B63
+
+L7B3D               cmpx      #$0057
+                    lbeq      L7A9B
+                    cmpx      #$0058
+                    lbeq      L7A9B
+                    cmpx      #$0059
+                    lbeq      L7A9B
+                    cmpx      #$0050
+                    lbeq      L7A9B
+                    cmpx      #$0051
+                    lbeq      L7A9B
+                    lbra      L7AEC
+
+L7B63               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0079
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0070
+                    ldx       $08,s
+                    std       $06,x
+                    lbra      L7D15
+
+L7B83               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       $06,u
+                    anda      #$7f
+                    cmpd      #$0034
+                    bne       L7B99
+                    puls      pc,u
+L7B99               pshs      u
+                    lbsr      L77AC
+                    leas      $02,s
+                    ldd       $08,u
+                    beq       L7BBC
+                    ldd       $08,u
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0074
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+L7BBC               ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       #$806E
+                    std       $06,u
+                    puls      pc,u
+L7BD2               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $0a,u
+                    std       $02,s
+                    pshs      d
+                    lbsr      L7E9C
+                    leas      $02,s
+                    ldx       $02,s
+                    ldd       $06,x
+                    std       ,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    lbeq      L7C56
+                    ldd       ,s
+                    anda      #$7f
+                    std       ,s
+                    tfr       d,x
+                    bra       L7C2E
+
+L7C02               ldx       $02,s
+                    ldd       $08,x
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L7C4A
+
+L7C1D               leax      L816E,pcr
+                    pshs      x
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0464
+                    leas      $04,s
+                    bra       L7C4A
+
+L7C2E               cmpx      #$0034
+                    beq       L7C02
+                    cmpx      #$0093
+                    lbeq      L7C02
+                    cmpx      #$0094
+                    lbeq      L7C02
+                    cmpx      #$0095
+                    lbeq      L7C02
+                    bra       L7C1D
+
+L7C4A               ldd       #$8093
+                    std       ,s
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L7D11
+
+L7C56               ldx       ,s
+                    lbra      L7CD2
+
+L7C5B               ldd       #$0095
+                    bra       L7C6E
+
+L7C60               ldd       #$0094
+                    bra       L7C6E
+
+L7C65               ldd       #$0093
+                    bra       L7C6E
+
+L7C6A               ldd       ,s
+                    ora       #$80
+L7C6E               std       ,s
+                    leax      $04,s
+                    bra       L7C83
+
+L7C74               ldd       #$8034
+                    std       ,s
+                    ldx       $02,s
+                    ldd       $14,x
+                    std       $14,u
+                    bra       L7C85
+
+L7C83               leas      -$04,x
+L7C85               ldx       $02,s
+                    ldd       $08,x
+                    bra       L7CAA
+
+L7C8B               ldd       $02,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0093
+                    std       ,s
+                    clra
+                    clrb
+L7CAA               std       $08,u
+                    bra       L7D11
+
+L7CAE               clra
+                    clrb
+                    std       $08,u
+                    ldx       $02,s
+                    ldd       $08,x
+                    std       $14,u
+                    ldd       #$0034
+                    bra       L7CCE
+
+L7CBE               leax      L817A,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0464
+                    leas      $04,s
+                    ldd       #$0093
+L7CCE               std       ,s
+                    bra       L7D11
+
+L7CD2               cmpx      #$006F
+                    lbeq      L7C5B
+                    cmpx      #$0076
+                    lbeq      L7C60
+                    cmpx      #$0071
+                    lbeq      L7C65
+                    cmpx      #$0093
+                    lbeq      L7C6A
+                    cmpx      #$0094
+                    lbeq      L7C6A
+                    cmpx      #$0095
+                    lbeq      L7C6A
+                    cmpx      #$0034
+                    lbeq      L7C74
+                    cmpx      #$0070
+                    lbeq      L7C8B
+                    cmpx      #$0036
+                    beq       L7CAE
+                    bra       L7CBE
+
+L7D11               ldd       ,s
+                    std       $06,u
+L7D15               leas      $04,s
+                    puls      pc,u
+L7D19               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L010F
+                    leas      -$08,s
+                    ldx       $0C,s
+                    ldu       $0a,x
+                    pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldx       $0C,s
+                    ldd       $06,x
+                    std       $02,s
+                    ldd       $06,u
+                    std       ,s
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    beq       L7D79
+                    ldx       $02,s
+                    bra       L7D6B
+
+L7D45               ldd       $0e,s
+                    cmpd      #$0070
+                    bne       L7D65
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L7DAA
+
+L7D65               ldd       ,s
+                    std       $0e,s
+                    bra       L7DAA
+
+L7D6B               cmpx      #$003E
+                    beq       L7D45
+                    cmpx      #$003F
+                    lbeq      L7D45
+                    bra       L7D65
+
+L7D79               ldd       $0e,s
+                    cmpd      #$0071
+                    bne       L7D90
+                    ldd       ,s
+                    anda      #$7f
+                    cmpd      #$0034
+                    beq       L7D90
+                    ldd       #$0070
+                    std       $0e,s
+L7D90               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       $0e,s
+                    std       ,s
+L7DAA               ldx       $0C,s
+                    ldd       $08,x
+                    std       $06,s
+                    ldx       $02,s
+                    bra       L7DEF
+
+L7DB4               ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+L7DBC               ldd       ,s
+                    cmpd      #$0070
+                    bne       L7DD6
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0050
+                    bra       L7DE6
+
+L7DD6               ldd       $06,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0074
+L7DE6               pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L7DFD
+
+L7DEF               cmpx      #$003D
+                    beq       L7DB4
+                    cmpx      #$003F
+                    lbeq      L7DB4
+                    bra       L7DBC
+
+L7DFD               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0079
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldx       $02,s
+                    bra       L7E48
+
+L7E16               clra
+                    clrb
+                    bra       L7E42
+
+L7E1A               ldd       ,s
+                    cmpd      #$0070
+                    bne       L7E3C
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0051
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L7E56
+
+L7E3C               ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+L7E42               ldx       $0C,s
+                    std       $08,x
+                    bra       L7E56
+
+L7E48               cmpx      #$003E
+                    beq       L7E1A
+                    cmpx      #$003F
+                    lbeq      L7E1A
+                    bra       L7E16
+
+L7E56               ldd       $0e,s
+                    ldx       $0C,s
+                    std       $06,x
+                    clra
+                    clrb
+                    std       $0066
+                    lbra      L812E
+
+L7E63               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010F
+                    ldu       $04,s
+                    pshs      u
+                    bsr       L7E9C
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0071
+                    bne       L7E7F
+                    ldd       $08,u
+                    beq       L7E95
+L7E7F               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+L7E95               ldd       #$0071
+                    std       $06,u
+                    puls      pc,u
+L7E9C               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L010F
+                    leas      -$08,s
+                    ldx       $0C,s
+                    ldu       $0a,x
+                    ldx       $0C,s
+                    ldd       $0C,x
+                    std       $06,s
+                    ldd       #$0071
+                    std       ,s
+                    ldx       $0C,s
+                    ldd       $06,x
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L80CE
+
+L7EC0               ldd       $0C,s
+                    pshs      d
+                    lbsr      L7BD2
+                    lbra      L80CA
+
+L7ECA               ldd       #$0071
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L7D19
+                    leas      $04,s
+                    lbra      L812E
+
+L7EDB               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    clra
+                    clrb
+                    lbra      L80BB
+
+L7EF6               ldd       $0C,s
+                    pshs      d
+                    lbsr      L6E42
+                    lbra      L80CA
+
+L7F00               ldd       $06,u
+                    cmpd      #$0041
+                    beq       L7F11
+                    ldx       $06,s
+                    ldd       $12,x
+                    lbne      L7FAF
+L7F11               ldd       $06,u
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    bne       L7F24
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L7F78
+L7F24               ldx       $06,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L7F40
+                    pshs      u
+                    lbsr      L7E9C
+                    leas      $02,s
+                    ldd       $06,u
+                    std       ,s
+                    ldx       $06,s
+                    ldd       $08,x
+                    lbra      L80A5
+
+L7F40               ldd       $06,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L7E9C
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0051
+                    bne       L7F62
+                    ldd       #$0043
+                    pshs      d
+                    lbsr      L4623
+                    leas      $02,s
+L7F62               ldd       $06,u
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    lbra      L80A3
+
+L7F78               ldd       $02,s
+                    cmpd      #$0050
+                    bne       L7F97
+                    ldd       $12,u
+                    ldx       $06,s
+                    cmpd      $12,x
+                    bge       L7F97
+                    leas      -$02,s
+                    stu       ,s
+                    ldu       $08,s
+                    ldd       ,s
+                    std       $08,s
+                    leas      $02,s
+L7F97               ldd       $06,s
+                    pshs      d
+                    lbsr      L76BF
+                    std       ,s++
+                    bne       L7FB4
+                    ldx       $06,s
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    bne       L7FB4
+L7FAF               leax      $08,s
+                    lbra      L80C1
+
+L7FB4               pshs      u
+                    lbsr      L7E9C
+                    leas      $02,s
+                    ldd       $06,u
+                    anda      #$7f
+                    tfr       d,x
+                    lbra      L8019
+
+L7FC4               ldd       $02,s
+                    cmpd      #$0050
+                    bne       L7FE8
+                    ldx       $06,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    beq       L7FE8
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L6E76
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $08,u
+                    leax      $08,s
+                    lbra      L8089
+
+L7FE8               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    clra
+                    clrb
+L8000               std       $08,u
+L8002               bra       L8054
+
+L8004               ldd       $06,u
+                    std       ,s
+                    bra       L8054
+
+L800A               leax      L8186,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0464
+                    leas      $04,s
+                    bra       L8054
+
+L8019               cmpx      #$0070
+                    lbeq      L7FC4
+                    cmpx      #$0034
+                    beq       L7FE8
+                    cmpx      #$0037
+                    lbeq      L7FE8
+                    cmpx      #$0093
+                    lbeq      L7FE8
+                    cmpx      #$0094
+                    lbeq      L7FE8
+                    cmpx      #$0095
+                    lbeq      L7FE8
+                    cmpx      #$0071
+                    beq       L8054
+                    cmpx      #$0076
+                    beq       L8004
+                    cmpx      #$006F
+                    lbeq      L8004
+                    bra       L800A
+
+L8054               ldx       $06,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L8064
+                    ldx       $06,s
+                    ldd       $08,x
+                    bra       L80A5
+
+L8064               ldd       $06,s
+                    pshs      d
+                    lbsr      L6E42
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0051
+                    bne       L808B
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0043
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L808B
+
+L8089               leas      -$08,x
+L808B               ldd       ,s
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    ldd       #$0071
+                    std       ,s
+L80A3               clra
+                    clrb
+L80A5               std       $04,s
+                    ldd       $02,s
+                    cmpd      #$0050
+                    bne       L80B3
+                    ldd       $04,s
+                    bra       L80B9
+
+L80B3               ldd       $04,s
+                    nega
+                    negb
+                    sbca      #$00
+L80B9               addd      $08,u
+L80BB               ldx       $0C,s
+                    std       $08,x
+                    bra       L8128
+
+L80C1               leas      -$08,x
+L80C3               ldd       $0C,s
+                    pshs      d
+                    lbsr      L6F83
+L80CA               leas      $02,s
+                    bra       L812E
+
+L80CE               cmpx      #$0042
+                    lbeq      L7EC0
+                    cmpx      #$0034
+                    beq       L812E
+                    cmpx      #$0076
+                    beq       L812E
+                    cmpx      #$006F
+                    beq       L812E
+                    cmpx      #$0036
+                    beq       L812E
+                    cmpx      #$0037
+                    beq       L812E
+                    cmpx      #$003E
+                    lbeq      L7ECA
+                    cmpx      #$003C
+                    lbeq      L7ECA
+                    cmpx      #$003D
+                    lbeq      L7ECA
+                    cmpx      #$003F
+                    lbeq      L7ECA
+                    cmpx      #$0041
+                    lbeq      L7EDB
+                    cmpx      #$0085
+                    lbeq      L7EF6
+                    cmpx      #$0051
+                    lbeq      L7F00
+                    cmpx      #$0050
+                    lbeq      L7F11
+                    bra       L80C3
+
+L8128               ldd       ,s
+                    ldx       $0C,s
+                    std       $06,x
+L812E               leas      $08,s
+                    puls      pc,u
+L8132               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldd       $04,s
+                    cmpd      #$006F
+                    beq       L814A
+                    ldd       $04,s
+                    cmpd      #$0076
+                    bne       L814F
+L814A               ldd       #$0001
+                    bra       L8151
+
+L814F               clra
+                    clrb
+L8151               puls      pc,u
+L8153               lsr       L7261
+                    jmp       -$0d,s
+                    inc       $01,s
+                    lsr       $696F
+                    jmp       0,x
+
+L815F               bcs       $81D9
+                    tst       $0000
+L8163               fcb       $62
+                    rol       $0e,s
+                    fcb       $61
+                    fcb       $72
+                    rol       $206F
+                    neg       L2E00
+L816E               rol       $0e,s
+                    lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+                    rol       $0f,s
+                    jmp       0,x
+
+L817A               rol       $0e,s
+                    lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+                    rol       $0f,s
+                    jmp       0,x
+
+L8186               asl       L2074
+                    fcb       $72
+                    fcb       $61
+                    jmp       -$0d,s
+                    inc       $01,s
+                    lsr       L6500
+L8192               pshs      u
+                    ldd       #$FFA2
+                    lbsr      L010F
+                    leas      -$14,s
+                    bra       L81AD
+
+L819F               leax      L925F,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbsr      $5F26
+L81AD               ldd       $003F
+                    cmpd      #$002A
+                    beq       L819F
+                    ldd       $003F
+                    cmpd      #$0029
+                    bne       L81E2
+                    leax      L9271,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L89B7
+                    leas      $02,s
+                    leax      >$0029,y
+                    pshs      x
+                    lbsr      L916F
+                    leas      $02,s
+                    lbsr      $5F26
+                    lbra      L843C
+
+L81E2               lbsr      L8B51
+                    std       $0a,s
+                    tfr       d,x
+                    bra       L81FD
+
+L81EB               leax      L9289,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L81F6               ldd       #$000C
+                    std       $0a,s
+                    bra       L820D
+
+L81FD               cmpx      #$0010
+                    beq       L81EB
+                    cmpx      #$000D
+                    lbeq      L81EB
+                    stx       -$02,s
+                    beq       L81F6
+L820D               leax      ,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    leax      $16,s
+                    pshs      x
+                    lbsr      L8BA0
+                    leas      $06,s
+                    std       $08,s
+                    bne       L8228
+                    ldd       #$0001
+                    std       $08,s
+L8228               ldd       $04,s
+                    std       $0C,s
+                    ldd       $08,s
+                    pshs      d
+                    leax      $0e,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    lbsr      L8EF5
+                    leas      $06,s
+                    std       $06,s
+                    ldu       $02,s
+                    bne       L825C
+                    ldd       $06,s
+                    cmpd      #$0004
+                    beq       L8256
+                    ldd       $06,s
+                    cmpd      #$0003
+                    beq       L8256
+                    lbsr      L924A
+L8256               leax      $14,s
+                    lbra      L841C
+
+L825C               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L8281
+                    ldd       $003F
+                    cmpd      #$0030
+                    beq       L8277
+                    ldd       $003F
+                    cmpd      #$0028
+                    bne       L827C
+L8277               ldd       #$000E
+                    bra       L8283
+
+L827C               ldd       #$000C
+                    bra       L8283
+
+L8281               ldd       $0a,s
+L8283               std       $0e,s
+                    ldd       ,u
+                    beq       L82CF
+                    ldd       ,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L87E6
+                    leas      $06,s
+                    std       -$02,s
+                    lbne      L83A3
+                    ldd       $0e,s
+                    cmpd      #$000E
+                    lbeq      L83A3
+                    ldd       $08,u
+                    cmpd      #$000E
+                    beq       L82BE
+                    ldd       $08,u
+                    cmpd      #$0022
+                    beq       L82BE
+                    lbsr      L0443
+                    lbra      L83A3
+
+L82BE               ldd       $0e,s
+                    std       $08,u
+                    ldd       $0C,s
+                    std       $04,u
+                    ldd       ,s
+                    std       $0a,u
+                    leax      $14,s
+                    bra       L82E1
+
+L82CF               ldd       $06,s
+                    std       ,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    ldd       $0e,s
+                    std       $08,u
+                    ldd       ,s
+                    std       $0a,u
+                    bra       L82E4
+
+L82E1               leas      -$14,x
+L82E4               ldd       $12,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L906B
+                    leas      $06,s
+                    std       $10,s
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    lbeq      L83A3
+                    ldd       $003F
+                    cmpd      #$0078
+                    bne       L831F
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L3CB7
+L831A               leas      $06,s
+                    lbra      L8389
+
+L831F               ldd       $10,s
+                    bne       L8332
+                    ldd       $0e,s
+                    cmpd      #$000E
+                    beq       L8332
+                    lbsr      L923C
+                    lbra      L8389
+
+L8332               ldx       $0e,s
+                    bra       L8371
+
+L8336               ldd       $0e,s
+                    cmpd      #$0023
+                    bne       L8343
+                    ldd       #$0001
+                    bra       L8345
+
+L8343               clra
+                    clrb
+L8345               pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L5C13
+                    bra       L831A
+
+L8353               ldd       $0e,s
+                    cmpd      #$0021
+                    bne       L8360
+                    ldd       #$0001
+                    bra       L8362
+
+L8360               clra
+                    clrb
+L8362               pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L5C03
+                    lbra      L831A
+
+L8371               cmpx      #$0023
+                    beq       L8336
+                    cmpx      #$000F
+                    lbeq      L8336
+                    cmpx      #$0021
+                    beq       L8353
+                    cmpx      #$000C
+                    lbeq      L8353
+L8389               ldd       $0e,s
+                    cmpd      #$000F
+                    bne       L8396
+                    ldd       #$000C
+                    bra       L83A1
+
+L8396               ldd       $0e,s
+                    cmpd      #$0023
+                    bne       L83A3
+                    ldd       #$0021
+L83A1               std       $08,u
+L83A3               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    lbne      L841F
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    std       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L83DF
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L83DF
+                    ldd       $06,s
+                    cmpd      #$0004
+                    beq       L83DF
+                    ldd       $06,s
+                    cmpd      #$0003
+                    bne       L83F4
+L83DF               leax      $9297,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    ldd       #$0031
+                    std       ,u
+                    ldd       #$0001
+                    std       $06,s
+L83F4               ldd       $0e,s
+                    cmpd      #$000E
+                    bne       L8409
+                    leax      >$0027,y
+                    pshs      x
+                    lbsr      L916F
+                    leas      $02,s
+                    bra       L841F
+
+L8409               ldd       $06,s
+                    std       $002D
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L886F
+                    leas      $04,s
+                    bra       L843C
+                    bra       L841F
+
+L841C               leas      -$14,x
+L841F               ldd       $003F
+                    cmpd      #$0030
+                    bne       L842D
+                    lbsr      $5F26
+                    lbra      L8228
+
+L842D               ldd       #$0028
+                    pshs      d
+                    lbsr      L06C1
+                    std       ,s++
+                    beq       L843C
+                    lbsr      L0704
+L843C               leas      $14,s
+                    puls      pc,u
+L8441               pshs      u
+                    ldd       #$FFA4
+                    lbsr      L010F
+                    leas      -$12,s
+                    lbsr      L8B51
+                    std       $10,s
+                    tfr       d,x
+                    bra       L8469
+
+L8456               leax      $92AB,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L8461               ldd       #$000D
+                    std       $10,s
+                    bra       L8474
+
+L8469               stx       -$02,s
+                    beq       L8461
+                    cmpx      #$0010
+                    beq       L8474
+                    bra       L8456
+
+L8474               leax      ,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    lbsr      L8BA0
+                    leas      $06,s
+                    std       $0e,s
+                    bne       L848E
+                    ldd       #$0001
+                    std       $0e,s
+L848E               ldd       $0a,s
+                    std       $0C,s
+                    ldd       $0e,s
+                    pshs      d
+                    leax      $0e,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    lbsr      L8EF5
+                    leas      $06,s
+                    std       $04,s
+                    ldu       $02,s
+                    ldd       $04,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L84C2
+                    ldd       $04,s
+                    cmpd      #$0004
+                    beq       L84C2
+                    ldd       $04,s
+                    cmpd      #$000A
+                    bne       L84CF
+L84C2               leax      $92BC,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L8500
+
+L84CF               ldd       $04,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L84EA
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L067C
+                    std       ,s
+                    lbsr      L0688
+                    leas      $02,s
+                    bra       L84F5
+
+L84EA               ldd       $04,s
+                    cmpd      #$0005
+                    bne       L84F7
+                    ldd       #$0006
+L84F5               std       $04,s
+L84F7               cmpu      #$0000
+                    bne       L8506
+                    lbsr      L924A
+L8500               leax      $12,s
+                    lbra      L8563
+
+L8506               ldd       $04,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L881A
+                    leas      $04,s
+                    std       $06,s
+                    ldx       $08,u
+                    bra       L8550
+
+L851A               ldd       $04,s
+                    std       ,u
+                    ldd       $06,s
+                    std       $08,u
+                    ldd       ,s
+                    std       $0a,u
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L906B
+                    leas      $06,s
+                    std       -$02,s
+                    bne       L8566
+                    lbsr      L923C
+                    bra       L8566
+
+L853E               lbsr      L0443
+                    bra       L8566
+
+L8543               leax      $92CB,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    bra       L8566
+
+L8550               cmpx      #$000B
+                    beq       L851A
+                    cmpx      #$000D
+                    beq       L853E
+                    cmpx      #$0010
+                    lbeq      L853E
+                    bra       L8543
+
+L8563               leas      -$12,x
+L8566               ldd       $003F
+                    cmpd      #$0078
+                    bne       L8571
+                    lbsr      L4203
+L8571               ldd       $003F
+                    cmpd      #$0030
+                    bne       L857F
+                    lbsr      $5F26
+                    lbra      L848E
+
+L857F               ldd       #$0028
+                    pshs      d
+                    lbsr      L06C1
+                    std       ,s++
+                    lbeq      L87E1
+                    lbsr      L0704
+                    lbra      L87E1
+
+L8593               pshs      u
+                    ldd       #$FF9E
+                    lbsr      L010F
+                    leas      -$12,s
+                    lbsr      L8B51
+                    std       $10,s
+                    tfr       d,x
+                    bra       L85BB
+
+L85A8               leax      $92DB,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L85B3               ldd       #$000D
+                    std       $10,s
+                    bra       L85C4
+
+L85BB               cmpx      #$0021
+                    beq       L85A8
+                    stx       -$02,s
+                    beq       L85B3
+L85C4               leax      $02,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    lbsr      L8BA0
+                    leas      $06,s
+                    std       $0e,s
+                    bne       L85DE
+                    ldd       #$0001
+                    std       $0e,s
+L85DE               leas      -$06,s
+                    ldd       $10,s
+                    std       ,s
+                    ldd       $14,s
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    lbsr      L8EF5
+                    leas      $06,s
+                    std       $12,s
+                    ldu       $0a,s
+                    bne       L861A
+                    ldd       $12,s
+                    cmpd      #$0004
+                    lbeq      L8685
+                    ldd       $12,s
+                    cmpd      #$0003
+                    lbeq      L8685
+                    lbsr      L924A
+                    lbra      L8685
+
+L861A               ldd       $12,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L862F
+                    ldd       $16,s
+                    cmpd      #$000E
+                    bne       L8666
+L862F               ldd       ,u
+                    bne       L8654
+                    ldd       $12,s
+                    std       ,u
+                    ldd       #$000E
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    ldd       $08,s
+                    std       $0a,u
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L906B
+                    bra       L8662
+
+L8654               ldd       $08,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L87E6
+L8662               leas      $06,s
+                    bra       L8685
+
+L8666               ldd       $12,s
+                    pshs      d
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L881A
+                    leas      $04,s
+                    std       $04,s
+                    ldd       ,u
+                    beq       L8692
+                    ldd       $0C,u
+                    cmpd      $0031
+                    bne       L868B
+                    lbsr      L0443
+L8685               leax      $18,s
+                    lbra      L87C0
+
+L868B               pshs      u
+                    lbsr      L0382
+                    leas      $02,s
+L8692               ldd       $12,s
+                    std       ,u
+                    ldd       $04,s
+                    std       $08,u
+                    ldd       $08,s
+                    std       $0a,u
+                    ldd       $0031
+                    std       $0C,u
+                    ldd       $002B
+                    std       $10,u
+                    stu       $002B
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L906B
+                    leas      $06,s
+                    std       $02,s
+                    bne       L86C8
+                    ldd       $003F
+                    cmpd      #$0078
+                    beq       L86C8
+                    lbsr      L923C
+L86C8               ldx       $04,s
+                    bra       L86E1
+
+L86CC               ldd       $0011
+                    subd      $02,s
+                    std       $0011
+                    ldd       $0011
+                    bra       L86DD
+
+L86D6               ldd       $000B
+                    addd      #$0001
+                    std       $000B
+L86DD               std       $06,u
+                    bra       L86F2
+
+L86E1               cmpx      #$000D
+                    beq       L86CC
+                    cmpx      #$0023
+                    beq       L86D6
+                    cmpx      #$000F
+                    lbeq      L86D6
+L86F2               ldd       $003F
+                    cmpd      #$0078
+                    lbne      L878F
+                    ldd       $04,s
+                    cmpd      #$000F
+                    beq       L870C
+                    ldd       $04,s
+                    cmpd      #$0023
+                    bne       L871F
+L870C               ldd       $12,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L3CB7
+L871A               leas      $06,s
+                    lbra      L87C3
+
+L871F               lbsr      $5F26
+                    ldd       $12,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    lbeq      L878A
+                    ldd       $12,s
+                    cmpd      #$0004
+                    lbeq      L878A
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      $0785
+                    leas      $02,s
+                    std       $0C,s
+                    beq       L878A
+                    ldd       $006E
+                    beq       L875E
+                    ldd       $006E
+                    std       $06,s
+                    tfr       d,x
+                    ldd       ,x
+                    std       $006E
+                    clra
+                    clrb
+                    std       [$06,s]
+                    bra       L876A
+
+L875E               ldd       #$0006
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       $06,s
+L876A               ldd       $0C,s
+                    ldx       $06,s
+                    std       $02,x
+                    ldx       $06,s
+                    stu       $04,x
+                    ldd       L006A
+                    beq       L8780
+                    ldd       $06,s
+                    std       [L006C,y]
+                    bra       L8784
+
+L8780               ldd       $06,s
+                    std       L006A
+L8784               ldd       $06,s
+                    std       L006C
+                    bra       L87C3
+
+L878A               lbsr      L4203
+                    bra       L87C3
+
+L878F               ldx       $04,s
+                    bra       L87B2
+
+L8793               ldd       $04,s
+                    cmpd      #$0023
+                    bne       L87A0
+                    ldd       #$0001
+                    bra       L87A2
+
+L87A0               clra
+                    clrb
+L87A2               pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    lbsr      L5BDC
+                    lbra      L871A
+
+L87B2               cmpx      #$000F
+                    beq       L8793
+                    cmpx      #$0023
+                    lbeq      L8793
+                    bra       L87C3
+
+L87C0               leas      -$18,x
+L87C3               ldd       $003F
+                    cmpd      #$0030
+                    beq       L87CF
+                    leas      $06,s
+                    bra       L87D7
+
+L87CF               lbsr      $5F26
+                    leas      $06,s
+                    lbra      L85DE
+
+L87D7               ldd       #$0028
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+L87E1               leas      $12,s
+                    puls      pc,u
+L87E6               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       ,u
+                    cmpd      $06,s
+                    bne       L8806
+                    ldd       $06,s
+                    cmpd      #$0004
+                    bne       L8816
+                    ldd       $0a,u
+                    cmpd      $08,s
+                    beq       L8816
+L8806               leax      $92E9,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    ldd       #$0001
+                    puls      pc,u
+L8816               clra
+                    clrb
+                    puls      pc,u
+L881A               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldd       $04,s
+                    cmpd      #$0010
+                    bne       L886B
+                    ldd       L0068
+                    cmpd      #$0001
+                    bge       L8866
+                    ldx       $06,s
+                    bra       L8858
+
+L8836               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L8866
+L8841               ldd       L0068
+                    addd      #$0001
+                    std       L0068
+                    cmpd      #$0001
+                    bne       L8853
+                    ldd       #$006F
+                    bra       L8856
+
+L8853               ldd       #$0076
+L8856               puls      pc,u
+L8858               cmpx      #$0001
+                    beq       L8841
+                    cmpx      #$0007
+                    lbeq      L8841
+                    bra       L8836
+
+L8866               ldd       #$000D
+                    puls      pc,u
+L886B               ldd       $04,s
+                    puls      pc,u
+L886F               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L010F
+                    leas      -$0a,s
+                    ldd       #$0001
+                    std       $0031
+                    clra
+                    clrb
+                    std       $000F
+                    std       $001B
+                    std       $0011
+                    std       L0068
+                    std       $0013
+                    bra       L888F
+
+L888C               lbsr      L8441
+L888F               ldd       $003F
+                    cmpd      #$0029
+                    bne       L888C
+                    ldd       $0e,s
+                    addd      #$0014
+                    std       $02,s
+                    ldd       $0017
+                    beq       L88B6
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       ,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L5C57
+                    leas      $04,s
+L88B6               ldd       ,s
+                    pshs      d
+                    ldd       $12,s
+                    cmpd      #$000F
+                    beq       L88C8
+                    ldd       #$0001
+                    bra       L88CA
+
+L88C8               clra
+                    clrb
+L88CA               pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L5C6F
+                    leas      $06,s
+                    ldu       $0027
+                    ldd       #$0004
+                    std       $08,s
+                    lbra      L8953
+
+L88DF               leas      -$02,s
+                    ldd       $0a,s
+                    std       $06,u
+                    ldx       ,u
+                    bra       L8901
+
+L88E9               ldd       #$0004
+                    bra       L88FD
+
+L88EE               ldd       #$0008
+                    bra       L88FD
+
+L88F3               ldd       $06,u
+                    addd      #$0001
+                    std       $06,u
+L88FA               ldd       #$0002
+L88FD               std       ,s
+                    bra       L8919
+
+L8901               cmpx      #$0008
+                    beq       L88E9
+                    cmpx      #$0005
+                    lbeq      L88E9
+                    cmpx      #$0006
+                    beq       L88EE
+                    cmpx      #$0002
+                    beq       L88F3
+                    bra       L88FA
+
+L8919               ldd       $08,u
+                    std       $08,s
+                    tfr       d,x
+                    bra       L8937
+
+L8921               ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L8948
+
+L8930               ldd       #$000D
+                    std       $08,u
+                    bra       L8948
+
+L8937               cmpx      #$006F
+                    beq       L8921
+                    cmpx      #$0076
+                    lbeq      L8921
+                    cmpx      #$000B
+                    beq       L8930
+L8948               ldd       $0a,s
+                    addd      ,s
+                    std       $0a,s
+                    ldu       $10,u
+                    leas      $02,s
+L8953               stu       -$02,s
+                    lbne      L88DF
+                    ldd       $0027
+                    std       $04,s
+                    clra
+                    clrb
+                    std       $0027
+                    lbsr      L89B7
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L916F
+                    leas      $02,s
+                    leax      >$0029,y
+                    pshs      x
+                    lbsr      L916F
+                    leas      $02,s
+                    ldd       $002F
+                    cmpd      #$0012
+                    beq       L8992
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0012
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+L8992               clra
+                    clrb
+                    std       $002F
+                    lbsr      L5D06
+                    clra
+                    clrb
+                    std       $0031
+                    ldd       $003F
+                    cmpd      #$FFFF
+                    bne       L89B0
+                    leax      $92FE,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L89B0               lbsr      $5F26
+                    leas      $0a,s
+                    puls      pc,u
+L89B7               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L010F
+                    leas      -$06,s
+                    ldd       $002B
+                    std       $02,s
+                    clra
+                    clrb
+                    std       $002B
+                    lbsr      $5F26
+                    ldd       $0031
+                    addd      #$0001
+                    std       $0031
+                    ldd       $0011
+                    std       ,s
+                    bra       L89DC
+
+L89D9               lbsr      L8593
+L89DC               lbsr      L0641
+                    std       -$02,s
+                    bne       L89D9
+                    lbsr      L05DF
+                    std       -$02,s
+                    lbne      L89D9
+                    ldd       $001B
+                    cmpd      $0011
+                    ble       L89F7
+                    ldd       $0011
+                    std       $001B
+L89F7               ldd       $0011
+                    pshs      d
+                    lbsr      L57E3
+                    leas      $02,s
+                    std       $000F
+                    lbra      L8A75
+
+L8A05               ldd       L006A
+                    std       $04,s
+                    ldx       $04,s
+                    ldu       $02,x
+                    ldd       $10,u
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    ldx       $08,s
+                    ldd       $04,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0034
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       $10,u
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldx       $0a,s
+                    ldd       $02,x
+                    pshs      d
+                    pshs      u
+                    ldd       #$0078
+                    pshs      d
+                    lbsr      L0FD8
+                    leas      $0C,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L111D
+                    std       ,s
+                    lbsr      L6F83
+                    std       ,s
+                    lbsr      L0598
+                    leas      $02,s
+                    ldd       [$04,s]
+                    std       $04,s
+                    ldd       $006E
+                    std       [L006A,y]
+                    ldd       L006A
+                    std       $006E
+                    ldd       $04,s
+                    std       L006A
+L8A75               ldd       L006A
+                    lbne      L8A05
+                    bra       L8A80
+
+L8A7D               lbsr      L29D5
+L8A80               ldd       $003F
+                    cmpd      #$002A
+                    beq       L8A90
+                    ldd       $003F
+                    cmpd      #$FFFF
+                    bne       L8A7D
+L8A90               leax      >$002b,y
+                    pshs      x
+                    lbsr      L916F
+                    leas      $02,s
+                    ldd       $02,s
+                    std       $002B
+                    ldd       $0031
+                    addd      #$FFFF
+                    std       $0031
+                    ldd       ,s
+                    std       $0011
+                    ldd       $002F
+                    cmpd      #$0012
+                    beq       L8ABD
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L57E3
+                    leas      $02,s
+                    bra       L8ABF
+
+L8ABD               ldd       ,s
+L8ABF               std       $000F
+                    leas      $06,s
+                    puls      pc,u
+L8AC5               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       [$06,s]
+L8AD4               lbsr      $5F26
+L8AD7               ldd       $003F
+                    cmpd      #$002E
+                    lbeq      L8B45
+                    ldd       $003F
+                    cmpd      #$0034
+                    bne       L8B38
+                    ldu       $0041
+                    ldd       $08,u
+                    cmpd      #$000B
+                    bne       L8AFE
+                    leax      L9312,pcr
+                    pshs      x
+                    lbsr      L0450
+                    bra       L8B07
+
+L8AFE               ldd       ,u
+                    beq       L8B09
+                    pshs      u
+                    lbsr      L0382
+L8B07               leas      $02,s
+L8B09               ldd       #$0001
+                    std       ,u
+                    ldd       #$000B
+                    std       $08,u
+                    ldd       #$0001
+                    std       $0C,u
+                    ldd       #$0002
+                    std       $02,u
+                    ldd       [$06,s]
+                    beq       L8B29
+                    ldx       ,s
+                    stu       $10,x
+                    bra       L8B2C
+
+L8B29               stu       [$06,s]
+L8B2C               clra
+                    clrb
+                    std       $10,u
+                    stu       ,s
+                    lbsr      $5F26
+                    bra       L8B3B
+
+L8B38               lbsr      L924A
+L8B3B               ldd       $003F
+                    cmpd      #$0030
+                    lbeq      L8AD4
+L8B45               ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    bra       L8B9C
+
+L8B51               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leas      -$02,s
+                    lbsr      L0641
+                    std       -$02,s
+                    beq       L8B9A
+                    ldd       $0041
+                    std       ,s
+                    lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0033
+                    bne       L8B96
+                    ldd       $0041
+                    cmpd      #$0021
+                    bne       L8B96
+                    ldx       ,s
+                    bra       L8B89
+
+L8B7D               ldd       #$0023
+                    bra       L8B85
+
+L8B82               ldd       #$0022
+L8B85               std       ,s
+                    bra       L8B93
+
+L8B89               cmpx      #$000F
+                    beq       L8B7D
+                    cmpx      #$000E
+                    beq       L8B82
+L8B93               lbsr      $5F26
+L8B96               ldd       ,s
+                    bra       L8B9C
+
+L8B9A               clra
+                    clrb
+L8B9C               leas      $02,s
+                    puls      pc,u
+L8BA0               pshs      u
+                    ldd       #$FF98
+                    lbsr      L010F
+                    leas      -$1a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       #$0002
+                    std       ,s
+                    clra
+                    clrb
+                    std       [$22,s]
+                    ldd       $003F
+                    cmpd      #$0033
+                    lbne      L8EBC
+                    ldd       $0041
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L8E7A
+
+L8BCC               ldd       #$0001
+                    std       $02,s
+L8BD1               lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0033
+                    lbne      L8EE4
+                    ldd       $0041
+                    cmpd      #$0001
+                    lbne      L8EE4
+                    bra       L8C22
+
+L8BEA               ldd       #$0001
+                    bra       L8C20
+
+L8BEF               lbsr      $5F26
+                    ldd       #$0004
+                    std       ,s
+                    ldd       $003F
+                    cmpd      #$0033
+                    lbne      L8EE4
+                    ldd       $0041
+                    cmpd      #$0001
+                    beq       L8C22
+                    ldd       $0041
+                    cmpd      #$0005
+                    lbne      L8EE4
+L8C13               ldd       #$0006
+                    std       $02,s
+                    ldd       #$0008
+                    bra       L8C20
+
+L8C1D               ldd       #$0004
+L8C20               std       ,s
+L8C22               lbsr      $5F26
+                    lbra      L8EE4
+
+L8C28               clra
+                    clrb
+                    std       $02,s
+                    lbra      L8EE4
+
+L8C2F               clra
+                    clrb
+                    std       $16,s
+                    std       ,s
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    clra
+                    clrb
+                    std       $18,s
+                    lbsr      $5F26
+                    ldd       L0021
+                    addd      #$FFFF
+                    std       L0021
+                    ldd       $003F
+                    cmpd      #$0034
+                    lbne      L8CC8
+                    ldd       $0041
+                    std       $18,s
+                    ldd       [$18,s]
+                    bne       L8C70
+                    ldd       #$000A
+                    std       [$18,s]
+                    ldd       #$0008
+                    ldx       $18,s
+                    std       $08,x
+                    bra       L8C86
+
+L8C70               ldx       $18,s
+                    ldd       $08,x
+                    cmpd      #$0008
+                    beq       L8C86
+                    leax      $931E,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L8C86               lbsr      $5F26
+                    ldd       $003F
+                    cmpd      #$0029
+                    beq       L8CBC
+                    ldd       [$18,s]
+                    cmpd      #$0004
+                    bne       L8CB0
+                    ldx       $18,s
+                    ldd       $02,x
+                    std       [$1e,s]
+                    ldx       $18,s
+                    ldd       $0a,x
+                    std       [$22,s]
+                    ldd       #$0004
+                    lbra      L8EF0
+
+L8CB0               ldd       $18,s
+                    std       [$1e,s]
+                    ldd       #$000A
+                    lbra      L8EF0
+
+L8CBC               ldd       [$18,s]
+                    cmpd      #$0004
+                    bne       L8CC8
+                    lbsr      L0443
+L8CC8               ldd       $003F
+                    cmpd      #$0029
+                    beq       L8CDE
+                    leax      L9329,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+                    lbra      L8EE4
+
+L8CDE               ldd       L0021
+                    addd      #$0001
+                    std       L0021
+L8CE5               ldd       L0021
+                    std       $10,s
+                    clra
+                    clrb
+                    std       L0021
+                    lbsr      $5F26
+                    ldd       $10,s
+                    std       L0021
+                    ldd       $003F
+                    cmpd      #$002A
+                    lbeq      L8E4D
+                    leax      $04,s
+                    pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    leax      $18,s
+                    pshs      x
+                    lbsr      L8BA0
+                    leas      $06,s
+                    std       $12,s
+                    bra       L8D17
+
+L8D17               leas      -$04,s
+                    ldd       $10,s
+                    std       $02,s
+                    ldd       $003F
+                    cmpd      #$0028
+                    lbeq      L8E37
+                    ldd       $0031
+                    addd      #$0001
+                    std       $0031
+                    ldd       $16,s
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L8EF5
+                    leas      $06,s
+                    std       $12,s
+                    ldu       ,s
+                    ldd       $0031
+                    addd      #$FFFF
+                    std       $0031
+                    cmpu      #$0000
+                    bne       L8D5C
+                    lbsr      L924A
+                    leax      $1e,s
+                    lbra      L8E2C
+
+L8D5C               ldd       ,u
+                    beq       L8D91
+                    ldd       $0C,u
+                    cmpd      $0031
+                    bne       L8D8A
+                    ldd       ,u
+                    cmpd      $12,s
+                    bne       L8D7F
+                    ldd       $08,u
+                    cmpd      #$0011
+                    bne       L8D7F
+                    ldd       $06,u
+                    cmpd      $1a,s
+                    beq       L8D91
+L8D7F               leax      $9337,pcr
+                    pshs      x
+                    lbsr      L0450
+                    bra       L8D8F
+
+L8D8A               pshs      u
+                    lbsr      L0382
+L8D8F               leas      $02,s
+L8D91               ldd       $12,s
+                    cmpd      #$000A
+                    bne       L8DA5
+                    leax      $934E,pcr
+                    pshs      x
+                    lbsr      L0450
+                    leas      $02,s
+L8DA5               ldd       $12,s
+                    std       ,u
+                    ldd       #$0011
+                    std       $08,u
+                    ldd       $1a,s
+                    std       $06,u
+                    ldd       $08,s
+                    std       $0a,u
+                    ldd       $18,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L906B
+                    leas      $06,s
+                    std       $0e,s
+                    beq       L8DEF
+                    ldd       $06,s
+                    cmpd      #$0004
+                    bne       L8DDE
+                    ldd       $1a,s
+                    addd      $0e,s
+                    std       $1a,s
+                    bra       L8DEB
+
+L8DDE               ldd       $0e,s
+                    cmpd      $04,s
+                    ble       L8DE9
+                    ldd       $0e,s
+                    bra       L8DEB
+
+L8DE9               ldd       $04,s
+L8DEB               std       $04,s
+                    bra       L8DF2
+
+L8DEF               lbsr      L923C
+L8DF2               ldd       $0031
+                    std       $0C,u
+                    ldd       $002B
+                    std       $10,u
+                    stu       $002B
+                    ldd       $06,s
+                    cmpd      #$0004
+                    bne       L8E2F
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    std       $0C,s
+                    ldx       $0C,s
+                    stu       $02,x
+                    ldd       [$26,s]
+                    beq       L8E21
+                    ldd       $0C,s
+                    std       [$0a,s]
+                    bra       L8E26
+
+L8E21               ldd       $0C,s
+                    std       [$26,s]
+L8E26               ldd       $0C,s
+                    std       $0a,s
+                    bra       L8E2F
+
+L8E2C               leas      -$1e,x
+L8E2F               ldd       $003F
+                    cmpd      #$0030
+                    beq       L8E3B
+L8E37               leas      $04,s
+                    bra       L8E43
+
+L8E3B               lbsr      $5F26
+                    leas      $04,s
+                    lbra      L8D17
+
+L8E43               ldd       $003F
+                    cmpd      #$0028
+                    lbeq      L8CE5
+L8E4D               ldd       L0021
+                    addd      #$FFFF
+                    std       L0021
+                    ldd       $18,s
+                    beq       L8E6E
+                    ldd       ,s
+                    ldx       $18,s
+                    std       $02,x
+                    ldd       #$0004
+                    std       [$18,s]
+                    ldd       [$22,s]
+                    ldx       $18,s
+                    std       $0a,x
+L8E6E               ldd       #$002A
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    bra       L8EE4
+
+L8E7A               cmpx      #$000A
+                    lbeq      L8BCC
+                    cmpx      #$0007
+                    lbeq      L8BD1
+                    cmpx      #$0002
+                    lbeq      L8BEA
+                    cmpx      #$0001
+                    lbeq      L8C22
+                    cmpx      #$0008
+                    lbeq      L8BEF
+                    cmpx      #$0006
+                    lbeq      L8C13
+                    cmpx      #$0005
+                    lbeq      L8C1D
+                    cmpx      #$0003
+                    lbeq      L8C2F
+                    cmpx      #$0004
+                    lbeq      L8C2F
+                    lbra      L8C28
+
+L8EBC               ldd       $003F
+                    cmpd      #$0034
+                    bne       L8EE4
+                    ldu       $0041
+                    ldd       $08,u
+                    cmpd      #$001E
+                    bne       L8EE4
+                    ldd       $02,u
+                    std       [$1e,s]
+                    ldd       $04,u
+                    std       [$20,s]
+                    ldd       $0a,u
+                    std       [$22,s]
+                    lbsr      $5F26
+                    ldd       ,u
+                    bra       L8EF0
+
+L8EE4               ldd       ,s
+                    std       [$1e,s]
+                    clra
+                    clrb
+                    std       [$20,s]
+                    ldd       $02,s
+L8EF0               leas      $1a,s
+                    puls      pc,u
+L8EF5               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L010F
+                    leas      -$0C,s
+                    clra
+                    clrb
+                    std       [$10,s]
+                    std       $0a,s
+                    bra       L8F16
+
+L8F08               ldd       $0a,s
+                    pshs      d
+                    lbsr      L0688
+                    leas      $02,s
+                    std       $0a,s
+                    lbsr      $5F26
+L8F16               ldd       $003F
+                    cmpd      #$0042
+                    beq       L8F08
+                    ldd       $003F
+                    cmpd      #$0034
+                    bne       L8F30
+                    ldd       $0041
+                    std       [$10,s]
+                    lbsr      $5F26
+                    bra       L8F6A
+
+L8F30               ldd       $003F
+                    cmpd      #$002D
+                    bne       L8F6A
+                    lbsr      $5F26
+                    ldd       $0031
+                    addd      #$0001
+                    std       $0031
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L8EF5
+                    leas      $06,s
+                    std       $14,s
+                    ldd       $0031
+                    addd      #$FFFF
+                    std       $0031
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+L8F6A               ldd       $003F
+                    cmpd      #$002D
+                    bne       L8FA1
+                    ldd       $0a,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      #$0030
+                    std       $0a,s
+                    ldd       $0031
+                    bne       L8F8C
+                    leax      >$0027,y
+                    pshs      x
+                    lbsr      L8AC5
+                    bra       L8F9C
+
+L8F8C               leax      ,s
+                    pshs      x
+                    lbsr      L8AC5
+                    leas      $02,s
+                    leax      ,s
+                    pshs      x
+                    lbsr      L916F
+L8F9C               leas      $02,s
+                    lbra      L9024
+
+L8FA1               clra
+                    clrb
+                    std       $06,s
+                    std       $04,s
+                    std       $02,s
+                    ldd       L0021
+                    std       $08,s
+                    clra
+                    clrb
+                    std       L0021
+                    lbra      L9008
+
+L8FB4               ldd       $0a,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      #$0020
+                    std       $0a,s
+                    lbsr      $5F26
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L6622
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       $04,s
+                    bne       L8FDE
+                    ldd       $003F
+                    cmpd      #$002C
+                    bne       L8FDE
+                    clra
+                    clrb
+                    bra       L8FE7
+
+L8FDE               clra
+                    clrb
+                    pshs      d
+                    lbsr      L0C54
+                    leas      $02,s
+L8FE7               std       ,u
+                    ldd       $06,s
+                    beq       L8FF3
+                    ldx       $06,s
+                    stu       $02,x
+                    bra       L8FF5
+
+L8FF3               stu       $02,s
+L8FF5               stu       $06,s
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L06C1
+                    leas      $02,s
+                    ldd       $04,s
+                    addd      #$0001
+                    std       $04,s
+L9008               ldd       $003F
+                    cmpd      #$002B
+                    lbeq      L8FB4
+                    ldd       $08,s
+                    std       L0021
+                    ldd       $02,s
+                    beq       L9024
+                    ldd       [$12,s]
+                    std       $02,u
+                    ldd       $02,s
+                    std       [$12,s]
+L9024               ldd       $0a,s
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    bsr       L9035
+                    leas      $04,s
+                    leas      $0C,s
+                    puls      pc,u
+L9035               pshs      u
+                    ldd       #$FFBC
+                    lbsr      L010F
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+                    bra       L905D
+
+L9045               ldd       ,s
+                    pshs      d
+                    ldd       #$0002
+                    lbsr      LB069
+                    std       ,s
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0002
+                    lbsr      LB08C
+                    std       $08,s
+L905D               ldd       ,s
+                    clra
+                    andb      #$30
+                    bne       L9045
+                    ldd       $06,s
+                    addd      $08,s
+                    lbra      L925B
+
+L906B               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       ,u
+                    std       $02,s
+                    clra
+                    andb      #$0f
+                    tfr       d,x
+                    bra       L90A0
+
+L9082               ldd       #$0001
+                    bra       L909C
+
+L9087               ldd       #$0002
+                    bra       L909C
+
+L908C               ldd       #$0004
+                    bra       L909C
+
+L9091               ldd       #$0008
+                    bra       L909C
+
+L9096               ldd       $0C,s
+                    bra       L909C
+
+L909A               clra
+                    clrb
+L909C               std       ,s
+                    bra       L90D3
+
+L90A0               cmpx      #$0002
+                    beq       L9082
+                    cmpx      #$0001
+                    beq       L9087
+                    cmpx      #$0007
+                    lbeq      L9087
+                    cmpx      #$0008
+                    beq       L908C
+                    cmpx      #$0005
+                    lbeq      L908C
+                    cmpx      #$0006
+                    beq       L9091
+                    cmpx      #$0003
+                    beq       L9096
+                    cmpx      #$0004
+                    lbeq      L9096
+                    cmpx      #$000A
+                    beq       L909A
+L90D3               ldd       ,s
+                    beq       L90DB
+                    ldd       ,s
+                    bra       L90DD
+
+L90DB               ldd       $0C,s
+L90DD               std       $02,u
+                    ldd       $0a,s
+                    std       $04,u
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    bsr       L90F5
+                    leas      $06,s
+                    leas      $04,s
+                    puls      pc,u
+L90F5               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010F
+                    ldu       $08,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L9117
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L911D
+L9117               ldd       #$0002
+                    lbra      L925B
+
+L911D               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L916A
+                    ldd       #$0001
+                    std       ,s
+L912D               ldd       ,s
+                    pshs      d
+                    ldd       ,u
+                    lbsr      LAF4B
+                    std       ,s
+                    ldu       $02,u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L067C
+                    leas      $02,s
+                    std       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L912D
+                    ldd       ,s
+                    pshs      d
+                    ldd       $08,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L9162
+                    ldd       #$0002
+                    bra       L9164
+
+L9162               ldd       $0a,s
+L9164               lbsr      LAF4B
+                    lbra      L925B
+
+L916A               ldd       $08,s
+                    lbra      L925B
+
+L916F               pshs      u
+                    ldd       #$FF74
+                    lbsr      L010F
+                    leas      -$40,s
+                    ldu       [$44,s]
+                    lbra      L922C
+
+L9180               ldd       $10,u
+                    std       $3C,s
+                    ldd       ,u
+                    cmpd      #$0009
+                    bne       L91C0
+                    ldd       $0a,u
+                    clra
+                    andb      #$01
+                    bne       L91C0
+                    ldd       #$0008
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    leax      $9362,pcr
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+                    pshs      d
+                    lbsr      $A6D1
+                    leas      $06,s
+                    pshs      d
+                    lbsr      L0450
+                    leas      $02,s
+L91C0               ldx       $08,u
+                    bra       L91CD
+
+L91C4               ldd       L0068
+                    addd      #$FFFF
+                    std       L0068
+                    bra       L91D9
+
+L91CD               cmpx      #$006F
+                    beq       L91C4
+                    cmpx      #$0076
+                    lbeq      L91C4
+L91D9               ldd       $0e,u
+                    std       $3e,s
+                    cmpd      L0046
+                    bls       L91F4
+                    ldd       $3e,s
+                    cmpd      L0048
+                    bcc       L91F4
+                    pshs      u
+                    lbsr      L03D4
+                    leas      $02,s
+                    bra       L9229
+
+L91F4               cmpu      [$3e,s]
+                    bne       L9202
+                    ldd       $12,u
+                    std       [$3e,s]
+                    bra       L9222
+
+L9202               ldd       [$3e,s]
+                    bra       L920D
+
+L9207               ldx       $3e,s
+                    ldd       $12,x
+L920D               std       $3e,s
+                    ldx       $3e,s
+                    cmpu      $12,x
+                    bne       L9207
+                    ldd       $12,u
+                    ldx       $3e,s
+                    std       $12,x
+L9222               ldd       $0062
+                    std       $12,u
+                    stu       $0062
+L9229               ldu       $3C,s
+L922C               stu       -$02,s
+                    lbne      L9180
+                    clra
+                    clrb
+                    std       [$44,s]
+                    leas      $40,s
+                    puls      pc,u
+L923C               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      L9375,pcr
+                    bra       L9256
+
+L924A               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    leax      $938A,pcr
+L9256               pshs      x
+                    lbsr      L0450
+L925B               leas      $02,s
+                    puls      pc,u
+L925F               lsr       $6F6F
+                    bra       $92D1
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       $92CB
+                    fcb       $72
+                    fcb       $61
+                    com       $0b,s
+                    fcb       $65
+                    lsr       $7300
+L9271               ror       -$0b,s
+                    jmp       $03,s
+                    lsr       $696F
+                    jmp       0,y
+                    asl       $05,s
+                    fcb       $61
+                    lsr       $05,s
+                    fcb       $72
+                    bra       L92EF
+                    rol       -$0d,s
+                    com       L696E
+                    asr       0,x
+L9289               com       $746F
+                    fcb       $72
+                    fcb       $61
+                    asr       $05,s
+                    bra       L92F7
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $0066
+                    fcb       $75
+                    jmp       $03,s
+                    lsr       $696F
+                    jmp       0,y
+                    lsr       $7970
+                    fcb       $65
+                    bra       $930B
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L0061
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    bra       $9328
+                    lsr       $6F72
+                    fcb       $61
+                    asr       $05,s
+                    neg       L0061
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    bra       $932B
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $006E
+                    clr       -$0C,s
+                    bra       L9331
+                    jmp       0,y
+                    fcb       $61
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    neg       $0073
+                    lsr       $6F72
+                    fcb       $61
+                    asr       $05,s
+                    bra       $9349
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $0064
+                    fcb       $65
+                    com       $0C,s
+                    fcb       $61
+                    fcb       $72
+L92EF               fcb       $61
+                    lsr       $696F
+                    jmp       0,y
+                    tst       $09,s
+L92F7               com       $6D61
+                    lsr       L6368
+                    neg       $0066
+                    fcb       $75
+                    jmp       $03,s
+                    lsr       $696F
+                    jmp       0,y
+                    fcb       $75
+                    jmp       $06,s
+                    rol       $0e,s
+                    rol       -$0d,s
+                    asl       $05,s
+                    lsr       0,x
+L9312               jmp       $01,s
+                    tst       $05,s
+                    lsr       0,y
+                    lsr       $7769
+                    com       $05,s
+                    neg       $006E
+                    fcb       $61
+                    tst       $05,s
+                    bra       $9387
+                    inc       $01,s
+                    com       $6800
+L9329               com       L7472
+                    fcb       $75
+                    com       -$0C,s
+                    bra       $93A4
+
+L9331               rol       L6E74
+                    fcb       $61
+                    asl       >$0073
+                    lsr       L7275
+                    com       -$0C,s
+                    bra       $93AC
+                    fcb       $65
+                    tst       $02,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $93B3
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       L6368
+                    neg       L0075
+                    jmp       $04,s
+                    fcb       $65
+                    ror       $09,s
+                    jmp       $05,s
+                    lsr       0,y
+                    com       L7472
+                    fcb       $75
+                    com       -$0C,s
+                    fcb       $75
+                    fcb       $72
+                    fcb       $65
+                    neg       L006C
+                    fcb       $61
+                    fcb       $62
+                    fcb       $65
+                    inc       0,y
+                    fcb       $75
+                    jmp       $04,s
+                    fcb       $65
+                    ror       $09,s
+                    jmp       $05,s
+                    lsr       0,y
+                    abx
+                    bra       L9375
+
+L9375               com       $01,s
+                    jmp       $0e,s
+                    clr       -$0C,s
+                    bra       $93E2
+                    ror       $616C
+                    fcb       $75
+                    fcb       $61
+                    lsr       $6520
+                    com       $697A
+                    fcb       $65
+                    neg       $0069
+                    lsr       $05,s
+                    jmp       -$0C,s
+                    rol       $06,s
+                    rol       $05,s
+                    fcb       $72
+                    bra       L9403
+                    rol       -$0d,s
+                    com       L696E
+                    asr       0,x
+L939D               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L94F9
+
+L93B2               ldd       #$0001
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L939D
+                    leas      $08,s
+                    leax      $04,s
+                    bra       L93F0
+
+L93D2               clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $02,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L939D
+                    leas      $08,s
+                    bra       L93F2
+
+L93F0               leas      -$04,x
+L93F2               ldd       ,s
+                    pshs      d
+                    lbsr      L57B2
+                    lbra      L945C
+
+L93FC               ldd       #$0001
+                    subd      $0e,s
+                    pshs      d
+L9403               ldd       $0C,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $0a,u
+                    lbra      L946C
+
+L9411               ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    pshs      u
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L9577
+                    leas      $0a,s
+                    lbra      L9573
+
+L942B               ldd       $08,u
+                    beq       L943B
+                    ldd       $0e,s
+                    bne       L943B
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0C,s
+                    bra       L944D
+
+L943B               ldd       $0e,s
+                    lbeq      L9573
+                    ldd       $08,u
+                    lbne      L9573
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0e,s
+L944D               pshs      d
+                    ldd       #$007C
+                    lbra      L94F0
+
+L9455               ldd       $0a,u
+                    pshs      d
+                    lbsr      L6F83
+L945C               leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0C,u
+L946C               pshs      d
+                    lbsr      L939D
+                    leas      $08,s
+                    lbra      L9573
+
+L9476               ldd       ,u
+                    cmpd      #$0008
+                    bne       L9496
+                    pshs      u
+                    lbsr      L34BE
+                    leas      $02,s
+                    ldd       #$008B
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    bra       L94D7
+
+L9496               ldd       ,u
+                    cmpd      #$0005
+                    beq       L94A6
+                    ldd       ,u
+                    cmpd      #$0006
+                    bne       L94CC
+L94A6               ldd       $06,u
+                    cmpd      #$008C
+                    bne       L94B0
+                    ldu       $0a,u
+L94B0               pshs      u
+                    lbsr      $3987
+                    leas      $02,s
+                    ldd       ,u
+                    pshs      d
+                    ldd       #$008B
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L94D7
+
+L94CC               pshs      u
+                    lbsr      L97AE
+                    leas      $02,s
+                    bra       L94D7
+                    leas      -$04,x
+L94D7               ldd       $0e,s
+                    beq       L94E4
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       #$005A
+                    bra       L94EB
+
+L94E4               ldd       $0a,s
+                    pshs      d
+                    ldd       #$005B
+L94EB               pshs      d
+                    ldd       #$0082
+L94F0               pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    bra       L9573
+
+L94F9               cmpx      #$0047
+                    lbeq      L93B2
+                    cmpx      #$0048
+                    lbeq      L93D2
+                    cmpx      #$0040
+                    lbeq      L93FC
+                    cmpx      #$005A
+                    lbeq      L9411
+                    cmpx      #$005B
+                    lbeq      L9411
+                    cmpx      #$005C
+                    lbeq      L9411
+                    cmpx      #$005D
+                    lbeq      L9411
+                    cmpx      #$005E
+                    lbeq      L9411
+                    cmpx      #$005F
+                    lbeq      L9411
+                    cmpx      #$0060
+                    lbeq      L9411
+                    cmpx      #$0061
+                    lbeq      L9411
+                    cmpx      #$0062
+                    lbeq      L9411
+                    cmpx      #$0063
+                    lbeq      L9411
+                    cmpx      #$0036
+                    lbeq      L942B
+                    cmpx      #$004B
+                    lbeq      L942B
+                    cmpx      #$004A
+                    lbeq      L942B
+                    cmpx      #$0030
+                    lbeq      L9455
+                    lbra      L9476
+
+L9573               leas      $04,s
+                    puls      pc,u
+L9577               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L010F
+                    leas      -$06,s
+                    ldx       $0C,s
+                    ldd       $0a,x
+                    std       ,s
+                    ldx       $0C,s
+                    ldu       $0C,x
+                    ldd       $12,s
+                    beq       L9595
+                    ldd       $10,s
+                    bra       L9597
+
+L9595               ldd       $0e,s
+L9597               std       $02,s
+                    ldd       $12,s
+                    beq       L95A9
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L98F1
+                    leas      $02,s
+                    bra       L95AB
+
+L95A9               ldd       $0a,s
+L95AB               std       $0a,s
+                    ldd       [,s]
+                    cmpd      #$0008
+                    bne       L95BE
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L34D9
+                    bra       L95D5
+
+L95BE               ldd       [,s]
+                    cmpd      #$0005
+                    beq       L95CE
+                    ldd       [,s]
+                    cmpd      #$0006
+                    bne       L95DC
+L95CE               ldd       $0C,s
+                    pshs      d
+                    lbsr      L39A2
+L95D5               leas      $02,s
+                    leax      $06,s
+                    lbra      L973C
+
+L95DC               ldd       ,s
+                    pshs      d
+                    lbsr      L9971
+                    std       ,s++
+                    bne       L9613
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L9754
+                    std       ,s++
+                    beq       L95FB
+                    pshs      u
+                    lbsr      L9754
+                    std       ,s++
+                    beq       L9613
+L95FB               ldd       $06,u
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    beq       L9626
+                    ldx       ,s
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    bne       L9626
+L9613               ldd       ,s
+                    std       $04,s
+                    stu       ,s
+                    ldu       $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L9929
+                    leas      $02,s
+                    std       $0a,s
+L9626               ldx       ,s
+                    ldd       $06,x
+                    std       $04,s
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    lbeq      L96A9
+                    pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L9682
+
+L9642               pshs      u
+                    lbsr      L6EAC
+                    leas      $02,s
+                    leax      $06,s
+                    bra       L966A
+
+L964D               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    ldd       #$0070
+                    std       $06,u
+                    bra       L966C
+
+L966A               leas      -$06,x
+L966C               ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       #$006E
+                    std       $06,u
+                    lbra      L9725
+
+L9682               cmpx      #$0041
+                    beq       L9642
+                    cmpx      #$0085
+                    beq       L964D
+                    cmpx      #$0071
+                    beq       L966C
+                    cmpx      #$0076
+                    lbeq      L966C
+                    cmpx      #$006F
+                    lbeq      L966C
+                    cmpx      #$0070
+                    lbeq      L966C
+                    lbra      L9725
+
+L96A9               pshs      u
+                    lbsr      L9971
+                    std       ,s++
+                    beq       L96C6
+                    ldd       $0a,s
+                    cmpd      #$0060
+                    bge       L96C6
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L97AE
+                    leas      $02,s
+                    lbra      L973E
+
+L96C6               ldd       ,s
+                    pshs      d
+                    lbsr      L6EAC
+                    leas      $02,s
+                    ldx       ,s
+                    ldd       $06,x
+                    std       $04,s
+                    pshs      u
+                    lbsr      L76BF
+                    std       ,s++
+                    bne       L96EF
+                    ldd       $04,s
+                    cmpd      #$0070
+                    bne       L96F8
+                    pshs      u
+                    lbsr      L9754
+                    std       ,s++
+                    beq       L96F8
+L96EF               pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    bra       L9725
+
+L96F8               ldd       $04,s
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L4623
+                    leas      $04,s
+                    ldd       #$006E
+                    ldx       ,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L6EAC
+                    leas      $02,s
+                    ldd       $06,u
+                    std       $04,s
+                    ldu       ,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L9929
+                    leas      $02,s
+                    std       $0a,s
+L9725               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0081
+                    pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L973E
+
+L973C               leas      -$06,x
+L973E               ldd       $02,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       #$0082
+                    pshs      d
+                    lbsr      L4623
+                    leas      $06,s
+                    leas      $06,s
+                    puls      pc,u
+L9754               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010F
+                    ldx       $04,s
+                    ldx       $06,x
+                    bra       L9772
+
+L9762               ldd       #$0001
+                    puls      pc,u
+L9767               ldd       $04,s
+                    pshs      d
+                    lbsr      L7759
+                    leas      $02,s
+                    puls      pc,u
+L9772               cmpx      #$0034
+                    beq       L9762
+                    cmpx      #$0036
+                    lbeq      L9762
+                    cmpx      #$0042
+                    beq       L9767
+                    lbra      L998C
+                    pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0034
+                    lbne      L998C
+                    ldx       $04,s
+                    ldx       $08,x
+                    ldd       $08,x
+                    cmpd      #$000D
+                    lbne      L998C
+                    ldd       #$0001
+                    lbra      L998E
+
+L97AE               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $06,u
+                    bra       L9813
+
+L97C2               ldd       $0C,u
+                    std       $02,s
+                    tfr       d,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L980B
+                    ldx       $02,s
+                    ldd       $08,x
+                    cmpd      #$00FF
+                    lbls      L9889
+                    bra       L980B
+
+L97DE               ldx       $0a,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    lbeq      L9889
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L9754
+                    std       ,s++
+                    lbne      L9889
+                    bra       L980B
+
+L97FC               ldx       $0a,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L8132
+                    std       ,s++
+                    lbeq      L9889
+L980B               ldd       #$0001
+                    std       ,s
+                    lbra      L9889
+
+L9813               cmpx      #$0057
+                    beq       L97C2
+                    cmpx      #$0078
+                    beq       L97DE
+                    cmpx      #$003E
+                    beq       L97FC
+                    cmpx      #$003F
+                    lbeq      L97FC
+                    cmpx      #$003D
+                    lbeq      L97FC
+                    cmpx      #$003C
+                    lbeq      L97FC
+                    cmpx      #$00A0
+                    lbeq      L97FC
+                    cmpx      #$00A1
+                    lbeq      L97FC
+                    cmpx      #$00A7
+                    lbeq      L97FC
+                    cmpx      #$00A8
+                    lbeq      L97FC
+                    cmpx      #$00A9
+                    lbeq      L97FC
+                    cmpx      #$0076
+                    beq       L980B
+                    cmpx      #$006F
+                    lbeq      L980B
+                    cmpx      #$0058
+                    lbeq      L980B
+                    cmpx      #$0059
+                    lbeq      L980B
+                    cmpx      #$0044
+                    lbeq      L980B
+                    cmpx      #$0043
+                    lbeq      L980B
+                    cmpx      #$0065
+                    lbeq      L980B
+L9889               clra
+                    clrb
+                    std       $0066
+                    pshs      u
+                    lbsr      L6F83
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L98CC
+
+L9898               ldd       ,s
+                    bne       L98A0
+                    ldd       $0066
+                    beq       L98ED
+L98A0               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$0081
+                    bra       L98C3
+
+L98B2               ldu       $0a,u
+L98B4               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+L98C3               pshs      d
+                    lbsr      L4623
+                    leas      $08,s
+                    bra       L98ED
+
+L98CC               cmpx      #$0071
+                    beq       L9898
+                    cmpx      #$0070
+                    lbeq      L9898
+                    cmpx      #$0076
+                    lbeq      L9898
+                    cmpx      #$006F
+                    lbeq      L9898
+                    cmpx      #$0085
+                    beq       L98B2
+                    bra       L98B4
+
+L98ED               leas      $04,s
+                    puls      pc,u
+L98F1               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldx       $04,s
+                    bra       L991B
+
+L98FD               ldd       #$005B
+                    puls      pc,u
+L9902               ldd       #$005A
+                    puls      pc,u
+L9907               ldd       $04,s
+                    cmpd      #$005F
+                    ble       L9914
+                    ldd       #$00C3
+                    bra       L9917
+
+L9914               ldd       #$00BB
+L9917               subd      $04,s
+                    puls      pc,u
+L991B               cmpx      #$005A
+                    beq       L98FD
+                    cmpx      #$005B
+                    beq       L9902
+                    bra       L9907
+                    puls      pc,u
+L9929               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldx       $04,s
+                    bra       L9947
+
+L9935               ldd       $04,s
+                    puls      pc,u
+L9939               ldd       $04,s
+                    addd      #$0002
+                    puls      pc,u
+L9940               ldd       $04,s
+                    addd      #$FFFE
+                    puls      pc,u
+L9947               cmpx      #$005A
+                    beq       L9935
+                    cmpx      #$005B
+                    lbeq      L9935
+                    cmpx      #$005C
+                    beq       L9939
+                    cmpx      #$005D
+                    lbeq      L9939
+                    cmpx      #$0060
+                    lbeq      L9939
+                    cmpx      #$0061
+                    lbeq      L9939
+                    bra       L9940
+                    puls      pc,u
+L9971               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010F
+                    ldu       $04,s
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L998C
+                    ldd       $08,u
+                    bne       L998C
+                    ldd       #$0001
+                    bra       L998E
+
+L998C               clra
+                    clrb
+L998E               puls      pc,u
+L9990               ldx       $02,s
+                    leas      -$08,s
+                    ldd       $05,x
+                    aslb
+                    rola
+                    std       $05,x
+                    std       $05,s
+                    ldd       $03,x
+                    rolb
+                    rola
+                    std       $03,x
+                    std       $03,s
+                    ldd       $01,x
+                    rolb
+                    rola
+                    std       $01,x
+                    std       $01,s
+                    lda       ,x
+                    rola
+                    sta       ,x
+                    sta       ,s
+                    asl       $06,x
+                    rol       $05,x
+                    rol       $04,x
+                    rol       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    bcs       L9A19
+                    asl       $06,x
+                    rol       $05,x
+                    rol       $04,x
+                    rol       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    bcs       L9A19
+                    ldd       $05,x
+                    addd      $05,s
+                    std       $05,x
+                    ldd       $03,x
+                    adcb      $04,s
+                    adca      $03,s
+                    std       $03,x
+                    ldd       $01,x
+                    adcb      $02,s
+                    adca      $01,s
+                    std       $01,x
+                    ldb       ,x
+                    adcb      ,s
+                    stb       ,x
+                    bcs       L9A19
+                    ldb       $0d,s
+                    andb      #$0f
+                    clra
+                    addd      $05,x
+                    std       $05,x
+                    ldd       #$0000
+                    adcb      $04,x
+                    adca      $03,x
+                    std       $03,x
+                    ldd       #$0000
+                    adcb      $02,x
+                    adca      $01,x
+                    std       $01,x
+                    lda       #$00
+                    adca      ,x
+                    sta       ,x
+                    bcs       L9A19
+                    leas      $08,s
+                    clra
+                    clrb
+                    rts
+
+L9A19               ldd       #$0001
+                    leas      $08,s
+                    rts
+
+L9A1F               pshs      u
+                    leax      $0253,y
+                    stx       L0070
+                    ldd       #$0001
+                    std       $0076
+                    leax      $06,s
+                    pshs      x
+                    ldd       $06,s
+                    bra       L9A45
+
+L9A34               pshs      u
+                    ldd       $04,s
+                    std       L0070
+                    ldd       #$0001
+                    std       $0076
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L9A45               pshs      d
+                    bsr       L9A6C
+                    leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $04,s
+                    std       L0070
+                    ldd       #$0002
+                    std       $0076
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L9A6C
+                    leas      $04,s
+                    clra
+                    clrb
+                    stb       [L0070,y]
+                    puls      pc,u
+L9A6C               pshs      u
+                    ldu       $04,s
+                    leas      -$0b,s
+                    bra       L9A84
+
+L9A74               ldb       $08,s
+                    lbeq      L9BE2
+                    ldb       $08,s
+                    sex
+                    pshs      d
+                    lbsr      L9DC1
+                    leas      $02,s
+L9A84               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    bne       L9A74
+                    ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L9AA7
+                    ldd       #$0001
+                    std       $0072
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L9AAB
+
+L9AA7               clra
+                    clrb
+                    std       $0072
+L9AAB               ldb       $08,s
+                    cmpb      #$30
+                    bne       L9AB6
+                    ldd       #$0030
+                    bra       L9AB9
+
+L9AB6               ldd       #$0020
+L9AB9               std       $0074
+                    bra       L9AD7
+
+L9ABD               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      LAF4B
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+L9AD7               ldb       $08,s
+                    sex
+L9ADA               leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L9ABD
+                    ldb       $08,s
+                    cmpb      #$2e
+                    bne       L9B1E
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L9B09
+
+L9AF3               ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      LAF4B
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+L9B09               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $00BA,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L9AF3
+                    bra       L9B22
+
+L9B1E               clra
+                    clrb
+                    std       $04,s
+L9B22               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L9BC4
+
+L9B2A               ldd       $06,s
+                    pshs      d
+                    ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L9BE6
+                    bra       L9B52
+
+L9B3F               ldd       $06,s
+                    pshs      d
+                    ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L9CA7
+L9B52               std       ,s
+                    lbra      L9BAF
+
+L9B57               ldx       $11,s
+                    leax      $02,x
+                    stx       $11,s
+                    ldd       -$02,x
+                    lbra      L9BBA
+
+L9B64               ldx       $11,s
+                    leax      $02,x
+                    stx       $11,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L9BA7
+                    ldd       $09,s
+                    std       $04,s
+                    bra       L9B86
+
+L9B7A               ldb       [$09,s]
+                    beq       L9B92
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+L9B86               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L9B7A
+L9B92               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L9D66
+                    leas      $06,s
+                    bra       L9BB4
+
+L9BA7               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    pshs      d
+L9BAF               lbsr      L9D06
+                    leas      $04,s
+L9BB4               lbra      L9A84
+
+L9BB7               ldb       $08,s
+                    sex
+L9BBA               pshs      d
+                    lbsr      L9DC1
+                    leas      $02,s
+                    lbra      L9A84
+
+L9BC4               cmpx      #$0064
+                    lbeq      L9B2A
+                    cmpx      #$0078
+                    lbeq      L9B3F
+                    cmpx      #$0063
+                    lbeq      L9B57
+                    cmpx      #$0073
+                    lbeq      L9B64
+                    bra       L9BB7
+
+L9BE2               leas      $0b,s
+                    puls      pc,u
+L9BE6               pshs      u,d
+                    leax      $088a,y
+                    stx       ,s
+                    ldd       $06,s
+                    bge       L9C1B
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+                    bge       L9C10
+                    leax      L9DE6,pcr
+                    pshs      x
+                    leax      $088a,y
+                    pshs      x
+                    lbsr      $A5D9
+                    leas      $04,s
+                    lbra      L9DBD
+
+L9C10               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L9C1B               ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L9C30
+                    leas      $04,s
+                    leax      $088a,y
+                    tfr       x,d
+                    lbra      L9DBD
+
+L9C30               pshs      u,y,x,d
+                    ldu       $0a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L9C4D
+
+L9C3E               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      $023e,y
+                    std       $0C,s
+L9C4D               ldd       $0C,s
+                    blt       L9C3E
+                    leax      $023e,y
+                    stx       $04,s
+                    bra       L9C8F
+
+L9C59               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L9C60               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    bge       L9C59
+                    ldd       $0C,s
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L9C79
+                    ldd       #$0001
+                    std       $02,s
+L9C79               ldd       $02,s
+                    beq       L9C84
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L9C84               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+L9C8F               ldd       $04,s
+                    cmpd      $0001
+                    bne       L9C60
+                    ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $06,s
+                    puls      pc,u
+L9CA7               pshs      u,x,d
+                    leax      $088a,y
+                    stx       $02,s
+                    leau      $0894,y
+L9CB3               ldd       $08,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L9CC9
+                    ldd       #$0057
+                    bra       L9CCC
+
+L9CC9               ldd       #$0030
+L9CCC               addd      ,s++
+                    stb       ,u+
+                    ldd       $08,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $08,s
+                    bne       L9CB3
+                    bra       L9CEC
+
+L9CE2               ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+L9CEC               leau      -$01,u
+                    pshs      u
+                    leax      $0894,y
+                    cmpx      ,s++
+                    bls       L9CE2
+                    clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $088a,y
+                    tfr       x,d
+                    lbra      L9DE2
+
+L9D06               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $A5C8
+                    leas      $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    leau      d,u
+                    ldd       $0072
+                    bne       L9D3D
+                    bra       L9D2A
+
+L9D21               ldd       $0074
+                    pshs      d
+                    lbsr      L9DC1
+                    leas      $02,s
+L9D2A               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bgt       L9D21
+                    bra       L9D3D
+
+L9D34               ldd       ,s
+                    pshs      d
+                    lbsr      L9DC1
+                    leas      $02,s
+L9D3D               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    sex
+                    std       ,s
+                    bne       L9D34
+                    ldd       $0072
+                    lbeq      L9DBD
+                    bra       L9D5B
+
+L9D52               ldd       $0074
+                    pshs      d
+                    lbsr      L9DC1
+                    leas      $02,s
+L9D5B               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bgt       L9D52
+                    lbra      L9DBD
+
+L9D66               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       ,s
+                    ldd       $0072
+                    bne       L9D97
+                    bra       L9D80
+
+L9D78               ldd       $0074
+                    pshs      d
+                    bsr       L9DC1
+                    leas      $02,s
+L9D80               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bgt       L9D78
+                    bra       L9D97
+
+L9D8E               ldb       ,u+
+                    sex
+                    pshs      d
+                    bsr       L9DC1
+                    leas      $02,s
+L9D97               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L9D8E
+                    ldd       $0072
+                    beq       L9DBD
+                    bra       L9DB1
+
+L9DA9               ldd       $0074
+                    pshs      d
+                    bsr       L9DC1
+                    leas      $02,s
+L9DB1               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bgt       L9DA9
+L9DBD               leas      $02,s
+                    puls      pc,u
+L9DC1               pshs      u
+                    ldd       $0076
+                    cmpd      #$0002
+                    bne       L9DD7
+                    ldd       $04,s
+                    ldx       L0070
+                    leax      $01,x
+                    stx       L0070
+                    stb       -$01,x
+                    bra       L9DE4
+
+L9DD7               ldd       L0070
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $A1CD
+L9DE2               leas      $04,s
+L9DE4               puls      pc,u
+L9DE6               blt       $9E1B
+                    leas      -$09,y
+                    pshu      y,x,dp
+                    neg       $0034
+                    nega
+                    leau      $0246,y
+L9DF3               ldd       $06,u
+                    clra
+                    andb      #$03
+                    lbeq      L9E64
+                    leau      $0d,u
+                    pshs      u
+                    leax      $0316,y
+                    cmpx      ,s++
+                    bhi       L9DF3
+                    ldd       #$00C8
+                    std       $0364,y
+                    lbra      L9E68
+                    puls      pc,u
+                    pshs      u
+                    ldu       $08,s
+                    bne       L9E1E
+                    bsr       $9DED
+                    tfr       d,u
+L9E1E               stu       -$02,s
+                    beq       L9E68
+                    ldd       $04,s
+                    std       $08,u
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$2b
+                    beq       L9E36
+                    ldx       $06,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L9E3C
+L9E36               ldd       $06,u
+                    orb       #$03
+                    bra       L9E5A
+
+L9E3C               ldd       $06,u
+                    pshs      d
+                    ldb       [$08,s]
+                    cmpb      #$72
+                    beq       L9E4E
+                    ldb       [$08,s]
+                    cmpb      #$64
+                    bne       L9E53
+L9E4E               ldd       #$0001
+                    bra       L9E56
+
+L9E53               ldd       #$0002
+L9E56               ora       ,s+
+                    orb       ,s+
+L9E5A               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+L9E64               tfr       u,d
+                    puls      pc,u
+L9E68               clra
+                    clrb
+                    puls      pc,u
+L9E6C               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $0a,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L9E9D
+
+L9E7F               ldx       $0a,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L9E8C
+                    ldd       #$0007
+                    bra       L9E94
+
+L9E8C               ldd       #$0004
+                    bra       L9E94
+
+L9E91               ldd       #$0003
+L9E94               std       ,s
+                    bra       L9EAD
+
+L9E98               leax      $04,s
+                    lbra      L9F05
+
+L9E9D               stx       -$02,s
+                    beq       L9EAD
+                    cmpx      #$0078
+                    beq       L9E7F
+                    cmpx      #$002B
+                    beq       L9E91
+                    bra       L9E98
+
+L9EAD               ldb       [$0a,s]
+                    sex
+                    tfr       d,x
+                    lbra      L9F12
+
+L9EB6               ldd       ,s
+                    orb       #$01
+                    bra       L9EF8
+
+L9EBC               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      $B116
+                    leas      $04,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L9EE7
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $B1EC
+                    leas      $08,s
+                    bra       L9F2C
+
+L9EE7               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      $B137
+                    bra       L9EFF
+
+L9EF4               ldd       ,s
+                    orb       #$81
+L9EF8               pshs      d
+                    pshs      u
+                    lbsr      $B116
+L9EFF               leas      $04,s
+                    std       $02,s
+                    bra       L9F2C
+
+L9F05               leas      -$04,x
+L9F07               ldd       #$00CB
+                    std       $0364,y
+                    clra
+                    clrb
+                    bra       L9F2E
+
+L9F12               cmpx      #$0072
+                    lbeq      L9EB6
+                    cmpx      #$0061
+                    lbeq      L9EBC
+                    cmpx      #$0077
+                    beq       L9EE7
+                    cmpx      #$0064
+                    beq       L9EF4
+                    bra       L9F07
+
+L9F2C               ldd       $02,s
+L9F2E               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      $9F8E
+
+L9F43               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L9E6C
+                    leas      $04,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L9F5E
+                    clra
+                    clrb
+                    bra       $9F93
+
+L9F5E               clra
+                    clrb
+                    bra       $9F86
+
+L9F62               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lsr       $0017
+                    com       $0053
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $9E6D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L9F85
+                    clra
+                    clrb
+                    bra       L9F94
+
+L9F85               ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $9E15
+                    leas      $06,s
+L9F94               puls      pc,u
+                    pshs      u
+                    leax      $0253,y
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    bsr       L9FB8
+                    leas      $04,s
+                    leax      $0253,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      LA1CE
+                    leas      $04,s
+                    puls      pc,u
+L9FB8               pshs      u
+                    ldu       $04,s
+                    leas      -$01,s
+                    bra       L9FCE
+
+L9FC0               ldd       $07,s
+                    pshs      d
+                    ldb       $02,s
+                    sex
+                    pshs      d
+                    lbsr      LA1CE
+                    leas      $04,s
+L9FCE               ldb       ,u+
+                    stb       ,s
+                    bne       L9FC0
+                    leas      $01,s
+                    puls      pc,u
+                    pshs      u,d
+                    ldu       $06,s
+                    bra       L9FE0
+
+L9FDE               leau      $01,u
+L9FE0               ldb       ,u
+                    sex
+                    std       ,s
+                    beq       L9FEF
+                    ldd       ,s
+                    cmpd      #$0058
+                    bne       L9FDE
+L9FEF               ldd       ,s
+                    beq       LA005
+                    lbsr      LB2D8
+                    pshs      d
+                    leax      >LA00B,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      $9A4E
+                    leas      $06,s
+LA005               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+LA00B               bcs       LA071
+                    neg       $0034
+                    nega
+                    ldu       $04,s
+                    leas      -$06,s
+                    cmpu      #$0000
+                    beq       LA021
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       LA027
+LA021               ldd       #$FFFF
+                    lbra      LA14A
+
+LA027               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       LA03A
+                    pshs      u
+                    lbsr      LA539
+                    leas      $02,s
+                    lbra      LA110
+
+LA03A               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       LA059
+                    pshs      u
+                    lbsr      LA2F9
+                    leas      $02,s
+                    ldd       $06,u
+                    anda      #$FE
+                    std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    lbra      LA10E
+
+LA059               ldd       ,u
+                    cmpd      $04,u
+                    lbcc      LA110
+                    leax      $02,s
+                    pshs      x
+                    leax      $0e,s
+                    lbsr      LAEE0
+                    ldx       $10,s
+                    lbra      LA0DD
+
+LA071               leax      $02,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    pshs      u
+                    lbsr      LA165
+                    leas      $02,s
+                    lbsr      LAE67
+                    lbsr      LAEE0
+LA08A               ldd       $0b,u
+                    lbsr      LAEC7
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    leax      $06,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       LA0A7
+                    neg       $0000
+                    neg       $0000
+LA0A7               puls      x
+                    lbsr      LAE7C
+                    bge       LA0B5
+                    leax      $06,s
+                    lbsr      LAEA0
+                    bra       LA0B7
+
+LA0B5               leax      $06,s
+LA0B7               lbsr      LAE7C
+                    blt       LA0EA
+                    ldd       $04,s
+                    addd      ,u
+                    std       ,s
+                    cmpd      $02,u
+                    bcs       LA0EA
+                    ldd       ,s
+                    cmpd      $04,u
+                    bcc       LA0EA
+                    ldd       ,s
+                    std       ,u
+                    ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    lbra      LA148
+                    bra       LA0EA
+
+LA0DD               stx       -$02,s
+                    lbeq      LA071
+                    cmpx      #$0001
+                    lbeq      LA08A
+LA0EA               ldd       $10,s
+                    cmpd      #$0001
+                    bne       LA10C
+                    leax      $0C,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $04,u
+                    subd      ,u
+                    lbsr      LAEC7
+                    lbsr      LAE67
+                    lbsr      LAEE0
+LA10C               ldd       $04,u
+LA10E               std       ,u
+LA110               ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    ldd       $10,s
+                    pshs      d
+                    leax      $0e,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB1ED
+                    leas      $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       $A13C
+                    stu       $FFFF
+                    stu       L3510
+                    lbsr      LAE7C
+                    bne       LA148
+                    ldd       #$FFFF
+                    bra       LA14A
+
+LA148               clra
+                    clrb
+LA14A               leas      $06,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      $A00E
+                    leas      $08,s
+                    puls      pc,u
+LA165               pshs      u
+                    ldu       $04,s
+                    beq       LA172
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       LA185
+LA172               bsr       $A178
+                    stu       $FFFF
+                    stu       L3510
+                    leau      $0358,y
+                    pshs      u
+                    lbsr      LAEE0
+                    puls      pc,u
+LA185               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       LA195
+                    pshs      u
+                    lbsr      LA539
+                    leas      $02,s
+LA195               ldd       #$0001
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB1ED
+                    leas      $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       LA1BE
+                    ldd       $02,u
+                    bra       LA1C0
+
+LA1BE               ldd       $04,u
+LA1C0               pshs      d
+                    ldd       ,u
+                    subd      ,s++
+                    lbsr      LAEC7
+                    lbsr      LAE52
+                    puls      pc,u
+LA1CE               pshs      u
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       LA1F2
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    lbne      LA30A
+                    pshs      u
+                    lbsr      LA539
+                    leas      $02,s
+LA1F2               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       LA22E
+                    ldd       #$0001
+                    pshs      d
+                    leax      $07,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       LA213
+                    leax      LB1DD,pcr
+                    bra       LA217
+
+LA213               leax      LB1C4,pcr
+LA217               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       LA26F
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      LA30A
+
+LA22E               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       LA23E
+                    pshs      u
+                    lbsr      LA327
+                    leas      $02,s
+LA23E               ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       LA264
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       LA26F
+                    ldd       $04,s
+                    cmpd      #$000D
+                    bne       LA26F
+LA264               pshs      u
+                    lbsr      LA327
+                    std       ,s++
+                    lbne      LA30A
+LA26F               ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      LB076
+                    pshs      d
+                    lbsr      LA1CE
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      LA1CE
+                    lbra      LA3E1
+
+LA296               pshs      u,d
+                    leau      $0246,y
+                    clra
+                    clrb
+                    std       ,s
+                    bra       LA2AC
+
+LA2A2               tfr       u,d
+                    leau      $0d,u
+                    pshs      d
+                    bsr       LA2BF
+                    leas      $02,s
+LA2AC               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    blt       LA2A2
+                    lbra      LA323
+
+LA2BF               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       LA2CF
+                    ldd       $06,u
+                    bne       LA2D5
+LA2CF               ldd       #$FFFF
+                    lbra      LA323
+
+LA2D5               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       LA2E4
+                    pshs      u
+                    bsr       LA2F9
+                    leas      $02,s
+                    bra       LA2E6
+
+LA2E4               clra
+                    clrb
+LA2E6               std       ,s
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB126
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $06,u
+                    ldd       ,s
+                    bra       LA323
+
+LA2F9               pshs      u
+                    ldu       $04,s
+                    beq       LA30A
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       LA30F
+LA30A               ldd       #$FFFF
+                    puls      pc,u
+LA30F               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       LA31F
+                    pshs      u
+                    lbsr      LA539
+                    leas      $02,s
+LA31F               pshs      u
+                    bsr       LA327
+LA323               leas      $02,s
+                    puls      pc,u
+LA327               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       LA359
+                    ldd       ,u
+                    cmpd      $04,u
+                    beq       LA359
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      LA165
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB1ED
+                    leas      $08,s
+LA359               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      LA3D1
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      LA3D1
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       LA3A8
+                    ldd       $02,u
+                    bra       LA3A0
+
+LA379               ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB1DD
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       LA396
+                    leax      $04,s
+                    bra       LA3C0
+
+LA396               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+LA3A0               std       ,u
+                    ldd       $02,s
+                    bne       LA379
+                    bra       LA3D1
+
+LA3A8               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB1C4
+                    leas      $06,s
+                    cmpd      $02,s
+                    beq       LA3D1
+                    bra       LA3C2
+
+LA3C0               leas      -$04,x
+LA3C2               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       LA3E1
+
+LA3D1               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+LA3E1               leas      $04,s
+                    puls      pc,u
+LA3E5               pshs      u
+                    ldu       $04,s
+                    beq       LA431
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       LA431
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       LA40D
+                    ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldb       ,x
+                    clra
+                    lbra      LA537
+
+LA40D               pshs      u
+                    lbsr      LA480
+                    lbra      LA535
+                    pshs      u
+                    ldu       $06,s
+                    beq       LA431
+                    ldd       $06,u
+                    clra
+                    andb      #$01
+                    beq       LA431
+                    ldd       $04,s
+                    cmpd      #$FFFF
+                    beq       LA431
+                    ldd       ,u
+                    cmpd      $02,u
+                    bhi       LA436
+LA431               ldd       #$FFFF
+                    puls      pc,u
+LA436               ldd       ,u
+                    addd      #$FFFF
+                    std       ,u
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      LA3E5
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       LA46B
+                    pshs      u
+                    lbsr      LA3E5
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       LA470
+LA46B               ldd       #$FFFF
+                    bra       LA47C
+
+LA470               ldd       $02,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      LB08D
+                    addd      ,s
+LA47C               leas      $04,s
+                    puls      pc,u
+LA480               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$31
+                    cmpd      #$8001
+                    beq       LA4A6
+                    ldd       $06,u
+                    clra
+                    andb      #$31
+                    cmpd      #$0001
+                    lbne      LA51F
+                    pshs      u
+                    lbsr      LA539
+                    leas      $02,s
+LA4A6               leax      $0246,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       LA4C3
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       LA4C3
+                    leax      $0253,y
+                    pshs      x
+                    lbsr      LA2F9
+                    leas      $02,s
+LA4C3               ldd       $06,u
+                    clra
+                    andb      #$08
+                    beq       LA4EF
+                    ldd       $0b,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       LA4E3
+                    leax      LB1B4,pcr
+                    bra       LA4E7
+
+LA4E3               leax      LB193,pcr
+LA4E7               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    bra       LA501
+
+LA4EF               ldd       #$0001
+                    pshs      d
+                    leax      $0a,u
+                    stx       $02,u
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      LB193
+LA501               leas      $06,s
+                    std       ,s
+                    ldd       ,s
+                    bgt       LA524
+                    ldd       $06,u
+                    pshs      d
+                    ldd       $02,s
+                    beq       LA516
+                    ldd       #$0020
+                    bra       LA519
+
+LA516               ldd       #$0010
+LA519               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+LA51F               ldd       #$FFFF
+                    bra       LA535
+
+LA524               ldd       $02,u
+                    addd      #$0001
+                    std       ,u
+                    ldd       $02,u
+                    addd      ,s
+                    std       $04,u
+                    ldb       [$02,u]
+                    clra
+LA535               leas      $02,s
+LA537               puls      pc,u
+LA539               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       LA571
+                    leas      -$20,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      LB0A8
+                    leas      $06,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       LA565
+                    ldd       #$0040
+                    bra       LA568
+
+LA565               ldd       #$0080
+LA568               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $20,s
+LA571               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       LA57E
+                    puls      pc,u
+LA57E               ldd       $0b,u
+                    bne       LA593
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       LA58E
+                    ldd       #$0080
+                    bra       LA591
+
+LA58E               ldd       #$0100
+LA591               std       $0b,u
+LA593               ldd       $02,u
+                    bne       LA5A8
+                    ldd       $0b,u
+                    pshs      d
+                    lbsr      LB2AB
+                    leas      $02,s
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       LA5B0
+LA5A8               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       LA5BF
+
+LA5B0               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+LA5BF               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+LA5CD               ldb       ,u+
+                    bne       LA5CD
+                    tfr       u,d
+                    subd      $04,s
+                    addd      #$FFFF
+                    puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+LA5E4               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       LA5E4
+                    bra       LA619
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+LA5FC               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       LA5FC
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+LA60D               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       LA60D
+LA619               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    bra       LA635
+
+LA625               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       LA633
+                    clra
+                    clrb
+                    puls      pc,u
+LA633               leau      $01,u
+LA635               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       LA625
+                    ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+                    puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+LA65A               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       LA67E
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       LA65A
+                    bra       LA67E
+
+LA674               clra
+                    clrb
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+LA67E               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       LA674
+                    lbra      LA70D
+                    pshs      u
+                    ldu       $04,s
+                    bra       LA6A3
+
+LA693               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       LA6A1
+                    clra
+                    clrb
+                    puls      pc,u
+LA6A1               leau      $01,u
+LA6A3               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    ble       LA6BD
+                    ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       LA693
+LA6BD               ldd       $08,s
+                    bge       LA6C5
+                    clra
+                    clrb
+                    bra       LA6D0
+
+LA6C5               ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+LA6D0               puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+LA6DC               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       LA6DC
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+LA6ED               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       LA705
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       LA6ED
+LA705               ldd       $0a,s
+                    bge       LA70D
+                    clra
+                    clrb
+                    stb       [,s]
+LA70D               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+LA717               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    stb       ,u+
+                    bgt       LA717
+                    ldb       -$01,u
+                    clra
+                    andb      #$7f
+                    stb       -$01,u
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $04,s
+                    puls      pc,u
+                    ldx       $02,s
+                    lbsr      LAE0E
+                    bsr       LA73A
+                    rts
+
+LA73A               pshs      u
+                    leas      -$1e,s
+                    tfr       s,u
+                    clr       $1d,u
+                    clr       $19,u
+                    lbsr      LA9B4
+                    lbra      LA7D9
+                    ldd       ,x
+                    eora      #$80
+                    lbra      LAD72
+                    lbsr      LABCC
+                    lbsr      LA8AE
+                    lbra      LA7D9
+                    lbsr      LABCC
+                    lbsr      LA884
+                    lbra      LA7D9
+                    lbsr      LABCC
+                    lbsr      LAA27
+                    bra       LA7D9
+                    lbsr      LABCC
+                    lbsr      LAA53
+                    bra       LA7D9
+
+LA776               lbsr      LAD70
+                    lbra      LAC70
+                    bsr       LA776
+                    ldd       $02,x
+LA780               rts
+                    ldd       ,x
+                    std       $0358,y
+                    ldd       $02,x
+                    leax      $0358,y
+                    std       $02,x
+                    lbra      LAC10
+                    leax      $0358,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+                    lbra      LAC10
+                    leax      $0358,y
+                    std       $02,x
+                    clr       ,x
+                    clr       $01,x
+                    lbra      LAC10
+                    ldd       ,x
+                    std       $0358,y
+                    lda       $02,x
+                    ldb       $07,x
+                    leax      $0358,y
+                    std       $02,x
+                    rts
+                    ldd       ,x
+                    std       $0358,y
+                    ldd       $02,x
+                    leax      $0358,y
+                    sta       $02,x
+                    stb       $07,x
+                    clr       $03,x
+                    clr       $04,x
+                    clr       $05,x
+                    clr       $06,x
+                    rts
+
+LA7D9               leax      $0358,y
+                    ldd       $22,u
+                    std       ,x
+                    ldd       $24,u
+                    std       $02,x
+                    ldd       $26,u
+                    std       $04,x
+                    ldd       $28,u
+                    std       $06,x
+                    leas      $1e,u
+                    puls      u
+                    puls      d
+                    std       $06,s
+                    leas      $06,s
+                    rts
+                    lda       $02,s
+                    eora      ,x
+                    bmi       LA86C
+                    lda       $02,s
+                    bmi       LA83F
+                    lda       $09,s
+                    beq       LA838
+                    ldb       $07,x
+                    beq       LA870
+                    cmpa      $07,x
+                    bne       LA843
+                    ldd       $02,s
+                    cmpd      ,x
+                    bne       LA843
+                    ldd       $04,s
+                    cmpd      $02,x
+                    bne       LA843
+                    ldd       $06,s
+                    cmpd      $04,x
+                    bne       LA843
+                    lda       $08,s
+                    anda      #$FE
+                    pshs      a
+                    ldb       $06,x
+                    andb      #$FE
+                    cmpa      ,s+
+                    bne       LA843
+                    bra       LA874
+
+LA838               lda       $07,x
+                    bne       LA87F
+                    clra
+                    bra       LA874
+
+LA83F               lda       $07,x
+                    cmpa      $09,s
+LA843               bhi       LA870
+                    bcs       LA87F
+                    ldd       ,x
+                    cmpd      $02,s
+                    bne       LA843
+                    ldd       $02,x
+                    cmpd      $04,s
+                    bne       LA843
+                    ldd       $04,x
+                    cmpd      $06,s
+                    bne       LA843
+                    lda       $06,x
+                    anda      #$FE
+                    pshs      a
+                    lda       $08,s
+                    anda      #$FE
+                    cmpa      ,s+
+                    bne       LA843
+                    bra       LA874
+
+LA86C               lda       ,x
+                    bpl       LA87F
+LA870               lda       #$01
+                    andcc     #$FE
+LA874               pshs      cc
+                    ldd       $01,s
+                    std       $09,s
+                    puls      cc
+                    leas      $08,s
+                    rts
+
+LA87F               clra
+                    cmpa      #$01
+                    bra       LA874
+
+LA884               lda       $17,u
+                    beq       LA8A5
+                    ldb       $1C,u
+                    eorb      #$80
+                    stb       $1C,u
+                    eorb      $18,u
+                    stb       $19,u
+                    ldb       $29,u
+                    bne       LA8B7
+                    lbsr      LAD40
+                    lda       $22,u
+                    lbra      LA9F7
+
+LA8A5               lda       $22,u
+                    ldb       $18,u
+                    lbra      LA9FA
+
+LA8AE               lbeq      LAD40
+                    lda       $17,u
+                    beq       LA8A5
+LA8B7               suba      $29,u
+                    beq       LA8E8
+                    sta       ,u
+                    bcs       LA8EE
+                    ldb       $17,u
+                    stb       $29,u
+                    ldd       $22,u
+LA8C9               lsra
+                    rorb
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+                    dec       ,u
+                    bne       LA8C9
+                    std       $22,u
+LA8E1               lda       $19,u
+                    bmi       LA95D
+                    bra       LA90E
+
+LA8E8               inc       ,u
+                    orcc      #$01
+                    bra       LA8E1
+
+LA8EE               ldd       $10,u
+LA8F1               lsra
+                    rorb
+                    ror       $12,u
+                    ror       $13,u
+                    ror       $14,u
+                    ror       $15,u
+                    ror       $16,u
+                    inc       ,u
+                    bne       LA8F1
+                    std       $10,u
+                    lda       $19,u
+                    bmi       LA960
+LA90E               ldd       $27,u
+                    adcb      $16,u
+                    adca      $15,u
+                    std       $27,u
+                    ldd       $25,u
+                    adcb      $14,u
+                    adca      $13,u
+                    std       $25,u
+                    ldb       $24,u
+                    adcb      $12,u
+                    stb       $24,u
+                    ldd       $22,u
+                    adcb      $11,u
+                    adca      $10,u
+                    std       $22,u
+                    bcc       LA955
+                    inc       $29,u
+                    ror       $22,u
+                    ror       $23,u
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+LA955               lda       $1C,u
+                    sta       $19,u
+                    bra       LA9B4
+
+LA95D               rola
+                    coma
+                    asra
+LA960               ldd       $27,u
+                    sbcb      $16,u
+                    sbca      $15,u
+                    std       $27,u
+                    ldd       $25,u
+                    sbcb      $14,u
+                    sbca      $13,u
+                    std       $25,u
+                    ldd       $23,u
+                    sbcb      $12,u
+                    sbca      $11,u
+                    std       $23,u
+                    lda       $22,u
+                    sbca      $10,u
+                    sta       $22,u
+                    lda       $18,u
+                    bcc       LA9B1
+                    com       $22,u
+                    com       $23,u
+                    com       $24,u
+                    com       $25,u
+                    com       $26,u
+                    com       $27,u
+                    com       $28,u
+                    lda       ,u
+                    beq       LA9AE
+                    lbsr      LACFD
+LA9AE               lda       $1C,u
+LA9B1               sta       $19,u
+LA9B4               clr       ,u
+LA9B6               lda       $22,u
+                    bmi       LA9F7
+                    ora       $23,u
+                    ora       $24,u
+                    ora       $25,u
+                    ora       $26,u
+                    ora       $27,u
+                    ora       $28,u
+                    beq       LAA0B
+                    ldd       $22,u
+LA9D2               dec       $29,u
+                    bne       LA9DA
+                    dec       $1d,u
+LA9DA               asl       ,u
+                    rol       $28,u
+                    rol       $27,u
+                    rol       $26,u
+                    rol       $25,u
+                    rol       $24,u
+                    rolb
+                    rola
+                    bpl       LA9D2
+                    stb       $23,u
+                    ldb       $29,u
+                    beq       LAA0F
+LA9F7               ldb       $19,u
+LA9FA               anda      #$7f
+                    andb      #$80
+                    pshs      b
+                    adda      ,s+
+                    sta       $22,u
+                    tst       $1d,u
+                    bne       LAA0F
+LAA0A               rts
+
+LAA0B               sta       $29,u
+                    rts
+
+LAA0F               lda       $1d,u
+                    ldb       $29,u
+                    subd      #$0000
+                    beq       LAA22
+                    bmi       LAA22
+LAA1C               ldd       #$0028
+                    lbra      LB099
+
+LAA22               lbsr      LAA4D
+                    bra       LAA1C
+
+LAA27               beq       LAA4D
+                    lda       $17,u
+                    beq       LAA4D
+                    lbsr      LAAC9
+                    clra
+                    ldb       $29,u
+                    addb      $17,u
+                    adca      #$00
+                    subd      #$0080
+                    stb       $29,u
+                    sta       $1d,u
+                    lbsr      LA9B6
+                    lda       ,u
+                    bpl       LAA0A
+                    lbra      LACFD
+
+LAA4D               clra
+                    sta       $29,u
+                    bra       LAAB3
+
+LAA53               ldb       $17,u
+                    bne       LAA5E
+                    ldd       #$0029
+                    lbra      LB099
+
+LAA5E               tsta
+                    beq       LAA4D
+                    lbsr      LAB27
+                    clra
+                    ldb       $29,u
+                    subb      $17,u
+                    sbca      #$00
+                    addd      #$0081
+                    sta       $1d,u
+                    stb       $29,u
+                    lda       $06,u
+                    coma
+                    asra
+                    ror       $22,u
+                    ror       $23,u
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+                    ror       ,u
+                    lbsr      LA9B6
+                    lda       ,u
+                    bpl       LAAC8
+                    lbra      LACFD
+
+LAA9B               pshs      a
+                    ldd       $22,u
+                    std       ,u
+                    ldd       $24,u
+                    std       $02,u
+                    ldd       $26,u
+                    std       $04,u
+                    ldb       $28,u
+                    stb       $06,u
+                    puls      a
+LAAB3               sta       $22,u
+                    sta       $23,u
+                    sta       $24,u
+                    sta       $25,u
+                    sta       $26,u
+                    sta       $27,u
+                    sta       $28,u
+LAAC8               rts
+
+LAAC9               clra
+                    bsr       LAA9B
+                    ldb       #$38
+                    stb       $08,u
+LAAD0               lda       $06,u
+                    lsra
+                    bcc       LAAFF
+                    ldd       $27,u
+                    addd      $15,u
+                    std       $27,u
+                    ldd       $25,u
+                    adcb      $14,u
+                    adca      $13,u
+                    std       $25,u
+                    ldd       $23,u
+                    adcb      $12,u
+                    adca      $11,u
+                    std       $23,u
+                    lda       $22,u
+                    adca      $10,u
+                    sta       $22,u
+LAAFF               ror       $22,u
+                    ror       $23,u
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+                    ror       ,u
+                    ror       $01,u
+                    ror       $02,u
+                    ror       $03,u
+                    ror       $04,u
+                    ror       $05,u
+                    ror       $06,u
+                    dec       $08,u
+                    bne       LAAD0
+                    rts
+
+LAB27               clra
+                    lbsr      LAA9B
+                    ldb       #$39
+                    stb       $08,u
+LAB2F               ldb       ,u
+                    cmpb      $10,u
+                    bcs       LAB66
+                    ldd       $05,u
+                    subd      $15,u
+                    std       $0d,u
+                    ldd       $03,u
+                    sbcb      $14,u
+                    sbca      $13,u
+                    std       $0b,u
+                    ldb       $02,u
+                    sbcb      $12,u
+                    stb       $0a,u
+                    ldd       ,u
+                    sbcb      $11,u
+                    sbca      $10,u
+                    bcs       LAB66
+                    std       ,u
+                    lda       $0a,u
+                    sta       $02,u
+                    ldd       $0b,u
+                    std       $03,u
+                    ldd       $0d,u
+                    std       $05,u
+LAB66               rol       $28,u
+                    rol       $27,u
+                    rol       $26,u
+                    rol       $25,u
+                    rol       $24,u
+                    rol       $23,u
+                    rol       $22,u
+                    rol       $06,u
+                    rol       $05,u
+                    rol       $04,u
+                    rol       $03,u
+                    rol       $02,u
+                    rol       $01,u
+                    rol       ,u
+                    dec       $08,u
+                    bhi       LAB2F
+                    beq       LABB4
+                    ldd       $05,u
+                    subd      $15,u
+                    std       $05,u
+                    ldd       $03,u
+                    sbcb      $14,u
+                    sbca      $13,u
+                    std       $03,u
+                    ldd       $01,u
+                    sbcb      $12,u
+                    sbca      $11,u
+                    std       $01,u
+                    lda       ,u
+                    sbca      $10,u
+                    sta       ,u
+                    clra
+                    bra       LAB66
+
+LABB4               ror       ,u
+                    com       $22,u
+                    com       $23,u
+                    com       $24,u
+                    com       $25,u
+                    com       $26,u
+                    com       $27,u
+                    com       $28,u
+                    rts
+
+LABCC               puls      d
+                    pshs      u
+                    leas      -$1e,s
+                    tfr       s,u
+                    pshs      d
+                    clr       $1d,u
+                    ldd       $06,x
+                    std       $16,u
+                    ldd       $04,x
+                    std       $14,u
+                    ldd       $02,x
+                    std       $12,u
+                    ldd       ,x
+                    stb       $11,u
+                    tfr       a,b
+                    sta       $1C,u
+                    ora       #$80
+                    sta       $10,u
+                    eorb      $22,u
+                    stb       $19,u
+                    lda       $22,u
+                    sta       $18,u
+                    ora       #$80
+                    sta       $22,u
+                    lda       $29,u
+                    rts
+                    leax      $22,u
+LAC10               lda       #$A0
+                    sta       $07,x
+                    clr       $04,x
+                    clr       $05,x
+                    clr       $06,x
+                    lda       ,x
+                    tfr       a,b
+                    orb       $01,x
+                    orb       $02,x
+                    orb       $03,x
+                    beq       LAC5C
+                    ldb       $01,x
+                    tsta
+                    bpl       LAC3E
+                    pshs      d
+                    clra
+                    clrb
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,s
+                    sbca      ,s
+                    leas      $02,s
+                    bvs       LAC48
+LAC3E               dec       $07,x
+                    asl       $03,x
+                    rol       $02,x
+                    rolb
+                    rola
+                    bpl       LAC3E
+LAC48               anda      #$7f
+                    tst       ,x
+                    bpl       LAC50
+                    ora       #$80
+LAC50               std       ,x
+                    rts
+                    leax      $22,u
+                    clr       $04,x
+                    clr       $05,x
+                    clr       $06,x
+LAC5C               clr       $07,x
+LAC5E               clr       ,x
+                    clr       $01,x
+                    clr       $02,x
+                    clr       $03,x
+                    rts
+
+LAC67               ldd       #$002A
+                    lbra      LB099
+                    leax      $22,u
+LAC70               ldb       $07,x
+                    beq       LAC5E
+                    subb      #$81
+                    bcs       LACEF
+                    negb
+                    addb      #$1f
+                    bmi       LAC67
+                    bne       LAC94
+                    ldd       ,x
+                    cmpd      #$8000
+                    bne       LAC67
+                    lda       $02,x
+                    ora       $03,x
+                    ora       $04,x
+                    ora       $05,x
+                    ora       $06,x
+                    bne       LAC67
+                    rts
+
+LAC94               pshs      b
+                    ldd       ,x
+                    bmi       LACAA
+                    ora       #$80
+LAC9C               lsra
+                    rorb
+                    ror       $02,x
+                    ror       $03,x
+                    dec       ,s
+                    bne       LAC9C
+                    std       ,x
+                    puls      pc,b
+LACAA               clr       ,-s
+LACAC               lsra
+                    rorb
+                    ror       $02,x
+                    ror       $03,x
+                    ror       $04,x
+                    ror       $05,x
+                    ror       $06,x
+                    bcc       LACBC
+                    inc       ,s
+LACBC               dec       $01,s
+                    bne       LACAC
+                    std       ,x
+                    ldd       ,s++
+                    bne       LACCE
+                    lda       $04,x
+                    ora       $05,x
+                    ora       $06,x
+                    beq       LACDF
+LACCE               ldd       $02,x
+                    addd      #$0001
+                    std       $02,x
+                    ldd       ,x
+                    adcb      #$00
+                    adca      #$00
+                    bcs       LAC67
+                    std       ,x
+LACDF               clra
+                    clrb
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       ,x
+                    rts
+
+LACEF               lda       ,x
+                    lbpl      LAC5E
+                    ldd       #$FFFF
+                    std       $02,x
+                    std       ,x
+                    rts
+
+LACFD               inc       $28,u
+                    bne       LAD33
+                    inc       $27,u
+                    bne       LAD33
+                    inc       $26,u
+                    bne       LAD33
+                    inc       $25,u
+                    bne       LAD33
+                    inc       $24,u
+                    bne       LAD33
+                    inc       $23,u
+                    bne       LAD33
+                    ldb       $22,u
+                    tfr       b,a
+                    anda      #$7f
+                    inca
+                    bpl       LAD2A
+                    inc       $29,u
+                    anda      #$7f
+LAD2A               andb      #$80
+                    pshs      b
+                    adda      ,s+
+                    sta       $22,u
+LAD33               rts
+
+LAD34               neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0081
+                    leax      >LAD34,pcr
+LAD40               pshs      a
+                    ldd       ,x
+                    std       $22,u
+                    ldd       $02,x
+                    std       $24,u
+                    ldd       $04,x
+                    std       $26,u
+                    ldd       $06,x
+                    std       $28,u
+                    puls      pc,a
+LAD58               pshs      a
+                    ldd       $22,u
+                    std       ,x
+                    ldd       $24,u
+                    std       $02,x
+                    ldd       $26,u
+                    std       $04,x
+                    ldd       $28,u
+                    std       $06,x
+                    puls      pc,a
+LAD70               ldd       ,x
+LAD72               std       $0358,y
+                    ldd       $02,x
+                    std       $035a,y
+                    ldd       $04,x
+                    std       $035C,y
+                    ldd       $06,x
+                    leax      $0358,y
+                    std       $06,x
+                    rts
+                    pshs      x
+                    bsr       LAE0E
+                    leax      LAD34,pcr
+                    pshs      x
+                    lbsr      LABCC
+                    lbsr      LA8AE
+LAD9A               ldx       $2a,u
+                    bsr       LAD58
+                    ldx       $1e,u
+                    leas      $2a,u
+                    tfr       x,u
+                    puls      pc,x
+                    pshs      x
+                    bsr       LAE0E
+                    leax      >LAD34,pcr
+                    pshs      x
+                    lbsr      LABCC
+                    lbsr      LA884
+                    bra       LAD9A
+                    pshs      x
+                    bsr       LADF7
+                    leax      LAD34,pcr
+                    pshs      x
+                    lbsr      LABCC
+                    lbsr      LA8AE
+LADCB               ldx       $2a,u
+                    ldd       $22,u
+                    std       ,x
+                    lda       $24,u
+                    ldb       $29,u
+                    std       $02,x
+                    ldx       $1e,u
+                    leas      $2a,u
+                    tfr       x,u
+                    puls      pc,x
+                    pshs      x
+                    bsr       LADF7
+                    leax      LAD34,pcr
+                    pshs      x
+                    lbsr      LABCC
+                    lbsr      LA884
+                    bra       LADCB
+
+LADF7               leas      -$08,s
+                    ldd       $08,s
+                    std       ,s
+                    clra
+                    clrb
+                    std       $05,s
+                    std       $07,s
+                    ldd       ,x
+                    std       $02,s
+                    ldd       $02,x
+                    sta       $04,s
+                    stb       $09,s
+LAE0D               rts
+
+LAE0E               leas      -$08,s
+                    ldd       $08,s
+                    std       ,s
+                    ldd       ,x
+                    std       $02,s
+                    ldd       $02,x
+                    std       $04,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       $06,x
+                    std       $08,s
+LAE24               rts
+                    pshs      u
+                    ldu       $04,s
+                    exg       x,u
+                    ldd       ,u
+                    std       ,x
+                    ldd       $02,u
+                    std       $02,x
+                    bra       LAE4B
+                    pshs      u
+                    ldu       $04,s
+                    exg       x,u
+                    ldd       ,u
+                    std       ,x
+                    ldd       $02,u
+                    std       $02,x
+                    ldd       $04,u
+                    std       $04,x
+                    ldd       $06,u
+                    std       $06,x
+LAE4B               puls      u
+                    puls      d
+                    std       ,s
+LAE51               rts
+
+LAE52               ldd       $04,s
+                    addd      $02,x
+                    std       $035a,y
+                    ldd       $02,s
+                    adcb      $01,x
+                    adca      ,x
+                    std       $0358,y
+                    lbra      LAF2E
+
+LAE67               ldd       $04,s
+                    subd      $02,x
+                    std       $035a,y
+                    ldd       $02,s
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       $0358,y
+                    lbra      LAF2E
+
+LAE7C               ldd       $02,s
+                    cmpd      ,x
+                    bne       LAE95
+                    ldd       $04,s
+                    cmpd      $02,x
+                    beq       LAE95
+                    bcs       LAE92
+                    lda       #$01
+                    andcc     #$FE
+                    bra       LAE95
+
+LAE92               clra
+                    cmpa      #$01
+LAE95               pshs      cc
+                    ldd       $01,s
+                    std       $05,s
+                    puls      cc
+                    leas      $04,s
+LAE9F               rts
+
+LAEA0               lbsr      LAF3D
+                    ldd       #$0000
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       ,x
+LAEB3               rts
+                    ldd       ,x
+                    coma
+                    comb
+                    std       $0358,y
+                    ldd       $02,x
+                    coma
+                    comb
+                    leax      $0358,y
+                    std       $02,x
+LAEC6               rts
+
+LAEC7               leax      $0358,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+                    rts
+                    leax      $0358,y
+                    std       $02,x
+                    clr       ,x
+                    clr       $01,x
+LAEDF               rts
+
+LAEE0               pshs      y
+                    ldy       $04,s
+                    ldd       ,x
+                    std       ,y
+                    ldd       $02,x
+                    std       $02,y
+                    puls      x
+                    exg       y,x
+                    puls      d
+                    std       ,s
+LAEF5               rts
+                    ldx       $02,s
+                    pshs      b
+                    lbsr      LAF3D
+                    puls      b
+                    tstb
+                    beq       LAF0D
+LAF02               asl       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    decb
+                    bne       LAF02
+LAF0D               puls      d
+                    std       ,s
+                    rts
+                    ldx       $02,s
+                    pshs      b
+                    lbsr      LAF3D
+                    puls      b
+                    tstb
+                    beq       LAF29
+LAF1E               asr       ,x
+                    ror       $01,x
+                    ror       $02,x
+                    ror       $03,x
+                    decb
+                    bne       LAF1E
+LAF29               puls      d
+                    std       ,s
+                    rts
+
+LAF2E               tfr       cc,a
+                    puls      x
+                    stx       $02,s
+                    leas      $02,s
+                    leax      $0358,y
+                    tfr       a,cc
+                    rts
+
+LAF3D               ldd       ,x
+                    std       $0358,y
+                    ldd       $02,x
+                    leax      $0358,y
+                    std       $02,x
+LAF4B               rts
+                    tsta
+                    bne       LAF61
+                    tst       $02,s
+                    bne       LAF61
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+LAF61               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       LAF7E
+                    inc       ,s
+LAF7E               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       LAF8B
+                    inc       ,s
+LAF8B               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+                    rts
+                    clr       $089e,y
+                    leax      >LAFE7,pcr
+                    stx       $089f,y
+                    bra       LAFC1
+                    leax      >LB000,pcr
+                    stx       $089f,y
+                    clr       $089e,y
+                    tst       $02,s
+                    bpl       LAFC1
+                    inc       $089e,y
+LAFC1               subd      #$0000
+                    bne       LAFCC
+                    puls      x
+                    ldd       ,s++
+                    jmp       ,x
+
+LAFCC               ldx       $02,s
+                    pshs      x
+                    jsr       [$089f,y]
+                    ldd       ,s
+                    std       $02,s
+                    tfr       x,d
+                    tst       $089e,y
+                    beq       LAFE4
+                    nega
+                    negb
+                    sbca      #$00
+LAFE4               std       ,s++
+                    rts
+
+LAFE7               subd      #$0000
+                    beq       LAFF6
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    bra       LB024
+
+LAFF6               puls      d
+                    std       ,s
+                    ldd       #$002D
+                    lbra      LB099
+
+LB000               subd      #$0000
+                    beq       LAFF6
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    tsta
+                    bpl       LB018
+                    nega
+                    negb
+                    sbca      #$00
+                    inc       $01,s
+                    std       $02,s
+LB018               ldd       $06,s
+                    bpl       LB024
+                    nega
+                    negb
+                    sbca      #$00
+                    com       $01,s
+                    std       $06,s
+LB024               lda       #$01
+LB026               inca
+                    asl       $03,s
+                    rol       $02,s
+                    bpl       LB026
+                    sta       ,s
+                    ldd       $06,s
+                    clr       $06,s
+                    clr       $07,s
+LB035               subd      $02,s
+                    bcc       LB03F
+                    addd      $02,s
+                    andcc     #$FE
+                    bra       LB041
+
+LB03F               orcc      #$01
+LB041               rol       $07,s
+                    rol       $06,s
+                    lsr       $02,s
+                    ror       $03,s
+                    dec       ,s
+                    bne       LB035
+                    std       $02,s
+                    tst       $01,s
+                    beq       LB05B
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+LB05B               ldx       $04,s
+                    ldd       $06,s
+                    std       $04,s
+                    stx       $06,s
+                    ldx       $02,s
+                    ldd       $04,s
+                    leas      $06,s
+LB069               rts
+                    tstb
+                    beq       LB080
+LB06D               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       LB06D
+                    bra       LB080
+
+LB076               tstb
+                    beq       LB080
+LB079               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       LB079
+LB080               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+                    leas      $04,s
+LB08C               rts
+
+LB08D               tstb
+                    beq       LB080
+LB090               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       LB090
+                    bra       LB080
+
+LB099               std       $0364,y
+                    pshs      y,b
+                    os9       F$ID
+                    puls      y,b
+                    os9       F$Send
+                    rts
+
+LB0A8               lda       $05,s
+                    ldb       $03,s
+                    beq       LB0DB
+                    cmpb      #$01
+                    beq       LB0DD
+                    cmpb      #$06
+                    beq       LB0DD
+                    cmpb      #$02
+                    beq       LB0C3
+                    cmpb      #$05
+                    beq       LB0C3
+                    ldb       #$D0
+                    lbra      LB33F
+
+LB0C3               pshs      u
+                    os9       I$GetStt
+                    bcc       LB0CF
+                    puls      u
+                    lbra      LB33F
+
+LB0CF               stx       [$08,s]
+                    ldx       $08,s
+                    stu       $02,x
+                    puls      u
+                    clra
+                    clrb
+                    rts
+
+LB0DB               ldx       $06,s
+LB0DD               os9       I$GetStt
+                    lbra      LB348
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       LB0F2
+                    cmpb      #$02
+                    beq       LB0FA
+                    ldb       #$D0
+                    lbra      LB33F
+
+LB0F2               ldx       $06,s
+                    os9       I$SetStt
+                    lbra      LB348
+
+LB0FA               pshs      u
+                    ldx       $08,s
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u
+                    lbra      LB348
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    bcs       LB114
+                    os9       I$Close
+LB114               lbra      LB348
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    lbcs      LB33F
+                    tfr       a,b
+                    clra
+                    rts
+
+LB126               lda       $03,s
+                    os9       I$Close
+                    lbra      LB348
+                    ldx       $02,s
+                    ldb       $05,s
+                    os9       I$MakDir
+                    lbra      LB348
+                    ldx       $02,s
+                    lda       $05,s
+                    tfr       a,b
+                    andb      #$24
+                    orb       #$0b
+                    os9       I$Create
+                    bcs       LB14B
+LB147               tfr       a,b
+                    clra
+                    rts
+
+LB14B               cmpb      #$DA
+                    lbne      LB33F
+                    lda       $05,s
+                    bita      #$80
+                    lbne      LB33F
+                    anda      #$07
+                    ldx       $02,s
+                    os9       I$Open
+                    lbcs      LB33F
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+                    bcc       LB147
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+                    lbra      LB33F
+                    ldx       $02,s
+                    os9       I$Delete
+                    lbra      LB348
+                    lda       $03,s
+                    os9       I$Dup
+                    lbcs      LB33F
+                    tfr       a,b
+                    clra
+                    rts
+
+LB193               pshs      y
+                    ldx       $06,s
+                    lda       $05,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$Read
+LB1A1               bcc       LB1B0
+                    cmpb      #$D3
+                    bne       LB1AB
+                    clra
+                    clrb
+                    puls      pc,y,x
+LB1AB               puls      y,x
+                    lbra      LB33F
+
+LB1B0               tfr       y,d
+                    puls      pc,y,x
+LB1B4               pshs      y
+                    lda       $05,s
+                    ldx       $06,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$ReadLn
+                    bra       LB1A1
+
+LB1C4               pshs      y
+                    ldy       $08,s
+                    beq       LB1D9
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$Write
+LB1D2               bcc       LB1D9
+                    puls      y
+                    lbra      LB33F
+
+LB1D9               tfr       y,d
+                    puls      pc,y
+LB1DD               pshs      y
+                    ldy       $08,s
+                    beq       LB1D9
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$WritLn
+                    bra       LB1D2
+
+LB1ED               pshs      u
+                    ldd       $0a,s
+                    bne       LB1FB
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       LB22F
+
+LB1FB               cmpd      #$0001
+                    beq       LB226
+                    cmpd      #$0002
+                    beq       LB21B
+                    ldb       #$F7
+LB209               clra
+                    std       $0364,y
+                    ldd       #$FFFF
+                    leax      $0358,y
+                    std       ,x
+                    std       $02,x
+                    puls      pc,u
+LB21B               lda       $05,s
+                    ldb       #$02
+                    os9       I$GetStt
+                    bcs       LB209
+                    bra       LB22F
+
+LB226               lda       $05,s
+                    ldb       #$05
+                    os9       I$GetStt
+                    bcs       LB209
+LB22F               tfr       u,d
+                    addd      $08,s
+                    std       $035a,y
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       LB209
+                    tfr       d,x
+                    std       $0358,y
+                    lda       $05,s
+                    os9       I$Seek
+                    bcs       LB209
+                    leax      $0358,y
+                    puls      pc,u
+                    ldd       $0356,y
+                    pshs      d
+                    ldd       $04,s
+                    cmpd      $08A1,y
+                    bcs       LB288
+                    addd      $0356,y
+                    pshs      y
+                    subd      ,s
+                    os9       F$Mem
+                    tfr       y,d
+                    puls      y
+                    bcc       LB27A
+                    ldd       #$FFFF
+                    leas      $02,s
+                    rts
+
+LB27A               std       $0356,y
+                    addd      $08A1,y
+                    subd      ,s
+                    std       $08A1,y
+LB288               leas      $02,s
+                    ldd       $08A1,y
+                    pshs      d
+                    subd      $04,s
+                    std       $08A1,y
+                    ldd       $0356,y
+                    subd      ,s++
+                    pshs      d
+                    clra
+                    ldx       ,s
+LB2A1               sta       ,x+
+                    cmpx      $0356,y
+                    bcs       LB2A1
+                    puls      pc,d
+LB2AB               ldd       $02,s
+                    addd      $0360,y
+                    bcs       LB2D4
+                    cmpd      $0362,y
+                    bcc       LB2D4
+                    pshs      d
+                    ldx       $0360,y
+                    clra
+LB2C1               cmpx      ,s
+                    bcc       LB2C9
+                    sta       ,x+
+                    bra       LB2C1
+
+LB2C9               ldd       $0360,y
+                    puls      x
+                    stx       $0360,y
+                    rts
+
+LB2D4               ldd       #$FFFF
+                    rts
+
+LB2D8               pshs      y
+                    os9       F$ID
+                    puls      y
+                    bcc       LB2E5
+                    lbcs      LB33F
+LB2E5               tfr       a,b
+                    clra
+                    rts
+
+LB2E9               pshs      y
+                    os9       F$ID
+                    bcc       LB2F5
+LB2F0               puls      y
+                    lbra      LB33F
+
+LB2F5               tfr       y,d
+                    puls      pc,y
+                    pshs      y
+                    bsr       LB2E9
+                    std       -$02,s
+                    beq       LB305
+                    ldb       #$D6
+                    bra       LB2F0
+
+LB305               ldy       $04,s
+                    os9       F$SUser
+                    bcc       LB319
+                    cmpb      #$D0
+                    bne       LB2F0
+                    tfr       y,d
+                    ldy       >$004B
+                    std       $09,y
+LB319               clra
+                    clrb
+                    puls      pc,y
+                    pshs      u
+                    tfr       y,u
+                    ldx       $04,s
+                    stx       $08A3,y
+                    leax      >LB333,pcr
+                    os9       F$Icpt
+                    puls      u
+                    lbra      LB348
+
+LB333               tfr       u,y
+                    clra
+                    pshs      d
+                    jsr       [$08A3,y]
+                    leas      $02,s
+                    rti
+
+LB33F               clra
+                    std       $0364,y
+                    ldd       #$FFFF
+                    rts
+
+LB348               bcs       LB33F
+                    clra
+                    clrb
+LB34C               rts
+                    lbsr      LB358
+                    lbsr      LA296
+                    ldd       $02,s
+                    os9       F$Exit
+LB358               rts
+                    neg       $0003
+                    neg       $0002
+                    rora
+                    fcb       $02
+                    ldx       $0000
+                    fcb       $01
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $000C
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       L008C
+                    com       -$0d,s
+                    lsr       L722E
+                    aslb
+                    aslb
+                    aslb
+                    aslb
+                    aslb
+                    neg       L0078
+                    bra       $B3F1
+                    asl       L7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+                    ror       $0083
+                    aslb
+                    tst       -$08,u
+                    neg       $5873
+                    aslb
+                    rol       L587F
+                    aslb
+                    anda      #$00
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $006D
+                    nega
+                    rol       0,x
+                    neg       L0054
+                    fcb       $41
+                    asl       $0d,y
+                    bgt       LB40F
+                    negb
+                    leax      $03,u
+                    fcb       $45
+                    comb
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    ble       $B406
+                    tstb
+                    asl       $5F64
+                    neg       L006A
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0b,y
+                    ror       $0C,y
+                    rolb
+                    dec       0,x
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+LB40F               dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    bvs       $B477
+                    bpl       $B465
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    rol       $0000
+                    neg       $0000
+                    tst       $000E
+                    neg       $0000
+                    neg       $000E
+                    inc       $0001
+                    jmp       $000F
+                    tst       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0003
+                    neg       $000A
+                    fcb       $02
+                    dec       $0003
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    asr       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    ror       $0000
+                    jmp       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0081
+                    bra       LB4AC
+
+LB4AC               neg       $0000
+                    neg       $0000
+                    neg       L0084
+                    asla
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $87
+                    dec       >$0000
+                    neg       $0000
+                    neg       $0000
+                    ora       #$1C
+                    nega
+                    neg       $0000
+                    neg       $0000
+                    neg       L008E
+                    coma
+                    negb
+                    neg       $0000
+                    neg       $0000
+                    neg       $0091
+                    lsr       L2400
+                    neg       $0000
+                    neg       $0000
+                    anda      L0018
+                    lda       L0080
+                    neg       $0000
+                    neg       $0000
+                    eora      L003E
+                    cmpx      L2000
+                    neg       $0000
+                    neg       $009B
+                    jmp       $0b,s
+                    bvc       LB4EE
+LB4EE               neg       $0000
+                    neg       L009E
+                    fcb       $15
+                    fcb       $02
+                    adcb      >$0000
+                    neg       $0000
+                    sbca      $0d,y
+                    asl       $EBC5
+                    cmpx      $02,s
+                    neg       $00C3
+                    rola
+                    sbcb      $C9CD
+                    lsr       $0067
+                    clra
+                    andb      0,x
+                    fcb       $02
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       $0020
+                    neg       $0040
+                    neg       L0080
+                    fcb       $01
+                    neg       $0002
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       $0020
+                    neg       $0040
+                    neg       $0027
+                    fcb       $10
+                    com       $00E8
+                    neg       $0064
+                    neg       $000A
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0006
+                    neg       L00B8
+                    neg       L00B6
+                    neg       L00B4
+                    neg       L00B2
+                    neg       L00B0
+                    neg       L00AE
+                    neg       $0003
+                    neg       L0094
+                    neg       L00AC
+                    neg       $0001
+                    com       $0e,y
+                    com       $0f,s
+                    tst       -$10,s
+
+                    emod
+eom                 equ       *
+                    end

--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,_start,size
+                    mod       eom,name,tylg,atrv,start,size
 
 u0000               rmb       4389
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.comp/
                     fcb       edition
 
-copybytes           lda       ,y+
+L0014               lda       ,y+
 L0016               sta       ,u+
 L0018               leax      -$01,x
-L001A               bne       copybytes
+L001A               bne       L0014
 L001C               rts
 
-_start              pshs      y
+start               pshs      y
 L001F               pshs      u
 L0021               clra
 L0022               clrb
@@ -37,12 +37,12 @@ L0030               pshs      x
 L0032               leay      LB358,pcr
 L0036               ldx       ,y++
 L0038               beq       L003E
-L003A               bsr       copybytes
+L003A               bsr       L0014
 L003C               ldu       $02,s
 L003E               leau      >$0078,u
 L0042               ldx       ,y++
 L0044               beq       L0049
-L0046               bsr       copybytes
+L0046               bsr       L0014
 L0048               clra
 L0049               cmpu      ,s
 L004C               beq       L0052
@@ -119,17 +119,17 @@ L00E0               leax      $0316,u
                     ldd       $0352,u
                     pshs      d
                     leay      ,u
-                    bsr       stkinit
-                    lbsr      main
+                    bsr       L00FA
+                    lbsr      L017C
                     clr       ,-s
                     clr       ,-s
-                    lbsr      exit
-stkinit             leax      $08A5,y
+                    lbsr      LB34C
+L00FA               leax      $08A5,y
                     stx       $0360,y
                     sts       $0354,y
                     sts       $0362,y
                     ldd       #$FF82
-stkcheck            leax      d,s
+L010F               leax      d,s
                     cmpx      $0362,y
                     bcc       L0121
                     cmpx      $0360,y
@@ -145,7 +145,7 @@ L013B               leax      L0122,pcr
                     ldy       #$0064
                     os9       I$WritLn
                     clr       ,-s
-                    lbsr      $B352
+                    lbsr      LB352
                     ldd       $0354,y
                     subd      $0362,y
                     rts
@@ -167,20 +167,20 @@ L016A               ldd       ,y++
                     leas      $04,s
                     rts
 
-main                pshs      u
+L017C               pshs      u
                     leax      L5DC9,pcr
                     pshs      x
-                    lbsr      $B31C
+                    lbsr      LB31C
                     leas      $02,s
                     leax      $0096,y
                     pshs      x
-                    lbsr      $9FD7
+                    lbsr      L9FD7
                     leas      $02,s
                     leax      L0300,pcr
                     pshs      x
                     ldd       $0094,y
                     pshs      d
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
                     lbsr      L6292
                     leax      $0246,y
@@ -229,7 +229,7 @@ L01E4               leau      $01,u
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     lbsr      L02F2
 L0215               leax      ,s
@@ -246,7 +246,7 @@ L0220               ldb       ,u
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     lbsr      L02F2
                     bra       L0257
@@ -312,7 +312,7 @@ L02AB               ldd       $003F
                     leas      $02,s
 L02CA               leax      $0253,y
                     pshs      x
-                    lbsr      $A2F8
+                    lbsr      LA2F8
                     leas      $02,s
                     ldd       $0009
                     beq       L02F0
@@ -322,14 +322,14 @@ L02CA               leax      $0253,y
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     bsr       L02F2
 L02F0               puls      pc,u
 L02F2               pshs      u
                     ldd       #$0001
                     pshs      d
-                    lbsr      exit
+                    lbsr      LB34C
                     leas      $02,s
                     puls      pc,u
 L0300               clrb
@@ -443,7 +443,7 @@ L042D               pshs      u
                     leas      $02,s
                     leax      $0260,y
                     pshs      x
-                    lbsr      $A2F8
+                    lbsr      LA2F8
                     lbra      L0548
 
 L0443               pshs      u
@@ -468,13 +468,13 @@ L0464               pshs      u
                     pshs      x
                     leax      $02,s
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
                     ldd       $38,s
                     pshs      d
                     leax      $02,s
                     pshs      x
-                    lbsr      $A5F1
+                    lbsr      LA5F1
                     leas      $04,s
                     leax      ,s
                     pshs      x
@@ -554,7 +554,7 @@ L0528               ldd       $0009
                     ble       L054D
                     leax      $0260,y
                     pshs      x
-                    lbsr      $A2F8
+                    lbsr      LA2F8
                     leas      $02,s
                     leax      $076D,pcr
                     pshs      x
@@ -571,7 +571,7 @@ L054F               pshs      u
                     pshs      d
                     leax      $0260,y
                     pshs      x
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $08,s
                     puls      pc,u
 L056A               pshs      u
@@ -579,7 +579,7 @@ L056A               pshs      u
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    lbsr      $9FB7
+                    lbsr      L9FB7
                     leas      $04,s
                     ldd       #$000D
                     pshs      d
@@ -592,7 +592,7 @@ L0584               pshs      u
                     ldb       $07,s
                     sex
                     pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
 L0594               leas      $04,s
                     puls      pc,u
 L0598               pshs      u
@@ -787,7 +787,7 @@ L0781               fcb       $4F,$52,$54
                     fcb       $00
 L0785               pshs      u
 L0787               ldd       #$FFA2
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0e,s
                     lbsr      L0899
                     std       $0C,s
@@ -912,7 +912,7 @@ L0895               leas      $0e,s
                     puls      pc,u
 L0899               pshs      u
                     ldd       #$FFA4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0C,s
                     ldu       #$0000
                     ldx       $003F
@@ -1307,7 +1307,7 @@ L0BF5               leas      $0C,s
                     puls      pc,u
 L0BF9               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     ldu       #$0000
                     bra       L0C08
@@ -1350,7 +1350,7 @@ L0C50               tfr       u,d
 
 L0C54               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
@@ -1385,7 +1385,7 @@ L0C9C               leas      $02,s
                     puls      pc,u
 L0CA0               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $003F
                     bra       L0CF9
 
@@ -1438,7 +1438,7 @@ L0CF9               cmpx      #$0041
                     puls      pc,u
 L0D26               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     lbra      L0E98
 
@@ -1458,7 +1458,7 @@ L0D4A               ldd       $08,s
                     ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      $AFFF
+                    lbsr      LAFFF
                     bra       L0D66
 
 L0D59               ldd       $08,s
@@ -1466,7 +1466,7 @@ L0D59               ldd       $08,s
                     ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      $AFAC
+                    lbsr      LAFAC
 L0D66               puls      pc,u
 L0D68               lbsr      L1572
                     lbra      L0E94
@@ -1662,7 +1662,7 @@ L0E98               cmpx      #$0050
                     puls      pc,u
 L0F4C               pshs      u
                     ldd       #$FFA2
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0e,s
                     ldd       L001F
                     std       $04,s
@@ -1728,7 +1728,7 @@ L0F9D               ldd       $02,s
                     puls      pc,u
 L0FD8               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $000D
                     beq       L0FEC
                     ldu       $000D
@@ -1760,7 +1760,7 @@ L0FF8               ldd       $04,s
                     puls      pc,u
 L101A               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L110A,pcr
                     pshs      x
                     lbsr      L0450
@@ -1768,7 +1768,7 @@ L101A               pshs      u
 
 L102E               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       [$04,s]
                     ldx       $06,u
                     bra       L1081
@@ -1832,7 +1832,7 @@ L110A               fcc       /expression missing/
                     fcb       $00
 L111D               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$0C,s
                     stu       -$02,s
@@ -1941,7 +1941,7 @@ L1204               tfr       u,d
                     puls      pc,u
 L120A               pshs      u
                     ldd       #$FFA8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$0e,s
                     stu       -$02,s
@@ -2288,8 +2288,8 @@ L14E1               ldx       $0C,s
                     ldx       ,s
                     pshs      x
                     ldx       $02,s
-                    lbsr      $A74C
-                    lbsr      $AE34
+                    lbsr      LA74C
+                    lbsr      LAE34
 L1501               pshs      u
                     lbsr      L05B9
                     leas      $02,s
@@ -2307,7 +2307,7 @@ L1524               leas      $0e,s
                     puls      pc,u
 L1528               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     stu       -$02,s
                     beq       L156E
@@ -2335,7 +2335,7 @@ L156E               clra
                     puls      pc,u
 L1572               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L287A,pcr
                     pshs      x
                     lbsr      L0450
@@ -2343,7 +2343,7 @@ L1572               pshs      u
                     puls      pc,u
 L1587               pshs      u
                     ldd       #$FF9C
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$14,s
                     ldx       $18,s
                     ldu       $0a,x
@@ -3674,7 +3674,7 @@ L2170               ldd       $0C,s
                     puls      pc,u
 L2193               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -3694,7 +3694,7 @@ L21A9               leax      L294E,pcr
 L21BF               puls      pc,u
 L21C1               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     pshs      u
@@ -3745,7 +3745,7 @@ L2224               ldd       ,s
                     puls      pc,u
 L222C               pshs      u
                     ldd       #$FFAC
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -3856,8 +3856,8 @@ L2302               ldd       $06,u
                     ldx       $02,s
                     pshs      x
                     ldd       $08,u
-                    lbsr      $A791
-                    lbsr      $AE34
+                    lbsr      LA791
+                    lbsr      LAE34
                     bra       L2326
 
 L2324               leas      -$04,x
@@ -3962,7 +3962,7 @@ L23E3               ldd       $06,u
                     pshs      x
                     ldx       $08,u
                     lbsr      LA780
-L2400               lbsr      $AE34
+L2400               lbsr      LAE34
                     leax      $04,s
                     lbra      L2324
 
@@ -4020,7 +4020,7 @@ L247E               ldd       $06,u
                     cmpd      #$004B
                     bne       L2492
                     ldx       $08,u
-                    lbsr      $A77B
+                    lbsr      LA77B
                     std       $08,u
                     leax      $04,s
                     lbra      L23BE
@@ -4034,7 +4034,7 @@ L2497               ldd       $06,u
                     ldx       $08,u
                     pshs      x
                     ldx       $08,u
-                    lbsr      $A775
+                    lbsr      LA775
                     lbsr      LAEDF
                     leax      $04,s
                     lbra      L22D5
@@ -4111,7 +4111,7 @@ L2540               ldd       $0a,s
 
 L2545               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
@@ -4170,7 +4170,7 @@ L25C5               leas      $04,s
                     puls      pc,u
 L25C9               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $08,s
                     pshs      d
                     ldd       $06,s
@@ -4244,7 +4244,7 @@ L2657               std       $12,u
                     puls      pc,u
 L2668               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -4290,7 +4290,7 @@ L26C1               leax      L2968,pcr
 
 L26D8               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0034
@@ -4308,7 +4308,7 @@ L26D8               pshs      u
 
 L2707               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldd       ,u
@@ -4391,7 +4391,7 @@ L27B6               leas      $02,s
 L27B8               puls      pc,u
 L27BA               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       ,u
                     cmpd      #$0004
@@ -4411,7 +4411,7 @@ L27E7               ldd       ,u
                     puls      pc,u
 L27EB               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       #$0006
                     pshs      d
@@ -4441,7 +4441,7 @@ L27EB               pshs      u
                     puls      pc,u
 L2832               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     bra       L2843
 
@@ -4460,7 +4460,7 @@ L2843               cmpx      #$0001
                     puls      pc,u
 L2861               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L29C4,pcr
                     pshs      x
                     ldd       $06,s
@@ -4508,7 +4508,7 @@ L29C4               fcc       /must be integral/
                     fcb       $00
 L29D5               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $003F
                     cmpd      #$0028
                     beq       L29ED
@@ -4581,7 +4581,7 @@ L2A48               cmpx      #$0013
                     beq       L2A21
                     cmpx      #$001A
                     beq       L2A26
-                    cmpx      #_start
+                    cmpx      #start
                     beq       L2A2C
                     cmpx      #$0015
                     beq       L2A32
@@ -4653,7 +4653,7 @@ L2B10               ldd       #$0028
                     puls      pc,u
 L2B1C               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$06,s
                     lbsr      L5F26
                     lbsr      L337E
@@ -4739,7 +4739,7 @@ L2BD2               ldd       $02,s
                     puls      pc,u
 L2BDF               pshs      u
                     ldd       #$FFAA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0a,s
                     ldd       $0033
                     std       $08,s
@@ -4816,7 +4816,7 @@ L2C52               ldd       $0035
                     puls      pc,u
 L2C8F               pshs      u
                     ldd       #$FFA8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0e,s
                     lbsr      L5F26
                     ldd       $0037
@@ -4981,7 +4981,7 @@ L2DCB               ldd       $0033
 
 L2DF6               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     lbsr      L5F26
                     clra
@@ -5033,7 +5033,7 @@ L2E5A               bsr       L2E9C
 
 L2E5E               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     lbsr      L5F26
                     ldd       $0037
                     bne       L2E6F
@@ -5059,7 +5059,7 @@ L2E90               leas      $02,s
 
 L2E9C               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L3447,pcr
                     pshs      x
                     lbsr      L0450
@@ -5067,7 +5067,7 @@ L2EAD               leas      $02,s
                     puls      pc,u
 L2EB1               pshs      u
                     ldd       #$FFAA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0a,s
                     ldd       $0033
                     std       $08,s
@@ -5139,7 +5139,7 @@ L2F1C               lbsr      L5F26
                     puls      pc,u
 L2F5F               pshs      u
                     ldd       #$FFA6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0e,s
                     clra
                     clrb
@@ -5282,7 +5282,7 @@ L3094               leas      $0e,s
                     puls      pc,u
 L3098               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0028
@@ -5413,7 +5413,7 @@ L3197               clra
 
 L31B8               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     lbsr      L5F26
                     ldd       $0033
                     bne       L31D4
@@ -5441,7 +5441,7 @@ L31F1               ldd       #$0018
 
 L31F7               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     lbsr      L5F26
                     ldd       $0035
                     bne       L3213
@@ -5469,7 +5469,7 @@ L3230               ldd       #$0019
 
 L3235               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0034
@@ -5489,7 +5489,7 @@ L3255               lbsr      L32C2
                     pshs      d
                     ldd       $06,u
                     pshs      d
-                    ldd       #_start
+                    ldd       #start
                     pshs      d
                     lbsr      L4623
                     leas      $06,s
@@ -5497,12 +5497,12 @@ L3255               lbsr      L32C2
                     orb       #$02
                     std       $0a,u
 L3276               lbsr      L5F26
-L3279               ldd       #_start
+L3279               ldd       #start
 L327C               std       $002F
                     puls      pc,u
 L3280               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     bsr       L32C2
                     tfr       d,u
                     stu       -$02,s
@@ -5532,7 +5532,7 @@ L32BA               lbsr      L5F26
                     puls      pc,u
 L32C2               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $0041
                     ldd       ,u
                     cmpd      #$0009
@@ -5571,7 +5571,7 @@ L32F4               ldd       #$0009
 
 L3319               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $04,s
                     pshs      d
                     lbsr      L0785
@@ -5589,7 +5589,7 @@ L3319               pshs      u
 
 L3342               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     pshs      u
                     lbsr      L26D8
@@ -5618,7 +5618,7 @@ L336D               pshs      u
 
 L337E               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     ldd       #$002D
                     pshs      d
@@ -5635,7 +5635,7 @@ L337E               pshs      u
 
 L33A5               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     clra
                     clrb
                     pshs      d
@@ -5658,7 +5658,7 @@ L33D3               tfr       u,d
                     puls      pc,u
 L33D7               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     stu       -$02,s
                     beq       L33FF
@@ -5699,7 +5699,7 @@ L34AD               fcc       /condition needed/
                     fcb       $00
 L34BE               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $04,s
                     pshs      d
                     bsr       L34D9
@@ -5711,7 +5711,7 @@ L34BE               pshs      u
                     puls      pc,u
 L34D9               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$06,s
                     ldd       $06,u
@@ -6107,7 +6107,7 @@ L3894               leas      $06,s
                     puls      pc,u
 L3898               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     ldx       $06,x
                     bra       L38D5
@@ -6143,7 +6143,7 @@ L38D5               cmpx      #$0034
 L38E6               puls      pc,u
 L38E8               pshs      u
                     ldd       #$FFB2
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $08,u
@@ -6212,7 +6212,7 @@ L3981               fcc       /longs/
                     fcb       $00
 L3987               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $04,s
                     pshs      d
                     bsr       L39A2
@@ -6224,7 +6224,7 @@ L3987               pshs      u
                     puls      pc,u
 L39A2               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$08,s
                     ldd       ,u
@@ -6550,7 +6550,7 @@ L3CB0               fcc       /floats/
                     fcb       $00
 L3CB7               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     ldx       $0a,s
@@ -6700,7 +6700,7 @@ L3DEE               leas      $04,s
                     puls      pc,u
 L3DF2               pshs      u
                     ldd       #$FFA8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $06,s
                     leas      -$0C,s
                     ldd       $16,s
@@ -6914,7 +6914,7 @@ L3FCC               leas      $0C,s
                     puls      pc,u
 L3FD0               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L428F,pcr
                     pshs      x
                     lbsr      L5756
@@ -6927,7 +6927,7 @@ L3FD0               pshs      u
                     puls      pc,u
 L3FF1               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$08,s
                     ldd       #$0002
                     pshs      d
@@ -7096,7 +7096,7 @@ L4147               ldd       $0C,s
                     ldx       $08,u
                     pshs      x
                     ldx       $08,u
-                    lbsr      $A7AE
+                    lbsr      LA7AE
                     lbsr      LAE24
 L415B               ldd       $0C,s
                     pshs      d
@@ -7132,7 +7132,7 @@ L419B               leas      $08,s
                     puls      pc,u
 L419F               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $08,s
@@ -7178,7 +7178,7 @@ L41FF               leas      $02,s
                     puls      pc,u
 L4203               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L4294,pcr
                     pshs      x
                     lbsr      L0450
@@ -7187,7 +7187,7 @@ L4203               pshs      u
                     puls      pc,u
 L421A               pshs      u
                     ldd       #$FFBC
-                    lbsr      stkcheck
+                    lbsr      L010F
 L4222               ldx       $003F
                     bra       L422D
 
@@ -7262,7 +7262,7 @@ L42F9               clra
                     pshs      x
                     leax      $0684,y
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
 L430E               lbsr      L4509
                     std       $004A
@@ -7297,7 +7297,7 @@ L4354               leax      $0584,y
                     pshs      x
                     leax      $0366,y
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
 L4365               lbsr      L4509
                     std       -$02,s
@@ -7308,7 +7308,7 @@ L4371               leax      $0584,y
                     pshs      x
                     leax      $078a,y
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
                     lbsr      L4509
                     std       -$02,s
@@ -7323,7 +7323,7 @@ L4371               leax      $0584,y
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $08,s
                     leax      $078a,y
                     pshs      x
@@ -7331,7 +7331,7 @@ L4371               leax      $0584,y
 L43B5               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     lbra      L430E
 
@@ -7339,7 +7339,7 @@ L43C3               leax      $0584,y
                     pshs      x
                     leax      $078a,y
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
                     lbsr      L4509
                     std       -$02,s
@@ -7389,7 +7389,7 @@ L442F               leax      $0584,y
                     beq       L447A
                     leax      $078a,y
                     pshs      x
-                    lbsr      $9F95
+                    lbsr      L9F95
                     leas      $02,s
                     bra       L4463
 
@@ -7397,7 +7397,7 @@ L4453               leax      $0253,y
                     pshs      x
                     ldd       #$0020
                     pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
                     leas      $04,s
 L4463               ldd       $02,s
                     addd      #$FFFF
@@ -7406,14 +7406,14 @@ L4463               ldd       $02,s
                     bne       L4453
                     leax      $45EA,pcr
                     pshs      x
-                    lbsr      $9F95
+                    lbsr      L9F95
                     leas      $02,s
 L447A               ldd       $04,s
                     cmpd      #$0031
                     lbne      L430E
                     ldd       #$0001
                     pshs      d
-                    lbsr      exit
+                    lbsr      LB34C
                     leas      $02,s
                     lbra      L430E
 
@@ -7470,7 +7470,7 @@ L4509               pshs      u,d
                     leau      $0584,y
                     ldd       $0003
                     pshs      d
-                    lbsr      $A3E4
+                    lbsr      LA3E4
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
@@ -7484,11 +7484,11 @@ L4509               pshs      u,d
                     pshs      x
                     leax      $45EC,pcr
                     pshs      x
-                    lbsr      $9FB7
+                    lbsr      L9FB7
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      exit
+                    lbsr      LB34C
                     leas      $02,s
 L4546               clra
                     clrb
@@ -7508,7 +7508,7 @@ L455A               ldd       ,s
                     stb       ,u+
                     ldd       $0003
                     pshs      d
-                    lbsr      $A3E4
+                    lbsr      LA3E4
                     leas      $02,s
                     std       ,s
                     bra       L4579
@@ -7599,7 +7599,7 @@ L465E               ldd       $0e,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     ldd       $000F
                     subd      #$0002
@@ -7858,7 +7858,7 @@ L48AE               std       $06,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     lbra      L4C78
 
 L48C9               ldd       $10,s
@@ -7908,7 +7908,7 @@ L48E7               cmpx      #$007A
                     lbeq      L471D
                     cmpx      #$0044
                     lbeq      L4724
-                    cmpx      #_start
+                    cmpx      #start
                     lbeq      L472B
                     cmpx      #$007C
                     lbeq      L4751
@@ -8101,7 +8101,7 @@ L4B30               ldd       $10,s
 L4B47               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     lbra      L4D75
 
@@ -8229,7 +8229,7 @@ L4C5D               ldd       $10,s
 L4C6F               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
 L4C78               leas      $08,s
                     lbra      L4D75
 
@@ -8335,7 +8335,7 @@ L4D5E               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
 L4D75               leas      $08,s
                     puls      pc,u
 L4D79               pshs      u
@@ -8557,7 +8557,7 @@ L4F9A               pshs      d
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     puls      pc,u
 L4FAD               cmpu      #$0005
@@ -9020,7 +9020,7 @@ L53CE               ldd       $04,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $08,s
                     ldd       $000F
                     addd      #$0002
@@ -9410,7 +9410,7 @@ L5756               pshs      u
                     pshs      d
                     ldd       #$0020
                     pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
                     leas      $04,s
                     ldd       $04,s
                     pshs      d
@@ -9434,7 +9434,7 @@ L5785               pshs      u
                     pshs      d
                     ldd       $06,s
 L578D               pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
                     bra       L57A1
 
 L5794               pshs      u
@@ -9442,7 +9442,7 @@ L5794               pshs      u
                     pshs      d
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
 L57A1               leas      $04,s
                     puls      pc,u
 L57A5               pshs      u
@@ -9518,7 +9518,7 @@ L5832               pshs      u
 L583C               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     puls      pc,u
 L5849               pshs      u
@@ -9534,7 +9534,7 @@ L5849               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $08,s
                     puls      pc,u
                     bge       $58E8
@@ -9937,7 +9937,7 @@ L5BE5               leas      $02,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     bra       L5C2D
 
 L5C03               pshs      u
@@ -9976,7 +9976,7 @@ L5C34               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $0a,s
                     puls      pc,u
 L5C57               pshs      u
@@ -9997,7 +9997,7 @@ L5C6F               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     ldd       $06,s
                     pshs      d
@@ -10019,7 +10019,7 @@ L5C6F               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
 L5CB8               ldd       $0017
                     lbeq      L5DFF
@@ -10050,7 +10050,7 @@ L5CEB               pshs      u
 L5CF9               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
 L5D04               puls      pc,u
 L5D06               pshs      u
@@ -10066,7 +10066,7 @@ L5D06               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $08,s
 L5D28               puls      pc,u
 L5D2A               pshs      u
@@ -10107,18 +10107,18 @@ L5D72               pshs      u
                     lbeq      L5DFF
                     ldd       L004C
                     pshs      d
-                    lbsr      $A14D
+                    lbsr      LA14D
                     leas      $02,s
                     bra       L5D90
 
 L5D85               ldd       $0005
                     pshs      d
                     pshs      u
-                    lbsr      $A1CD
+                    lbsr      LA1CD
                     leas      $04,s
 L5D90               ldd       L004C
                     pshs      d
-                    lbsr      $A3E4
+                    lbsr      LA3E4
                     leas      $02,s
                     tfr       d,u
                     cmpu      #$FFFF
@@ -10134,11 +10134,11 @@ L5D90               ldd       L004C
                     leas      $02,s
 L5DB5               ldd       L004C
                     pshs      d
-                    lbsr      $A2BE
+                    lbsr      LA2BE
                     leas      $02,s
                     leax      $0096,y
                     pshs      x
-                    lbsr      $B17D
+                    lbsr      LB17D
                     bra       L5DFD
 
 L5DC9               pshs      u,d
@@ -10153,15 +10153,15 @@ L5DDA               std       ,s
                     beq       L5DF4
                     ldd       L004C
                     pshs      d
-                    lbsr      $A2BE
+                    lbsr      LA2BE
                     leas      $02,s
                     leax      $0096,y
                     pshs      x
-                    lbsr      $B17D
+                    lbsr      LB17D
                     leas      $02,s
 L5DF4               ldd       ,s
                     pshs      d
-                    lbsr      $B352
+                    lbsr      LB352
                     leas      $02,s
 L5DFD               leas      $02,s
 L5DFF               puls      pc,u
@@ -10405,7 +10405,7 @@ L6004               ldd       #$0008
                     leax      ,u
                     pshs      x
                     ldx       $0a,s
-                    lbsr      $AE34
+                    lbsr      LAE34
                     stu       $0041
                     ldd       #$004B
                     bra       L6033
@@ -10773,7 +10773,7 @@ L6292               pshs      u
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
-                    ldd       #_start
+                    ldd       #start
                     pshs      d
                     leax      L6D56,pcr
                     pshs      x
@@ -10986,7 +10986,7 @@ L6556               ldb       $14,u
                     pshs      d
                     ldd       $0e,s
                     pshs      d
-                    lbsr      $A68C
+                    lbsr      LA68C
                     leas      $06,s
                     std       -$02,s
                     beq       L65CA
@@ -11012,7 +11012,7 @@ L659E               ldd       #$0008
                     ldd       #$0014
                     addd      ,s++
                     pshs      d
-                    lbsr      $A64F
+                    lbsr      LA64F
                     leas      $06,s
                     clra
                     clrb
@@ -11036,7 +11036,7 @@ L65D0               pshs      u
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    lbsr      $A64F
+                    lbsr      LA64F
                     leas      $06,s
                     clra
                     clrb
@@ -11074,7 +11074,7 @@ L6610               std       $02,s
 L6622               pshs      u,d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $B253
+                    lbsr      LB253
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
@@ -11107,7 +11107,7 @@ L6654               pshs      u
                     neg       $0000
                     neg       $0000
 L666C               puls      x
-                    lbsr      $AE34
+                    lbsr      LAE34
                     leax      $08,s
                     stx       ,s
                     ldd       $14,s
@@ -11296,9 +11296,9 @@ L67F4               ldd       #$00B8
                     pshs      x
                     leax      $0a,s
                     pshs      x
-                    lbsr      $A731
+                    lbsr      LA731
                     leas      $02,s
-                    lbsr      $AE34
+                    lbsr      LAE34
                     ldb       $0045
                     cmpb      #$45
                     beq       L6819
@@ -11383,7 +11383,7 @@ L689A               std       $04,s
                     lbsr      LAE0D
                     lbsr      L6926
                     leas      $0C,s
-                    lbsr      $AE34
+                    lbsr      LAE34
                     ldd       #$0006
                     lbra      L6921
 
@@ -11451,20 +11451,20 @@ L6926               pshs      u
                     ldd       $10,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      $AFFF
+                    lbsr      LAFFF
                     addd      #$0009
                     pshs      d
                     leax      $0a,s
                     lbsr      LAE0D
                     bsr       L6970
                     leas      $0C,s
-                    lbsr      $AE34
+                    lbsr      LAE34
 L6955               ldd       $0e,s
                     pshs      d
                     ldd       $0e,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      $AFAC
+                    lbsr      LAFAC
                     pshs      d
                     leax      $08,s
                     lbsr      LAE0D
@@ -11493,22 +11493,22 @@ L6970               pshs      u
                     leax      $06,s
                     lbsr      LAE0D
                     ldx       $08,s
-                    lbsr      $A765
+                    lbsr      LA765
                     bra       L69AA
 
 L69A0               leax      $06,s
                     lbsr      LAE0D
                     ldx       $08,s
-                    lbsr      $A76D
+                    lbsr      LA76D
 L69AA               leau      $0358,y
                     pshs      u
-                    lbsr      $AE34
+                    lbsr      LAE34
                     lbra      L6C9A
 
 L69B6               leax      $04,s
                     leau      $0358,y
                     pshs      u
-                    lbsr      $AE34
+                    lbsr      LAE34
                     puls      pc,u
 L69C3               pshs      u
                     lbsr      L42CF
@@ -11580,7 +11580,7 @@ L6A37               clra
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $08,s
                     bra       L6A99
 
@@ -11622,7 +11622,7 @@ L6AA2               clra
                     pshs      d
                     ldd       #$000D
                     pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
                     leas      $04,s
                     clra
                     clrb
@@ -11636,7 +11636,7 @@ L6AC1               pshs      u
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $04,s
 L6AD6               ldd       $04,s
                     cmpd      #$0020
@@ -11650,7 +11650,7 @@ L6AE6               ldd       $04,s
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     bra       L6B27
 
@@ -11658,7 +11658,7 @@ L6AFB               ldd       $0064
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
                     leas      $04,s
                     ldd       $003D
                     addd      #$0001
@@ -11670,7 +11670,7 @@ L6AFB               ldd       $0064
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $04,s
 L6B27               clra
                     clrb
@@ -11686,7 +11686,7 @@ L6B34               pshs      u
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      fprintf
+                    lbsr      L9A34
                     leas      $06,s
                     puls      pc,u
 L6B4B               pshs      u,d
@@ -11888,7 +11888,8 @@ L6CD5               ldb       $05,s
 L6CDA               clra
                     clrb
 L6CDC               puls      pc,u
-L6CDE               fcc       /bad character/
+L6CDE               fcc       /bad ch/
+L6CE4               fcc       /aracter/
                     fcb       $00
 L6CEC               fcc       /constant overflow/
                     fcb       $00
@@ -11985,7 +11986,7 @@ L6E36               bhi       $6E45
                     tst       $0000
 L6E42               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     pshs      u
                     lbsr      L6EAC
@@ -12007,7 +12008,7 @@ L6E42               pshs      u
 
 L6E76               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     pshs      u
                     lbsr      L7E9C
@@ -12029,7 +12030,7 @@ L6EA8               std       $06,u
 L6EAA               puls      pc,u
 L6EAC               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldx       ,u
                     bra       L6ED7
@@ -12061,7 +12062,7 @@ L6ED7               cmpx      #$0008
 L6EEA               puls      pc,u
 L6EEC               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldx       $06,u
                     lbra      L6F5F
@@ -12130,7 +12131,7 @@ L6F5F               cmpx      #$0037
 L6F81               puls      pc,u
 L6F83               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -12340,7 +12341,7 @@ L7176               tfr       u,d
                     puls      pc,u
 L717C               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$06,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -12688,7 +12689,7 @@ L7494               ldd       #$0070
 
 L749E               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       #$0000
                     bra       L74C2
 
@@ -12709,7 +12710,7 @@ L74C2               cmpu      #$000E
 
 L74CB               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     ldd       #$0001
@@ -12777,7 +12778,7 @@ L74CB               pshs      u
 
 L7567               pshs      u
                     ldd       #$FFAE
-L756C               lbsr      stkcheck
+L756C               lbsr      L010F
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -12833,7 +12834,7 @@ L75DF               leas      $06,s
                     puls      pc,u
 L75E3               pshs      u
                     ldd       #$FFB2
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$04,s
                     ldd       $000F
                     std       ,s
@@ -12933,7 +12934,7 @@ L7680               ldx       $02,s
 
 L76BF               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $06,u
@@ -12976,7 +12977,7 @@ L7719               leas      $02,s
                     puls      pc,u
 L771D               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldx       $06,u
                     bra       L774B
@@ -13002,7 +13003,7 @@ L774B               cmpx      #$0050
 
 L7759               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     ldd       $12,x
                     cmpd      #$0002
@@ -13012,7 +13013,7 @@ L7759               pshs      u
 
 L7771               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldx       $06,u
                     bra       L7790
@@ -13038,7 +13039,7 @@ L77A8               clra
 L77AA               puls      pc,u
 L77AC               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$80
@@ -13065,7 +13066,7 @@ L77AC               pshs      u
 L77E4               puls      pc,u
 L77E6               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -13231,7 +13232,7 @@ L792C               pshs      u
 
 L794A               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -13480,7 +13481,7 @@ L7B63               pshs      u
 
 L7B83               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$7f
@@ -13513,7 +13514,7 @@ L7BBC               ldd       #$0071
                     puls      pc,u
 L7BD2               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $0a,u
@@ -13663,7 +13664,7 @@ L7D15               leas      $04,s
                     puls      pc,u
 L7D19               pshs      u
                     ldd       #$FFAC
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -13822,7 +13823,7 @@ L7E56               ldd       $0e,s
 
 L7E63               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     pshs      u
                     bsr       L7E9C
@@ -13846,7 +13847,7 @@ L7E95               ldd       #$0071
                     puls      pc,u
 L7E9C               pshs      u
                     ldd       #$FFAC
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -14140,7 +14141,7 @@ L812E               leas      $08,s
                     puls      pc,u
 L8132               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $04,s
                     cmpd      #$006F
                     beq       L814A
@@ -14167,7 +14168,7 @@ L8186               fcc       /x translate/
                     fcb       $00
 L8192               pshs      u
                     ldd       #$FFA2
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$14,s
                     bra       L81AD
 
@@ -14469,7 +14470,7 @@ L843C               leas      $14,s
                     puls      pc,u
 L8441               pshs      u
                     ldd       #$FFA4
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$12,s
                     lbsr      L8B51
                     std       $10,s
@@ -14621,7 +14622,7 @@ L857F               ldd       #$0028
 
 L8593               pshs      u
                     ldd       #$FF9E
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$12,s
                     lbsr      L8B51
                     std       $10,s
@@ -14889,7 +14890,7 @@ L87E1               leas      $12,s
                     puls      pc,u
 L87E6               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       ,u
                     cmpd      $06,s
@@ -14911,7 +14912,7 @@ L8816               clra
                     puls      pc,u
 L881A               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldd       $04,s
                     cmpd      #$0010
                     bne       L886B
@@ -14948,7 +14949,7 @@ L886B               ldd       $04,s
                     puls      pc,u
 L886F               pshs      u
                     ldd       #$FFAC
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0a,s
                     ldd       #$0001
                     std       $0031
@@ -15104,7 +15105,7 @@ L89B0               lbsr      L5F26
                     puls      pc,u
 L89B7               pshs      u
                     ldd       #$FFAA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$06,s
                     ldd       $002B
                     std       $02,s
@@ -15228,7 +15229,7 @@ L8ABF               std       $000F
                     puls      pc,u
 L8AC5               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     clra
                     clrb
@@ -15288,7 +15289,7 @@ L8B45               ldd       #$002E
 
 L8B51               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     lbsr      L0641
                     std       -$02,s
@@ -15326,7 +15327,7 @@ L8B9C               leas      $02,s
                     puls      pc,u
 L8BA0               pshs      u
                     ldd       #$FF98
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$1a,s
                     clra
                     clrb
@@ -15680,7 +15681,7 @@ L8EF0               leas      $1a,s
                     puls      pc,u
 L8EF5               pshs      u
                     ldd       #$FFAA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$0C,s
                     clra
                     clrb
@@ -15831,7 +15832,7 @@ L9024               ldd       $0a,s
                     puls      pc,u
 L9035               pshs      u
                     ldd       #$FFBC
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
@@ -15857,7 +15858,7 @@ L905D               ldd       ,s
 
 L906B               pshs      u
                     ldd       #$FFB2
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     ldd       ,u
@@ -15925,7 +15926,7 @@ L90DD               std       $02,u
                     puls      pc,u
 L90F5               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $08,s
                     leas      -$02,s
                     ldd       $06,s
@@ -15982,7 +15983,7 @@ L916A               ldd       $08,s
 
 L916F               pshs      u
                     ldd       #$FF74
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$40,s
                     ldu       [$44,s]
                     lbra      L922C
@@ -16006,10 +16007,10 @@ L9180               ldd       $10,u
                     pshs      x
                     leax      $06,s
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
                     pshs      d
-                    lbsr      $A6D1
+                    lbsr      LA6D1
                     leas      $06,s
                     pshs      d
                     lbsr      L0450
@@ -16069,13 +16070,13 @@ L922C               stu       -$02,s
                     puls      pc,u
 L923C               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L9375,pcr
                     bra       L9256
 
 L924A               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leax      L938A,pcr
 L9256               pshs      x
                     lbsr      L0450
@@ -16119,7 +16120,7 @@ L938A               fcc       /identifier missing/
                     fcb       $00
 L939D               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
@@ -16325,7 +16326,7 @@ L9573               leas      $04,s
                     puls      pc,u
 L9577               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L010F
                     leas      -$06,s
                     ldx       $0C,s
                     ldd       $0a,x
@@ -16541,7 +16542,7 @@ L973E               ldd       $02,s
                     puls      pc,u
 L9754               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     ldx       $06,x
                     bra       L9772
@@ -16562,7 +16563,7 @@ L9772               cmpx      #$0034
                     lbra      L998C
                     pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0034
@@ -16577,7 +16578,7 @@ L9772               cmpx      #$0034
 
 L97AE               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -16708,7 +16709,7 @@ L98ED               leas      $04,s
                     puls      pc,u
 L98F1               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     bra       L991B
 
@@ -16733,7 +16734,7 @@ L991B               cmpx      #$005A
                     puls      pc,u
 L9929               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldx       $04,s
                     bra       L9947
 
@@ -16761,7 +16762,7 @@ L9947               cmpx      #$005A
                     puls      pc,u
 L9971               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L010F
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -16862,7 +16863,7 @@ L9A1F               pshs      u
                     ldd       $06,s
                     bra       L9A45
 
-fprintf             pshs      u
+L9A34               pshs      u
                     ldd       $04,s
                     std       L0070
                     ldd       #$0001
@@ -16871,10 +16872,10 @@ fprintf             pshs      u
                     pshs      x
                     ldd       $08,s
 L9A45               pshs      d
-                    bsr       doprnt
+                    bsr       L9A6C
                     leas      $04,s
                     puls      pc,u
-                    pshs      u
+L9A4D               pshs      u
                     ldd       $04,s
                     std       L0070
                     ldd       #$0002
@@ -16883,13 +16884,13 @@ L9A45               pshs      d
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       doprnt
+                    bsr       L9A6C
                     leas      $04,s
                     clra
                     clrb
                     stb       [L0070,y]
                     puls      pc,u
-doprnt              pshs      u
+L9A6C               pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L9A84
@@ -17089,7 +17090,7 @@ L9BE6               pshs      u,d
                     pshs      x
                     leax      $088a,y
                     pshs      x
-                    lbsr      $A5D9
+                    lbsr      LA5D9
                     leas      $04,s
                     lbra      L9DBD
 
@@ -17221,7 +17222,7 @@ L9D06               pshs      u
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      $A5C8
+                    lbsr      LA5C8
                     leas      $02,s
                     nega
                     negb
@@ -17327,7 +17328,7 @@ L9DD7               ldd       L0070
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $A1CD
+                    lbsr      LA1CD
 L9DE2               leas      $04,s
 L9DE4               puls      pc,u
 L9DE6               blt       $9E1B
@@ -17349,7 +17350,7 @@ L9DF3               ldd       $06,u
                     std       $0364,y
                     lbra      L9E68
                     puls      pc,u
-                    pshs      u
+L9E14               pshs      u
                     ldu       $08,s
                     bne       L9E1E
                     bsr       $9DED
@@ -17444,7 +17445,7 @@ L9EBC               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      $B116
+                    lbsr      LB116
                     leas      $04,s
                     std       $02,s
                     cmpd      #$FFFF
@@ -17457,7 +17458,7 @@ L9EBC               ldd       ,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      $B1EC
+                    lbsr      LB1EC
                     leas      $08,s
                     bra       L9F2C
 
@@ -17465,14 +17466,14 @@ L9EE7               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      $B137
+                    lbsr      LB137
                     bra       L9EFF
 
 L9EF4               ldd       ,s
                     orb       #$81
 L9EF8               pshs      d
                     pshs      u
-                    lbsr      $B116
+                    lbsr      LB116
 L9EFF               leas      $04,s
                     std       $02,s
                     bra       L9F2C
@@ -17505,7 +17506,7 @@ L9F2E               leas      $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbra      $9F8E
+                    lbra      L9F8E
 
 L9F43               pshs      u
                     ldd       $06,s
@@ -17519,125 +17520,124 @@ L9F43               pshs      u
                     bne       L9F5E
                     clra
                     clrb
-                    bra       $9F93
+                    bra       L9F93
 
 L9F5E               clra
                     clrb
-                    bra       $9F86
+                    bra       L9F86
 
 L9F62               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lsr       $0017
-                    com       $0053
+                    lbsr      LA2BE
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $9E6D
+                    lbsr      L9E6C
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    bge       L9F85
+                    bge       L9F84
                     clra
                     clrb
-                    bra       L9F94
+                    bra       L9F93
 
-L9F85               ldd       $08,s
-                    pshs      d
+L9F84               ldd       $08,s
+L9F86               pshs      d
                     ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      $9E15
+L9F8E               lbsr      L9E14
                     leas      $06,s
-L9F94               puls      pc,u
-                    pshs      u
+L9F93               puls      pc,u
+L9F95               pshs      u
                     leax      $0253,y
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    bsr       L9FB8
+                    bsr       L9FB7
                     leas      $04,s
                     leax      $0253,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      LA1CE
+                    lbsr      LA1CD
                     leas      $04,s
                     puls      pc,u
-L9FB8               pshs      u
+L9FB7               pshs      u
                     ldu       $04,s
                     leas      -$01,s
-                    bra       L9FCE
+                    bra       L9FCD
 
-L9FC0               ldd       $07,s
+L9FBF               ldd       $07,s
                     pshs      d
                     ldb       $02,s
                     sex
                     pshs      d
-                    lbsr      LA1CE
+                    lbsr      LA1CD
                     leas      $04,s
-L9FCE               ldb       ,u+
+L9FCD               ldb       ,u+
                     stb       ,s
-                    bne       L9FC0
+                    bne       L9FBF
                     leas      $01,s
                     puls      pc,u
-                    pshs      u,d
+L9FD7               pshs      u,d
                     ldu       $06,s
-                    bra       L9FE0
+                    bra       L9FDF
 
-L9FDE               leau      $01,u
-L9FE0               ldb       ,u
+L9FDD               leau      $01,u
+L9FDF               ldb       ,u
                     sex
                     std       ,s
-                    beq       L9FEF
+                    beq       L9FEE
                     ldd       ,s
                     cmpd      #$0058
-                    bne       L9FDE
-L9FEF               ldd       ,s
-                    beq       LA005
-                    lbsr      LB2D8
+                    bne       L9FDD
+L9FEE               ldd       ,s
+                    beq       LA004
+                    lbsr      LB2D7
                     pshs      d
-                    leax      >LA00B,pcr
+                    leax      >LA00A,pcr
                     pshs      x
                     pshs      u
-                    lbsr      $9A4E
+                    lbsr      L9A4D
                     leas      $06,s
-LA005               ldd       $06,s
+LA004               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
-LA00B               bcs       LA071
+LA00A               bcs       LA070
                     neg       $0034
                     nega
                     ldu       $04,s
                     leas      -$06,s
                     cmpu      #$0000
-                    beq       LA021
+                    beq       LA020
                     ldd       $06,u
                     clra
                     andb      #$03
-                    bne       LA027
-LA021               ldd       #$FFFF
-                    lbra      LA14A
+                    bne       LA026
+LA020               ldd       #$FFFF
+                    lbra      LA149
 
-LA027               ldd       $06,u
+LA026               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       LA03A
+                    bne       LA039
                     pshs      u
-                    lbsr      LA539
+                    lbsr      LA538
                     leas      $02,s
-                    lbra      LA110
+                    lbra      LA10F
 
-LA03A               ldd       $06,u
+LA039               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    beq       LA059
+                    beq       LA058
                     pshs      u
-                    lbsr      LA2F9
+                    lbsr      LA2F8
                     leas      $02,s
                     ldd       $06,u
                     anda      #$FE
@@ -17645,31 +17645,31 @@ LA03A               ldd       $06,u
                     ldd       $02,u
                     addd      $0b,u
                     std       $04,u
-                    lbra      LA10E
+                    lbra      LA10D
 
-LA059               ldd       ,u
+LA058               ldd       ,u
                     cmpd      $04,u
-                    lbcc      LA110
+                    lbcc      LA10F
                     leax      $02,s
                     pshs      x
                     leax      $0e,s
-                    lbsr      LAEE0
+                    lbsr      LAEDF
                     ldx       $10,s
-                    lbra      LA0DD
+                    lbra      LA0DC
 
-LA071               leax      $02,s
+LA070               leax      $02,s
                     pshs      x
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
                     pshs      u
-                    lbsr      LA165
+                    lbsr      LA164
                     leas      $02,s
-                    lbsr      LAE67
-                    lbsr      LAEE0
-LA08A               ldd       $0b,u
-                    lbsr      LAEC7
+                    lbsr      LAE66
+                    lbsr      LAEDF
+LA089               ldd       $0b,u
+                    lbsr      LAEC6
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
@@ -17679,42 +17679,42 @@ LA08A               ldd       $0b,u
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       LA0A7
+                    bsr       LA0A6
                     neg       $0000
                     neg       $0000
-LA0A7               puls      x
-                    lbsr      LAE7C
-                    bge       LA0B5
+LA0A6               puls      x
+                    lbsr      LAE7B
+                    bge       LA0B4
                     leax      $06,s
-                    lbsr      LAEA0
-                    bra       LA0B7
+                    lbsr      LAE9F
+                    bra       LA0B6
 
-LA0B5               leax      $06,s
-LA0B7               lbsr      LAE7C
-                    blt       LA0EA
+LA0B4               leax      $06,s
+LA0B6               lbsr      LAE7B
+                    blt       LA0E9
                     ldd       $04,s
                     addd      ,u
                     std       ,s
                     cmpd      $02,u
-                    bcs       LA0EA
+                    bcs       LA0E9
                     ldd       ,s
                     cmpd      $04,u
-                    bcc       LA0EA
+                    bcc       LA0E9
                     ldd       ,s
                     std       ,u
                     ldd       $06,u
                     andb      #$EF
                     std       $06,u
-                    lbra      LA148
-                    bra       LA0EA
+                    lbra      LA147
+                    bra       LA0E9
 
-LA0DD               stx       -$02,s
-                    lbeq      LA071
+LA0DC               stx       -$02,s
+                    lbeq      LA070
                     cmpx      #$0001
-                    lbeq      LA08A
-LA0EA               ldd       $10,s
+                    lbeq      LA089
+LA0E9               ldd       $10,s
                     cmpd      #$0001
-                    bne       LA10C
+                    bne       LA10B
                     leax      $0C,s
                     pshs      x
                     ldd       $02,x
@@ -17723,12 +17723,12 @@ LA0EA               ldd       $10,s
                     pshs      d
                     ldd       $04,u
                     subd      ,u
-                    lbsr      LAEC7
-                    lbsr      LAE67
-                    lbsr      LAEE0
-LA10C               ldd       $04,u
-LA10E               std       ,u
-LA110               ldd       $06,u
+                    lbsr      LAEC6
+                    lbsr      LAE66
+                    lbsr      LAEDF
+LA10B               ldd       $04,u
+LA10D               std       ,u
+LA10F               ldd       $06,u
                     andb      #$EF
                     std       $06,u
                     ldd       $10,s
@@ -17740,25 +17740,25 @@ LA110               ldd       $06,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB1ED
+                    lbsr      LB1EC
                     leas      $08,s
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $A13C
+                    bsr       $A13B
                     stu       $FFFF
                     stu       L3510
-                    lbsr      LAE7C
-                    bne       LA148
+                    lbsr      LAE7B
+                    bne       LA147
                     ldd       #$FFFF
-                    bra       LA14A
+                    bra       LA149
 
-LA148               clra
+LA147               clra
                     clrb
-LA14A               leas      $06,s
+LA149               leas      $06,s
                     puls      pc,u
-                    pshs      u
+LA14D               pshs      u
                     clra
                     clrb
                     pshs      d
@@ -17768,32 +17768,32 @@ LA14A               leas      $06,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      $A00E
+                    lbsr      $A00D
                     leas      $08,s
                     puls      pc,u
-LA165               pshs      u
+LA164               pshs      u
                     ldu       $04,s
-                    beq       LA172
+                    beq       LA171
                     ldd       $06,u
                     clra
                     andb      #$03
-                    bne       LA185
-LA172               bsr       $A178
+                    bne       LA184
+LA171               bsr       $A177
                     stu       $FFFF
                     stu       L3510
                     leau      $0358,y
                     pshs      u
-                    lbsr      LAEE0
+                    lbsr      LAEDF
                     puls      pc,u
-LA185               ldd       $06,u
+LA184               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       LA195
+                    bne       LA194
                     pshs      u
-                    lbsr      LA539
+                    lbsr      LA538
                     leas      $02,s
-LA195               ldd       #$0001
+LA194               ldd       #$0001
                     pshs      d
                     clra
                     clrb
@@ -17801,7 +17801,7 @@ LA195               ldd       #$0001
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB1ED
+                    lbsr      LB1EC
                     leas      $08,s
                     ldd       $02,x
                     pshs      d
@@ -17811,36 +17811,36 @@ LA195               ldd       #$0001
                     anda      #$01
                     clrb
                     std       -$02,s
-                    beq       LA1BE
+                    beq       LA1BD
                     ldd       $02,u
-                    bra       LA1C0
+                    bra       LA1BF
 
-LA1BE               ldd       $04,u
-LA1C0               pshs      d
+LA1BD               ldd       $04,u
+LA1BF               pshs      d
                     ldd       ,u
                     subd      ,s++
-                    lbsr      LAEC7
-                    lbsr      LAE52
+                    lbsr      LAEC6
+                    lbsr      LAE51
                     puls      pc,u
-LA1CE               pshs      u
+LA1CD               pshs      u
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$22
                     cmpd      #$8002
-                    beq       LA1F2
+                    beq       LA1F1
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    lbne      LA30A
+                    lbne      LA309
                     pshs      u
-                    lbsr      LA539
+                    lbsr      LA538
                     leas      $02,s
-LA1F2               ldd       $06,u
+LA1F1               ldd       $06,u
                     clra
                     andb      #$04
-                    beq       LA22E
+                    beq       LA22D
                     ldd       #$0001
                     pshs      d
                     leax      $07,s
@@ -17850,31 +17850,31 @@ LA1F2               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       LA213
-                    leax      LB1DD,pcr
-                    bra       LA217
+                    beq       LA212
+                    leax      LB1DC,pcr
+                    bra       LA216
 
-LA213               leax      LB1C4,pcr
-LA217               tfr       x,d
+LA212               leax      LB1C3,pcr
+LA216               tfr       x,d
                     tfr       d,x
                     jsr       ,x
                     leas      $06,s
                     cmpd      #$FFFF
-                    bne       LA26F
+                    bne       LA26E
                     ldd       $06,u
                     orb       #$20
                     std       $06,u
-                    lbra      LA30A
+                    lbra      LA309
 
-LA22E               ldd       $06,u
+LA22D               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       LA23E
+                    bne       LA23D
                     pshs      u
-                    lbsr      LA327
+                    lbsr      LA326
                     leas      $02,s
-LA23E               ldd       ,u
+LA23D               ldd       ,u
                     addd      #$0001
                     std       ,u
                     subd      #$0001
@@ -17883,19 +17883,19 @@ LA23E               ldd       ,u
                     stb       ,x
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       LA264
+                    bcc       LA263
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       LA26F
+                    beq       LA26E
                     ldd       $04,s
                     cmpd      #$000D
-                    bne       LA26F
-LA264               pshs      u
-                    lbsr      LA327
+                    bne       LA26E
+LA263               pshs      u
+                    lbsr      LA326
                     std       ,s++
-                    lbne      LA30A
-LA26F               ldd       $04,s
+                    lbne      LA309
+LA26E               ldd       $04,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
@@ -17903,106 +17903,106 @@ LA26F               ldd       $04,s
                     pshs      d
                     pshs      u
                     ldd       #$0008
-                    lbsr      LB076
+                    lbsr      LB075
                     pshs      d
-                    lbsr      LA1CE
+                    lbsr      LA1CD
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      LA1CE
-                    lbra      LA3E1
+                    lbsr      LA1CD
+                    lbra      LA3E0
 
-LA296               pshs      u,d
+LA295               pshs      u,d
                     leau      $0246,y
                     clra
                     clrb
                     std       ,s
-                    bra       LA2AC
+                    bra       LA2AB
 
-LA2A2               tfr       u,d
+LA2A1               tfr       u,d
                     leau      $0d,u
                     pshs      d
-                    bsr       LA2BF
+                    bsr       LA2BE
                     leas      $02,s
-LA2AC               ldd       ,s
+LA2AB               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0010
-                    blt       LA2A2
-                    lbra      LA323
+                    blt       LA2A1
+                    lbra      LA322
 
-LA2BF               pshs      u
+LA2BE               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     cmpu      #$0000
-                    beq       LA2CF
+                    beq       LA2CE
                     ldd       $06,u
-                    bne       LA2D5
-LA2CF               ldd       #$FFFF
-                    lbra      LA323
+                    bne       LA2D4
+LA2CE               ldd       #$FFFF
+                    lbra      LA322
 
-LA2D5               ldd       $06,u
+LA2D4               ldd       $06,u
                     clra
                     andb      #$02
-                    beq       LA2E4
+                    beq       LA2E3
                     pshs      u
-                    bsr       LA2F9
+                    bsr       LA2F8
                     leas      $02,s
-                    bra       LA2E6
+                    bra       LA2E5
 
-LA2E4               clra
+LA2E3               clra
                     clrb
-LA2E6               std       ,s
+LA2E5               std       ,s
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB126
+                    lbsr      LB125
                     leas      $02,s
                     clra
                     clrb
                     std       $06,u
                     ldd       ,s
-                    bra       LA323
+                    bra       LA322
 
-LA2F9               pshs      u
+LA2F8               pshs      u
                     ldu       $04,s
-                    beq       LA30A
+                    beq       LA309
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    beq       LA30F
-LA30A               ldd       #$FFFF
+                    beq       LA30E
+LA309               ldd       #$FFFF
                     puls      pc,u
-LA30F               ldd       $06,u
+LA30E               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       LA31F
+                    bne       LA31E
                     pshs      u
-                    lbsr      LA539
+                    lbsr      LA538
                     leas      $02,s
-LA31F               pshs      u
-                    bsr       LA327
-LA323               leas      $02,s
+LA31E               pshs      u
+                    bsr       LA326
+LA322               leas      $02,s
                     puls      pc,u
-LA327               pshs      u
+LA326               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       LA359
+                    bne       LA358
                     ldd       ,u
                     cmpd      $04,u
-                    beq       LA359
+                    beq       LA358
                     clra
                     clrb
                     pshs      d
                     pshs      u
-                    lbsr      LA165
+                    lbsr      LA164
                     leas      $02,s
                     ldd       $02,x
                     pshs      d
@@ -18010,70 +18010,70 @@ LA327               pshs      u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB1ED
+                    lbsr      LB1EC
                     leas      $08,s
-LA359               ldd       ,u
+LA358               ldd       ,u
                     subd      $02,u
                     std       $02,s
-                    lbeq      LA3D1
+                    lbeq      LA3D0
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      LA3D1
+                    lbeq      LA3D0
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       LA3A8
+                    beq       LA3A7
                     ldd       $02,u
-                    bra       LA3A0
+                    bra       LA39F
 
-LA379               ldd       $02,s
+LA378               ldd       $02,s
                     pshs      d
                     ldd       ,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB1DD
+                    lbsr      LB1DC
                     leas      $06,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       LA396
+                    bne       LA395
                     leax      $04,s
-                    bra       LA3C0
+                    bra       LA3BF
 
-LA396               ldd       $02,s
+LA395               ldd       $02,s
                     subd      ,s
                     std       $02,s
                     ldd       ,u
                     addd      ,s
-LA3A0               std       ,u
+LA39F               std       ,u
                     ldd       $02,s
-                    bne       LA379
-                    bra       LA3D1
+                    bne       LA378
+                    bra       LA3D0
 
-LA3A8               ldd       $02,s
+LA3A7               ldd       $02,s
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB1C4
+                    lbsr      LB1C3
                     leas      $06,s
                     cmpd      $02,s
-                    beq       LA3D1
-                    bra       LA3C2
+                    beq       LA3D0
+                    bra       LA3C1
 
-LA3C0               leas      -$04,x
-LA3C2               ldd       $06,u
+LA3BF               leas      -$04,x
+LA3C1               ldd       $06,u
                     orb       #$20
                     std       $06,u
                     ldd       $04,u
                     std       ,u
                     ldd       #$FFFF
-                    bra       LA3E1
+                    bra       LA3E0
 
-LA3D1               ldd       $06,u
+LA3D0               ldd       $06,u
                     ora       #$01
                     std       $06,u
                     ldd       $02,u
@@ -18082,19 +18082,19 @@ LA3D1               ldd       $06,u
                     std       $04,u
                     clra
                     clrb
-LA3E1               leas      $04,s
+LA3E0               leas      $04,s
                     puls      pc,u
-LA3E5               pshs      u
+LA3E4               pshs      u
                     ldu       $04,s
-                    beq       LA431
+                    beq       LA430
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       LA431
+                    bne       LA430
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       LA40D
+                    bcc       LA40C
                     ldd       ,u
                     addd      #$0001
                     std       ,u
@@ -18102,27 +18102,27 @@ LA3E5               pshs      u
                     tfr       d,x
                     ldb       ,x
                     clra
-                    lbra      LA537
+                    lbra      LA536
 
-LA40D               pshs      u
-                    lbsr      LA480
-                    lbra      LA535
+LA40C               pshs      u
+                    lbsr      LA47F
+                    lbra      LA534
                     pshs      u
                     ldu       $06,s
-                    beq       LA431
+                    beq       LA430
                     ldd       $06,u
                     clra
                     andb      #$01
-                    beq       LA431
+                    beq       LA430
                     ldd       $04,s
                     cmpd      #$FFFF
-                    beq       LA431
+                    beq       LA430
                     ldd       ,u
                     cmpd      $02,u
-                    bhi       LA436
-LA431               ldd       #$FFFF
+                    bhi       LA435
+LA430               ldd       #$FFFF
                     puls      pc,u
-LA436               ldd       ,u
+LA435               ldd       ,u
                     addd      #$FFFF
                     std       ,u
                     tfr       d,x
@@ -18134,59 +18134,59 @@ LA436               ldd       ,u
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
-                    lbsr      LA3E5
+                    lbsr      LA3E4
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       LA46B
+                    beq       LA46A
                     pshs      u
-                    lbsr      LA3E5
+                    lbsr      LA3E4
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       LA470
-LA46B               ldd       #$FFFF
-                    bra       LA47C
+                    bne       LA46F
+LA46A               ldd       #$FFFF
+                    bra       LA47B
 
-LA470               ldd       $02,s
+LA46F               ldd       $02,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      LB08D
+                    lbsr      LB08C
                     addd      ,s
-LA47C               leas      $04,s
+LA47B               leas      $04,s
                     puls      pc,u
-LA480               pshs      u
+LA47F               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$31
                     cmpd      #$8001
-                    beq       LA4A6
+                    beq       LA4A5
                     ldd       $06,u
                     clra
                     andb      #$31
                     cmpd      #$0001
-                    lbne      LA51F
+                    lbne      LA51E
                     pshs      u
-                    lbsr      LA539
+                    lbsr      LA538
                     leas      $02,s
-LA4A6               leax      $0246,y
+LA4A5               leax      $0246,y
                     pshs      x
                     cmpu      ,s++
-                    bne       LA4C3
+                    bne       LA4C2
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       LA4C3
+                    beq       LA4C2
                     leax      $0253,y
                     pshs      x
-                    lbsr      LA2F9
+                    lbsr      LA2F8
                     leas      $02,s
-LA4C3               ldd       $06,u
+LA4C2               ldd       $06,u
                     clra
                     andb      #$08
-                    beq       LA4EF
+                    beq       LA4EE
                     ldd       $0b,u
                     pshs      d
                     ldd       $02,u
@@ -18196,43 +18196,43 @@ LA4C3               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       LA4E3
-                    leax      LB1B4,pcr
-                    bra       LA4E7
+                    beq       LA4E2
+                    leax      LB1B3,pcr
+                    bra       LA4E6
 
-LA4E3               leax      LB193,pcr
-LA4E7               tfr       x,d
+LA4E2               leax      LB192,pcr
+LA4E6               tfr       x,d
                     tfr       d,x
                     jsr       ,x
-                    bra       LA501
+                    bra       LA500
 
-LA4EF               ldd       #$0001
+LA4EE               ldd       #$0001
                     pshs      d
                     leax      $0a,u
                     stx       $02,u
                     pshs      x
                     ldd       $08,u
                     pshs      d
-                    lbsr      LB193
-LA501               leas      $06,s
+                    lbsr      LB192
+LA500               leas      $06,s
                     std       ,s
                     ldd       ,s
-                    bgt       LA524
+                    bgt       LA523
                     ldd       $06,u
                     pshs      d
                     ldd       $02,s
-                    beq       LA516
+                    beq       LA515
                     ldd       #$0020
-                    bra       LA519
+                    bra       LA518
 
-LA516               ldd       #$0010
-LA519               ora       ,s+
+LA515               ldd       #$0010
+LA518               ora       ,s+
                     orb       ,s+
                     std       $06,u
-LA51F               ldd       #$FFFF
-                    bra       LA535
+LA51E               ldd       #$FFFF
+                    bra       LA534
 
-LA524               ldd       $02,u
+LA523               ldd       $02,u
                     addd      #$0001
                     std       ,u
                     ldd       $02,u
@@ -18240,14 +18240,14 @@ LA524               ldd       $02,u
                     std       $04,u
                     ldb       [$02,u]
                     clra
-LA535               leas      $02,s
-LA537               puls      pc,u
-LA539               pshs      u
+LA534               leas      $02,s
+LA536               puls      pc,u
+LA538               pshs      u
                     ldu       $04,s
                     ldd       $06,u
                     clra
                     andb      #$C0
-                    bne       LA571
+                    bne       LA570
                     leas      -$20,s
                     leax      ,s
                     pshs      x
@@ -18256,126 +18256,127 @@ LA539               pshs      u
                     clra
                     clrb
                     pshs      d
-                    lbsr      LB0A8
+                    lbsr      LB0A7
                     leas      $06,s
                     ldd       $06,u
                     pshs      d
                     ldb       $02,s
-                    bne       LA565
+                    bne       LA564
                     ldd       #$0040
-                    bra       LA568
+                    bra       LA567
 
-LA565               ldd       #$0080
-LA568               ora       ,s+
+LA564               ldd       #$0080
+LA567               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     leas      $20,s
-LA571               ldd       $06,u
+LA570               ldd       $06,u
                     ora       #$80
                     std       $06,u
                     clra
                     andb      #$0C
-                    beq       LA57E
+                    beq       LA57D
                     puls      pc,u
-LA57E               ldd       $0b,u
-                    bne       LA593
+LA57D               ldd       $0b,u
+                    bne       LA592
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       LA58E
+                    beq       LA58D
                     ldd       #$0080
-                    bra       LA591
+                    bra       LA590
 
-LA58E               ldd       #$0100
-LA591               std       $0b,u
-LA593               ldd       $02,u
-                    bne       LA5A8
+LA58D               ldd       #$0100
+LA590               std       $0b,u
+LA592               ldd       $02,u
+                    bne       LA5A7
                     ldd       $0b,u
                     pshs      d
-                    lbsr      LB2AB
+                    lbsr      LB2AA
                     leas      $02,s
                     std       $02,u
                     cmpd      #$FFFF
-                    beq       LA5B0
-LA5A8               ldd       $06,u
+                    beq       LA5AF
+LA5A7               ldd       $06,u
                     orb       #$08
                     std       $06,u
-                    bra       LA5BF
+                    bra       LA5BE
 
-LA5B0               ldd       $06,u
+LA5AF               ldd       $06,u
                     orb       #$04
                     std       $06,u
                     leax      $0a,u
                     stx       $02,u
                     ldd       #$0001
                     std       $0b,u
-LA5BF               ldd       $02,u
+LA5BE               ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
                     puls      pc,u
-                    pshs      u
+LA5C8               pshs      u
                     ldu       $04,s
-LA5CD               ldb       ,u+
-                    bne       LA5CD
+LA5CC               ldb       ,u+
+                    bne       LA5CC
                     tfr       u,d
                     subd      $04,s
                     addd      #$FFFF
                     puls      pc,u
-                    pshs      u
+LA5D9               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-LA5E4               ldb       ,u+
+LA5E3               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       LA5E4
-                    bra       LA619
-                    pshs      u
+                    bne       LA5E3
+                    bra       LA618
+
+LA5F1               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-LA5FC               ldx       ,s
+LA5FB               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       LA5FC
+                    bne       LA5FB
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-LA60D               ldb       ,u+
+LA60C               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       LA60D
-LA619               ldd       $06,s
+                    bne       LA60C
+LA618               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
-                    bra       LA635
+                    bra       LA634
 
-LA625               ldx       $06,s
+LA624               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       LA633
+                    bne       LA632
                     clra
                     clrb
                     puls      pc,u
-LA633               leau      $01,u
-LA635               ldb       ,u
+LA632               leau      $01,u
+LA634               ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       LA625
+                    beq       LA624
                     ldb       [$06,s]
                     sex
                     pshs      d
@@ -18383,114 +18384,115 @@ LA635               ldb       ,u
                     sex
                     subd      ,s++
                     puls      pc,u
-                    pshs      u
+LA64F               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-LA65A               ldd       $0a,s
+LA659               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       LA67E
+                    ble       LA67D
                     ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       LA65A
-                    bra       LA67E
+                    bne       LA659
+                    bra       LA67D
 
-LA674               clra
+LA673               clra
                     clrb
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-LA67E               ldd       $0a,s
+LA67D               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    bgt       LA674
-                    lbra      LA70D
-                    pshs      u
-                    ldu       $04,s
-                    bra       LA6A3
+                    bgt       LA673
+                    lbra      LA70C
 
-LA693               ldx       $06,s
+LA68C               pshs      u
+                    ldu       $04,s
+                    bra       LA6A2
+
+LA692               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       LA6A1
+                    bne       LA6A0
                     clra
                     clrb
                     puls      pc,u
-LA6A1               leau      $01,u
-LA6A3               ldd       $08,s
+LA6A0               leau      $01,u
+LA6A2               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    ble       LA6BD
+                    ble       LA6BC
                     ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       LA693
-LA6BD               ldd       $08,s
-                    bge       LA6C5
+                    beq       LA692
+LA6BC               ldd       $08,s
+                    bge       LA6C4
                     clra
                     clrb
-                    bra       LA6D0
+                    bra       LA6CF
 
-LA6C5               ldb       [$06,s]
+LA6C4               ldb       [$06,s]
                     sex
                     pshs      d
                     ldb       ,u
                     sex
                     subd      ,s++
-LA6D0               puls      pc,u
-                    pshs      u
+LA6CF               puls      pc,u
+LA6D1               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-LA6DC               ldx       ,s
+LA6DB               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       LA6DC
+                    bne       LA6DB
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-LA6ED               ldd       $0a,s
+LA6EC               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       LA705
+                    ble       LA704
                     ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       LA6ED
-LA705               ldd       $0a,s
-                    bge       LA70D
+                    bne       LA6EC
+LA704               ldd       $0a,s
+                    bge       LA70C
                     clra
                     clrb
                     stb       [,s]
-LA70D               ldd       $06,s
+LA70C               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
-LA717               ldx       $06,s
+LA716               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
                     stb       ,u+
-                    bgt       LA717
+                    bgt       LA716
                     ldb       -$01,u
                     clra
                     andb      #$7f
@@ -18500,58 +18502,65 @@ LA717               ldx       $06,s
                     stb       ,u
                     ldd       $04,s
                     puls      pc,u
-                    ldx       $02,s
-                    lbsr      LAE0E
-                    bsr       LA73A
+LA731               ldx       $02,s
+                    lbsr      LAE0D
+                    bsr       LA739
                     rts
 
-LA73A               pshs      u
+LA739               pshs      u
                     leas      -$1e,s
                     tfr       s,u
                     clr       $1d,u
                     clr       $19,u
-                    lbsr      LA9B4
-                    lbra      LA7D9
-                    ldd       ,x
-                    eora      #$80
-                    lbra      LAD72
-                    lbsr      LABCC
-                    lbsr      LA8AE
-                    lbra      LA7D9
-                    lbsr      LABCC
-                    lbsr      LA884
-                    lbra      LA7D9
-                    lbsr      LABCC
-                    lbsr      LAA27
-                    bra       LA7D9
-                    lbsr      LABCC
-                    lbsr      LAA53
-                    bra       LA7D9
+                    lbsr      LA9B3
+                    lbra      LA7D8
 
-LA776               lbsr      LAD70
-                    lbra      LAC70
-                    bsr       LA776
+LA74C               ldd       ,x
+                    eora      #$80
+                    lbra      LAD71
+                    lbsr      LABCB
+                    lbsr      LA8AD
+                    lbra      LA7D8
+                    lbsr      LABCB
+                    lbsr      LA883
+                    lbra      LA7D8
+
+LA765               lbsr      LABCB
+                    lbsr      LAA26
+                    bra       LA7D8
+
+LA76D               lbsr      LABCB
+                    lbsr      LAA52
+                    bra       LA7D8
+
+LA775               lbsr      LAD6F
+                    lbra      LAC6F
+
+LA77B               bsr       LA775
                     ldd       $02,x
-LA780               rts
-                    ldd       ,x
+                    rts
+
+LA780               ldd       ,x
                     std       $0358,y
                     ldd       $02,x
                     leax      $0358,y
                     std       $02,x
-                    lbra      LAC10
-                    leax      $0358,y
+                    lbra      LAC0F
+
+LA791               leax      $0358,y
                     std       $02,x
                     tfr       a,b
                     sex
                     tfr       a,b
                     std       ,x
-                    lbra      LAC10
+                    lbra      LAC0F
                     leax      $0358,y
                     std       $02,x
                     clr       ,x
                     clr       $01,x
-                    lbra      LAC10
-                    ldd       ,x
+                    lbra      LAC0F
+
+LA7AE               ldd       ,x
                     std       $0358,y
                     lda       $02,x
                     ldb       $07,x
@@ -18570,7 +18579,7 @@ LA780               rts
                     clr       $06,x
                     rts
 
-LA7D9               leax      $0358,y
+LA7D8               leax      $0358,y
                     ldd       $22,u
                     std       ,x
                     ldd       $24,u
@@ -18587,103 +18596,103 @@ LA7D9               leax      $0358,y
                     rts
                     lda       $02,s
                     eora      ,x
-                    bmi       LA86C
+                    bmi       LA86B
                     lda       $02,s
-                    bmi       LA83F
+                    bmi       LA83E
                     lda       $09,s
-                    beq       LA838
+                    beq       LA837
                     ldb       $07,x
-                    beq       LA870
+                    beq       LA86F
                     cmpa      $07,x
-                    bne       LA843
+                    bne       LA842
                     ldd       $02,s
                     cmpd      ,x
-                    bne       LA843
+                    bne       LA842
                     ldd       $04,s
                     cmpd      $02,x
-                    bne       LA843
+                    bne       LA842
                     ldd       $06,s
                     cmpd      $04,x
-                    bne       LA843
+                    bne       LA842
                     lda       $08,s
                     anda      #$FE
                     pshs      a
                     ldb       $06,x
                     andb      #$FE
                     cmpa      ,s+
-                    bne       LA843
-                    bra       LA874
+                    bne       LA842
+                    bra       LA873
 
-LA838               lda       $07,x
-                    bne       LA87F
+LA837               lda       $07,x
+                    bne       LA87E
                     clra
-                    bra       LA874
+                    bra       LA873
 
-LA83F               lda       $07,x
+LA83E               lda       $07,x
                     cmpa      $09,s
-LA843               bhi       LA870
-                    bcs       LA87F
+LA842               bhi       LA86F
+                    bcs       LA87E
                     ldd       ,x
                     cmpd      $02,s
-                    bne       LA843
+                    bne       LA842
                     ldd       $02,x
                     cmpd      $04,s
-                    bne       LA843
+                    bne       LA842
                     ldd       $04,x
                     cmpd      $06,s
-                    bne       LA843
+                    bne       LA842
                     lda       $06,x
                     anda      #$FE
                     pshs      a
                     lda       $08,s
                     anda      #$FE
                     cmpa      ,s+
-                    bne       LA843
-                    bra       LA874
+                    bne       LA842
+                    bra       LA873
 
-LA86C               lda       ,x
-                    bpl       LA87F
-LA870               lda       #$01
+LA86B               lda       ,x
+                    bpl       LA87E
+LA86F               lda       #$01
                     andcc     #$FE
-LA874               pshs      cc
+LA873               pshs      cc
                     ldd       $01,s
                     std       $09,s
                     puls      cc
                     leas      $08,s
                     rts
 
-LA87F               clra
+LA87E               clra
                     cmpa      #$01
-                    bra       LA874
+                    bra       LA873
 
-LA884               lda       $17,u
-                    beq       LA8A5
+LA883               lda       $17,u
+                    beq       LA8A4
                     ldb       $1C,u
                     eorb      #$80
                     stb       $1C,u
                     eorb      $18,u
                     stb       $19,u
                     ldb       $29,u
-                    bne       LA8B7
-                    lbsr      LAD40
+                    bne       LA8B6
+                    lbsr      LAD3F
                     lda       $22,u
-                    lbra      LA9F7
+                    lbra      LA9F6
 
-LA8A5               lda       $22,u
+LA8A4               lda       $22,u
                     ldb       $18,u
-                    lbra      LA9FA
+                    lbra      LA9F9
 
-LA8AE               lbeq      LAD40
+LA8AD               lbeq      LAD3F
                     lda       $17,u
-                    beq       LA8A5
-LA8B7               suba      $29,u
-                    beq       LA8E8
+                    beq       LA8A4
+LA8B6               suba      $29,u
+                    beq       LA8E7
                     sta       ,u
-                    bcs       LA8EE
+                    bcs       LA8ED
                     ldb       $17,u
                     stb       $29,u
                     ldd       $22,u
-LA8C9               lsra
+LA8C8               lsra
                     rorb
                     ror       $24,u
                     ror       $25,u
@@ -18691,18 +18700,18 @@ LA8C9               lsra
                     ror       $27,u
                     ror       $28,u
                     dec       ,u
-                    bne       LA8C9
+                    bne       LA8C8
                     std       $22,u
-LA8E1               lda       $19,u
-                    bmi       LA95D
-                    bra       LA90E
+LA8E0               lda       $19,u
+                    bmi       LA95C
+                    bra       LA90D
 
-LA8E8               inc       ,u
+LA8E7               inc       ,u
                     orcc      #$01
-                    bra       LA8E1
+                    bra       LA8E0
 
-LA8EE               ldd       $10,u
-LA8F1               lsra
+LA8ED               ldd       $10,u
+LA8F0               lsra
                     rorb
                     ror       $12,u
                     ror       $13,u
@@ -18710,11 +18719,11 @@ LA8F1               lsra
                     ror       $15,u
                     ror       $16,u
                     inc       ,u
-                    bne       LA8F1
+                    bne       LA8F0
                     std       $10,u
                     lda       $19,u
-                    bmi       LA960
-LA90E               ldd       $27,u
+                    bmi       LA95F
+LA90D               ldd       $27,u
                     adcb      $16,u
                     adca      $15,u
                     std       $27,u
@@ -18729,7 +18738,7 @@ LA90E               ldd       $27,u
                     adcb      $11,u
                     adca      $10,u
                     std       $22,u
-                    bcc       LA955
+                    bcc       LA954
                     inc       $29,u
                     ror       $22,u
                     ror       $23,u
@@ -18738,14 +18747,14 @@ LA90E               ldd       $27,u
                     ror       $26,u
                     ror       $27,u
                     ror       $28,u
-LA955               lda       $1C,u
+LA954               lda       $1C,u
                     sta       $19,u
-                    bra       LA9B4
+                    bra       LA9B3
 
-LA95D               rola
+LA95C               rola
                     coma
                     asra
-LA960               ldd       $27,u
+LA95F               ldd       $27,u
                     sbcb      $16,u
                     sbca      $15,u
                     std       $27,u
@@ -18761,7 +18770,7 @@ LA960               ldd       $27,u
                     sbca      $10,u
                     sta       $22,u
                     lda       $18,u
-                    bcc       LA9B1
+                    bcc       LA9B0
                     com       $22,u
                     com       $23,u
                     com       $24,u
@@ -18770,25 +18779,25 @@ LA960               ldd       $27,u
                     com       $27,u
                     com       $28,u
                     lda       ,u
-                    beq       LA9AE
-                    lbsr      LACFD
-LA9AE               lda       $1C,u
-LA9B1               sta       $19,u
-LA9B4               clr       ,u
-LA9B6               lda       $22,u
-                    bmi       LA9F7
+                    beq       LA9AD
+                    lbsr      LACFC
+LA9AD               lda       $1C,u
+LA9B0               sta       $19,u
+LA9B3               clr       ,u
+LA9B5               lda       $22,u
+                    bmi       LA9F6
                     ora       $23,u
                     ora       $24,u
                     ora       $25,u
                     ora       $26,u
                     ora       $27,u
                     ora       $28,u
-                    beq       LAA0B
+                    beq       LAA0A
                     ldd       $22,u
-LA9D2               dec       $29,u
-                    bne       LA9DA
+LA9D1               dec       $29,u
+                    bne       LA9D9
                     dec       $1d,u
-LA9DA               asl       ,u
+LA9D9               asl       ,u
                     rol       $28,u
                     rol       $27,u
                     rol       $26,u
@@ -18796,38 +18805,38 @@ LA9DA               asl       ,u
                     rol       $24,u
                     rolb
                     rola
-                    bpl       LA9D2
+                    bpl       LA9D1
                     stb       $23,u
                     ldb       $29,u
-                    beq       LAA0F
-LA9F7               ldb       $19,u
-LA9FA               anda      #$7f
+                    beq       LAA0E
+LA9F6               ldb       $19,u
+LA9F9               anda      #$7f
                     andb      #$80
                     pshs      b
                     adda      ,s+
                     sta       $22,u
                     tst       $1d,u
-                    bne       LAA0F
-LAA0A               rts
+                    bne       LAA0E
+LAA09               rts
 
-LAA0B               sta       $29,u
+LAA0A               sta       $29,u
                     rts
 
-LAA0F               lda       $1d,u
+LAA0E               lda       $1d,u
                     ldb       $29,u
                     subd      #$0000
-                    beq       LAA22
-                    bmi       LAA22
-LAA1C               ldd       #$0028
-                    lbra      LB099
+                    beq       LAA21
+                    bmi       LAA21
+LAA1B               ldd       #$0028
+                    lbra      LB098
 
-LAA22               lbsr      LAA4D
-                    bra       LAA1C
+LAA21               lbsr      LAA4C
+                    bra       LAA1B
 
-LAA27               beq       LAA4D
+LAA26               beq       LAA4C
                     lda       $17,u
-                    beq       LAA4D
-                    lbsr      LAAC9
+                    beq       LAA4C
+                    lbsr      LAAC8
                     clra
                     ldb       $29,u
                     addb      $17,u
@@ -18835,23 +18844,23 @@ LAA27               beq       LAA4D
                     subd      #$0080
                     stb       $29,u
                     sta       $1d,u
-                    lbsr      LA9B6
+                    lbsr      LA9B5
                     lda       ,u
-                    bpl       LAA0A
-                    lbra      LACFD
+                    bpl       LAA09
+                    lbra      LACFC
 
-LAA4D               clra
+LAA4C               clra
                     sta       $29,u
-                    bra       LAAB3
+                    bra       LAAB2
 
-LAA53               ldb       $17,u
-                    bne       LAA5E
+LAA52               ldb       $17,u
+                    bne       LAA5D
                     ldd       #$0029
-                    lbra      LB099
+                    lbra      LB098
 
-LAA5E               tsta
-                    beq       LAA4D
-                    lbsr      LAB27
+LAA5D               tsta
+                    beq       LAA4C
+                    lbsr      LAB26
                     clra
                     ldb       $29,u
                     subb      $17,u
@@ -18870,12 +18879,12 @@ LAA5E               tsta
                     ror       $27,u
                     ror       $28,u
                     ror       ,u
-                    lbsr      LA9B6
+                    lbsr      LA9B5
                     lda       ,u
-                    bpl       LAAC8
-                    lbra      LACFD
+                    bpl       LAAC7
+                    lbra      LACFC
 
-LAA9B               pshs      a
+LAA9A               pshs      a
                     ldd       $22,u
                     std       ,u
                     ldd       $24,u
@@ -18885,22 +18894,22 @@ LAA9B               pshs      a
                     ldb       $28,u
                     stb       $06,u
                     puls      a
-LAAB3               sta       $22,u
+LAAB2               sta       $22,u
                     sta       $23,u
                     sta       $24,u
                     sta       $25,u
                     sta       $26,u
                     sta       $27,u
                     sta       $28,u
-LAAC8               rts
+LAAC7               rts
 
-LAAC9               clra
-                    bsr       LAA9B
+LAAC8               clra
+                    bsr       LAA9A
                     ldb       #$38
                     stb       $08,u
-LAAD0               lda       $06,u
+LAACF               lda       $06,u
                     lsra
-                    bcc       LAAFF
+                    bcc       LAAFE
                     ldd       $27,u
                     addd      $15,u
                     std       $27,u
@@ -18915,7 +18924,7 @@ LAAD0               lda       $06,u
                     lda       $22,u
                     adca      $10,u
                     sta       $22,u
-LAAFF               ror       $22,u
+LAAFE               ror       $22,u
                     ror       $23,u
                     ror       $24,u
                     ror       $25,u
@@ -18930,16 +18939,16 @@ LAAFF               ror       $22,u
                     ror       $05,u
                     ror       $06,u
                     dec       $08,u
-                    bne       LAAD0
+                    bne       LAACF
                     rts
 
-LAB27               clra
-                    lbsr      LAA9B
+LAB26               clra
+                    lbsr      LAA9A
                     ldb       #$39
                     stb       $08,u
-LAB2F               ldb       ,u
+LAB2E               ldb       ,u
                     cmpb      $10,u
-                    bcs       LAB66
+                    bcs       LAB65
                     ldd       $05,u
                     subd      $15,u
                     std       $0d,u
@@ -18953,7 +18962,7 @@ LAB2F               ldb       ,u
                     ldd       ,u
                     sbcb      $11,u
                     sbca      $10,u
-                    bcs       LAB66
+                    bcs       LAB65
                     std       ,u
                     lda       $0a,u
                     sta       $02,u
@@ -18961,7 +18970,7 @@ LAB2F               ldb       ,u
                     std       $03,u
                     ldd       $0d,u
                     std       $05,u
-LAB66               rol       $28,u
+LAB65               rol       $28,u
                     rol       $27,u
                     rol       $26,u
                     rol       $25,u
@@ -18976,8 +18985,8 @@ LAB66               rol       $28,u
                     rol       $01,u
                     rol       ,u
                     dec       $08,u
-                    bhi       LAB2F
-                    beq       LABB4
+                    bhi       LAB2E
+                    beq       LABB3
                     ldd       $05,u
                     subd      $15,u
                     std       $05,u
@@ -18993,9 +19002,9 @@ LAB66               rol       $28,u
                     sbca      $10,u
                     sta       ,u
                     clra
-                    bra       LAB66
+                    bra       LAB65
 
-LABB4               ror       ,u
+LABB3               ror       ,u
                     com       $22,u
                     com       $23,u
                     com       $24,u
@@ -19005,7 +19014,7 @@ LABB4               ror       ,u
                     com       $28,u
                     rts
 
-LABCC               puls      d
+LABCB               puls      d
                     pshs      u
                     leas      -$1e,s
                     tfr       s,u
@@ -19032,7 +19041,7 @@ LABCC               puls      d
                     lda       $29,u
                     rts
                     leax      $22,u
-LAC10               lda       #$A0
+LAC0F               lda       #$A0
                     sta       $07,x
                     clr       $04,x
                     clr       $05,x
@@ -19042,10 +19051,10 @@ LAC10               lda       #$A0
                     orb       $01,x
                     orb       $02,x
                     orb       $03,x
-                    beq       LAC5C
+                    beq       LAC5B
                     ldb       $01,x
                     tsta
-                    bpl       LAC3E
+                    bpl       LAC3D
                     pshs      d
                     clra
                     clrb
@@ -19055,92 +19064,92 @@ LAC10               lda       #$A0
                     sbcb      $01,s
                     sbca      ,s
                     leas      $02,s
-                    bvs       LAC48
-LAC3E               dec       $07,x
+                    bvs       LAC47
+LAC3D               dec       $07,x
                     asl       $03,x
                     rol       $02,x
                     rolb
                     rola
-                    bpl       LAC3E
-LAC48               anda      #$7f
+                    bpl       LAC3D
+LAC47               anda      #$7f
                     tst       ,x
-                    bpl       LAC50
+                    bpl       LAC4F
                     ora       #$80
-LAC50               std       ,x
+LAC4F               std       ,x
                     rts
                     leax      $22,u
                     clr       $04,x
                     clr       $05,x
                     clr       $06,x
-LAC5C               clr       $07,x
-LAC5E               clr       ,x
+LAC5B               clr       $07,x
+LAC5D               clr       ,x
                     clr       $01,x
                     clr       $02,x
                     clr       $03,x
                     rts
 
-LAC67               ldd       #$002A
-                    lbra      LB099
+LAC66               ldd       #$002A
+                    lbra      LB098
                     leax      $22,u
-LAC70               ldb       $07,x
-                    beq       LAC5E
+LAC6F               ldb       $07,x
+                    beq       LAC5D
                     subb      #$81
-                    bcs       LACEF
+                    bcs       LACEE
                     negb
                     addb      #$1f
-                    bmi       LAC67
-                    bne       LAC94
+                    bmi       LAC66
+                    bne       LAC93
                     ldd       ,x
                     cmpd      #$8000
-                    bne       LAC67
+                    bne       LAC66
                     lda       $02,x
                     ora       $03,x
                     ora       $04,x
                     ora       $05,x
                     ora       $06,x
-                    bne       LAC67
+                    bne       LAC66
                     rts
 
-LAC94               pshs      b
+LAC93               pshs      b
                     ldd       ,x
-                    bmi       LACAA
+                    bmi       LACA9
                     ora       #$80
-LAC9C               lsra
+LAC9B               lsra
                     rorb
                     ror       $02,x
                     ror       $03,x
                     dec       ,s
-                    bne       LAC9C
+                    bne       LAC9B
                     std       ,x
                     puls      pc,b
-LACAA               clr       ,-s
-LACAC               lsra
+LACA9               clr       ,-s
+LACAB               lsra
                     rorb
                     ror       $02,x
                     ror       $03,x
                     ror       $04,x
                     ror       $05,x
                     ror       $06,x
-                    bcc       LACBC
+                    bcc       LACBB
                     inc       ,s
-LACBC               dec       $01,s
-                    bne       LACAC
+LACBB               dec       $01,s
+                    bne       LACAB
                     std       ,x
                     ldd       ,s++
-                    bne       LACCE
+                    bne       LACCD
                     lda       $04,x
                     ora       $05,x
                     ora       $06,x
-                    beq       LACDF
-LACCE               ldd       $02,x
+                    beq       LACDE
+LACCD               ldd       $02,x
                     addd      #$0001
                     std       $02,x
                     ldd       ,x
                     adcb      #$00
                     adca      #$00
-                    bcs       LAC67
+                    bcs       LAC66
                     std       ,x
-LACDF               clra
+LACDE               clra
                     clrb
                     subd      $02,x
                     std       $02,x
@@ -19150,44 +19159,44 @@ LACDF               clra
                     std       ,x
                     rts
 
-LACEF               lda       ,x
-                    lbpl      LAC5E
+LACEE               lda       ,x
+                    lbpl      LAC5D
                     ldd       #$FFFF
                     std       $02,x
                     std       ,x
                     rts
 
-LACFD               inc       $28,u
-                    bne       LAD33
+LACFC               inc       $28,u
+                    bne       LAD32
                     inc       $27,u
-                    bne       LAD33
+                    bne       LAD32
                     inc       $26,u
-                    bne       LAD33
+                    bne       LAD32
                     inc       $25,u
-                    bne       LAD33
+                    bne       LAD32
                     inc       $24,u
-                    bne       LAD33
+                    bne       LAD32
                     inc       $23,u
-                    bne       LAD33
+                    bne       LAD32
                     ldb       $22,u
                     tfr       b,a
                     anda      #$7f
                     inca
-                    bpl       LAD2A
+                    bpl       LAD29
                     inc       $29,u
                     anda      #$7f
-LAD2A               andb      #$80
+LAD29               andb      #$80
                     pshs      b
                     adda      ,s+
                     sta       $22,u
-LAD33               rts
+LAD32               rts
 
-LAD34               neg       $0000
+LAD33               neg       $0000
                     neg       $0000
                     neg       $0000
                     neg       $0081
-                    leax      >LAD34,pcr
-LAD40               pshs      a
+                    leax      >LAD33,pcr
+LAD3F               pshs      a
                     ldd       ,x
                     std       $22,u
                     ldd       $02,x
@@ -19197,7 +19206,7 @@ LAD40               pshs      a
                     ldd       $06,x
                     std       $28,u
                     puls      pc,a
-LAD58               pshs      a
+LAD57               pshs      a
                     ldd       $22,u
                     std       ,x
                     ldd       $24,u
@@ -19207,8 +19216,8 @@ LAD58               pshs      a
                     ldd       $28,u
                     std       $06,x
                     puls      pc,a
-LAD70               ldd       ,x
-LAD72               std       $0358,y
+LAD6F               ldd       ,x
+LAD71               std       $0358,y
                     ldd       $02,x
                     std       $035a,y
                     ldd       $04,x
@@ -19218,31 +19227,31 @@ LAD72               std       $0358,y
                     std       $06,x
                     rts
                     pshs      x
-                    bsr       LAE0E
-                    leax      LAD34,pcr
+                    bsr       LAE0D
+                    leax      LAD33,pcr
                     pshs      x
-                    lbsr      LABCC
-                    lbsr      LA8AE
-LAD9A               ldx       $2a,u
-                    bsr       LAD58
+                    lbsr      LABCB
+                    lbsr      LA8AD
+LAD99               ldx       $2a,u
+                    bsr       LAD57
                     ldx       $1e,u
                     leas      $2a,u
                     tfr       x,u
                     puls      pc,x
                     pshs      x
-                    bsr       LAE0E
-                    leax      >LAD34,pcr
+                    bsr       LAE0D
+                    leax      >LAD33,pcr
                     pshs      x
-                    lbsr      LABCC
-                    lbsr      LA884
-                    bra       LAD9A
+                    lbsr      LABCB
+                    lbsr      LA883
+                    bra       LAD99
                     pshs      x
-                    bsr       LADF7
-                    leax      LAD34,pcr
+                    bsr       LADF6
+                    leax      LAD33,pcr
                     pshs      x
-                    lbsr      LABCC
-                    lbsr      LA8AE
-LADCB               ldx       $2a,u
+                    lbsr      LABCB
+                    lbsr      LA8AD
+LADCA               ldx       $2a,u
                     ldd       $22,u
                     std       ,x
                     lda       $24,u
@@ -19253,14 +19262,14 @@ LADCB               ldx       $2a,u
                     tfr       x,u
                     puls      pc,x
                     pshs      x
-                    bsr       LADF7
-                    leax      LAD34,pcr
+                    bsr       LADF6
+                    leax      LAD33,pcr
                     pshs      x
-                    lbsr      LABCC
-                    lbsr      LA884
-                    bra       LADCB
+                    lbsr      LABCB
+                    lbsr      LA883
+                    bra       LADCA
 
-LADF7               leas      -$08,s
+LADF6               leas      -$08,s
                     ldd       $08,s
                     std       ,s
                     clra
@@ -19272,9 +19281,9 @@ LADF7               leas      -$08,s
                     ldd       $02,x
                     sta       $04,s
                     stb       $09,s
-LAE0D               rts
+                    rts
 
-LAE0E               leas      -$08,s
+LAE0D               leas      -$08,s
                     ldd       $08,s
                     std       ,s
                     ldd       ,x
@@ -19285,16 +19294,18 @@ LAE0E               leas      -$08,s
                     std       $06,s
                     ldd       $06,x
                     std       $08,s
-LAE24               rts
-                    pshs      u
+                    rts
+
+LAE24               pshs      u
                     ldu       $04,s
                     exg       x,u
                     ldd       ,u
                     std       ,x
                     ldd       $02,u
                     std       $02,x
-                    bra       LAE4B
-                    pshs      u
+                    bra       LAE4A
+
+LAE34               pshs      u
                     ldu       $04,s
                     exg       x,u
                     ldd       ,u
@@ -19305,50 +19316,50 @@ LAE24               rts
                     std       $04,x
                     ldd       $06,u
                     std       $06,x
-LAE4B               puls      u
+LAE4A               puls      u
                     puls      d
                     std       ,s
-LAE51               rts
+                    rts
 
-LAE52               ldd       $04,s
+LAE51               ldd       $04,s
                     addd      $02,x
                     std       $035a,y
                     ldd       $02,s
                     adcb      $01,x
                     adca      ,x
                     std       $0358,y
-                    lbra      LAF2E
+                    lbra      LAF2D
 
-LAE67               ldd       $04,s
+LAE66               ldd       $04,s
                     subd      $02,x
                     std       $035a,y
                     ldd       $02,s
                     sbcb      $01,x
                     sbca      ,x
                     std       $0358,y
-                    lbra      LAF2E
+                    lbra      LAF2D
 
-LAE7C               ldd       $02,s
+LAE7B               ldd       $02,s
                     cmpd      ,x
-                    bne       LAE95
+                    bne       LAE94
                     ldd       $04,s
                     cmpd      $02,x
-                    beq       LAE95
-                    bcs       LAE92
+                    beq       LAE94
+                    bcs       LAE91
                     lda       #$01
                     andcc     #$FE
-                    bra       LAE95
+                    bra       LAE94
 
-LAE92               clra
+LAE91               clra
                     cmpa      #$01
-LAE95               pshs      cc
+LAE94               pshs      cc
                     ldd       $01,s
                     std       $05,s
                     puls      cc
                     leas      $04,s
-LAE9F               rts
+                    rts
 
-LAEA0               lbsr      LAF3D
+LAE9F               lbsr      LAF3C
                     ldd       #$0000
                     subd      $02,x
                     std       $02,x
@@ -19356,8 +19367,9 @@ LAEA0               lbsr      LAF3D
                     sbcb      $01,x
                     sbca      ,x
                     std       ,x
-LAEB3               rts
-                    ldd       ,x
+                    rts
+
+LAEB3               ldd       ,x
                     coma
                     comb
                     std       $0358,y
@@ -19366,9 +19378,9 @@ LAEB3               rts
                     comb
                     leax      $0358,y
                     std       $02,x
-LAEC6               rts
+                    rts
 
-LAEC7               leax      $0358,y
+LAEC6               leax      $0358,y
                     std       $02,x
                     tfr       a,b
                     sex
@@ -19379,9 +19391,9 @@ LAEC7               leax      $0358,y
                     std       $02,x
                     clr       ,x
                     clr       $01,x
-LAEDF               rts
+                    rts
 
-LAEE0               pshs      y
+LAEDF               pshs      y
                     ldy       $04,s
                     ldd       ,x
                     std       ,y
@@ -19391,39 +19403,40 @@ LAEE0               pshs      y
                     exg       y,x
                     puls      d
                     std       ,s
-LAEF5               rts
-                    ldx       $02,s
+                    rts
+
+LAEF5               ldx       $02,s
                     pshs      b
-                    lbsr      LAF3D
+                    lbsr      LAF3C
                     puls      b
                     tstb
-                    beq       LAF0D
-LAF02               asl       $03,x
+                    beq       LAF0C
+LAF01               asl       $03,x
                     rol       $02,x
                     rol       $01,x
                     rol       ,x
                     decb
-                    bne       LAF02
-LAF0D               puls      d
+                    bne       LAF01
+LAF0C               puls      d
                     std       ,s
                     rts
                     ldx       $02,s
                     pshs      b
-                    lbsr      LAF3D
+                    lbsr      LAF3C
                     puls      b
                     tstb
-                    beq       LAF29
-LAF1E               asr       ,x
+                    beq       LAF28
+LAF1D               asr       ,x
                     ror       $01,x
                     ror       $02,x
                     ror       $03,x
                     decb
-                    bne       LAF1E
-LAF29               puls      d
+                    bne       LAF1D
+LAF28               puls      d
                     std       ,s
                     rts
 
-LAF2E               tfr       cc,a
+LAF2D               tfr       cc,a
                     puls      x
                     stx       $02,s
                     leas      $02,s
@@ -19431,16 +19444,17 @@ LAF2E               tfr       cc,a
                     tfr       a,cc
                     rts
 
-LAF3D               ldd       ,x
+LAF3C               ldd       ,x
                     std       $0358,y
                     ldd       $02,x
                     leax      $0358,y
                     std       $02,x
-LAF4B               rts
-                    tsta
-                    bne       LAF61
+                    rts
+
+LAF4B               tsta
+                    bne       LAF60
                     tst       $02,s
-                    bne       LAF61
+                    bne       LAF60
                     lda       $03,s
                     mul
                     ldx       ,s
@@ -19448,7 +19462,7 @@ LAF4B               rts
                     ldx       #$0000
                     std       ,s
                     puls      pc,d
-LAF61               pshs      d
+LAF60               pshs      d
                     ldd       #$0000
                     pshs      d
                     pshs      d
@@ -19461,16 +19475,16 @@ LAF61               pshs      d
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       LAF7E
+                    bcc       LAF7D
                     inc       ,s
-LAF7E               lda       $04,s
+LAF7D               lda       $04,s
                     ldb       $09,s
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       LAF8B
+                    bcc       LAF8A
                     inc       ,s
-LAF8B               lda       $04,s
+LAF8A               lda       $04,s
                     ldb       $08,s
                     mul
                     addd      ,s
@@ -19482,164 +19496,166 @@ LAF8B               lda       $04,s
                     leas      $08,s
                     rts
                     clr       $089e,y
-                    leax      >LAFE7,pcr
+                    leax      >LAFE6,pcr
                     stx       $089f,y
-                    bra       LAFC1
-                    leax      >LB000,pcr
+                    bra       LAFC0
+
+LAFAC               leax      >LAFFF,pcr
                     stx       $089f,y
                     clr       $089e,y
                     tst       $02,s
-                    bpl       LAFC1
+                    bpl       LAFC0
                     inc       $089e,y
-LAFC1               subd      #$0000
-                    bne       LAFCC
+LAFC0               subd      #$0000
+                    bne       LAFCB
                     puls      x
                     ldd       ,s++
                     jmp       ,x
 
-LAFCC               ldx       $02,s
+LAFCB               ldx       $02,s
                     pshs      x
                     jsr       [$089f,y]
                     ldd       ,s
                     std       $02,s
                     tfr       x,d
                     tst       $089e,y
-                    beq       LAFE4
+                    beq       LAFE3
                     nega
                     negb
                     sbca      #$00
-LAFE4               std       ,s++
+LAFE3               std       ,s++
                     rts
 
-LAFE7               subd      #$0000
-                    beq       LAFF6
+LAFE6               subd      #$0000
+                    beq       LAFF5
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
-                    bra       LB024
+                    bra       LB023
 
-LAFF6               puls      d
+LAFF5               puls      d
                     std       ,s
                     ldd       #$002D
-                    lbra      LB099
+                    lbra      LB098
 
-LB000               subd      #$0000
-                    beq       LAFF6
+LAFFF               subd      #$0000
+                    beq       LAFF5
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
                     tsta
-                    bpl       LB018
+                    bpl       LB017
                     nega
                     negb
                     sbca      #$00
                     inc       $01,s
                     std       $02,s
-LB018               ldd       $06,s
-                    bpl       LB024
+LB017               ldd       $06,s
+                    bpl       LB023
                     nega
                     negb
                     sbca      #$00
                     com       $01,s
                     std       $06,s
-LB024               lda       #$01
-LB026               inca
+LB023               lda       #$01
+LB025               inca
                     asl       $03,s
                     rol       $02,s
-                    bpl       LB026
+                    bpl       LB025
                     sta       ,s
                     ldd       $06,s
                     clr       $06,s
                     clr       $07,s
-LB035               subd      $02,s
-                    bcc       LB03F
+LB034               subd      $02,s
+                    bcc       LB03E
                     addd      $02,s
                     andcc     #$FE
-                    bra       LB041
+                    bra       LB040
 
-LB03F               orcc      #$01
-LB041               rol       $07,s
+LB03E               orcc      #$01
+LB040               rol       $07,s
                     rol       $06,s
                     lsr       $02,s
                     ror       $03,s
                     dec       ,s
-                    bne       LB035
+                    bne       LB034
                     std       $02,s
                     tst       $01,s
-                    beq       LB05B
+                    beq       LB05A
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-LB05B               ldx       $04,s
+LB05A               ldx       $04,s
                     ldd       $06,s
                     std       $04,s
                     stx       $06,s
                     ldx       $02,s
                     ldd       $04,s
                     leas      $06,s
-LB069               rts
-                    tstb
-                    beq       LB080
-LB06D               asr       $02,s
-                    ror       $03,s
-                    decb
-                    bne       LB06D
-                    bra       LB080
+                    rts
 
-LB076               tstb
-                    beq       LB080
-LB079               lsr       $02,s
+LB069               tstb
+                    beq       LB07F
+LB06C               asr       $02,s
                     ror       $03,s
                     decb
-                    bne       LB079
-LB080               ldd       $02,s
+                    bne       LB06C
+                    bra       LB07F
+
+LB075               tstb
+                    beq       LB07F
+LB078               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       LB078
+LB07F               ldd       $02,s
                     pshs      d
                     ldd       $02,s
                     std       $04,s
                     ldd       ,s
                     leas      $04,s
-LB08C               rts
+                    rts
 
-LB08D               tstb
-                    beq       LB080
-LB090               asl       $03,s
+LB08C               tstb
+                    beq       LB07F
+LB08F               asl       $03,s
                     rol       $02,s
                     decb
-                    bne       LB090
-                    bra       LB080
+                    bne       LB08F
+                    bra       LB07F
 
-LB099               std       $0364,y
+LB098               std       $0364,y
                     pshs      y,b
                     os9       F$ID
                     puls      y,b
                     os9       F$Send
                     rts
 
-LB0A8               lda       $05,s
+LB0A7               lda       $05,s
                     ldb       $03,s
-                    beq       LB0DB
+                    beq       LB0DA
                     cmpb      #$01
-                    beq       LB0DD
+                    beq       LB0DC
                     cmpb      #$06
-                    beq       LB0DD
+                    beq       LB0DC
                     cmpb      #$02
-                    beq       LB0C3
+                    beq       LB0C2
                     cmpb      #$05
-                    beq       LB0C3
+                    beq       LB0C2
                     ldb       #$D0
-                    lbra      LB33F
+                    lbra      LB33E
 
-LB0C3               pshs      u
+LB0C2               pshs      u
                     os9       I$GetStt
-                    bcc       LB0CF
+                    bcc       LB0CE
                     puls      u
-                    lbra      LB33F
+                    lbra      LB33E
 
-LB0CF               stx       [$08,s]
+LB0CE               stx       [$08,s]
                     ldx       $08,s
                     stu       $02,x
                     puls      u
@@ -19647,199 +19663,202 @@ LB0CF               stx       [$08,s]
                     clrb
                     rts
 
-LB0DB               ldx       $06,s
-LB0DD               os9       I$GetStt
-                    lbra      LB348
+LB0DA               ldx       $06,s
+LB0DC               os9       I$GetStt
+                    lbra      LB347
                     lda       $05,s
                     ldb       $03,s
-                    beq       LB0F2
+                    beq       LB0F1
                     cmpb      #$02
-                    beq       LB0FA
+                    beq       LB0F9
                     ldb       #$D0
-                    lbra      LB33F
+                    lbra      LB33E
 
-LB0F2               ldx       $06,s
+LB0F1               ldx       $06,s
                     os9       I$SetStt
-                    lbra      LB348
+                    lbra      LB347
 
-LB0FA               pshs      u
+LB0F9               pshs      u
                     ldx       $08,s
                     ldu       $0a,s
                     os9       I$SetStt
                     puls      u
-                    lbra      LB348
+                    lbra      LB347
                     ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    bcs       LB114
+                    bcs       LB113
                     os9       I$Close
-LB114               lbra      LB348
-                    ldx       $02,s
+LB113               lbra      LB347
+
+LB116               ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    lbcs      LB33F
+                    lbcs      LB33E
                     tfr       a,b
                     clra
                     rts
 
-LB126               lda       $03,s
+LB125               lda       $03,s
                     os9       I$Close
-                    lbra      LB348
+                    lbra      LB347
                     ldx       $02,s
                     ldb       $05,s
                     os9       I$MakDir
-                    lbra      LB348
-                    ldx       $02,s
+                    lbra      LB347
+
+LB137               ldx       $02,s
                     lda       $05,s
                     tfr       a,b
                     andb      #$24
                     orb       #$0b
                     os9       I$Create
-                    bcs       LB14B
-LB147               tfr       a,b
+                    bcs       LB14A
+LB146               tfr       a,b
                     clra
                     rts
 
-LB14B               cmpb      #$DA
-                    lbne      LB33F
+LB14A               cmpb      #$DA
+                    lbne      LB33E
                     lda       $05,s
                     bita      #$80
-                    lbne      LB33F
+                    lbne      LB33E
                     anda      #$07
                     ldx       $02,s
                     os9       I$Open
-                    lbcs      LB33F
+                    lbcs      LB33E
                     pshs      u,a
                     ldx       #$0000
                     leau      ,x
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-                    bcc       LB147
+                    bcc       LB146
                     pshs      b
                     os9       I$Close
                     puls      b
-                    lbra      LB33F
-                    ldx       $02,s
+                    lbra      LB33E
+
+LB17D               ldx       $02,s
                     os9       I$Delete
-                    lbra      LB348
+                    lbra      LB347
                     lda       $03,s
                     os9       I$Dup
-                    lbcs      LB33F
+                    lbcs      LB33E
                     tfr       a,b
                     clra
                     rts
 
-LB193               pshs      y
+LB192               pshs      y
                     ldx       $06,s
                     lda       $05,s
                     ldy       $08,s
                     pshs      y
                     os9       I$Read
-LB1A1               bcc       LB1B0
+LB1A0               bcc       LB1AF
                     cmpb      #$D3
-                    bne       LB1AB
+                    bne       LB1AA
                     clra
                     clrb
                     puls      pc,y,x
-LB1AB               puls      y,x
-                    lbra      LB33F
+LB1AA               puls      y,x
+                    lbra      LB33E
 
-LB1B0               tfr       y,d
+LB1AF               tfr       y,d
                     puls      pc,y,x
-LB1B4               pshs      y
+LB1B3               pshs      y
                     lda       $05,s
                     ldx       $06,s
                     ldy       $08,s
                     pshs      y
                     os9       I$ReadLn
-                    bra       LB1A1
+                    bra       LB1A0
 
-LB1C4               pshs      y
+LB1C3               pshs      y
                     ldy       $08,s
-                    beq       LB1D9
+                    beq       LB1D8
                     lda       $05,s
                     ldx       $06,s
                     os9       I$Write
-LB1D2               bcc       LB1D9
+LB1D1               bcc       LB1D8
                     puls      y
-                    lbra      LB33F
+                    lbra      LB33E
 
-LB1D9               tfr       y,d
+LB1D8               tfr       y,d
                     puls      pc,y
-LB1DD               pshs      y
+LB1DC               pshs      y
                     ldy       $08,s
-                    beq       LB1D9
+                    beq       LB1D8
                     lda       $05,s
                     ldx       $06,s
                     os9       I$WritLn
-                    bra       LB1D2
+                    bra       LB1D1
 
-LB1ED               pshs      u
+LB1EC               pshs      u
                     ldd       $0a,s
-                    bne       LB1FB
+                    bne       LB1FA
                     ldu       #$0000
                     ldx       #$0000
-                    bra       LB22F
+                    bra       LB22E
 
-LB1FB               cmpd      #$0001
-                    beq       LB226
+LB1FA               cmpd      #$0001
+                    beq       LB225
                     cmpd      #$0002
-                    beq       LB21B
+                    beq       LB21A
                     ldb       #$F7
-LB209               clra
+LB208               clra
                     std       $0364,y
                     ldd       #$FFFF
                     leax      $0358,y
                     std       ,x
                     std       $02,x
                     puls      pc,u
-LB21B               lda       $05,s
+LB21A               lda       $05,s
                     ldb       #$02
                     os9       I$GetStt
-                    bcs       LB209
-                    bra       LB22F
+                    bcs       LB208
+                    bra       LB22E
 
-LB226               lda       $05,s
+LB225               lda       $05,s
                     ldb       #$05
                     os9       I$GetStt
-                    bcs       LB209
-LB22F               tfr       u,d
+                    bcs       LB208
+LB22E               tfr       u,d
                     addd      $08,s
                     std       $035a,y
                     tfr       d,u
                     tfr       x,d
                     adcb      $07,s
                     adca      $06,s
-                    bmi       LB209
+                    bmi       LB208
                     tfr       d,x
                     std       $0358,y
                     lda       $05,s
                     os9       I$Seek
-                    bcs       LB209
+                    bcs       LB208
                     leax      $0358,y
                     puls      pc,u
-                    ldd       $0356,y
+LB253               ldd       $0356,y
                     pshs      d
                     ldd       $04,s
                     cmpd      $08A1,y
-                    bcs       LB288
+                    bcs       LB287
                     addd      $0356,y
                     pshs      y
                     subd      ,s
                     os9       F$Mem
                     tfr       y,d
                     puls      y
-                    bcc       LB27A
+                    bcc       LB279
                     ldd       #$FFFF
                     leas      $02,s
                     rts
 
-LB27A               std       $0356,y
+LB279               std       $0356,y
                     addd      $08A1,y
                     subd      ,s
                     std       $08A1,y
-LB288               leas      $02,s
+LB287               leas      $02,s
                     ldd       $08A1,y
                     pshs      d
                     subd      $04,s
@@ -19849,232 +19868,410 @@ LB288               leas      $02,s
                     pshs      d
                     clra
                     ldx       ,s
-LB2A1               sta       ,x+
+LB2A0               sta       ,x+
                     cmpx      $0356,y
-                    bcs       LB2A1
+                    bcs       LB2A0
                     puls      pc,d
-LB2AB               ldd       $02,s
+LB2AA               ldd       $02,s
                     addd      $0360,y
-                    bcs       LB2D4
+                    bcs       LB2D3
                     cmpd      $0362,y
-                    bcc       LB2D4
+                    bcc       LB2D3
                     pshs      d
                     ldx       $0360,y
                     clra
-LB2C1               cmpx      ,s
-                    bcc       LB2C9
+LB2C0               cmpx      ,s
+                    bcc       LB2C8
                     sta       ,x+
-                    bra       LB2C1
+                    bra       LB2C0
 
-LB2C9               ldd       $0360,y
+LB2C8               ldd       $0360,y
                     puls      x
                     stx       $0360,y
                     rts
 
-LB2D4               ldd       #$FFFF
+LB2D3               ldd       #$FFFF
                     rts
 
-LB2D8               pshs      y
+LB2D7               pshs      y
                     os9       F$ID
                     puls      y
-                    bcc       LB2E5
-                    lbcs      LB33F
-LB2E5               tfr       a,b
+                    bcc       LB2E4
+                    lbcs      LB33E
+LB2E4               tfr       a,b
                     clra
                     rts
 
-LB2E9               pshs      y
+LB2E8               pshs      y
                     os9       F$ID
-                    bcc       LB2F5
-LB2F0               puls      y
-                    lbra      LB33F
+                    bcc       LB2F4
+LB2EF               puls      y
+                    lbra      LB33E
 
-LB2F5               tfr       y,d
+LB2F4               tfr       y,d
                     puls      pc,y
                     pshs      y
-                    bsr       LB2E9
+                    bsr       LB2E8
                     std       -$02,s
-                    beq       LB305
+                    beq       LB304
                     ldb       #$D6
-                    bra       LB2F0
+                    bra       LB2EF
 
-LB305               ldy       $04,s
+LB304               ldy       $04,s
                     os9       F$SUser
-                    bcc       LB319
+                    bcc       LB318
                     cmpb      #$D0
-                    bne       LB2F0
+                    bne       LB2EF
                     tfr       y,d
                     ldy       >$004B
                     std       $09,y
-LB319               clra
+LB318               clra
                     clrb
                     puls      pc,y
-                    pshs      u
+LB31C               pshs      u
                     tfr       y,u
                     ldx       $04,s
                     stx       $08A3,y
-                    leax      >LB333,pcr
+                    leax      >LB332,pcr
                     os9       F$Icpt
                     puls      u
-                    lbra      LB348
+                    lbra      LB347
 
-LB333               tfr       u,y
+LB332               tfr       u,y
                     clra
                     pshs      d
                     jsr       [$08A3,y]
                     leas      $02,s
                     rti
 
-LB33F               clra
+LB33E               clra
                     std       $0364,y
                     ldd       #$FFFF
                     rts
 
-LB348               bcs       LB33F
+LB347               bcs       LB33E
                     clra
                     clrb
-exit                rts
-                    lbsr      LB358
-                    lbsr      LA296
-                    ldd       $02,s
+                    rts
+
+LB34C               lbsr      LB357
+                    lbsr      LA295
+LB352               ldd       $02,s
                     os9       F$Exit
-* ------------------------------------------------------------------
-* LB358 - cc1-style init image for the c.comp work block (see _start).
-* First byte is an rts (the exit routine's stub); the table proper
-* follows: count1+block1 -> base, count2+block2 -> base+$78, then two
-* relocation directories.
-* ------------------------------------------------------------------
-LB358               rts                 exit rts stub / table anchor
-                    fdb       $0003     count1 - bytes copied to base
-                    fcb       $00,$02   block1
-                    fcb       $46
-                    fdb       $029E     count2 - bytes copied to base+$78
-* block2 - work block template ($29E bytes)
-                    fcb       $00,$01,$00,$02,$00,$00,$00,$00
-                    fcb       $00,$0C,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$8C
+LB357               rts
+
+LB358               neg       $0003
+                    neg       $0002
+                    rora
+                    fcb       $02
+                    ldx       $0000
+                    fcb       $01
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $000C
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       L008C
                     fcc       /cstr.XXXXX/
                     fcb       $00
                     fcc       /x expected/
-                    fcb       $00,$06,$83
-                    fcc       /XmXpXsXyX/
-                    fcb       $7F
-                    fcb       $58
-                    fcb       $84,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
                     fcb       $00
-                    fcb       $6D,$40,$69
-                    fcb       $00,$00
-                    fcc       |TAh-.BP0CESkkkkkkkkkk/(]x_d|
+                    ror       $0083
+                    aslb
+                    tst       -$08,u
+                    neg       $5873
+                    aslb
+                    rol       L587F
+                    aslb
+                    anda      #$00
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $006D
+                    nega
+                    rol       0,x
+                    neg       L0054
+                    fcc       |Ah-.BP0CESkkkkkkkkkk/(]x_d|
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj+f,Yj/
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj)X*D/
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$09,$00,$00,$00,$0D,$0E
-                    fcb       $00,$00,$00,$0E,$0C,$01,$0E,$0F
-                    fcb       $0D,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$03,$00,$0A,$02,$0A
-                    fcb       $03,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$07
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$06,$00,$0E
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $81
-                    fcb       $20
-                    fcb       $00,$00,$00,$00,$00,$00,$84
-                    fcb       $48
-                    fcb       $00,$00,$00,$00,$00,$00,$87
-                    fcb       $7A
-                    fcb       $00,$00,$00,$00,$00,$00,$8A,$1C
-                    fcb       $40
-                    fcb       $00,$00,$00,$00,$00,$8E
-                    fcb       $43,$50
-                    fcb       $00,$00,$00,$00,$00,$91
-                    fcb       $74,$24
-                    fcb       $00,$00,$00,$00,$00,$94,$18,$96
-                    fcb       $80,$00,$00,$00,$00,$98
-                    fcb       $3E
-                    fcb       $BC
-                    fcb       $20
-                    fcb       $00,$00,$00,$00,$9B
-                    fcb       $6E,$6B,$28
-                    fcb       $00,$00,$00,$00,$9E,$15,$02,$F9
-                    fcb       $00,$00,$00,$00,$A2
-                    fcb       $2D,$78
-                    fcb       $EB,$C5,$AC
-                    fcb       $62
-                    fcb       $00,$C3
-                    fcb       $49
-                    fcb       $F2,$C9,$CD,$04
-                    fcb       $67,$4F
-                    fcb       $E4,$00,$02,$00,$04,$00,$08,$00
-                    fcb       $10,$00
-                    fcb       $20
-                    fcb       $00
-                    fcb       $40
-                    fcb       $00,$80,$01,$00,$02,$00,$04,$00
-                    fcb       $08,$00,$10,$00
-                    fcb       $20
-                    fcb       $00
-                    fcb       $40
-                    fcb       $00
-                    fcb       $27
-                    fcb       $10,$03,$E8,$00
-                    fcb       $64
-                    fcb       $00,$0A,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$01,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$02,$00
-                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
                     fcb       $00,$00,$00
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0009
+                    neg       $0000
+                    neg       $000D
+                    jmp       $0000
+                    neg       $0000
+                    jmp       $000C
+                    fcb       $01
+                    jmp       $000F
+                    tst       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0003
+                    neg       $000A
+                    fcb       $02
+                    dec       $0003
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    asr       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    ror       $0000
+                    jmp       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0081
+                    bra       LB4AB
+
+LB4AB               neg       $0000
+                    neg       $0000
+                    neg       L0084
+                    asla
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $87
+                    dec       >$0000
+                    neg       $0000
+                    neg       $0000
+                    ora       #$1C
+                    nega
+                    neg       $0000
+                    neg       $0000
+                    neg       L008E
+                    coma
+                    negb
+                    neg       $0000
+                    neg       $0000
+                    neg       $0091
+                    lsr       L2400
+                    neg       $0000
+                    neg       $0000
+                    anda      L0018
+                    lda       L0080
+                    neg       $0000
+                    neg       $0000
+                    eora      L003E
+                    cmpx      L2000
+                    neg       $0000
+                    neg       $009B
+                    jmp       $0b,s
+                    bvc       LB4ED
+LB4ED               neg       $0000
+                    neg       L009E
+                    fcb       $15,$02
+                    adcb      >$0000
+                    neg       $0000
+                    sbca      $0d,y
+                    asl       $EBC5
+                    cmpx      $02,s
+                    neg       $00C3
+                    rola
+                    sbcb      $C9CD
+                    lsr       $0067
+                    clra
+                    andb      0,x
+                    fcb       $02
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       $0020
+                    neg       $0040
+                    neg       L0080
+                    fcb       $01
+                    neg       $0002
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       $0020
+                    neg       $0040
+                    neg       $0027
+                    fcb       $10
+                    com       $00E8
+                    neg       $0064
+                    neg       $000A
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
                     fcb       $42
-                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00
-                    fdb       $0006     nreloc1
-* relocate by module base
-                    fdb       $00B8
-                    fdb       $00B6
-                    fdb       $00B4
-                    fdb       $00B2
-                    fdb       $00B0
-                    fdb       $00AE
-                    fdb       $0003     nreloc2
-* relocate by work base
-                    fdb       $0094
-                    fdb       $00AC
-                    fdb       $0001
-* trailing module name
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0006
+                    neg       L00B8
+                    neg       L00B6
+                    neg       L00B4
+                    neg       L00B2
+                    neg       L00B0
+                    neg       L00AE
+                    neg       $0003
+                    neg       L0094
+                    neg       L00AC
+                    neg       $0001
                     fcc       /c.comp/
+                    fcb       $00
 
                     emod
 eom                 equ       *

--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -10915,10 +10915,7 @@ L6654               pshs      u
                     leax      $08,s
                     pshs      x
                     bsr       L666C
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
 L666C               puls      x
                     lbsr      LAE34
                     leax      $08,s
@@ -10944,8 +10941,7 @@ L6684               ldb       $0045
 L66A0               leax      $02,s
                     pshs      x
                     bsr       L66AA
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00
 L66AA               puls      x
                     lbsr      LAEDF
                     ldb       $0045
@@ -17488,8 +17484,7 @@ LA089               ldd       $0b,u
                     ldd       ,x
                     pshs      d
                     bsr       LA0A6
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00
 LA0A6               puls      x
                     lbsr      LAE7B
                     bge       LA0B4
@@ -17554,9 +17549,9 @@ LA10F               ldd       $06,u
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $A13B
-                    stu       $FFFF
-                    stu       L3510
+                    bsr       LA13B
+                    fcb       $FF,$FF,$FF,$FF
+LA13B               puls      x
                     lbsr      LAE7B
                     bne       LA147
                     ldd       #$FFFF
@@ -17586,9 +17581,9 @@ LA164               pshs      u
                     clra
                     andb      #$03
                     bne       LA184
-LA171               bsr       $A177
-                    stu       $FFFF
-                    stu       L3510
+LA171               bsr       LA177
+                    fcb       $FF,$FF,$FF,$FF
+LA177               puls      x
                     leau      $0358,y
                     pshs      u
                     lbsr      LAEDF

--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -135,23 +135,39 @@ stkcheck            leax      d,s
                     cmpx      $0360,y
                     bcs       L013B
                     stx       $0362,y
-L0121               fcb       $39
-L0122               fcc       /**** STACK OVERFLOW ****/
-                    fcb       $0D
+L0121               rts
+
+L0122               bpl       $014E
+                    bpl       L0150
+                    bra       L017B
+                    lsrb
+                    fcb       $41
+                    coma
+                    fcb       $4B
+                    bra       $017D
+                    rorb
+                    fcb       $45,$52
+                    rora
+                    inca
+                    clra
+                    asrb
+                    bra       L0161
+                    bpl       $0163
+                    bpl       L0148
 L013B               leax      L0122,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
-                    os9       I$WritLn
+L0148               os9       I$WritLn
                     clr       ,-s
                     lbsr      LB352
-                    ldd       $0354,y
+L0150               ldd       $0354,y
                     subd      $0362,y
                     rts
                     ldd       $0362,y
                     subd      $0360,y
-                    rts
+L0161               rts
 
 L0162               pshs      x
                     leax      d,y
@@ -165,7 +181,7 @@ L016A               ldd       ,y++
                     cmpy      ,s
                     bne       L016A
                     leas      $04,s
-                    rts
+L017B               rts
 
 main                pshs      u
                     leax      L5DC9,pcr
@@ -225,7 +241,7 @@ L01E4               leau      $01,u
                     std       $0005
                     bne       L0215
                     pshs      u
-                    leax      $030A,pcr
+                    leax      L030A,pcr
                     pshs      x
                     leax      $0260,y
                     pshs      x
@@ -284,7 +300,7 @@ L0265               ldd       L0052
                     leas      $06,s
                     std       $0003
                     bne       L0295
-                    leax      $032F,pcr
+                    leax      L032F,pcr
                     pshs      x
                     lbsr      L042D
                     leas      $02,s
@@ -332,22 +348,17 @@ L02F2               pshs      u
                     lbsr      exit
                     leas      $02,s
                     puls      pc,u
-L0300               clrb
-                    fcc       /dummy_/
+L0300               fcc       /_dummy_/
                     fcb       $00
-L0308               asr       >L0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       L033B
-                    com       $0D00
+L0308               fcb       $77
+                    fcb       $00
+L030A               fcc       /can't open %s/
+                    fcb       $0D,$00
 L0319               fcc       /unknown flag : -%c/
                     fcb       $0D,$00
 L032D               fcb       $72
-                    neg       L0063
-                    fcc       /an't open i/
-L033B               fcc       /nput file/
+                    fcb       $00
+L032F               fcc       /can't open input file/
                     fcb       $00
 L0345               fcc       /error writing assembly code file/
                     fcb       $00
@@ -556,7 +567,7 @@ L0528               ldd       $0009
                     pshs      x
                     lbsr      LA2F8
                     leas      $02,s
-                    leax      $076D,pcr
+                    leax      L076D,pcr
                     pshs      x
                     bsr       L056A
 L0548               leas      $02,s
@@ -763,30 +774,22 @@ L070B               ldd       $003F
                     cmpd      #$FFFF
                     bne       L0708
 L0723               puls      pc,u
-L0725               bcs       L079A
-                    bra       L0763
-                    bra       L072B
+L0725               fcc       /%s : /
+                    fcb       $00
 L072B               fcc       /multiple definition/
                     fcb       $00
 L073F               fcc       /compiler error - /
                     fcb       $00
 L0751               fcc       /line %d  /
                     fcb       $00
-L075B               bpl       L0787
-                    bpl       $0789
-                    bra       L0781
-                    bcs       $07D6
-L0763               bra       L0785
-                    bpl       $0791
-                    bpl       $0793
-                    tst       $0000
+L075B               fcc       /****  %s  ****/
+                    fcb       $0D,$00
 L076B               fcb       $5E
-                    neg       $0074
-                    fcc       /oo many errors - AB/
-L0781               fcb       $4F,$52,$54
+                    fcb       $00
+L076D               fcc       /too many errors - ABORT/
                     fcb       $00
 L0785               pshs      u
-L0787               ldd       #$FFA2
+                    ldd       #$FFA2
                     lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L0899
@@ -794,7 +797,7 @@ L0787               ldd       #$FFA2
                     lbne      L087E
                     clra
                     clrb
-L079A               lbra      L0895
+                    lbra      L0895
                     lbra      L087E
 
 L07A0               ldd       $003F
@@ -3558,7 +3561,7 @@ L2017               ldd       [$12,s]
                     ldx       $12,s
                     ldd       $04,x
 L2028               std       $06,s
-L202A               lbra      L2170
+                    lbra      L2170
 
 L202D               ldd       $0e,s
                     cmpd      #$00A0
@@ -3579,14 +3582,14 @@ L204E               cmpx      #$0034
                     cmpx      #$0036
                     lbeq      L16DA
                     cmpx      #$004A
-L205F               lbeq      L16E1
+                    lbeq      L16E1
                     cmpx      #$004B
                     lbeq      L16F1
                     cmpx      #$0037
                     lbeq      L1701
                     cmpx      #$0020
                     lbeq      L170C
-L2078               cmpx      #$0041
+                    cmpx      #$0041
                     lbeq      L178B
                     cmpx      #$0042
                     lbeq      L17D9
@@ -4122,7 +4125,7 @@ L2545               pshs      u
                     pshs      d
                     lbsr      L21C1
                     leas      $02,s
-L2563               std       ,s
+                    std       ,s
                     ldd       $02,s
                     cmpd      #$0006
                     bne       L2572
@@ -7290,7 +7293,7 @@ L4336               leax      $0584,y
 L4345               lbsr      L5D40
 L4348               leax      $0584,y
                     pshs      x
-                    leax      $459F,pcr
+                    leax      L459F,pcr
                     bra       L43B5
 
 L4354               leax      $0584,y
@@ -7404,7 +7407,7 @@ L4463               ldd       $02,s
                     std       $02,s
                     subd      #$FFFF
                     bne       L4453
-                    leax      $45EA,pcr
+                    leax      L45EA,pcr
                     pshs      x
                     lbsr      L9F95
                     leas      $02,s
@@ -7482,7 +7485,7 @@ L4509               pshs      u,d
                     beq       L4546
                     leax      $0260,y
                     pshs      x
-                    leax      $45EC,pcr
+                    leax      L45EC,pcr
                     pshs      x
                     lbsr      L9FB7
                     leas      $04,s
@@ -7533,37 +7536,24 @@ L4579               cmpu      $00AC,y
                     leas      $02,s
 L459A               leas      $02,s
                     puls      pc,u
-L459E               neg       L0025
-                    com       $0D00
-L45A3               bra       L4615
-                    fcc       /sect %s,0,0,%d,0,0/
+L459E               fcb       $00
+L459F               fcb       $25,$73
                     fcb       $0D,$00
-L45B9               bra       $4629
-                    fcb       $61
-                    tst       0,y
-                    bcs       $4633
-                    tst       $0000
+L45A3               fcc       / psect %s,0,0,%d,0,0/
+                    fcb       $0D,$00
+L45B9               fcc       / nam %s/
+                    fcb       $0D,$00
 L45C2               fcc       /%s : line %d /
                     fcb       $00
 L45D0               fcc       /argument : /
                     fcb       $00
-L45DC               bpl       L4608
-                    bpl       L460A
-                    bra       L4607
-                    com       L202A
-                    bpl       L4611
-                    bpl       L45F6
-                    neg       $005E
-                    neg       L0049
-                    fcc       /NPUT FILE/
-L45F6               fcc       / ERROR : TEMPORAR/
-L4607               fcb       $59
-L4608               fcb       $20,$46
-L460A               fcb       $49,$4C,$45
+L45DC               fcc       /**** %s ****/
                     fcb       $0D,$00
-L460F               fcb       $69,$6E
-L4611               fcc       /put /
-L4615               fcc       /line too long/
+L45EA               fcb       $5E
+                    fcb       $00
+L45EC               fcc       /INPUT FILE ERROR : TEMPORARY FILE/
+                    fcb       $0D,$00
+L460F               fcc       /input line too long/
                     fcb       $00
 L4623               pshs      u
                     ldu       $0a,s
@@ -7624,7 +7614,7 @@ L468B               ldd       $10,s
                     std       $10,s
                     ldd       #$005A
                     std       $0e,s
-L46AE               leax      $58A2,pcr
+L46AE               leax      L58A2,pcr
                     pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -7637,7 +7627,7 @@ L46AE               leax      $58A2,pcr
 L46C5               ldd       $0017
                     beq       L46CC
                     lbsr      L5CEB
-L46CC               leax      $58A5,pcr
+L46CC               leax      L58A5,pcr
                     lbra      L4840
 
 L46D3               pshs      u
@@ -7649,7 +7639,7 @@ L46D3               pshs      u
                     leas      $06,s
                     lbra      L4D75
 
-L46E7               leax      $58B0,pcr
+L46E7               leax      L58B0,pcr
                     bra       L4715
 
 L46ED               leax      L58B7,pcr
@@ -7777,7 +7767,7 @@ L47E4               leax      L5912,pcr
 L4805               leax      L5917,pcr
                     bra       L4840
 
-L480B               leax      $591B,pcr
+L480B               leax      L591B,pcr
                     pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -7865,7 +7855,7 @@ L48C9               ldd       $10,s
                     pshs      d
                     lbsr      L4D27
                     std       ,s
-                    leax      $5956,pcr
+                    leax      L5956,pcr
                     lbra      L4B47
 
 L48DA               cmpx      #$0077
@@ -7956,10 +7946,10 @@ L48E7               cmpx      #$007A
                     ldx       $0C,s
                     bra       L4A05
 
-L49EC               leax      $595C,pcr
+L49EC               leax      L595C,pcr
                     bra       L49FC
 
-L49F2               leax      $5960,pcr
+L49F2               leax      L5960,pcr
                     bra       L49FC
 
 L49F8               leax      L5968,pcr
@@ -8081,7 +8071,7 @@ L4B04               ldd       $0e,s
                     bne       L4B29
                     cmpu      #$0000
                     bne       L4B29
-                    leax      $5977,pcr
+                    leax      L5977,pcr
                     pshs      x
 L4B21               lbsr      L576F
 L4B24               leas      $02,s
@@ -8097,7 +8087,7 @@ L4B30               ldd       $10,s
                     bne       L4B55
                     ldd       $06,s
                     pshs      d
-                    leax      $5985,pcr
+                    leax      L5985,pcr
 L4B47               pshs      x
                     ldd       $0005
                     pshs      d
@@ -8138,10 +8128,10 @@ L4B99               pshs      d
 L4B9E               leas      $04,s
                     lbra      L4D75
 
-L4BA3               leax      $5995,pcr
+L4BA3               leax      L5995,pcr
                     bra       L4BAD
 
-L4BA9               leax      $5998,pcr
+L4BA9               leax      L5998,pcr
 L4BAD               pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -8152,7 +8142,7 @@ L4BB8               ldd       #$0043
                     pshs      d
                     lbsr      L4623
                     leas      $02,s
-L4BC2               leax      $599C,pcr
+L4BC2               leax      L599C,pcr
                     lbra      L4C42
 
 L4BC9               leas      -$08,x
@@ -8204,7 +8194,7 @@ L4C2B               cmpx      #$0021
                     lbeq      L4BE3
                     cmpx      #$0023
                     lbeq      L4BE3
-L4C3E               leax      $59A0,pcr
+L4C3E               leax      L59A0,pcr
 L4C42               pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -8225,7 +8215,7 @@ L4C5D               ldd       $10,s
                     std       ,s
                     ldd       $08,s
                     pshs      d
-                    leax      $59A4,pcr
+                    leax      L59A4,pcr
 L4C6F               pshs      x
                     ldd       $0005
                     pshs      d
@@ -8240,7 +8230,7 @@ L4C7D               ldd       $06,s
                     ldx       $10,s
                     bra       L4CCC
 
-L4C8B               leax      $59B0,pcr
+L4C8B               leax      L59B0,pcr
                     pshs      x
                     lbsr      L5794
                     leas      $02,s
@@ -8405,7 +8395,7 @@ L4E00               leax      L5A0F,pcr
 L4E06               leax      L5A15,pcr
                     bra       L4E2F
 
-L4E0C               leax      $5A1A,pcr
+L4E0C               leax      L5A1A,pcr
                     bra       L4E2F
 
 L4E12               leax      L5A20,pcr
@@ -8854,13 +8844,13 @@ L5266               std       $02,s
 L5274               leax      ,u
                     bra       L528C
 
-L5278               leax      $5B11,pcr
+L5278               leax      L5B11,pcr
                     bra       L5288
 
-L527E               leax      $5B15,pcr
+L527E               leax      L5B15,pcr
                     bra       L5288
 
-L5284               leax      $5B18,pcr
+L5284               leax      L5B18,pcr
 L5288               stx       $04,s
                     bra       L529B
 
@@ -8939,7 +8929,7 @@ L5327               cmpu      #$0057
                     beq       L536D
                     cmpu      #$0059
                     bne       L5340
-                    leax      $5B1C,pcr
+                    leax      L5B1C,pcr
                     pshs      x
 L5339               lbsr      L576F
                     leas      $02,s
@@ -9027,7 +9017,7 @@ L53CE               ldd       $04,s
                     std       $000F
                     bra       L5425
 
-L53EE               leax      $5B3E,pcr
+L53EE               leax      L5B3E,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -9238,7 +9228,7 @@ L55C1               pshs      d
 L55C3               lbsr      L5794
                     lbra      L567C
 
-L55C9               leax      $5B5B,pcr
+L55C9               leax      L5B5B,pcr
                     lbra      L5677
 
 L55D0               cmpx      #$000D
@@ -9310,7 +9300,7 @@ L5654               ldd       $00B0,y
                     std       $000F
                     bra       L56B8
 
-L5673               leax      $5B6C,pcr
+L5673               leax      L5B6C,pcr
 L5677               pshs      x
                     lbsr      L0450
 L567C               leas      $02,s
@@ -9474,7 +9464,7 @@ L57C3               pshs      u
 L57D6               pshs      u
                     ldd       $04,s
                     pshs      d
-                    leax      $5BAA,pcr
+                    leax      L5BAA,pcr
                     lbra      L583C
 
 L57E3               pshs      u,d
@@ -9482,7 +9472,7 @@ L57E3               pshs      u,d
                     subd      $000F
                     std       ,s
                     beq       L580F
-                    leax      $5BAF,pcr
+                    leax      L5BAF,pcr
                     pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -9537,10 +9527,11 @@ L5849               pshs      u
                     lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
-                    bge       $58E8
-                    neg       L002C
-                    com       >L006C
-                    fcc       /bsr /
+                    fcb       $2C,$79
+                    fcb       $00
+                    fcb       $2C,$73
+                    fcb       $00
+L5873               fcc       /lbsr /
                     fcb       $00
                     fcc       /lbra /
                     fcb       $00
@@ -9548,20 +9539,13 @@ L587F               fcc       /clra/
                     fcb       $00
                     fcc       /unknown operator : /
                     fcb       $00
-L5898               bra       L590A
-                    com       L6873
-                    bra       L58C4
-                    com       $0d,x
-                    neg       L006C
-                    fcb       $62
-                    neg       L0070
-                    fcb       $75
-                    inc       -$0d,s
-                    bra       $5920
-                    bge       $591D
-                    com       $0d,x
-                    neg       L0063
-                    fcc       /cmult/
+L5898               fcc       / pshs %c/
+                    fcb       $0D,$00
+L58A2               fcb       $6C,$62
+                    fcb       $00
+L58A5               fcc       /puls u,pc/
+                    fcb       $0D,$00
+L58B0               fcc       /ccmult/
                     fcb       $00
 L58B7               fcc       /ccudiv/
                     fcb       $00
@@ -9577,45 +9561,39 @@ L58D6               fcc       /ccumod/
                     fcb       $00
 L58DD               fcc       /ccmod/
                     fcb       $00
-L58E3               jmp       $05,s
-                    asr       $01,s
-                    tst       $0020
-                    jmp       $05,s
-                    asr       $02,s
-                    tst       $0020
-                    fcc       /sbca #0/
+L58E3               fcc       /nega/
+                    fcb       $0D
+                    fcc       / negb/
+                    fcb       $0D
+                    fcc       / sbca #0/
                     fcb       $00
-L58F7               com       $0f,s
-                    tst       $01,s
-                    tst       $0020
-                    fcc       /comb/
+L58F7               fcc       /coma/
+                    fcb       $0D
+                    fcc       / comb/
                     fcb       $00
 L5902               fcc       /leax /
                     fcb       $00
-L5908               fcb       $6C,$65
-L590A               fcb       $61,$73,$20
+L5908               fcc       /leas /
                     fcb       $00
-L590E               bge       $5988
-                    tst       $0000
+L590E               fcb       $2C,$78
+                    fcb       $0D,$00
 L5912               fcc       /jsr /
                     fcb       $00
-L5917               com       $6578
-                    neg       L006C
-                    lsr       0,x
-L591E               fcb       $61
-                    com       L6C62
-                    tst       $0020
-                    fcc       /rola/
+L5917               fcb       $73,$65,$78
                     fcb       $00
-L5929               fcb       $61
-                    com       L7261
-                    tst       $0020
-                    fcc       /rorb/
+L591B               fcb       $6C,$64
                     fcb       $00
-L5934               inc       -$0d,s
-                    fcb       $72,$61
-                    tst       $0020
-                    fcc       /rorb/
+L591E               fcc       /aslb/
+                    fcb       $0D
+                    fcc       / rola/
+                    fcb       $00
+L5929               fcc       /asra/
+                    fcb       $0D
+                    fcc       / rorb/
+                    fcb       $00
+L5934               fcc       /lsra/
+                    fcb       $0D
+                    fcc       / rorb/
                     fcb       $00
 L593F               fcc       /ldy /
                     fcb       $00
@@ -9623,204 +9601,131 @@ L5944               fcc       /ldu /
                     fcb       $00
 L5949               fcc       /leax /
                     fcb       $00
-L594F               bcs       L59B5
-                    bge       L5978
-                    com       $0d,x
-                    neg       $0064
-                    bge       L597E
-                    com       $0d,x
-                    neg       $0073
-                    fcb       $65
-                    asl       >L0061
-                    fcc       /dca #0/
+L594F               fcc       /%d,%c/
+                    fcb       $0D,$00
+L5956               fcc       /d,%c/
+                    fcb       $0D,$00
+L595C               fcb       $73,$65,$78
+                    fcb       $00
+L5960               fcc       /adca #0/
                     fcb       $00
 L5968               fcc       /sbca #0/
                     fcb       $00
-L5970               bcs       $59D6
-                    bge       L5999
-                    com       $0d,x
-                    neg       L0063
-L5978               inc       -$0e,s
-                    fcb       $61
-                    tst       $0020
-                    fcb       $63
-L597E               fcb       $6C,$72,$62
+L5970               fcc       /%d,%c/
+                    fcb       $0D,$00
+L5977               fcc       /clra/
+                    fcb       $0D
+                    fcc       / clrb/
                     fcb       $00
-L5982               inc       $04,s
-                    neg       $0020
-                    com       L7425
-                    com       0,y
-                    blt       L59BF
-                    bge       L5A02
-                    tst       $0000
-L5991               com       $0d,s
-                    neg       >$0073
-                    lsr       >$0073
-L5999               fcb       $75,$62
-                    neg       L0061
-                    lsr       $04,s
-                    neg       L006C
-                    fcb       $65,$61
-                    neg       $0020
-                    fcb       $65
-                    asl       $6720
-                    bcs       L5A0E
-                    bge       L59D2
-                    com       $0d,x
-                    neg       $0064
-                    bge       L59B3
-L59B3               fcb       $4C,$45
-L59B5               fcc       /A arg/
+L5982               fcb       $6C,$64
                     fcb       $00
-L59BB               bra       L5A31
-                    ror       -$0e,s
-L59BF               bra       L59E6
-                    com       $0C,y
-                    bcs       L5A28
-                    tst       $0000
-L59C7               inc       $04,s
-                    fcb       $61
-                    bra       L59FC
-                    bge       L5A46
-                    tst       $0020
-                    clr       -$0e,s
-L59D2               fcb       $61
-                    bra       L5A06
-                    bge       L5A4F
-                    tst       $0020
-                    clr       -$0e,s
-                    fcb       $61
-                    bra       L5A10
-                    bge       L5A58
-                    tst       $0020
-                    fcc       /ora /
-L59E6               fcb       $33,$2C,$78
+L5985               fcc       / st%c -2,s/
+                    fcb       $0D,$00
+L5991               fcb       $63,$6D,$70
                     fcb       $00
-L59EA               clrb
-                    fcc       /lmove/
+L5995               fcb       $73,$74
                     fcb       $00
-L59F1               clrb
-                    fcc       /ladd/
+L5998               fcb       $73,$75,$62
                     fcb       $00
-L59F7               clrb
-                    fcc       /lsub/
-L59FC               fcb       $00
-L59FD               clrb
-                    fcc       /lmul/
-L5A02               fcb       $00
-L5A03               clrb
-                    fcb       $6C,$64
-L5A06               fcb       $69,$76
+L599C               fcb       $61,$64,$64
                     fcb       $00
-L5A09               clrb
-                    fcc       /lmod/
-L5A0E               fcb       $00
-L5A0F               clrb
-L5A10               fcc       /land/
+L59A0               fcb       $6C,$65,$61
                     fcb       $00
-L5A15               clrb
-                    inc       $0f,s
-                    fcb       $72
-                    neg       L005F
-                    fcc       /lxor/
+L59A4               fcc       / exg %c,%c/
+                    fcb       $0D,$00
+L59B0               fcb       $64,$2C
                     fcb       $00
-L5A20               clrb
-                    fcc       /lshl/
+L59B3               fcc       /LEA arg/
                     fcb       $00
-L5A26               clrb
-                    fcb       $6C
-L5A28               fcb       $73,$68,$72
+L59BB               fcc       / tfr %c,%c/
+                    fcb       $0D,$00
+L59C7               fcc       /lda 0,x/
+                    fcb       $0D
+                    fcc       / ora 1,x/
+                    fcb       $0D
+                    fcc       / ora 2,x/
+                    fcb       $0D
+                    fcc       / ora 3,x/
                     fcb       $00
-L5A2C               clrb
-                    fcc       /lcmp/
-L5A31               fcb       $72
+L59EA               fcc       /_lmove/
                     fcb       $00
-L5A33               clrb
-                    fcc       /lneg/
+L59F1               fcc       /_ladd/
                     fcb       $00
-L5A39               clrb
-                    fcc       /lcompl/
+L59F7               fcc       /_lsub/
                     fcb       $00
-L5A41               clrb
-                    fcc       /lito/
-L5A46               fcb       $6C
+L59FD               fcc       /_lmul/
                     fcb       $00
-L5A48               clrb
-                    fcc       /lutol/
+L5A03               fcc       /_ldiv/
                     fcb       $00
-L5A4F               clrb
-                    fcc       /linc/
+L5A09               fcc       /_lmod/
                     fcb       $00
-L5A55               clrb
-                    fcb       $6C,$64
-L5A58               fcb       $65,$63
+L5A0F               fcc       /_land/
+                    fcb       $00
+L5A15               fcc       /_lor/
+                    fcb       $00
+L5A1A               fcc       /_lxor/
+                    fcb       $00
+L5A20               fcc       /_lshl/
+                    fcb       $00
+L5A26               fcc       /_lshr/
+                    fcb       $00
+L5A2C               fcc       /_lcmpr/
+                    fcb       $00
+L5A33               fcc       /_lneg/
+                    fcb       $00
+L5A39               fcc       /_lcompl/
+                    fcb       $00
+L5A41               fcc       /_litol/
+                    fcb       $00
+L5A48               fcc       /_lutol/
+                    fcb       $00
+L5A4F               fcc       /_linc/
+                    fcb       $00
+L5A55               fcc       /_ldec/
                     fcb       $00
 L5A5B               fcc       /codgen - longs/
                     fcb       $00
-L5A6A               clrb
-                    fcc       /dstack/
+L5A6A               fcc       /_dstack/
                     fcb       $00
-L5A72               bra       L5AE0
-                    lsr       $01,s
-                    bra       L5A9D
-                    com       $0C,y
-                    asl       $0D00
-L5A7D               clrb
-                    fcc       /fmove/
+L5A72               fcc       / lda %c,x/
+                    fcb       $0D,$00
+L5A7D               fcc       /_fmove/
                     fcb       $00
-L5A84               clrb
-                    fcc       /dmove/
+L5A84               fcc       /_dmove/
                     fcb       $00
-L5A8B               clrb
-                    fcc       /dadd/
+L5A8B               fcc       /_dadd/
                     fcb       $00
-L5A91               clrb
-                    fcc       /dsub/
+L5A91               fcc       /_dsub/
                     fcb       $00
-L5A97               clrb
-                    fcc       /dmul/
+L5A97               fcc       /_dmul/
                     fcb       $00
-L5A9D               clrb
-                    fcc       /ddiv/
+L5A9D               fcc       /_ddiv/
                     fcb       $00
-L5AA3               clrb
-                    fcc       /dcmpr/
+L5AA3               fcc       /_dcmpr/
                     fcb       $00
-L5AAA               clrb
-                    fcc       /dneg/
+L5AAA               fcc       /_dneg/
                     fcb       $00
-L5AB0               clrb
-                    fcc       /finc/
+L5AB0               fcc       /_finc/
                     fcb       $00
-L5AB6               clrb
-                    fcc       /dinc/
+L5AB6               fcc       /_dinc/
                     fcb       $00
-L5ABC               clrb
-                    fcc       /fdec/
+L5ABC               fcc       /_fdec/
                     fcb       $00
-L5AC2               clrb
-                    fcc       /ddec/
+L5AC2               fcc       /_ddec/
                     fcb       $00
-L5AC8               clrb
-                    fcc       /dtof/
+L5AC8               fcc       /_dtof/
                     fcb       $00
-L5ACE               clrb
-                    fcc       /ftod/
+L5ACE               fcc       /_ftod/
                     fcb       $00
-L5AD4               clrb
-                    fcc       /ltod/
+L5AD4               fcc       /_ltod/
                     fcb       $00
-L5ADA               clrb
-                    fcc       /itod/
+L5ADA               fcc       /_itod/
                     fcb       $00
-L5AE0               clrb
-                    fcc       /utod/
+L5AE0               fcc       /_utod/
                     fcb       $00
-L5AE6               clrb
-                    fcc       /dtol/
+L5AE6               fcc       /_dtol/
                     fcb       $00
-L5AEC               clrb
-                    fcc       /dtoi/
+L5AEC               fcc       /_dtoi/
                     fcb       $00
 L5AF2               fcc       /codgen - floats/
                     fcb       $00
@@ -9828,92 +9733,68 @@ L5B02               fcc       /bsr /
                     fcb       $00
 L5B07               fcc       /puls x/
                     fcb       $00
-L5B0E               leax      $0C,y
-                    neg       L0061
-                    jmp       $04,s
-                    neg       $006F
-                    fcb       $72
-                    neg       L0065
-                    clr       -$0e,s
-                    neg       L0063
-                    fcb       $6F,$6D,$61
+L5B0E               fcb       $30,$2C
+                    fcb       $00
+L5B11               fcb       $61,$6E,$64
+                    fcb       $00
+L5B15               fcb       $6F,$72
+                    fcb       $00
+L5B18               fcb       $65,$6F,$72
+                    fcb       $00
+L5B1C               fcc       /coma/
                     fcb       $00
 L5B21               fcc       /clrb/
                     fcb       $00
 L5B26               fcc       /comb/
                     fcb       $00
-L5B2B               bra       L5B52
-                    com       L6120
-                    bge       L5BA5
-                    bmi       L5B41
-                    bra       $5B5B
-                    com       $6220
-                    bge       $5BAE
-                    bmi       L5B4A
-                    neg       L0063
-                    fcb       $6F,$6D
-L5B41               fcc       /piler tro/
-L5B4A               fcc       /uble/
+L5B2B               fcc       / %sa ,s+/
+                    fcb       $0D
+                    fcc       / %sb ,s+/
+                    fcb       $0D,$00
+L5B3E               fcc       /compiler trouble/
                     fcb       $00
-L5B4F               clrb
-                    fcb       $66,$6C
-L5B52               fcb       $61,$63,$63
+L5B4F               fcc       /_flacc/
                     fcb       $00
-L5B56               bge       $5BC8
-                    com       -$0e,s
-                    neg       $0073
-                    fcc       /torage error/
+L5B56               fcc       /,pcr/
                     fcb       $00
-L5B69               bmi       $5B96
-                    neg       $0064
-                    fcc       /ereference/
+L5B5B               fcc       /storage error/
+                    fcb       $00
+L5B69               fcb       $2B,$2B
+                    fcb       $00
+L5B6C               fcc       /dereference/
                     fcb       $00
 L5B78               fcc       /rel op/
                     fcb       $00
-L5B7F               fcb       $65,$71
-                    bra       L5B83
-
-L5B83               jmp       $05,s
-                    bra       L5B87
-
-L5B87               inc       $05,s
-                    bra       L5B8B
-
-L5B8B               inc       -$0C,s
-                    bra       L5B8F
-
-L5B8F               asr       $05,s
-                    bra       L5B93
-
-L5B93               asr       -$0C,s
-                    bra       L5B97
-
-L5B97               inc       -$0d,s
-                    bra       L5B9B
-
-L5B9B               inc       $0f,s
-                    bra       L5B9F
-
-L5B9F               asl       -$0d,s
-                    bra       L5BA3
-
-L5BA3               asl       $09,s
-L5BA5               bra       L5BA7
-
-L5BA7               bcs       $5C0D
-                    neg       L0025
-                    bgt       L5BE5
-                    com       >L006C
-                    fcc       /eas /
+L5B7F               fcb       $65,$71,$20
                     fcb       $00
-L5BB5               bra       L5C23
-                    fcc       /ea%c /
+L5B83               fcb       $6E,$65,$20
                     fcb       $00
-L5BBD               bcs       $5C22
-                    bcs       L5C25
-                    bge       $5C33
-                    com       -$0e,s
-                    tst       $0000
+L5B87               fcb       $6C,$65,$20
+                    fcb       $00
+L5B8B               fcb       $6C,$74,$20
+                    fcb       $00
+L5B8F               fcb       $67,$65,$20
+                    fcb       $00
+L5B93               fcb       $67,$74,$20
+                    fcb       $00
+L5B97               fcb       $6C,$73,$20
+                    fcb       $00
+L5B9B               fcb       $6C,$6F,$20
+                    fcb       $00
+L5B9F               fcb       $68,$73,$20
+                    fcb       $00
+L5BA3               fcb       $68,$69,$20
+                    fcb       $00
+L5BA7               fcb       $25,$64
+                    fcb       $00
+L5BAA               fcc       /%.8s/
+                    fcb       $00
+L5BAF               fcc       /leas /
+                    fcb       $00
+L5BB5               fcc       / lea%c /
+                    fcb       $00
+L5BBD               fcc       /%c%d,pcr/
+                    fcb       $0D,$00
 L5BC7               pshs      u
                     lbsr      L5D72
                     lbsr      L5D64
@@ -9926,7 +9807,7 @@ L5BDC               pshs      u
                     ldd       $08,s
                     pshs      d
                     lbsr      L5D4E
-L5BE5               leas      $02,s
+                    leas      $02,s
                     ldd       $04,s
                     pshs      d
                     lbsr      L57C3
@@ -9955,8 +9836,8 @@ L5C13               pshs      u
                     leas      $02,s
                     ldd       #$0020
 L5C21               pshs      d
-L5C23               ldd       $08,s
-L5C25               pshs      d
+                    ldd       $08,s
+                    pshs      d
                     ldd       $08,s
                     pshs      d
                     bsr       L5C34
@@ -9972,7 +9853,7 @@ L5C34               pshs      u
                     ldd       $08,s
                     addd      #$0014
                     pshs      d
-                    leax      $5E1D,pcr
+                    leax      L5E1D,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
@@ -9987,7 +9868,7 @@ L5C57               pshs      u
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    leax      $5E2C,pcr
+                    leax      L5E2C,pcr
                     lbra      L5CF9
 
 L5C6F               pshs      u
@@ -10088,7 +9969,7 @@ L5D46               pshs      x
 L5D4E               pshs      u
                     ldd       $04,s
                     beq       L5D5A
-                    leax      $5F03,pcr
+                    leax      L5F03,pcr
                     bra       L5D5E
 
 L5D5A               leax      L5F0C,pcr
@@ -10167,138 +10048,70 @@ L5DFD               leas      $02,s
 L5DFF               puls      pc,u
 L5E01               fcc       /fail source errors/
                     fcb       $00
-L5E14               bra       $5E88
-                    tst       $02,s
-                    bra       $5E3F
-                    lsr       $0d,x
-                    neg       L0025
-                    bgt       L5E58
-                    com       L2563
-                    bra       L5E97
-                    tst       $02,s
-                    bra       L5E4E
-                    lsr       $0d,x
-                    neg       $0020
-                    ror       $03,s
-                    com       0,y
-                    bhi       L5E58
-                    bgt       L5E6D
-                    com       $220D
-                    bra       L5EA0
-                    com       $02,s
-                    bra       L5E6E
-                    tst       $0000
-L5E40               bra       L5EB6
-                    lsr       $6C20
-                    bcs       L5E75
-                    fcb       $38
-                    com       $0D00
-L5E4B               fcb       $70,$73,$68
-L5E4E               fcb       $73,$20,$75
+L5E14               fcc       / rmb %d/
+                    fcb       $0D,$00
+L5E1D               fcc       /%.8s%c rmb %d/
+                    fcb       $0D,$00
+L5E2C               fcc       / fcc "%.8s"/
+                    fcb       $0D
+                    fcc       / fcb 0/
+                    fcb       $0D,$00
+L5E40               fcc       / ttl %.8s/
+                    fcb       $0D,$00
+L5E4B               fcc       /pshs u/
                     fcb       $00
-L5E52               bra       L5EC0
-                    lsr       $04,s
-                    bra       $5E7B
-
-L5E58               clrb
-                    bcs       $5EBF
-                    tst       $0020
-                    inc       $02,s
-                    com       L7220
-                    clrb
-                    com       L746B
-                    com       $08,s
-                    fcb       $65
-                    com       $0b,s
-                    tst       $0000
-L5E6D               fcb       $6C
-L5E6E               fcc       /eax /
+L5E52               fcc       / ldd #_%d/
+                    fcb       $0D
+                    fcc       / lbsr _stkcheck/
+                    fcb       $0D,$00
+L5E6D               fcc       /leax /
                     fcb       $00
-L5E73               bge       $5EE5
-L5E75               com       -$0e,s
-                    tst       $0020
-                    neg       L7368
-                    com       L2078
-                    tst       $0020
-                    fcc       /leax /
+L5E73               fcc       /,pcr/
+                    fcb       $0D
+                    fcc       / pshs x/
+                    fcb       $0D
+                    fcc       / leax /
                     fcb       $00
-L5E87               bge       L5EF9
-                    com       -$0e,s
-                    tst       $0020
-                    neg       L7368
-                    com       L2078
-                    tst       $0020
-                    inc       $02,s
-L5E97               com       L7220
-                    clrb
-                    neg       L726F
-                    ror       $0d,x
-L5EA0               bra       L5F0E
-                    fcb       $65,$61
-                    com       $2034
-                    bge       L5F1C
-                    tst       $0000
-L5EAB               bra       L5F1D
-                    com       L6873
-                    bra       L5F16
-                    tst       $0020
-                    inc       $05,s
-L5EB6               fcb       $61
-                    asl       L205F
-                    bcs       L5F20
-                    bge       L5F2E
-                    com       -$0e,s
-L5EC0               tst       $0020
-                    neg       L7368
-                    com       L2078
-                    tst       $0020
-                    inc       $02,s
-                    com       L7220
-                    clrb
-                    fcb       $65
-                    neg       L726F
-                    ror       $0d,x
-                    bra       $5F44
-                    fcb       $65,$61
-                    com       $2032
-                    bge       L5F52
-                    tst       $0020
-                    neg       L756C
-                    com       $2064
-                    tst       $0000
-L5EE9               clrb
-                    bcs       $5F50
-                    bra       $5F53
-                    fcb       $71,$75
-                    bra       L5F17
-                    lsr       $0d,x
-                    tst       $0000
-L5EF6               fcb       $66,$63,$62
-L5EF9               fcb       $20
+L5E87               fcc       /,pcr/
+                    fcb       $0D
+                    fcc       / pshs x/
+                    fcb       $0D
+                    fcc       / lbsr _prof/
+                    fcb       $0D
+                    fcc       / leas 4,s/
+                    fcb       $0D,$00
+L5EAB               fcc       / pshs d/
+                    fcb       $0D
+                    fcc       / leax _%d,pcr/
+                    fcb       $0D
+                    fcc       / pshs x/
+                    fcb       $0D
+                    fcc       / lbsr _eprof/
+                    fcb       $0D
+                    fcc       / leas 2,s/
+                    fcb       $0D
+                    fcc       / puls d/
+                    fcb       $0D,$00
+L5EE9               fcc       /_%d equ %d/
+                    fcb       $0D,$0D,$00
+L5EF6               fcc       /fcb /
                     fcb       $00
 L5EFB               fcc       /fdb /
                     fcb       $00
-L5F00               bpl       L5F22
-                    neg       $0076
-                    fcc       /sect dp/
+L5F00               fcb       $2A,$20
                     fcb       $00
-L5F0C               fcb       $76,$73
-L5F0E               fcb       $65,$63,$74
+L5F03               fcc       /vsect dp/
                     fcb       $00
-L5F12               fcc       /ends/
-L5F16               fcb       $65
-L5F17               fcb       $63,$74
+L5F0C               fcc       /vsect/
                     fcb       $00
-L5F1A               fcb       $64,$75
-L5F1C               fcb       $6D
-L5F1D               fcb       $70,$73,$74
-L5F20               fcb       $72,$69
-L5F22               fcb       $6E,$67,$73
+L5F12               fcc       /endsect/
+                    fcb       $00
+L5F1A               fcc       /dumpstrings/
                     fcb       $00
 L5F26               pshs      u
                     leas      -$15,s
                     lbsr      L42B9
-L5F2E               ldb       $0045
+                    ldb       $0045
                     sex
                     cmpd      #$FFFF
                     bne       L5F41
@@ -10314,7 +10127,7 @@ L5F41               ldd       $004A
                     bra       L5F60
 
 L5F4E               leax      L6CDE,pcr
-L5F52               pshs      x
+                    pshs      x
                     lbsr      L0450
                     leas      $02,s
                     lbsr      L42CF
@@ -10528,7 +10341,7 @@ L6111               ldb       $0045
                     bra       L60E2
 
 L611E               ldb       $0045
-L6120               cmpb      #$3d
+                    cmpb      #$3d
                     lbne      L628D
                     ldd       $003F
                     addd      #$0050
@@ -10724,13 +10537,13 @@ L6292               pshs      u
                     std       L0021
                     ldd       #$0001
                     pshs      d
-                    leax      $6D25,pcr
+                    leax      L6D25,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$0005
                     pshs      d
-                    leax      $6D29,pcr
+                    leax      L6D29,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -10793,7 +10606,7 @@ L6292               pshs      u
                     leas      $04,s
                     ldd       #$0014
                     pshs      d
-                    leax      $6D65,pcr
+                    leax      L6D65,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -10835,7 +10648,7 @@ L6292               pshs      u
                     leas      $04,s
                     ldd       #$001B
                     pshs      d
-                    leax      $6D8E,pcr
+                    leax      L6D8E,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -10847,7 +10660,7 @@ L6292               pshs      u
                     leas      $04,s
                     ldd       #$0004
                     pshs      d
-                    leax      $6D9A,pcr
+                    leax      L6D9A,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11348,7 +11161,7 @@ L6858               ldb       $0045
                     cmpd      #$0028
                     lbge      L68CB
                     ldd       $02,s
-L6873               pshs      d
+                    pshs      d
                     ldd       $06,s
                     beq       L6881
                     ldd       $08,s
@@ -11682,7 +11495,7 @@ L6B2B               ldd       $0060
 L6B34               pshs      u
                     ldd       $04,s
                     pshs      d
-                    leax      $6E39,pcr
+                    leax      L6E39,pcr
                     pshs      x
                     ldd       $0064
                     pshs      d
@@ -11822,7 +11635,7 @@ L6C54               pshs      u
                     leau      -$30,u
                     clra
                     clrb
-L6C62               std       ,s
+                    std       ,s
                     bra       L6C7D
 
 L6C66               tfr       u,d
@@ -11903,11 +11716,11 @@ L6D13               fcc       /static/
                     fcb       $00
 L6D1A               fcc       /sizeof/
                     fcb       $00
-L6D21               rol       $0e,s
-                    lsr       >$0069
-                    jmp       -$0C,s
-                    neg       $0066
-                    fcc       /loat/
+L6D21               fcb       $69,$6E,$74
+                    fcb       $00
+L6D25               fcb       $69,$6E,$74
+                    fcb       $00
+L6D29               fcc       /float/
                     fcb       $00
 L6D2F               fcc       /char/
                     fcb       $00
@@ -11925,9 +11738,9 @@ L6D56               fcc       /goto/
                     fcb       $00
 L6D5B               fcc       /return/
                     fcb       $00
-L6D62               rol       $06,s
-                    neg       $0077
-                    fcc       /hile/
+L6D62               fcb       $69,$66
+                    fcb       $00
+L6D65               fcc       /while/
                     fcb       $00
 L6D6B               fcc       /else/
                     fcb       $00
@@ -11939,14 +11752,13 @@ L6D7C               fcc       /break/
                     fcb       $00
 L6D82               fcc       /continue/
                     fcb       $00
-L6D8B               lsr       $0f,s
-                    neg       $0064
-                    fcc       /efault/
+L6D8B               fcb       $64,$6F
                     fcb       $00
-L6D96               ror       $0f,s
-                    fcb       $72
-                    neg       $0073
-                    fcc       /truct/
+L6D8E               fcc       /default/
+                    fcb       $00
+L6D96               fcb       $66,$6F,$72
+                    fcb       $00
+L6D9A               fcc       /struct/
                     fcb       $00
 L6DA1               fcc       /union/
                     fcb       $00
@@ -11962,28 +11774,24 @@ L6DC1               fcc       /out of memory/
                     fcb       $00
 L6DCF               fcc       /unterminated character constant/
                     fcb       $00
-L6DEF               asr       $2B00
+L6DEF               fcb       $77,$2B
+                    fcb       $00
 L6DF2               fcc       /can't open strings file/
                     fcb       $00
 L6E0A               fcc       /%c%d/
                     fcb       $00
 L6E0F               fcc       /unterminated string/
                     fcb       $00
-L6E23               bra       $6E8B
-                    fcc       /cc "/
+L6E23               fcc       / fcc "/
                     fcb       $00
-L6E2A               bhi       $6E39
-                    bra       L6E94
-                    com       $02,s
-                    bra       $6E56
-                    bcs       L6EAC
-                    tst       $0000
-L6E36               bhi       $6E45
-                    neg       $0020
-                    fcb       $72
-                    dec       $6220
-                    bcs       $6EA4
-                    tst       $0000
+L6E2A               fcb       $22
+                    fcb       $0D
+                    fcc       / fcb $%x/
+                    fcb       $0D,$00
+L6E36               fcb       $22
+                    fcb       $0D,$00
+L6E39               fcc       / rzb %d/
+                    fcb       $0D,$00
 L6E42               pshs      u
                     ldd       #$FFB4
                     lbsr      stkcheck
@@ -12018,7 +11826,7 @@ L6E76               pshs      u
                     beq       L6EAA
                     pshs      u
                     ldd       #$0077
-L6E94               pshs      d
+                    pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$0075
@@ -12417,7 +12225,7 @@ L71F7               ldd       $04,s
                     leas      $04,s
                     ldd       #$006E
                     ldx       $04,s
-L7220               std       $06,x
+                    std       $06,x
                     pshs      u
                     lbsr      L6E42
                     bra       L7237
@@ -12453,7 +12261,7 @@ L7261               ldd       $06,u
 L7269               leas      -$02,s
                     stu       ,s
                     ldu       $06,s
-L726F               ldd       ,s
+                    ldd       ,s
                     std       $06,s
                     leas      $02,s
 L7275               ldd       $06,u
@@ -12570,7 +12378,7 @@ L735E               ldd       $06,u
                     cmpd      #$0036
                     bne       L7372
                     leas      -$02,s
-L7368               stu       ,s
+                    stu       ,s
                     ldu       $06,s
                     ldd       ,s
                     std       $06,s
@@ -12646,7 +12454,7 @@ L73E6               cmpx      #$0051
                     lbeq      L72EC
                     cmpx      #$005D
                     lbeq      L72EC
-L7425               cmpx      #$005C
+                    cmpx      #$005C
                     lbeq      L72EC
                     cmpx      #$005E
                     lbeq      L72EC
@@ -12666,7 +12474,7 @@ L7425               cmpx      #$005C
                     lbeq      L72F6
                     cmpx      #$0052
                     lbeq      L735E
-L746B               cmpx      #$004E
+                    cmpx      #$004E
                     lbeq      L7372
                     cmpx      #$0053
                     lbeq      L73AA
@@ -12778,7 +12586,7 @@ L74CB               pshs      u
 
 L7567               pshs      u
                     ldd       #$FFAE
-L756C               lbsr      stkcheck
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -14156,8 +13964,8 @@ L814F               clra
 L8151               puls      pc,u
 L8153               fcc       /translation/
                     fcb       $00
-L815F               bcs       $81D9
-                    tst       $0000
+L815F               fcb       $25,$78
+                    fcb       $0D,$00
 L8163               fcc       /binary op./
                     fcb       $00
 L816E               fcc       /indirection/

--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -17135,11 +17135,9 @@ L9DD7               ldd       L0070
                     lbsr      LA1CD
 L9DE2               leas      $04,s
 L9DE4               puls      pc,u
-L9DE6               blt       $9E1B
-                    leas      -$09,y
-                    pshu      y,x,dp
-                    neg       $0034
-                    nega
+L9DE6               fcc       /-32768/
+                    fcb       $00
+L9DED               pshs      u
                     leau      $0246,y
 L9DF3               ldd       $06,u
                     clra
@@ -17411,9 +17409,9 @@ L9FEE               ldd       ,s
 LA004               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
-LA00A               bcs       LA070
-                    neg       $0034
-                    nega
+LA00A               fcc       /%d/
+                    fcb       $00
+LA00D               pshs      u
                     ldu       $04,s
                     leas      -$06,s
                     cmpu      #$0000
@@ -18994,10 +18992,7 @@ LAD29               andb      #$80
                     sta       $22,u
 LAD32               rts
 
-LAD33               neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0081
+LAD33               fcb       $00,$00,$00,$00,$00,$00,$00,$81
                     leax      >LAD33,pcr
 LAD3F               pshs      a
                     ldd       ,x

--- a/3rdparty/packages/ccompiler/c.comp_dis.asm
+++ b/3rdparty/packages/ccompiler/c.comp_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       4389
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.comp/
                     fcb       edition
 
-L0014               lda       ,y+
+copybytes           lda       ,y+
 L0016               sta       ,u+
 L0018               leax      -$01,x
-L001A               bne       L0014
+L001A               bne       copybytes
 L001C               rts
 
-start               pshs      y
+_start              pshs      y
 L001F               pshs      u
 L0021               clra
 L0022               clrb
@@ -37,12 +37,12 @@ L0030               pshs      x
 L0032               leay      LB358,pcr
 L0036               ldx       ,y++
 L0038               beq       L003E
-L003A               bsr       L0014
+L003A               bsr       copybytes
 L003C               ldu       $02,s
 L003E               leau      >$0078,u
 L0042               ldx       ,y++
 L0044               beq       L0049
-L0046               bsr       L0014
+L0046               bsr       copybytes
 L0048               clra
 L0049               cmpu      ,s
 L004C               beq       L0052
@@ -119,27 +119,25 @@ L00E0               leax      $0316,u
                     ldd       $0352,u
                     pshs      d
                     leay      ,u
-                    bsr       L00FA
-                    lbsr      L017C
+                    bsr       stkinit
+                    lbsr      main
                     clr       ,-s
                     clr       ,-s
-                    lbsr      LB34C
-L00FA               leax      $08A5,y
+                    lbsr      exit
+stkinit             leax      $08A5,y
                     stx       $0360,y
                     sts       $0354,y
                     sts       $0362,y
                     ldd       #$FF82
-L010F               leax      d,s
+stkcheck            leax      d,s
                     cmpx      $0362,y
                     bcc       L0121
                     cmpx      $0360,y
                     bcs       L013B
                     stx       $0362,y
 L0121               fcb       $39
-L0122               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+L0122               fcc       /**** STACK OVERFLOW ****/
+                    fcb       $0D
 L013B               leax      L0122,pcr
                     ldb       #$CF
                     pshs      b
@@ -169,7 +167,7 @@ L016A               ldd       ,y++
                     leas      $04,s
                     rts
 
-L017C               pshs      u
+main                pshs      u
                     leax      L5DC9,pcr
                     pshs      x
                     lbsr      $B31C
@@ -231,7 +229,7 @@ L01E4               leau      $01,u
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L02F2
 L0215               leax      ,s
@@ -248,7 +246,7 @@ L0220               ldb       ,u
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L02F2
                     bra       L0257
@@ -295,7 +293,7 @@ L0295               ldd       $04,s
                     std       $04,s
                     lbgt      L01B7
                     lbsr      L42A6
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L02AB
 
 L02A8               lbsr      L8192
@@ -308,7 +306,7 @@ L02AB               ldd       $003F
                     clra
                     andb      #$20
                     beq       L02CA
-                    leax      $0345,pcr
+                    leax      L0345,pcr
                     pshs      x
                     lbsr      L042D
                     leas      $02,s
@@ -320,24 +318,23 @@ L02CA               leax      $0253,y
                     beq       L02F0
                     ldd       $0009
                     pshs      d
-                    leax      $0366,pcr
+                    leax      L0366,pcr
                     pshs      x
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     bsr       L02F2
 L02F0               puls      pc,u
 L02F2               pshs      u
                     ldd       #$0001
                     pshs      d
-                    lbsr      LB34C
+                    lbsr      exit
                     leas      $02,s
                     puls      pc,u
 L0300               clrb
-                    lsr       -$0b,s
-                    tst       $0d,s
-                    rol       L5F00
+                    fcc       /dummy_/
+                    fcb       $00
 L0308               asr       >L0063
                     fcb       $61
                     jmp       $07,y
@@ -345,46 +342,17 @@ L0308               asr       >L0063
                     neg       $656E
                     bra       L033B
                     com       $0D00
-L0319               fcb       $75,$6e,$6b,$6e,$6f,$77,$6e,$20
-                    fcb       $66,$6C,$61,$67,$20,$3a,$20,$2d
-                    fcb       $25,$63,$0d,$00
+L0319               fcc       /unknown flag : -%c/
+                    fcb       $0D,$00
 L032D               fcb       $72
                     neg       L0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       $03A4
-
-L033B               jmp       -$10,s
-                    fcb       $75
-                    lsr       L2066
-                    rol       $0C,s
-                    fcb       $65
-                    neg       L0065
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       $03C3
-                    fcb       $72
-                    rol       -$0C,s
-                    rol       $0e,s
-                    asr       0,y
-                    fcb       $61
-                    com       $7365
-                    tst       $02,s
-                    inc       -$07,s
-                    bra       $03C0
-                    clr       $04,s
-                    fcb       $65
-                    bra       $03C8
-                    rol       $0C,s
-                    fcb       $65
-                    neg       L0065
-                    fcb       $72,$72,$6f,$72,$73,$20,$69,$6e
-                    fcb       $20,$63,$6f,$6d,$70,$69,$6C,$61
-                    fcb       $74,$69,$6f,$6e,$20,$3a,$20,$25
-                    fcb       $64,$0d,$00
+                    fcc       /an't open i/
+L033B               fcc       /nput file/
+                    fcb       $00
+L0345               fcc       /error writing assembly code file/
+                    fcb       $00
+L0366               fcc       /errors in compilation : %d/
+                    fcb       $0D,$00
 L0382               pshs      u
                     ldu       $04,s
                     leas      -$06,s
@@ -603,7 +571,7 @@ L054F               pshs      u
                     pshs      d
                     leax      $0260,y
                     pshs      x
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
 L056A               pshs      u
@@ -756,7 +724,7 @@ L06C1               pshs      u
                     ldd       $003F
                     cmpd      $04,s
                     bne       L06D1
-                    lbsr      $5F26
+                    lbsr      L5F26
 L06CD               clra
                     clrb
 L06CF               puls      pc,u
@@ -784,7 +752,7 @@ L06FF               ldd       #$0001
 L0704               pshs      u
                     bra       L070B
 
-L0708               lbsr      $5F26
+L0708               lbsr      L5F26
 L070B               ldd       $003F
                     cmpd      #$0028
                     beq       L0723
@@ -798,70 +766,34 @@ L0723               puls      pc,u
 L0725               bcs       L079A
                     bra       L0763
                     bra       L072B
-
-L072B               tst       -$0b,s
-                    inc       -$0C,s
-                    rol       -$10,s
-                    inc       $05,s
-                    bra       L0799
-                    fcb       $65
-                    ror       $09,s
-                    jmp       $09,s
-                    lsr       $696F
-                    jmp       0,x
-
-L073F               com       $0f,s
-                    tst       -$10,s
-                    rol       $0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L07AE
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       $077C
-                    bra       L0751
-
-L0751               inc       $09,s
-                    jmp       $05,s
-                    bra       $077C
-                    lsr       0,y
-                    bra       L075B
-
+L072B               fcc       /multiple definition/
+                    fcb       $00
+L073F               fcc       /compiler error - /
+                    fcb       $00
+L0751               fcc       /line %d  /
+                    fcb       $00
 L075B               bpl       L0787
                     bpl       $0789
                     bra       L0781
                     bcs       $07D6
-L0763               bra       $0785
+L0763               bra       L0785
                     bpl       $0791
                     bpl       $0793
                     tst       $0000
-L076B               fcb       $5e
+L076B               fcb       $5E
                     neg       $0074
-                    clr       $0f,s
-                    bra       $07DF
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       L07DC
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    com       L202D
-                    bra       L07C1
-                    fcb       $42
-L0781               clra
-                    fcb       $52
-                    lsrb
-                    neg       $0034
-                    nega
+                    fcc       /oo many errors - AB/
+L0781               fcb       $4F,$52,$54
+                    fcb       $00
+L0785               pshs      u
 L0787               ldd       #$FFA2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L0899
                     std       $0C,s
                     lbne      L087E
                     clra
-L0799               clrb
+                    clrb
 L079A               lbra      L0895
                     lbra      L087E
 
@@ -872,16 +804,16 @@ L07A0               ldd       $003F
                     std       ,s
                     ldd       L001F
                     std       $04,s
-L07AE               ldd       $0043
+                    ldd       $0043
                     std       $02,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldx       $0a,s
                     bra       L07D2
 
 L07B9               ldd       $0a,s
                     cmpd      #$00A0
                     blt       L07C9
-L07C1               ldd       $0a,s
+                    ldd       $0a,s
                     cmpd      #$00A9
                     ble       L07DE
 L07C9               ldd       $08,s
@@ -893,11 +825,11 @@ L07D2               cmpx      #$0064
                     beq       L07DE
                     cmpx      #$0078
                     beq       L07DE
-L07DC               bra       L07B9
+                    bra       L07B9
 
 L07DE               ldd       ,s
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
@@ -916,7 +848,7 @@ L07DE               ldd       ,s
                     std       $04,s
                     ldd       #$0003
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     std       $06,s
                     beq       L083C
@@ -980,7 +912,7 @@ L0895               leas      $0e,s
                     puls      pc,u
 L0899               pshs      u
                     ldd       #$FFA4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0C,s
                     ldu       #$0000
                     ldx       $003F
@@ -1003,10 +935,10 @@ L08AB               ldd       $0043
                     lbsr      L0FD8
                     leas      $0C,s
                     tfr       d,u
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L0A63
 
-L08D0               lbsr      $5F26
+L08D0               lbsr      L5F26
                     lbsr      L05DF
                     std       -$02,s
                     beq       L08FE
@@ -1028,7 +960,7 @@ L08D0               lbsr      $5F26
 L08FE               clra
                     clrb
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
@@ -1066,7 +998,7 @@ L093F               ldd       $003F
                     std       $06,s
                     ldd       $0043
                     std       $04,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbsr      L0899
                     std       $0a,s
                     beq       L097A
@@ -1097,11 +1029,11 @@ L0986               ldd       L001F
                     std       $06,s
                     ldd       $0043
                     std       $04,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $003F
                     cmpd      #$002D
                     bne       L09C8
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbsr      L05DF
                     std       -$02,s
                     beq       L09AA
@@ -1112,7 +1044,7 @@ L0986               ldd       L001F
 L09AA               clra
                     clrb
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     std       $0a,s
                     bne       L09BC
@@ -1195,7 +1127,7 @@ L0A73               ldd       $0043
                     std       $04,s
                     ldd       L001F
                     std       $06,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $04,s
                     pshs      d
                     ldd       $08,s
@@ -1213,10 +1145,10 @@ L0A73               ldd       $0043
                     ldd       #$002E
                     lbra      L0B1A
 
-L0AA4               lbsr      $5F26
+L0AA4               lbsr      L5F26
                     ldd       #$0002
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     std       $0a,s
                     bne       L0AD8
@@ -1283,7 +1215,7 @@ L0B24               ldd       $003F
                     ldd       L0021
                     addd      #$0001
                     std       L0021
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       L0021
                     addd      #$FFFF
                     std       L0021
@@ -1324,7 +1256,7 @@ L0B4F               ldd       $0043
                     lbsr      L0FD8
                     leas      $0C,s
                     tfr       d,u
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L0A6E
 
 L0B94               cmpx      #$002D
@@ -1363,7 +1295,7 @@ L0BC6               ldd       $0043
                     lbsr      L0FD8
                     leas      $0C,s
                     tfr       d,u
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L0BF3
 
 L0BE9               cmpx      #$003C
@@ -1375,7 +1307,7 @@ L0BF5               leas      $0C,s
                     puls      pc,u
 L0BF9               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldu       #$0000
                     bra       L0C08
@@ -1385,7 +1317,7 @@ L0C08               ldd       $003F
                     beq       L0C50
                     ldd       #$0002
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     std       ,s
                     beq       L0C43
@@ -1410,7 +1342,7 @@ L0C08               ldd       $003F
 L0C43               ldd       $003F
                     cmpd      #$0030
                     bne       L0C50
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L0C08
 
 L0C50               tfr       u,d
@@ -1418,11 +1350,11 @@ L0C50               tfr       u,d
 
 L0C54               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     std       ,s
                     lbsr      L111D
                     leas      $02,s
@@ -1453,7 +1385,7 @@ L0C9C               leas      $02,s
                     puls      pc,u
 L0CA0               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $003F
                     bra       L0CF9
 
@@ -1506,7 +1438,7 @@ L0CF9               cmpx      #$0041
                     puls      pc,u
 L0D26               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     lbra      L0E98
 
@@ -1730,7 +1662,7 @@ L0E98               cmpx      #$0050
                     puls      pc,u
 L0F4C               pshs      u
                     ldd       #$FFA2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     ldd       L001F
                     std       $04,s
@@ -1759,7 +1691,7 @@ L0F4C               pshs      u
                     leas      $02,s
                     ldd       $06,s
                     beq       L0F9D
-                    leax      $10FB,pcr
+                    leax      L10FB,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -1796,7 +1728,7 @@ L0F9D               ldd       $02,s
                     puls      pc,u
 L0FD8               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $000D
                     beq       L0FEC
                     ldu       $000D
@@ -1828,7 +1760,7 @@ L0FF8               ldd       $04,s
                     puls      pc,u
 L101A               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L110A,pcr
                     pshs      x
                     lbsr      L0450
@@ -1836,7 +1768,7 @@ L101A               pshs      u
 
 L102E               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       [$04,s]
                     ldx       $06,u
                     bra       L1081
@@ -1884,74 +1816,23 @@ L1081               cmpx      #$0034
                     lbeq      L1072
                     lbra      L103D
                     puls      pc,u
-L109C               lsr       L6869
-                    fcb       $72
-                    lsr       0,y
-                    fcb       $65
-                    asl       $7072
-                    fcb       $65
-                    com       $7369
-                    clr       $0e,s
-                    bra       L111B
-                    rol       -$0d,s
-                    com       L696E
-                    asr       0,x
-L10B5               clr       -$10,s
-                    fcb       $65
-                    fcb       $72
-                    fcb       $61
-                    jmp       $04,s
-                    bra       $1123
-                    asl       L7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-L10C6               neg       L7269
-                    tst       $01,s
-                    fcb       $72
-                    rol       $2065
-                    asl       L7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-L10D7               com       $0f,s
-                    jmp       -$0d,s
-                    lsr       $616E
-                    lsr       $2072
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L10E9               com       $0f,s
-                    jmp       -$0d,s
-                    lsr       $616E
-                    lsr       $206F
-                    neg       $6572
-                    fcb       $61
-                    lsr       $6F72
-                    neg       $006E
-                    fcb       $61
-                    tst       $05,s
-                    bra       L116A
-                    jmp       0,y
-                    fcb       $61
-                    bra       $1169
-                    fcb       $61
-                    com       $7400
-L110A               fcb       $65
-                    asl       $7072
-                    fcb       $65
-                    com       $7369
-                    clr       $0e,s
-                    bra       $1183
-                    rol       -$0d,s
-                    com       L696E
-L111B               asr       0,x
+L109C               fcc       /third expression missing/
+                    fcb       $00
+L10B5               fcc       /operand expected/
+                    fcb       $00
+L10C6               fcc       /primary expected/
+                    fcb       $00
+L10D7               fcc       /constant required/
+                    fcb       $00
+L10E9               fcc       /constant operator/
+                    fcb       $00
+L10FB               fcc       /name in a cast/
+                    fcb       $00
+L110A               fcc       /expression missing/
+                    fcb       $00
 L111D               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0C,s
                     stu       -$02,s
@@ -1984,7 +1865,7 @@ L115B               pshs      u
                     ldd       $0a,u
                     std       $0a,s
                     ldd       $0C,u
-L116A               std       $08,s
+                    std       $08,s
                     ldd       $06,u
                     std       $04,s
                     cmpd      #$0064
@@ -2060,7 +1941,7 @@ L1204               tfr       u,d
                     puls      pc,u
 L120A               pshs      u
                     ldd       #$FFA8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0e,s
                     stu       -$02,s
@@ -2426,7 +2307,7 @@ L1524               leas      $0e,s
                     puls      pc,u
 L1528               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L156E
@@ -2454,7 +2335,7 @@ L156E               clra
                     puls      pc,u
 L1572               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L287A,pcr
                     pshs      x
                     lbsr      L0450
@@ -2462,7 +2343,7 @@ L1572               pshs      u
                     puls      pc,u
 L1587               pshs      u
                     ldd       #$FF9C
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$14,s
                     ldx       $18,s
                     ldu       $0a,x
@@ -2651,7 +2532,7 @@ L170C               pshs      u
                     andb      #$30
                     cmpd      #$0020
                     bne       L1747
-L172C               leax      $28A2,pcr
+L172C               leax      L28A2,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3593,7 +3474,7 @@ L1F57               ldd       $02,u
                     lbra      L2028
 
 L1F6B               leas      -$14,x
-                    leax      $2924,pcr
+                    leax      L2924,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3624,7 +3505,7 @@ L1F7F               ldd       ,u
                     ldx       $12,s
                     cmpd      $02,x
                     beq       L1FCA
-L1FB7               leax      $2932,pcr
+L1FB7               leax      L2932,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3685,7 +3566,7 @@ L202D               ldd       $0e,s
                     leax      $14,s
                     lbra      L1E76
 
-L203B               leax      $2943,pcr
+L203B               leax      L2943,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3700,11 +3581,11 @@ L204E               cmpx      #$0034
                     cmpx      #$004A
 L205F               lbeq      L16E1
                     cmpx      #$004B
-L2066               lbeq      L16F1
+                    lbeq      L16F1
                     cmpx      #$0037
                     lbeq      L1701
                     cmpx      #$0020
-L2074               lbeq      L170C
+                    lbeq      L170C
 L2078               cmpx      #$0041
                     lbeq      L178B
                     cmpx      #$0042
@@ -3793,14 +3674,14 @@ L2170               ldd       $0C,s
                     puls      pc,u
 L2193               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
                     bne       L21A9
                     ldd       $08,u
                     beq       L21BF
-L21A9               leax      $294E,pcr
+L21A9               leax      L294E,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0498
@@ -3813,7 +3694,7 @@ L21A9               leax      $294E,pcr
 L21BF               puls      pc,u
 L21C1               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     pshs      u
@@ -3835,7 +3716,7 @@ L21E4               std       ,s
                     leas      $04,s
                     bra       L2224
 
-L21F0               leax      $295D,pcr
+L21F0               leax      L295D,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0498
@@ -3864,7 +3745,7 @@ L2224               ldd       ,s
                     puls      pc,u
 L222C               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -4230,7 +4111,7 @@ L2540               ldd       $0a,s
 
 L2545               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
@@ -4289,7 +4170,7 @@ L25C5               leas      $04,s
                     puls      pc,u
 L25C9               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $08,s
                     pshs      d
                     ldd       $06,s
@@ -4363,7 +4244,7 @@ L2657               std       $12,u
                     puls      pc,u
 L2668               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -4397,7 +4278,7 @@ L26B5               bne       L26C1
                     ldd       ,u
                     cmpd      #$0004
                     lbne      L27B6
-L26C1               leax      $2968,pcr
+L26C1               leax      L2968,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0498
@@ -4409,7 +4290,7 @@ L26C1               leax      $2968,pcr
 
 L26D8               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0034
@@ -4427,7 +4308,7 @@ L26D8               pshs      u
 
 L2707               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       ,u
@@ -4487,7 +4368,7 @@ L276C               ldd       #$0036
                     bra       L278B
 
 L2789               leas      -$02,x
-L278B               leax      $298C,pcr
+L278B               leax      L298C,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0498
@@ -4510,7 +4391,7 @@ L27B6               leas      $02,s
 L27B8               puls      pc,u
 L27BA               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       ,u
                     cmpd      #$0004
@@ -4530,7 +4411,7 @@ L27E7               ldd       ,u
                     puls      pc,u
 L27EB               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       #$0006
                     pshs      d
@@ -4560,7 +4441,7 @@ L27EB               pshs      u
                     puls      pc,u
 L2832               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L2843
 
@@ -4579,7 +4460,7 @@ L2843               cmpx      #$0001
                     puls      pc,u
 L2861               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L29C4,pcr
                     pshs      x
                     ldd       $06,s
@@ -4587,207 +4468,47 @@ L2861               pshs      u
                     lbsr      L0498
                     leas      $04,s
                     puls      pc,u
-L287A               lsr       $09,s
-                    ror       $6964
-                    fcb       $65
-                    bra       L28E4
-                    rol       $207A
-                    fcb       $65
-                    fcb       $72
-                    clr       0,x
-L2889               lsr       $7970
-                    fcb       $65
-                    lsr       $05,s
-                    ror       0,y
-                    blt       $28B3
-                    jmp       $0f,s
-                    lsr       $2061
-                    bra       L2910
-                    fcb       $61
-                    fcb       $72
-                    rol       $01,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       L0063
-                    fcb       $61
-                    jmp       $0e,s
-                    clr       -$0C,s
-                    bra       L290D
-                    fcb       $61
-                    com       $7400
-L28AE               com       $01,s
-                    jmp       $07,y
-                    lsr       L2074
-                    fcb       $61
-                    fcb       $6b
-                    fcb       $65
-                    bra       $291B
-                    lsr       $04,s
-                    fcb       $72
-                    fcb       $65
-                    com       $7300
-L28C1               neg       L6F69
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $293C
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L28D2               neg       L6F69
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $294A
-                    fcb       $72
-                    bra       L2947
-                    jmp       -$0C,s
-                    fcb       $65
-                    asr       $05,s
-                    fcb       $72
-L28E4               bra       $2958
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L28EE               jmp       $0f,s
-                    lsr       $2061
-                    bra       L295B
-                    fcb       $75
-                    jmp       $03,s
-                    lsr       $696F
-                    jmp       0,x
-L28FD               fcb       $62
-                    clr       -$0C,s
-                    asl       0,y
-                    tst       -$0b,s
-                    com       $7420
-                    fcb       $62
-                    fcb       $65
-                    bra       $2974
-                    jmp       -$0C,s
-L290D               fcb       $65
-                    asr       -$0e,s
-L2910               fcb       $61
-                    inc       0,x
-L2913               neg       L6F69
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L2989
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       L6368
-                    neg       $0074
-                    rol       L7065
-                    bra       L2997
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       L6368
-                    neg       L0070
-                    clr       $09,s
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $29A8
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       L6368
-                    neg       $0074
-                    rol       L7065
-L2947               bra       L29AC
-                    asl       $05,s
-                    com       $0b,s
-                    neg       $0073
-                    asl       $0f,s
-                    fcb       $75
-                    inc       $04,s
-                    bra       $29B8
-                    fcb       $65
-                    bra       L29A7
-                    fcb       $55
-                    inca
-L295B               inca
-                    neg       $0074
-                    rol       L7065
-                    bra       $29C8
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L006C
-                    ror       $616C
-                    fcb       $75
-                    fcb       $65
-                    bra       $29E2
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L2978               fcb       $75
-                    jmp       $04,s
-                    fcb       $65
-                    com       $0C,s
-                    fcb       $61
-                    fcb       $72
-                    fcb       $65
-                    lsr       0,y
-                    ror       L6172
-                    rol       $01,s
-                    fcb       $62
-L2989               inc       $05,s
-                    neg       $0073
-                    lsr       L7275
-                    com       -$0C,s
-                    bra       $2A01
-                    fcb       $65
-                    tst       $02,s
-L2997               fcb       $65
-                    fcb       $72
-                    bra       $2A0D
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L29A3               com       L7472
-                    fcb       $75
-L29A7               com       -$0C,s
-                    fcb       $75
-                    fcb       $72
-                    fcb       $65
-L29AC               bra       $2A1D
-                    fcb       $72
-                    bra       L2A26
-                    jmp       $09,s
-                    clr       $0e,s
-                    bra       $2A20
-                    jmp       $01,s
-                    neg       $7072
-                    clr       -$10,s
-                    fcb       $72
-                    rol       $01,s
-                    lsr       L6500
-L29C4               tst       -$0b,s
-                    com       $7420
-                    fcb       $62
-                    fcb       $65
-                    bra       L2A36
-                    jmp       -$0C,s
-                    fcb       $65
-                    asr       -$0e,s
-                    fcb       $61
-                    inc       0,x
+L287A               fcc       /divide by zero/
+                    fcb       $00
+L2889               fcc       /typedef - not a variable/
+                    fcb       $00
+L28A2               fcc       /cannot cast/
+                    fcb       $00
+L28AE               fcc       /can't take address/
+                    fcb       $00
+L28C1               fcc       /pointer required/
+                    fcb       $00
+L28D2               fcc       /pointer or integer required/
+                    fcb       $00
+L28EE               fcc       /not a function/
+                    fcb       $00
+L28FD               fcc       /both must be integral/
+                    fcb       $00
+L2913               fcc       /pointer mismatch/
+                    fcb       $00
+L2924               fcc       /type mismatch/
+                    fcb       $00
+L2932               fcc       /pointer mismatch/
+                    fcb       $00
+L2943               fcc       /type check/
+                    fcb       $00
+L294E               fcc       /should be NULL/
+                    fcb       $00
+L295D               fcc       /type error/
+                    fcb       $00
+L2968               fcc       /lvalue required/
+                    fcb       $00
+L2978               fcc       /undeclared variable/
+                    fcb       $00
+L298C               fcc       /struct member required/
+                    fcb       $00
+L29A3               fcc       /structure or union inappropriate/
+                    fcb       $00
+L29C4               fcc       /must be integral/
+                    fcb       $00
 L29D5               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $003F
                     cmpd      #$0028
                     beq       L29ED
@@ -4831,10 +4552,10 @@ L2A2C               lbsr      L3235
                     lbra      L2B10
 
 L2A32               leax      L3401,pcr
-L2A36               pshs      x
+                    pshs      x
                     lbsr      L0450
                     leas      $02,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L2A9C
 
 L2A43               leax      ,s
@@ -4860,14 +4581,14 @@ L2A48               cmpx      #$0013
                     beq       L2A21
                     cmpx      #$001A
                     beq       L2A26
-                    cmpx      #start
+                    cmpx      #_start
                     beq       L2A2C
                     cmpx      #$0015
                     beq       L2A32
                     bra       L2A43
 
 L2A86               lbsr      L89B7
-                    lbsr      $5F26
+                    lbsr      L5F26
                     puls      pc,u
 L2A8E               puls      pc,u
 L2A90               lbsr      L42B9
@@ -4892,7 +4613,7 @@ L2AB5               leax      L3414,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
-L2AC0               lbsr      $5F26
+L2AC0               lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0028
                     bne       L2AC0
@@ -4923,7 +4644,7 @@ L2AEC               cmpx      #$0028
                     lbeq      L2A8E
                     cmpx      #$0034
                     lbeq      L2A90
-L2B0D               lbra      L2AA7
+                    lbra      L2AA7
 
 L2B10               ldd       #$0028
                     pshs      d
@@ -4932,9 +4653,9 @@ L2B10               ldd       #$0028
                     puls      pc,u
 L2B1C               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbsr      L337E
                     std       ,s
                     ldd       $000B
@@ -4948,7 +4669,7 @@ L2B1C               pshs      u
                     ldd       $003F
                     cmpd      #$0028
                     bne       L2B6B
-                    lbsr      $5F26
+                    lbsr      L5F26
                     clra
                     clrb
                     pshs      d
@@ -4987,7 +4708,7 @@ L2B8D               ldd       $003F
                     ldd       $0041
                     cmpd      #$0015
                     bne       L2BD2
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0028
                     beq       L2BD2
@@ -5018,7 +4739,7 @@ L2BD2               ldd       $02,s
                     puls      pc,u
 L2BDF               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       $0033
                     std       $08,s
@@ -5028,7 +4749,7 @@ L2BDF               pshs      u
                     std       $04,s
                     ldd       $0788,y
                     std       $02,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $000B
                     addd      #$0001
                     std       $000B
@@ -5095,9 +4816,9 @@ L2C52               ldd       $0035
                     puls      pc,u
 L2C8F               pshs      u
                     ldd       #$FFA8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $0037
                     addd      #$0001
                     std       $0037
@@ -5130,7 +4851,7 @@ L2C8F               pshs      u
                     clra
                     clrb
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     std       ,s
                     lbsr      L111D
                     leas      $02,s
@@ -5260,9 +4981,9 @@ L2DCB               ldd       $0033
 
 L2DF6               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
-L2E00               lbsr      $5F26
+                    lbsr      L5F26
                     clra
                     clrb
                     pshs      d
@@ -5312,14 +5033,14 @@ L2E5A               bsr       L2E9C
 
 L2E5E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
-                    lbsr      $5F26
+                    lbsr      stkcheck
+                    lbsr      L5F26
                     ldd       $0037
                     bne       L2E6F
                     bsr       L2E9C
 L2E6F               ldd       $0784,y
                     beq       L2E80
-L2E75               leax      $3435,pcr
+L2E75               leax      L3435,pcr
                     pshs      x
                     lbsr      L0450
                     bra       L2E90
@@ -5338,15 +5059,15 @@ L2E90               leas      $02,s
 
 L2E9C               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
-                    leax      $3447,pcr
+                    lbsr      stkcheck
+                    leax      L3447,pcr
                     pshs      x
                     lbsr      L0450
 L2EAD               leas      $02,s
                     puls      pc,u
 L2EB1               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       $0033
                     std       $08,s
@@ -5367,7 +5088,7 @@ L2EB1               pshs      u
                     addd      #$0001
                     std       $000B
                     std       $0033
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $000B
                     addd      #$0001
                     std       $000B
@@ -5382,11 +5103,11 @@ L2EB1               pshs      u
                     ldd       $0041
                     cmpd      #$0014
                     beq       L2F1C
-L2F11               leax      $345B,pcr
+L2F11               leax      L345B,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
-L2F1C               lbsr      $5F26
+L2F1C               lbsr      L5F26
                     ldd       $0035
                     pshs      d
                     lbsr      L57B2
@@ -5418,7 +5139,7 @@ L2F1C               lbsr      $5F26
                     puls      pc,u
 L2F5F               pshs      u
                     ldd       #$FFA6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0e,s
                     clra
                     clrb
@@ -5444,7 +5165,7 @@ L2F5F               pshs      u
                     addd      #$0001
                     std       $000B
                     std       $0033
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       #$002D
                     pshs      d
                     lbsr      L06C1
@@ -5482,7 +5203,7 @@ L2FE5               ldd       #$0028
                     clra
                     clrb
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     std       ,s
                     lbsr      L111D
                     leas      $02,s
@@ -5561,15 +5282,15 @@ L3094               leas      $0e,s
                     puls      pc,u
 L3098               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
-                    lbsr      $5F26
+                    lbsr      stkcheck
+                    lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0028
                     lbeq      L3197
                     clra
                     clrb
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
@@ -5607,7 +5328,7 @@ L30F5               pshs      u
                     bra       L3109
 
 L3100               pshs      u
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     bra       L310B
 
@@ -5692,8 +5413,8 @@ L3197               clra
 
 L31B8               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
-                    lbsr      $5F26
+                    lbsr      stkcheck
+                    lbsr      L5F26
                     ldd       $0033
                     bne       L31D4
                     leax      L346A,pcr
@@ -5720,11 +5441,11 @@ L31F1               ldd       #$0018
 
 L31F7               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
-                    lbsr      $5F26
+                    lbsr      stkcheck
+                    lbsr      L5F26
                     ldd       $0035
                     bne       L3213
-                    leax      $3476,pcr
+                    leax      L3476,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -5748,12 +5469,12 @@ L3230               ldd       #$0019
 
 L3235               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
-                    lbsr      $5F26
+                    lbsr      stkcheck
+                    lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0034
                     beq       L3255
-                    leax      $3485,pcr
+                    leax      L3485,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -5768,20 +5489,20 @@ L3255               lbsr      L32C2
                     pshs      d
                     ldd       $06,u
                     pshs      d
-                    ldd       #start
+                    ldd       #_start
                     pshs      d
                     lbsr      L4623
                     leas      $06,s
                     ldd       $0a,u
                     orb       #$02
                     std       $0a,u
-L3276               lbsr      $5F26
-L3279               ldd       #start
+L3276               lbsr      L5F26
+L3279               ldd       #_start
 L327C               std       $002F
                     puls      pc,u
 L3280               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     bsr       L32C2
                     tfr       d,u
                     stu       -$02,s
@@ -5806,12 +5527,12 @@ L329D               ldd       #$000F
                     ldd       $0a,u
                     orb       #$01
                     std       $0a,u
-L32BA               lbsr      $5F26
-                    lbsr      $5F26
+L32BA               lbsr      L5F26
+                    lbsr      L5F26
                     puls      pc,u
 L32C2               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $0041
                     ldd       ,u
                     cmpd      #$0009
@@ -5850,10 +5571,10 @@ L32F4               ldd       #$0009
 
 L3319               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
@@ -5868,7 +5589,7 @@ L3319               pshs      u
 
 L3342               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L26D8
@@ -5897,7 +5618,7 @@ L336D               pshs      u
 
 L337E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       #$002D
                     pshs      d
@@ -5914,11 +5635,11 @@ L337E               pshs      u
 
 L33A5               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     clra
                     clrb
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     std       ,s
                     lbsr      L111D
                     leas      $02,s
@@ -5929,7 +5650,7 @@ L33A5               pshs      u
                     lbsr      L26D8
                     bra       L33D1
 
-L33C8               leax      $34AD,pcr
+L33C8               leax      L34AD,pcr
                     pshs      x
                     lbsr      L0450
 L33D1               leas      $02,s
@@ -5937,7 +5658,7 @@ L33D3               tfr       u,d
                     puls      pc,u
 L33D7               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L33FF
@@ -5954,118 +5675,31 @@ L33D7               pshs      u
                     lbsr      L0598
 L33FD               leas      $02,s
 L33FF               puls      pc,u
-L3401               jmp       $0f,s
-                    bra       $342C
-                    rol       $06,s
-                    beq       $3429
-                    ror       $0f,s
-                    fcb       $72
-                    bra       $3435
-                    fcb       $65
-                    inc       -$0d,s
-                    fcb       $65
-                    beq       L3414
-L3414               rol       $0C,s
-                    inc       $05,s
-                    asr       $01,s
-                    inc       0,y
-                    lsr       $05,s
-                    com       $0C,s
-                    fcb       $61
-                    fcb       $72
-                    fcb       $61
-                    lsr       $696F
-                    jmp       0,x
-
-L3428               com       L796E
-                    lsr       $6178
-                    bra       L3495
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $006D
-                    fcb       $75
-                    inc       -$0C,s
-                    rol       -$10,s
-                    inc       $05,s
-                    bra       $34A3
-                    fcb       $65
-                    ror       $01,s
-                    fcb       $75
-                    inc       -$0C,s
-                    com       >$006E
-                    clr       0,y
-                    com       $7769
-                    lsr       L6368
-                    bra       $34C5
-                    lsr       L6174
-                    fcb       $65
-                    tst       $05,s
-                    jmp       -$0C,s
-                    neg       $0077
-                    asl       $09,s
-                    inc       $05,s
-                    bra       $34C7
-                    asl       L7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-L346A               fcb       $62
-                    fcb       $72
-                    fcb       $65
-                    fcb       $61
-                    fcb       $6b
-                    bra       $34D6
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L0063
-                    clr       $0e,s
-                    lsr       L696E
-                    fcb       $75
-                    fcb       $65
-                    bra       L34E5
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L006C
-                    fcb       $61
-                    fcb       $62
-                    fcb       $65
-                    inc       0,y
-                    fcb       $72
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L3494               fcb       $61
-L3495               inc       -$0e,s
-                    fcb       $65
-                    fcb       $61
-                    lsr       -$07,s
-                    bra       L34FE
-                    bra       L350B
-                    clr       $03,s
-                    fcb       $61
-                    inc       0,y
-                    ror       L6172
-                    rol       $01,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       L0063
-                    clr       $0e,s
-                    lsr       $09,s
-                    lsr       $696F
-                    jmp       0,y
-                    jmp       $05,s
-                    fcb       $65
-                    lsr       $05,s
-                    lsr       0,x
+L3401               fcc       /no 'if' for 'else'/
+                    fcb       $00
+L3414               fcc       /illegal declaration/
+                    fcb       $00
+L3428               fcc       /syntax error/
+                    fcb       $00
+L3435               fcc       /multiple defaults/
+                    fcb       $00
+L3447               fcc       /no switch statement/
+                    fcb       $00
+L345B               fcc       /while expected/
+                    fcb       $00
+L346A               fcc       /break error/
+                    fcb       $00
+L3476               fcc       /continue error/
+                    fcb       $00
+L3485               fcc       /label required/
+                    fcb       $00
+L3494               fcc       /already a local variable/
+                    fcb       $00
+L34AD               fcc       /condition needed/
+                    fcb       $00
 L34BE               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L34D9
@@ -6077,10 +5711,10 @@ L34BE               pshs      u
                     puls      pc,u
 L34D9               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
-L34E5               ldd       $06,u
+                    ldd       $06,u
                     std       $02,s
                     tfr       d,x
                     lbra      L379C
@@ -6092,13 +5726,13 @@ L34EE               pshs      u
                     lbsr      L77AC
                     leas      $02,s
                     ldx       $06,u
-L34FE               bra       L351A
+                    bra       L351A
 
 L3500               ldd       $08,u
                     lbeq      L3894
                     pshs      u
                     ldd       #$0077
-L350B               pshs      d
+                    pshs      d
                     ldd       #$007B
 L3510               pshs      d
                     lbsr      L4623
@@ -6122,7 +5756,7 @@ L3530               ldd       $0a,u
 
 L353F               ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       $0a,u
                     pshs      d
@@ -6473,7 +6107,7 @@ L3894               leas      $06,s
                     puls      pc,u
 L3898               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L38D5
@@ -6509,7 +6143,7 @@ L38D5               cmpx      #$0034
 L38E6               puls      pc,u
 L38E8               pshs      u
                     ldd       #$FFB2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $08,u
@@ -6574,12 +6208,11 @@ L396E               ldd       #$0070
                     leas      $04,s
                     leas      $02,s
                     puls      pc,u
-L3981               inc       $0f,s
-                    jmp       $07,s
-                    com       >$0034
-                    nega
+L3981               fcc       /longs/
+                    fcb       $00
+L3987               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L39A2
@@ -6591,7 +6224,7 @@ L3981               inc       $0f,s
                     puls      pc,u
 L39A2               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$08,s
                     ldd       ,u
@@ -6633,7 +6266,7 @@ L39EC               ldd       $0a,u
 
 L39F5               ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
 L39FC               leas      $02,s
                     leax      $08,s
                     bra       L39D0
@@ -6648,7 +6281,7 @@ L3A02               ldd       $08,u
                     leas      $06,s
                     lbra      L3BAE
 
-L3A18               leax      $3987,pcr
+L3A18               leax      L3987,pcr
                     pshs      x
                     pshs      u
                     lbsr      L7567
@@ -6657,7 +6290,7 @@ L3A18               leax      $3987,pcr
 
 L3A27               ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
@@ -6686,7 +6319,7 @@ L3A47               ldd       #$0080
                     leas      $04,s
                     ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
@@ -6727,7 +6360,7 @@ L3ABA               pshs      u
 
 L3AC3               ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
@@ -6737,7 +6370,7 @@ L3AC3               ldd       $0a,u
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
@@ -6750,7 +6383,7 @@ L3AF2               leax      $08,s
 
 L3AF7               ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
@@ -6760,7 +6393,7 @@ L3AF7               ldd       $0a,u
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     leax      $08,s
                     lbra      L3B95
@@ -6774,7 +6407,7 @@ L3B1D               leas      -$08,x
                     ldx       $04,s
                     ldd       $0a,x
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
@@ -6789,7 +6422,7 @@ L3B1D               leas      -$08,x
 
 L3B4F               ldd       $04,s
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
@@ -6913,12 +6546,11 @@ L3BD7               cmpx      #$0080
 
 L3CAC               leas      $08,s
                     puls      pc,u
-L3CB0               ror       $0C,s
-                    clr       $01,s
-                    lsr       $7300
+L3CB0               fcc       /floats/
+                    fcb       $00
 L3CB7               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldx       $0a,s
@@ -6983,7 +6615,7 @@ L3D3C               ldd       $0C,s
                     bne       L3D90
                     ldd       #$0001
                     std       L0056
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0037
                     bne       L3D89
@@ -7008,7 +6640,7 @@ L3D76               leax      L4244,pcr
                     pshs      x
                     lbsr      L0450
 L3D7F               leas      $02,s
-L3D81               lbsr      $5F26
+L3D81               lbsr      L5F26
                     leax      $04,s
                     lbra      L3DE5
 
@@ -7018,7 +6650,7 @@ L3D89               ldd       #$0002
 
 L3D90               ldd       #$0002
                     std       L0056
-                    lbsr      $5F26
+                    lbsr      L5F26
 L3D98               ldd       $0C,s
                     cmpd      #$0004
                     bne       L3DB5
@@ -7068,7 +6700,7 @@ L3DEE               leas      $04,s
                     puls      pc,u
 L3DF2               pshs      u
                     ldd       #$FFA8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $06,s
                     leas      -$0C,s
                     ldd       $16,s
@@ -7084,7 +6716,7 @@ L3E0F               ldd       $003F
                     bne       L3E21
                     ldd       #$0001
                     std       $0a,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L3E25
 
 L3E21               clra
@@ -7138,7 +6770,7 @@ L3E62               ldd       $16,s
                     ldd       $003F
                     cmpd      #$0030
                     bne       L3EA0
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L3E98
 
 L3E98               ldd       $003F
@@ -7180,11 +6812,11 @@ L3EDE               ldd       $16,s
 L3EE9               ldd       $003F
                     cmpd      #$0030
                     bne       L3EF4
-                    lbsr      $5F26
+                    lbsr      L5F26
 L3EF4               ldd       $003F
                     cmpd      #$002A
                     bne       L3F02
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L3FB7
 
 L3F02               leax      L424D,pcr
@@ -7200,7 +6832,7 @@ L3F13               ldd       $10,s
                     ldd       $14,s
                     std       ,s
                     bne       L3F6C
-                    leax      $425F,pcr
+                    leax      L425F,pcr
                     lbra      L3FC0
 
 L3F2C               ldx       ,s
@@ -7229,7 +6861,7 @@ L3F46               pshs      d
                     ldd       $003F
                     cmpd      #$0030
                     bne       L3F95
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L3F6C
 
 L3F6C               ldd       $003F
@@ -7282,7 +6914,7 @@ L3FCC               leas      $0C,s
                     puls      pc,u
 L3FD0               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L428F,pcr
                     pshs      x
                     lbsr      L5756
@@ -7295,11 +6927,11 @@ L3FD0               pshs      u
                     puls      pc,u
 L3FF1               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldd       #$0002
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     std       ,s
                     lbsr      L111D
                     leas      $02,s
@@ -7500,7 +7132,7 @@ L419B               leas      $08,s
                     puls      pc,u
 L419F               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $08,s
@@ -7546,8 +7178,8 @@ L41FF               leas      $02,s
                     puls      pc,u
 L4203               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
-                    leax      $4294,pcr
+                    lbsr      stkcheck
+                    leax      L4294,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -7555,12 +7187,12 @@ L4203               pshs      u
                     puls      pc,u
 L421A               pshs      u
                     ldd       #$FFBC
-                    lbsr      L010F
+                    lbsr      stkcheck
 L4222               ldx       $003F
                     bra       L422D
 
 L4226               puls      pc,u
-L4228               lbsr      $5F26
+L4228               lbsr      L5F26
                     bra       L4222
 
 L422D               cmpx      #$0030
@@ -7571,54 +7203,18 @@ L422D               cmpx      #$0030
                     lbeq      L4226
                     bra       L4228
                     puls      pc,u
-L4244               lsr       $6F6F
-                    bra       $42B5
-                    clr       $0e,s
-                    asr       0,x
-L424D               lsr       $6F6F
-                    bra       L42BF
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       $42BC
-                    inc       $05,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    com       >L0075
-                    jmp       $09,s
-                    clr       $0e,s
-                    com       $206E
-                    clr       -$0C,s
-                    bra       $42CC
-                    inc       $0C,s
-                    clr       -$09,s
-                    fcb       $65
-                    lsr       0,x
-L4272               com       $0f,s
-                    jmp       -$0d,s
-                    lsr       $616E
-                    lsr       $2065
-                    asl       $7072
-                    fcb       $65
-                    com       $7369
-                    clr       $0e,s
-                    bra       L42F9
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L428F               fcb       $72
-                    dec       $6220
-                    neg       L0063
-                    fcb       $61
-                    jmp       $0e,s
-                    clr       -$0C,s
-                    bra       $4305
-                    jmp       $09,s
-                    lsr       $6961
-                    inc       $09,s
-                    dec       L6500
+L4244               fcc       /too long/
+                    fcb       $00
+L424D               fcc       /too many elements/
+                    fcb       $00
+L425F               fcc       /unions not allowed/
+                    fcb       $00
+L4272               fcc       /constant expression required/
+                    fcb       $00
+L428F               fcc       /rzb /
+                    fcb       $00
+L4294               fcc       /cannot initialize/
+                    fcb       $00
 L42A6               pshs      u
                     leax      $0584,y
                     stx       $004A
@@ -7727,7 +7323,7 @@ L4371               leax      $0584,y
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     leax      $078a,y
                     pshs      x
@@ -7735,7 +7331,7 @@ L4371               leax      $0584,y
 L43B5               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L430E
 
@@ -7779,7 +7375,7 @@ L4409               ldd       $06,s
                     leas      $06,s
                     bra       L442F
 
-L4424               leax      $45D0,pcr
+L4424               leax      L45D0,pcr
                     pshs      x
                     lbsr      L9A1F
                     leas      $02,s
@@ -7817,7 +7413,7 @@ L447A               ldd       $04,s
                     lbne      L430E
                     ldd       #$0001
                     pshs      d
-                    lbsr      LB34C
+                    lbsr      exit
                     leas      $02,s
                     lbra      L430E
 
@@ -7892,7 +7488,7 @@ L4509               pshs      u,d
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      LB34C
+                    lbsr      exit
                     leas      $02,s
 L4546               clra
                     clrb
@@ -7939,30 +7535,18 @@ L459A               leas      $02,s
                     puls      pc,u
 L459E               neg       L0025
                     com       $0D00
-L45A3               bra       $4615
-                    fcb       $73,$65,$63,$74,$20,$25,$73,$2C
-                    fcb       $30,$2C,$30,$2C,$25,$64,$2C,$30
-                    fcb       $2C,$30,$0d,$00
+L45A3               bra       L4615
+                    fcc       /sect %s,0,0,%d,0,0/
+                    fcb       $0D,$00
 L45B9               bra       $4629
                     fcb       $61
                     tst       0,y
                     bcs       $4633
                     tst       $0000
-L45C2               bcs       $4637
-                    bra       L4600
-                    bra       L4634
-                    rol       $0e,s
-                    fcb       $65
-                    bra       L45F2
-                    lsr       0,y
-                    neg       L0061
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    bra       L4614
-                    bra       L45DC
-
+L45C2               fcc       /%s : line %d /
+                    fcb       $00
+L45D0               fcc       /argument : /
+                    fcb       $00
 L45DC               bpl       L4608
                     bpl       L460A
                     bra       L4607
@@ -7971,24 +7555,16 @@ L45DC               bpl       L4608
                     bpl       L45F6
                     neg       $005E
                     neg       L0049
-                    fcb       $4e,$50,$55,$54,$20
-L45F2               fcb       $46,$49,$4C,$45
-L45F6               fcb       $20,$45,$52,$52,$4f,$52,$20,$3a
-                    fcb       $20,$54
-L4600               fcb       $45,$4d,$50,$4f,$52,$41,$52
+                    fcc       /NPUT FILE/
+L45F6               fcc       / ERROR : TEMPORAR/
 L4607               fcb       $59
 L4608               fcb       $20,$46
-L460A               fcb       $49,$4C,$45,$0d,$00
-L460F               rol       $0e,s
-L4611               neg       $7574
-L4614               bra       $4682
-                    rol       $0e,s
-                    fcb       $65
-                    bra       $468F
-                    clr       $0f,s
-                    bra       L468B
-                    clr       $0e,s
-                    asr       0,x
+L460A               fcb       $49,$4C,$45
+                    fcb       $0D,$00
+L460F               fcb       $69,$6E
+L4611               fcc       /put /
+L4615               fcc       /line too long/
+                    fcb       $00
 L4623               pshs      u
                     ldu       $0a,s
                     leas      -$08,s
@@ -7996,7 +7572,7 @@ L4623               pshs      u
                     cmpd      #$0088
                     bne       L4641
                     ldd       $10,s
-L4634               pshs      d
+                    pshs      d
                     ldd       $10,s
                     pshs      d
                     lbsr      L4D79
@@ -8023,7 +7599,7 @@ L465E               ldd       $0e,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       $000F
                     subd      #$0002
@@ -8076,13 +7652,13 @@ L46D3               pshs      u
 L46E7               leax      $58B0,pcr
                     bra       L4715
 
-L46ED               leax      $58B7,pcr
+L46ED               leax      L58B7,pcr
                     bra       L4715
 
-L46F3               leax      $58BE,pcr
+L46F3               leax      L58BE,pcr
                     bra       L4715
 
-L46F9               leax      $58C4,pcr
+L46F9               leax      L58C4,pcr
                     bra       L4715
 
 L46FF               leax      L58CA,pcr
@@ -8091,7 +7667,7 @@ L46FF               leax      L58CA,pcr
 L4705               leax      L58D0,pcr
                     bra       L4715
 
-L470B               leax      $58D6,pcr
+L470B               leax      L58D6,pcr
                     bra       L4715
 
 L4711               leax      L58DD,pcr
@@ -8105,7 +7681,7 @@ L471D               leax      L58E3,pcr
 L4724               leax      L58F7,pcr
                     lbra      L4840
 
-L472B               leax      $5902,pcr
+L472B               leax      L5902,pcr
                     pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -8219,14 +7795,14 @@ L480B               leax      $591B,pcr
 L4830               leax      L591E,pcr
                     bra       L4840
 
-L4836               leax      $5929,pcr
+L4836               leax      L5929,pcr
                     bra       L4840
 
-L483C               leax      $5934,pcr
+L483C               leax      L5934,pcr
 L4840               pshs      x
                     lbra      L4B21
 
-L4845               leax      $593F,pcr
+L4845               leax      L593F,pcr
                     pshs      x
                     lbsr      L5756
                     leas      $02,s
@@ -8282,7 +7858,7 @@ L48AE               std       $06,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     lbra      L4C78
 
 L48C9               ldd       $10,s
@@ -8332,7 +7908,7 @@ L48E7               cmpx      #$007A
                     lbeq      L471D
                     cmpx      #$0044
                     lbeq      L4724
-                    cmpx      #start
+                    cmpx      #_start
                     lbeq      L472B
                     cmpx      #$007C
                     lbeq      L4751
@@ -8511,7 +8087,7 @@ L4B21               lbsr      L576F
 L4B24               leas      $02,s
                     lbra      L4D75
 
-L4B29               leax      $5982,pcr
+L4B29               leax      L5982,pcr
                     lbra      L4BAD
 
 L4B30               ldd       $10,s
@@ -8521,11 +8097,11 @@ L4B30               ldd       $10,s
                     bne       L4B55
                     ldd       $06,s
                     pshs      d
-                    leax      L5985,pcr
+                    leax      $5985,pcr
 L4B47               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L4D75
 
@@ -8653,7 +8229,7 @@ L4C5D               ldd       $10,s
 L4C6F               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
 L4C78               leas      $08,s
                     lbra      L4D75
 
@@ -8759,7 +8335,7 @@ L4D5E               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
 L4D75               leas      $08,s
                     puls      pc,u
 L4D79               pshs      u
@@ -8805,37 +8381,37 @@ L4DD0               leax      L59C7,pcr
                     lbsr      L576F
                     lbra      L5470
 
-L4DDC               leax      $59EA,pcr
+L4DDC               leax      L59EA,pcr
                     bra       L4E1C
 
-L4DE2               leax      $59F1,pcr
+L4DE2               leax      L59F1,pcr
                     bra       L4E2F
 
-L4DE8               leax      $59F7,pcr
+L4DE8               leax      L59F7,pcr
                     bra       L4E2F
 
-L4DEE               leax      $59FD,pcr
+L4DEE               leax      L59FD,pcr
                     bra       L4E2F
 
 L4DF4               leax      L5A03,pcr
                     bra       L4E2F
 
-L4DFA               leax      $5A09,pcr
+L4DFA               leax      L5A09,pcr
                     bra       L4E2F
 
-L4E00               leax      $5A0F,pcr
+L4E00               leax      L5A0F,pcr
                     bra       L4E2F
 
-L4E06               leax      $5A15,pcr
+L4E06               leax      L5A15,pcr
                     bra       L4E2F
 
 L4E0C               leax      $5A1A,pcr
                     bra       L4E2F
 
-L4E12               leax      $5A20,pcr
+L4E12               leax      L5A20,pcr
                     bra       L4E1C
 
-L4E18               leax      $5A26,pcr
+L4E18               leax      L5A26,pcr
 L4E1C               pshs      x
                     lbsr      L520E
                     leas      $02,s
@@ -8843,12 +8419,12 @@ L4E1C               pshs      x
                     subd      #$0002
                     lbra      L5229
 
-L4E2B               leax      $5A2C,pcr
+L4E2B               leax      L5A2C,pcr
 L4E2F               pshs      x
                     lbsr      L520E
                     lbra      L5470
 
-L4E37               leax      $5A33,pcr
+L4E37               leax      L5A33,pcr
                     bra       L4E59
 
 L4E3D               leax      L5A39,pcr
@@ -8857,13 +8433,13 @@ L4E3D               leax      L5A39,pcr
 L4E43               leax      L5A41,pcr
                     bra       L4E59
 
-L4E49               leax      $5A48,pcr
+L4E49               leax      L5A48,pcr
                     bra       L4E59
 
-L4E4F               leax      $5A4F,pcr
+L4E4F               leax      L5A4F,pcr
                     bra       L4E59
 
-L4E55               leax      $5A55,pcr
+L4E55               leax      L5A55,pcr
 L4E59               pshs      x
                     lbsr      L520E
                     leas      $02,s
@@ -8962,7 +8538,7 @@ L4F6B               ldd       #$0004
 L4F72               lbsr      L5130
 L4F75               leas      $04,s
                     puls      pc,u
-L4F79               leax      $5A6A,pcr
+L4F79               leax      L5A6A,pcr
                     pshs      x
                     lbsr      L522D
                     leas      $02,s
@@ -8977,11 +8553,11 @@ L4F8C               cmpu      #$0005
 
 L4F97               ldd       #$0037
 L4F9A               pshs      d
-                    leax      $5A72,pcr
+                    leax      L5A72,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L4FAD               cmpu      #$0005
@@ -8989,25 +8565,25 @@ L4FAD               cmpu      #$0005
                     leax      L5A7D,pcr
                     bra       L4FBD
 
-L4FB9               leax      $5A84,pcr
+L4FB9               leax      L5A84,pcr
 L4FBD               tfr       x,d
                     pshs      d
                     lbsr      L522D
                     lbra      L5205
 
-L4FC7               leax      $5A8B,pcr
+L4FC7               leax      L5A8B,pcr
                     bra       L4FE3
 
-L4FCD               leax      $5A91,pcr
+L4FCD               leax      L5A91,pcr
                     bra       L4FE3
 
-L4FD3               leax      $5A97,pcr
+L4FD3               leax      L5A97,pcr
                     bra       L4FE3
 
 L4FD9               leax      L5A9D,pcr
                     bra       L4FE3
 
-L4FDF               leax      $5AA3,pcr
+L4FDF               leax      L5AA3,pcr
 L4FE3               pshs      x
                     lbsr      L522D
                     leas      $02,s
@@ -9015,7 +8591,7 @@ L4FE3               pshs      x
                     addd      #$0008
                     lbra      L5229
 
-L4FF2               leax      $5AAA,pcr
+L4FF2               leax      L5AAA,pcr
                     bra       L5048
 
 L4FF8               cmpu      #$0005
@@ -9023,12 +8599,12 @@ L4FF8               cmpu      #$0005
                     leax      L5AB0,pcr
                     bra       L501A
 
-L5004               leax      $5AB6,pcr
+L5004               leax      L5AB6,pcr
                     bra       L501A
 
 L500A               cmpu      #$0005
                     bne       L5016
-                    leax      $5ABC,pcr
+                    leax      L5ABC,pcr
                     bra       L501A
 
 L5016               leax      L5AC2,pcr
@@ -9039,27 +8615,27 @@ L501A               tfr       x,d
 L5020               leax      L5AC8,pcr
                     bra       L5048
 
-L5026               leax      $5ACE,pcr
+L5026               leax      L5ACE,pcr
                     bra       L5048
 
-L502C               leax      $5AD4,pcr
+L502C               leax      L5AD4,pcr
                     bra       L5048
 
-L5032               leax      $5ADA,pcr
+L5032               leax      L5ADA,pcr
                     bra       L5048
 
-L5038               leax      $5AE0,pcr
+L5038               leax      L5AE0,pcr
                     bra       L5048
 
-L503E               leax      $5AE6,pcr
+L503E               leax      L5AE6,pcr
                     bra       L5048
 
-L5044               leax      $5AEC,pcr
+L5044               leax      L5AEC,pcr
 L5048               pshs      x
 L504A               lbsr      L522D
                     lbra      L5470
 
-L5050               leax      $5AF2,pcr
+L5050               leax      L5AF2,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -9151,7 +8727,7 @@ L5130               pshs      u,d
                     pshs      d
                     lbsr      L57C3
                     leas      $02,s
-                    leax      $5B07,pcr
+                    leax      L5B07,pcr
                     pshs      x
                     lbsr      L576F
                     leas      $02,s
@@ -9175,7 +8751,7 @@ L518B               cmpu      #$0000
                     std       ,s
                     bra       L51A3
 
-L5198               leax      $5B0E,pcr
+L5198               leax      L5B0E,pcr
                     pshs      x
                     lbsr      L5794
                     leas      $02,s
@@ -9278,7 +8854,7 @@ L5266               std       $02,s
 L5274               leax      ,u
                     bra       L528C
 
-L5278               leax      L5B11,pcr
+L5278               leax      $5B11,pcr
                     bra       L5288
 
 L527E               leax      $5B15,pcr
@@ -9400,14 +8976,14 @@ L536D               ldd       $0e,s
 
 L5376               cmpu      #$0057
                     lbne      L5425
-                    leax      $5B21,pcr
+                    leax      L5B21,pcr
                     bra       L5396
 
 L5384               cmpu      #$0057
                     lbeq      L5425
                     cmpu      #$0059
                     bne       L53A0
-                    leax      $5B26,pcr
+                    leax      L5B26,pcr
 L5396               pshs      x
                     lbsr      L576F
                     leas      $02,s
@@ -9440,11 +9016,11 @@ L53CE               ldd       $04,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      $5B2B,pcr
+                    leax      L5B2B,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     ldd       $000F
                     addd      #$0002
@@ -9554,7 +9130,7 @@ L54C9               ldd       #$0023
                     ldd       $0a,s
                     lbra      L5605
 
-L54D8               leax      $5B4F,pcr
+L54D8               leax      L5B4F,pcr
                     pshs      x
                     lbsr      L5794
                     leas      $02,s
@@ -9653,7 +9229,7 @@ L55AA               ldd       ,u
                     andb      #$30
                     cmpd      #$0030
                     bne       L55BD
-                    leax      $5B56,pcr
+                    leax      L5B56,pcr
                     pshs      x
                     bra       L55C3
 
@@ -9725,7 +9301,7 @@ L5654               ldd       $00B0,y
                     pshs      d
                     lbsr      L5794
                     leas      $02,s
-                    leax      $5B69,pcr
+                    leax      L5B69,pcr
                     pshs      x
                     lbsr      L5794
                     leas      $02,s
@@ -9734,7 +9310,7 @@ L5654               ldd       $00B0,y
                     std       $000F
                     bra       L56B8
 
-L5673               leax      L5B6C,pcr
+L5673               leax      $5B6C,pcr
 L5677               pshs      x
                     lbsr      L0450
 L567C               leas      $02,s
@@ -9773,11 +9349,11 @@ L56D0               pshs      u
                     ldx       $04,s
                     bra       L571F
 
-L56D6               leax      $5B78,pcr
+L56D6               leax      L5B78,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
-L56E1               leax      $5B7F,pcr
+L56E1               leax      L5B7F,pcr
                     bra       L571B
 
 L56E7               leax      L5B83,pcr
@@ -9866,7 +9442,7 @@ L5794               pshs      u
                     pshs      d
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
 L57A1               leas      $04,s
                     puls      pc,u
 L57A5               pshs      u
@@ -9942,7 +9518,7 @@ L5832               pshs      u
 L583C               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L5849               pshs      u
@@ -9958,38 +9534,23 @@ L5849               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
                     bge       $58E8
                     neg       L002C
                     com       >L006C
-                    fcb       $62
-                    com       L7220
-                    neg       L006C
-                    fcb       $62
-                    fcb       $72
-                    fcb       $61
-                    bra       L587F
-
-L587F               com       $0C,s
-                    fcb       $72
-                    fcb       $61
-                    neg       L0075
-                    jmp       $0b,s
-                    jmp       $0f,s
-                    asr       L6E20
-                    clr       -$10,s
-                    fcb       $65
-                    fcb       $72
-                    fcb       $61
-                    lsr       $6F72
-                    bra       L58D0
-                    bra       L5898
-
+                    fcc       /bsr /
+                    fcb       $00
+                    fcc       /lbra /
+                    fcb       $00
+L587F               fcc       /clra/
+                    fcb       $00
+                    fcc       /unknown operator : /
+                    fcb       $00
 L5898               bra       L590A
                     com       L6873
-                    bra       $58C4
+                    bra       L58C4
                     com       $0d,x
                     neg       L006C
                     fcb       $62
@@ -10000,108 +9561,81 @@ L5898               bra       L590A
                     bge       $591D
                     com       $0d,x
                     neg       L0063
-                    com       $0d,s
-                    fcb       $75
-                    inc       -$0C,s
-                    neg       L0063
-                    com       -$0b,s
-                    lsr       $09,s
-                    ror       >L0063
-                    com       $04,s
-                    rol       -$0a,s
-                    neg       L0063
-                    com       $01,s
-                    com       $6C00
-L58CA               com       $03,s
-                    fcb       $61
-                    com       L7200
-L58D0               com       $03,s
-                    inc       -$0d,s
-                    fcb       $72
-                    neg       L0063
-                    com       -$0b,s
-                    tst       $0f,s
-                    lsr       0,x
-L58DD               com       $03,s
-                    tst       $0f,s
-                    lsr       0,x
+                    fcc       /cmult/
+                    fcb       $00
+L58B7               fcc       /ccudiv/
+                    fcb       $00
+L58BE               fcc       /ccdiv/
+                    fcb       $00
+L58C4               fcc       /ccasl/
+                    fcb       $00
+L58CA               fcc       /ccasr/
+                    fcb       $00
+L58D0               fcc       /cclsr/
+                    fcb       $00
+L58D6               fcc       /ccumod/
+                    fcb       $00
+L58DD               fcc       /ccmod/
+                    fcb       $00
 L58E3               jmp       $05,s
                     asr       $01,s
                     tst       $0020
                     jmp       $05,s
                     asr       $02,s
                     tst       $0020
-                    com       $6263
-                    fcb       $61
-                    bra       $5918
-                    leax      0,x
+                    fcc       /sbca #0/
+                    fcb       $00
 L58F7               com       $0f,s
                     tst       $01,s
                     tst       $0020
-                    com       $0f,s
-                    tst       $02,s
-                    neg       L006C
-                    fcb       $65
-                    fcb       $61
-                    asl       L2000
-L5908               inc       $05,s
-L590A               fcb       $61
-                    com       L2000
+                    fcc       /comb/
+                    fcb       $00
+L5902               fcc       /leax /
+                    fcb       $00
+L5908               fcb       $6C,$65
+L590A               fcb       $61,$73,$20
+                    fcb       $00
 L590E               bge       $5988
                     tst       $0000
-L5912               dec       -$0d,s
-                    fcb       $72
-                    bra       L5917
-
+L5912               fcc       /jsr /
+                    fcb       $00
 L5917               com       $6578
                     neg       L006C
                     lsr       0,x
 L591E               fcb       $61
                     com       L6C62
                     tst       $0020
-                    fcb       $72
-                    clr       $0C,s
-                    fcb       $61
-                    neg       L0061
+                    fcc       /rola/
+                    fcb       $00
+L5929               fcb       $61
                     com       L7261
                     tst       $0020
-                    fcb       $72
-                    clr       -$0e,s
-                    fcb       $62
-                    neg       L006C
-                    com       L7261
+                    fcc       /rorb/
+                    fcb       $00
+L5934               inc       -$0d,s
+                    fcb       $72,$61
                     tst       $0020
-                    fcb       $72
-                    clr       -$0e,s
-                    fcb       $62
-                    neg       L006C
-                    lsr       -$07,s
-                    bra       L5944
-
-L5944               inc       $04,s
-                    fcb       $75
-                    bra       L5949
-
-L5949               inc       $05,s
-                    fcb       $61
-                    asl       L2000
+                    fcc       /rorb/
+                    fcb       $00
+L593F               fcc       /ldy /
+                    fcb       $00
+L5944               fcc       /ldu /
+                    fcb       $00
+L5949               fcc       /leax /
+                    fcb       $00
 L594F               bcs       L59B5
                     bge       L5978
                     com       $0d,x
                     neg       $0064
-                    bge       $597E
+                    bge       L597E
                     com       $0d,x
                     neg       $0073
                     fcb       $65
                     asl       >L0061
-                    lsr       $03,s
-                    fcb       $61
-                    bra       $5989
-                    leax      0,x
-L5968               com       $6263
-                    fcb       $61
-                    bra       L5991
-                    leax      0,x
+                    fcc       /dca #0/
+                    fcb       $00
+L5968               fcc       /sbca #0/
+                    fcb       $00
 L5970               bcs       $59D6
                     bge       L5999
                     com       $0d,x
@@ -10109,26 +9643,24 @@ L5970               bcs       $59D6
 L5978               inc       -$0e,s
                     fcb       $61
                     tst       $0020
-                    com       $0C,s
-                    fcb       $72
-                    fcb       $62
-                    neg       L006C
-                    lsr       0,x
-L5985               bra       L59FA
-                    lsr       L2563
-                    bra       L59B9
-                    leas      $0C,y
-                    com       $0D00
+                    fcb       $63
+L597E               fcb       $6C,$72,$62
+                    fcb       $00
+L5982               inc       $04,s
+                    neg       $0020
+                    com       L7425
+                    com       0,y
+                    blt       L59BF
+                    bge       L5A02
+                    tst       $0000
 L5991               com       $0d,s
                     neg       >$0073
                     lsr       >$0073
-L5999               fcb       $75
-                    fcb       $62
+L5999               fcb       $75,$62
                     neg       L0061
                     lsr       $04,s
                     neg       L006C
-                    fcb       $65
-                    fcb       $61
+                    fcb       $65,$61
                     neg       $0020
                     fcb       $65
                     asl       $6720
@@ -10137,265 +9669,212 @@ L5999               fcb       $75
                     com       $0d,x
                     neg       $0064
                     bge       L59B3
-L59B3               inca
-                    fcb       $45
-L59B5               fcb       $41
-                    bra       L5A19
-                    fcb       $72
-L59B9               asr       0,x
+L59B3               fcb       $4C,$45
+L59B5               fcc       /A arg/
+                    fcb       $00
 L59BB               bra       L5A31
                     ror       -$0e,s
-                    bra       $59E6
+L59BF               bra       L59E6
                     com       $0C,y
-                    bcs       $5A28
+                    bcs       L5A28
                     tst       $0000
 L59C7               inc       $04,s
                     fcb       $61
                     bra       L59FC
-                    bge       $5A46
+                    bge       L5A46
                     tst       $0020
                     clr       -$0e,s
 L59D2               fcb       $61
                     bra       L5A06
-                    bge       $5A4F
+                    bge       L5A4F
                     tst       $0020
                     clr       -$0e,s
                     fcb       $61
                     bra       L5A10
                     bge       L5A58
                     tst       $0020
-                    clr       -$0e,s
-                    fcb       $61
-                    bra       $5A1A
-                    bge       $5A61
-                    neg       L005F
-                    inc       $0d,s
-                    clr       -$0a,s
-                    fcb       $65
-                    neg       L005F
-                    inc       $01,s
-                    lsr       $04,s
-                    neg       L005F
-                    inc       -$0d,s
-L59FA               fcb       $75
-                    fcb       $62
-L59FC               neg       L005F
-                    inc       $0d,s
-                    fcb       $75
-                    inc       0,x
+                    fcc       /ora /
+L59E6               fcb       $33,$2C,$78
+                    fcb       $00
+L59EA               clrb
+                    fcc       /lmove/
+                    fcb       $00
+L59F1               clrb
+                    fcc       /ladd/
+                    fcb       $00
+L59F7               clrb
+                    fcc       /lsub/
+L59FC               fcb       $00
+L59FD               clrb
+                    fcc       /lmul/
+L5A02               fcb       $00
 L5A03               clrb
-                    inc       $04,s
-L5A06               rol       -$0a,s
-                    neg       L005F
-                    inc       $0d,s
-                    clr       $04,s
-L5A0E               neg       L005F
-L5A10               inc       $01,s
-                    jmp       $04,s
-                    neg       L005F
+                    fcb       $6C,$64
+L5A06               fcb       $69,$76
+                    fcb       $00
+L5A09               clrb
+                    fcc       /lmod/
+L5A0E               fcb       $00
+L5A0F               clrb
+L5A10               fcc       /land/
+                    fcb       $00
+L5A15               clrb
                     inc       $0f,s
                     fcb       $72
-L5A19               neg       L005F
-                    inc       -$08,s
-                    clr       -$0e,s
                     neg       L005F
-                    inc       -$0d,s
-                    asl       $0C,s
-                    neg       L005F
-                    inc       -$0d,s
-                    asl       -$0e,s
-                    neg       L005F
-                    inc       $03,s
-                    tst       -$10,s
+                    fcc       /lxor/
+                    fcb       $00
+L5A20               clrb
+                    fcc       /lshl/
+                    fcb       $00
+L5A26               clrb
+                    fcb       $6C
+L5A28               fcb       $73,$68,$72
+                    fcb       $00
+L5A2C               clrb
+                    fcc       /lcmp/
 L5A31               fcb       $72
-                    neg       L005F
-                    inc       $0e,s
-                    fcb       $65
-                    asr       0,x
+                    fcb       $00
+L5A33               clrb
+                    fcc       /lneg/
+                    fcb       $00
 L5A39               clrb
-                    inc       $03,s
-                    clr       $0d,s
-                    neg       $6C00
+                    fcc       /lcompl/
+                    fcb       $00
 L5A41               clrb
-                    inc       $09,s
-                    lsr       $6F6C
-                    neg       L005F
-                    inc       -$0b,s
-                    lsr       $6F6C
-                    neg       L005F
-                    inc       $09,s
-                    jmp       $03,s
-                    neg       L005F
-                    inc       $04,s
-L5A58               fcb       $65
-                    com       0,x
-L5A5B               com       $0f,s
-                    lsr       $07,s
-                    fcb       $65
-                    jmp       0,y
-                    blt       $5A84
-                    inc       $0f,s
-                    jmp       $07,s
-                    com       >L005F
-                    lsr       -$0d,s
-                    lsr       L6163
-                    fcb       $6b
-                    neg       $0020
-                    inc       $04,s
-                    fcb       $61
+                    fcc       /lito/
+L5A46               fcb       $6C
+                    fcb       $00
+L5A48               clrb
+                    fcc       /lutol/
+                    fcb       $00
+L5A4F               clrb
+                    fcc       /linc/
+                    fcb       $00
+L5A55               clrb
+                    fcb       $6C,$64
+L5A58               fcb       $65,$63
+                    fcb       $00
+L5A5B               fcc       /codgen - longs/
+                    fcb       $00
+L5A6A               clrb
+                    fcc       /dstack/
+                    fcb       $00
+L5A72               bra       L5AE0
+                    lsr       $01,s
                     bra       L5A9D
                     com       $0C,y
                     asl       $0D00
 L5A7D               clrb
-                    ror       $0d,s
-                    clr       -$0a,s
-                    fcb       $65
-                    neg       L005F
-                    lsr       $0d,s
-                    clr       -$0a,s
-                    fcb       $65
-                    neg       L005F
-                    lsr       $01,s
-                    lsr       $04,s
-                    neg       L005F
-                    lsr       -$0d,s
-                    fcb       $75
-                    fcb       $62
-                    neg       L005F
-                    lsr       $0d,s
-                    fcb       $75
-                    inc       0,x
+                    fcc       /fmove/
+                    fcb       $00
+L5A84               clrb
+                    fcc       /dmove/
+                    fcb       $00
+L5A8B               clrb
+                    fcc       /dadd/
+                    fcb       $00
+L5A91               clrb
+                    fcc       /dsub/
+                    fcb       $00
+L5A97               clrb
+                    fcc       /dmul/
+                    fcb       $00
 L5A9D               clrb
-                    lsr       $04,s
-                    rol       -$0a,s
-                    neg       L005F
-                    lsr       $03,s
-                    tst       -$10,s
-                    fcb       $72
-                    neg       L005F
-                    lsr       $0e,s
-                    fcb       $65
-                    asr       0,x
+                    fcc       /ddiv/
+                    fcb       $00
+L5AA3               clrb
+                    fcc       /dcmpr/
+                    fcb       $00
+L5AAA               clrb
+                    fcc       /dneg/
+                    fcb       $00
 L5AB0               clrb
-                    ror       $09,s
-                    jmp       $03,s
-                    neg       L005F
-                    lsr       $09,s
-                    jmp       $03,s
-                    neg       L005F
-                    ror       $04,s
-                    fcb       $65
-                    com       0,x
+                    fcc       /finc/
+                    fcb       $00
+L5AB6               clrb
+                    fcc       /dinc/
+                    fcb       $00
+L5ABC               clrb
+                    fcc       /fdec/
+                    fcb       $00
 L5AC2               clrb
-                    lsr       $04,s
-                    fcb       $65
-                    com       0,x
+                    fcc       /ddec/
+                    fcb       $00
 L5AC8               clrb
-                    lsr       -$0C,s
-                    clr       $06,s
-                    neg       L005F
-                    ror       -$0C,s
-                    clr       $04,s
-                    neg       L005F
-                    inc       -$0C,s
-                    clr       $04,s
-                    neg       L005F
-                    rol       -$0C,s
-                    clr       $04,s
-                    neg       L005F
-                    fcb       $75
-                    lsr       $6F64
-                    neg       L005F
-                    lsr       -$0C,s
-                    clr       $0C,s
-                    neg       L005F
-                    lsr       -$0C,s
-                    clr       $09,s
-                    neg       L0063
-                    clr       $04,s
-                    asr       $05,s
-                    jmp       0,y
-                    blt       L5B1B
-                    ror       $0C,s
-                    clr       $01,s
-                    lsr       $7300
-L5B02               fcb       $62
-                    com       L7220
-                    neg       L0070
-                    fcb       $75
-                    inc       -$0d,s
-                    bra       L5B85
-                    neg       L0030
-                    bge       L5B11
-L5B11               fcb       $61
+                    fcc       /dtof/
+                    fcb       $00
+L5ACE               clrb
+                    fcc       /ftod/
+                    fcb       $00
+L5AD4               clrb
+                    fcc       /ltod/
+                    fcb       $00
+L5ADA               clrb
+                    fcc       /itod/
+                    fcb       $00
+L5AE0               clrb
+                    fcc       /utod/
+                    fcb       $00
+L5AE6               clrb
+                    fcc       /dtol/
+                    fcb       $00
+L5AEC               clrb
+                    fcc       /dtoi/
+                    fcb       $00
+L5AF2               fcc       /codgen - floats/
+                    fcb       $00
+L5B02               fcc       /bsr /
+                    fcb       $00
+L5B07               fcc       /puls x/
+                    fcb       $00
+L5B0E               leax      $0C,y
+                    neg       L0061
                     jmp       $04,s
                     neg       $006F
                     fcb       $72
                     neg       L0065
                     clr       -$0e,s
-L5B1B               neg       L0063
-                    clr       $0d,s
-                    fcb       $61
                     neg       L0063
-                    inc       -$0e,s
-                    fcb       $62
-                    neg       L0063
-                    clr       $0d,s
-                    fcb       $62
-                    neg       $0020
-                    bcs       L5BA1
-                    fcb       $61
-                    bra       $5B5D
-                    com       L2B0D
+                    fcb       $6F,$6D,$61
+                    fcb       $00
+L5B21               fcc       /clrb/
+                    fcb       $00
+L5B26               fcc       /comb/
+                    fcb       $00
+L5B2B               bra       L5B52
+                    com       L6120
+                    bge       L5BA5
+                    bmi       L5B41
                     bra       $5B5B
                     com       $6220
                     bge       $5BAE
-                    bmi       $5B4A
+                    bmi       L5B4A
                     neg       L0063
-                    clr       $0d,s
-                    neg       L696C
-                    fcb       $65
-                    fcb       $72
-                    bra       $5BBC
-                    fcb       $72
-                    clr       -$0b,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       L005F
-                    ror       $0C,s
-                    fcb       $61
-                    com       $03,s
-                    neg       L002C
-                    neg       L6372
+                    fcb       $6F,$6D
+L5B41               fcc       /piler tro/
+L5B4A               fcc       /uble/
+                    fcb       $00
+L5B4F               clrb
+                    fcb       $66,$6C
+L5B52               fcb       $61,$63,$63
+                    fcb       $00
+L5B56               bge       $5BC8
+                    com       -$0e,s
                     neg       $0073
-                    lsr       $6F72
-                    fcb       $61
-                    asr       $05,s
-                    bra       L5BC9
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $002B
-                    bmi       L5B6C
-L5B6C               lsr       $05,s
-                    fcb       $72
-                    fcb       $65
-                    ror       $05,s
-                    fcb       $72
-                    fcb       $65
-                    jmp       $03,s
-                    fcb       $65
-                    neg       $0072
-                    fcb       $65
-                    inc       0,y
-                    clr       -$10,s
-                    neg       L0065
-                    fcb       $71
+                    fcc       /torage error/
+                    fcb       $00
+L5B69               bmi       $5B96
+                    neg       $0064
+                    fcc       /ereference/
+                    fcb       $00
+L5B78               fcc       /rel op/
+                    fcb       $00
+L5B7F               fcb       $65,$71
                     bra       L5B83
 
 L5B83               jmp       $05,s
-
-L5B85               bra       L5B87
+                    bra       L5B87
 
 L5B87               inc       $05,s
                     bra       L5B8B
@@ -10416,31 +9895,27 @@ L5B9B               inc       $0f,s
                     bra       L5B9F
 
 L5B9F               asl       -$0d,s
-L5BA1               bra       L5BA3
+                    bra       L5BA3
 
 L5BA3               asl       $09,s
-                    bra       L5BA7
+L5BA5               bra       L5BA7
 
 L5BA7               bcs       $5C0D
                     neg       L0025
                     bgt       L5BE5
                     com       >L006C
-                    fcb       $65
-                    fcb       $61
-                    com       L2000
+                    fcc       /eas /
+                    fcb       $00
 L5BB5               bra       L5C23
-                    fcb       $65
-                    fcb       $61
-                    bcs       L5C1E
-                    bra       L5BBD
-
+                    fcc       /ea%c /
+                    fcb       $00
 L5BBD               bcs       $5C22
                     bcs       L5C25
                     bge       $5C33
                     com       -$0e,s
                     tst       $0000
 L5BC7               pshs      u
-L5BC9               lbsr      L5D72
+                    lbsr      L5D72
                     lbsr      L5D64
                     ldd       $0009
                     lbeq      L5DFF
@@ -10458,11 +9933,11 @@ L5BE5               leas      $02,s
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
-                    leax      $5E14,pcr
+                    leax      L5E14,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     bra       L5C2D
 
 L5C03               pshs      u
@@ -10478,7 +9953,7 @@ L5C13               pshs      u
                     pshs      d
                     lbsr      L5D4E
                     leas      $02,s
-L5C1E               ldd       #$0020
+                    ldd       #$0020
 L5C21               pshs      d
 L5C23               ldd       $08,s
 L5C25               pshs      d
@@ -10501,7 +9976,7 @@ L5C34               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $0a,s
                     puls      pc,u
 L5C57               pshs      u
@@ -10522,7 +9997,7 @@ L5C6F               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       $06,s
                     pshs      d
@@ -10540,11 +10015,11 @@ L5C6F               pshs      u
                     std       $000B
                     std       L005C
                     pshs      d
-                    leax      $5E52,pcr
+                    leax      L5E52,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
 L5CB8               ldd       $0017
                     lbeq      L5DFF
@@ -10575,7 +10050,7 @@ L5CEB               pshs      u
 L5CF9               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
 L5D04               puls      pc,u
 L5D06               pshs      u
@@ -10591,7 +10066,7 @@ L5D06               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
 L5D28               puls      pc,u
 L5D2A               pshs      u
@@ -10616,13 +10091,13 @@ L5D4E               pshs      u
                     leax      $5F03,pcr
                     bra       L5D5E
 
-L5D5A               leax      $5F0C,pcr
+L5D5A               leax      L5F0C,pcr
 L5D5E               tfr       x,d
                     pshs      d
                     bra       L5D6C
 
 L5D64               pshs      u
-                    leax      $5F12,pcr
+                    leax      L5F12,pcr
 L5D6A               pshs      x
 L5D6C               lbsr      L576F
                     lbra      L5DFD
@@ -10653,7 +10128,7 @@ L5D90               ldd       L004C
                     clra
                     andb      #$20
                     beq       L5DB5
-                    leax      $5F1A,pcr
+                    leax      L5F1A,pcr
                     pshs      x
                     lbsr      L042D
                     leas      $02,s
@@ -10690,23 +10165,14 @@ L5DF4               ldd       ,s
                     leas      $02,s
 L5DFD               leas      $02,s
 L5DFF               puls      pc,u
-L5E01               ror       $01,s
-                    rol       $0C,s
-                    bra       $5E7A
-                    clr       -$0b,s
-                    fcb       $72
-                    com       $05,s
-                    bra       L5E73
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    com       >$0020
-                    fcb       $72
+L5E01               fcc       /fail source errors/
+                    fcb       $00
+L5E14               bra       $5E88
                     tst       $02,s
                     bra       $5E3F
                     lsr       $0d,x
                     neg       L0025
-                    bgt       $5E58
+                    bgt       L5E58
                     com       L2563
                     bra       L5E97
                     tst       $02,s
@@ -10715,24 +10181,26 @@ L5E01               ror       $01,s
                     neg       $0020
                     ror       $03,s
                     com       0,y
-                    bhi       $5E58
+                    bhi       L5E58
                     bgt       L5E6D
                     com       $220D
                     bra       L5EA0
                     com       $02,s
-                    bra       $5E6E
+                    bra       L5E6E
                     tst       $0000
 L5E40               bra       L5EB6
                     lsr       $6C20
                     bcs       L5E75
                     fcb       $38
                     com       $0D00
-L5E4B               neg       L7368
-L5E4E               com       $2075
-                    neg       $0020
-                    inc       $04,s
-                    lsr       0,y
-                    bls       $5EB8
+L5E4B               fcb       $70,$73,$68
+L5E4E               fcb       $73,$20,$75
+                    fcb       $00
+L5E52               bra       L5EC0
+                    lsr       $04,s
+                    bra       $5E7B
+
+L5E58               clrb
                     bcs       $5EBF
                     tst       $0020
                     inc       $02,s
@@ -10743,18 +10211,17 @@ L5E4E               com       $2075
                     fcb       $65
                     com       $0b,s
                     tst       $0000
-L5E6D               inc       $05,s
-                    fcb       $61
-                    asl       L2000
+L5E6D               fcb       $6C
+L5E6E               fcc       /eax /
+                    fcb       $00
 L5E73               bge       $5EE5
 L5E75               com       -$0e,s
                     tst       $0020
                     neg       L7368
                     com       L2078
                     tst       $0020
-                    inc       $05,s
-                    fcb       $61
-                    asl       L2000
+                    fcc       /leax /
+                    fcb       $00
 L5E87               bge       L5EF9
                     com       -$0e,s
                     tst       $0020
@@ -10766,23 +10233,22 @@ L5E97               com       L7220
                     clrb
                     neg       L726F
                     ror       $0d,x
-L5EA0               bra       $5F0E
-                    fcb       $65
-                    fcb       $61
+L5EA0               bra       L5F0E
+                    fcb       $65,$61
                     com       $2034
                     bge       L5F1C
                     tst       $0000
-L5EAB               bra       $5F1D
+L5EAB               bra       L5F1D
                     com       L6873
-                    bra       $5F16
+                    bra       L5F16
                     tst       $0020
                     inc       $05,s
 L5EB6               fcb       $61
                     asl       L205F
-                    bcs       $5F20
+                    bcs       L5F20
                     bge       L5F2E
                     com       -$0e,s
-                    tst       $0020
+L5EC0               tst       $0020
                     neg       L7368
                     com       L2078
                     tst       $0020
@@ -10793,8 +10259,7 @@ L5EB6               fcb       $61
                     neg       L726F
                     ror       $0d,x
                     bra       $5F44
-                    fcb       $65
-                    fcb       $61
+                    fcb       $65,$61
                     com       $2032
                     bge       L5F52
                     tst       $0020
@@ -10804,36 +10269,33 @@ L5EB6               fcb       $61
 L5EE9               clrb
                     bcs       $5F50
                     bra       $5F53
-                    fcb       $71
-                    fcb       $75
-                    bra       $5F17
+                    fcb       $71,$75
+                    bra       L5F17
                     lsr       $0d,x
                     tst       $0000
-L5EF6               ror       $03,s
-                    fcb       $62
-L5EF9               bra       L5EFB
-
-L5EFB               ror       $04,s
-                    fcb       $62
-                    bra       L5F00
-
-L5F00               bpl       $5F22
+L5EF6               fcb       $66,$63,$62
+L5EF9               fcb       $20
+                    fcb       $00
+L5EFB               fcc       /fdb /
+                    fcb       $00
+L5F00               bpl       L5F22
                     neg       $0076
-                    com       L6563
-                    lsr       $2064
-                    neg       >$0076
-                    com       L6563
-                    lsr       >L0065
-                    jmp       $04,s
-                    com       L6563
-                    lsr       >$0064
-                    fcb       $75
-L5F1C               tst       -$10,s
-                    com       L7472
-                    rol       $0e,s
-                    asr       -$0d,s
-                    neg       $0034
-                    nega
+                    fcc       /sect dp/
+                    fcb       $00
+L5F0C               fcb       $76,$73
+L5F0E               fcb       $65,$63,$74
+                    fcb       $00
+L5F12               fcc       /ends/
+L5F16               fcb       $65
+L5F17               fcb       $63,$74
+                    fcb       $00
+L5F1A               fcb       $64,$75
+L5F1C               fcb       $6D
+L5F1D               fcb       $70,$73,$74
+L5F20               fcb       $72,$69
+L5F22               fcb       $6E,$67,$73
+                    fcb       $00
+L5F26               pshs      u
                     leas      -$15,s
                     lbsr      L42B9
 L5F2E               ldb       $0045
@@ -10948,7 +10410,7 @@ L6004               ldd       #$0008
                     ldd       #$004B
                     bra       L6033
 
-L6020               leax      $6CEC,pcr
+L6020               leax      L6CEC,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -11066,7 +10528,7 @@ L6111               ldb       $0045
                     bra       L60E2
 
 L611E               ldb       $0045
-                    cmpb      #$3d
+L6120               cmpb      #$3d
                     lbne      L628D
                     ldd       $003F
                     addd      #$0050
@@ -11096,7 +10558,7 @@ L6155               ldd       #$005C
                     lbra      L61F7
 
 L6160               cmpx      #$003C
-L6163               beq       L6135
+                    beq       L6135
                     cmpx      #$003D
                     beq       L6155
                     lbra      L628D
@@ -11104,7 +10566,7 @@ L6163               beq       L6135
 L616D               ldb       $0045
                     sex
                     tfr       d,x
-L6172               bra       L619F
+                    bra       L619F
 
 L6174               ldd       #$0055
                     std       $003F
@@ -11224,19 +10686,19 @@ L628D               leas      $15,s
 L6292               pshs      u
                     ldd       #$0006
                     pshs      d
-                    leax      $6CFE,pcr
+                    leax      L6CFE,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$0005
                     pshs      d
-                    leax      $6D05,pcr
+                    leax      L6D05,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$001E
                     pshs      d
-                    leax      $6D0B,pcr
+                    leax      L6D0B,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11248,13 +10710,13 @@ L6292               pshs      u
                     leas      $04,s
                     ldd       #$003B
                     pshs      d
-                    leax      $6D1A,pcr
+                    leax      L6D1A,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    leax      $6D21,pcr
+                    leax      L6D21,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11277,19 +10739,19 @@ L6292               pshs      u
                     std       L0021
                     ldd       #$0002
                     pshs      d
-                    leax      $6D2F,pcr
+                    leax      L6D2F,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$000A
                     pshs      d
-                    leax      $6D34,pcr
+                    leax      L6D34,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$000D
                     pshs      d
-                    leax      $6D3A,pcr
+                    leax      L6D3A,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11303,17 +10765,17 @@ L6292               pshs      u
                     pshs      d
                     leax      L6D46,pcr
                     pshs      x
-L6368               lbsr      L65D0
+                    lbsr      L65D0
                     leas      $04,s
                     ldd       #$0010
                     pshs      d
-L6372               leax      $6D4D,pcr
+                    leax      L6D4D,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
-                    ldd       #start
+                    ldd       #_start
                     pshs      d
-                    leax      $6D56,pcr
+                    leax      L6D56,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11337,19 +10799,19 @@ L6372               leax      $6D4D,pcr
                     leas      $04,s
                     ldd       #$0015
                     pshs      d
-                    leax      $6D6B,pcr
+                    leax      L6D6B,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$0016
                     pshs      d
-                    leax      $6D70,pcr
+                    leax      L6D70,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$0017
                     pshs      d
-                    leax      $6D77,pcr
+                    leax      L6D77,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11361,25 +10823,25 @@ L6372               leax      $6D4D,pcr
                     leas      $04,s
                     ldd       #$0019
                     pshs      d
-                    leax      $6D82,pcr
+                    leax      L6D82,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$001A
                     pshs      d
-                    leax      $6D8B,pcr
+                    leax      L6D8B,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$001B
                     pshs      d
-                    leax      L6D8E,pcr
+                    leax      $6D8E,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$001C
                     pshs      d
-                    leax      $6D96,pcr
+                    leax      L6D96,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11391,13 +10853,13 @@ L6372               leax      $6D4D,pcr
                     leas      $04,s
                     ldd       #$0003
                     pshs      d
-                    leax      $6DA1,pcr
+                    leax      L6DA1,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
                     ldd       #$0007
                     pshs      d
-                    leax      $6DA7,pcr
+                    leax      L6DA7,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
@@ -11407,7 +10869,7 @@ L6372               leax      $6D4D,pcr
                     pshs      x
                     lbsr      L65D0
                     leas      $04,s
-                    leax      $6DB5,pcr
+                    leax      L6DB5,pcr
                     pshs      x
                     lbsr      L652E
                     leas      $02,s
@@ -11418,7 +10880,7 @@ L6372               leax      $6D4D,pcr
                     std       $08,u
                     ldd       #$0002
                     std       $02,u
-                    leax      $6DBB,pcr
+                    leax      L6DBB,pcr
                     pshs      x
                     lbsr      L652E
                     leas      $02,s
@@ -11466,7 +10928,7 @@ L64F9               ldb       $0045
                     sex
                     pshs      d
                     bsr       L6507
-L6500               std       ,s++
+                    std       ,s++
                     bne       L64F6
                     lbra      L6650
 
@@ -11515,8 +10977,8 @@ L6556               ldb       $14,u
                     ldb       [$0C,s]
                     sex
                     cmpd      ,s++
-L6563               bne       L6580
-L6565               ldd       #$0008
+                    bne       L6580
+                    ldd       #$0008
                     pshs      d
                     pshs      u
                     ldd       #$0014
@@ -11617,7 +11079,7 @@ L6622               pshs      u,d
                     std       ,s
                     cmpd      #$FFFF
                     bne       L6640
-                    leax      $6DC1,pcr
+                    leax      L6DC1,pcr
                     pshs      x
                     lbsr      L042D
                     leas      $02,s
@@ -11883,7 +11345,7 @@ L6858               ldb       $0045
                     cmpb      #$6b
                     beq       L683F
                     ldd       $06,s
-L6869               cmpd      #$0028
+                    cmpd      #$0028
                     lbge      L68CB
                     ldd       $02,s
 L6873               pshs      d
@@ -12003,15 +11465,15 @@ L6955               ldd       $0e,s
                     pshs      d
                     ldd       #$000A
                     lbsr      $AFAC
-L6963               pshs      d
+                    pshs      d
                     leax      $08,s
                     lbsr      LAE0D
                     bsr       L6970
-L696C               leas      $0C,s
-L696E               puls      pc,u
+                    leas      $0C,s
+                    puls      pc,u
 L6970               pshs      u
                     ldd       $0C,s
-L6974               beq       L69B6
+                    beq       L69B6
                     leas      -$02,s
                     leax      $01BA,y
                     stx       ,s
@@ -12064,7 +11526,7 @@ L69D5               ldb       $0045
 L69DD               ldb       $0045
                     cmpb      #$27
                     lbeq      L6ABC
-                    leax      $6DCF,pcr
+                    leax      L6DCF,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -12076,7 +11538,7 @@ L69F3               pshs      u
 
 L69F9               ldd       L004C
                     bne       L6A1D
-                    leax      $6DEF,pcr
+                    leax      L6DEF,pcr
                     pshs      x
                     leax      $0096,y
                     pshs      x
@@ -12114,11 +11576,11 @@ L6A37               clra
                     pshs      d
                     ldd       #$005F
                     pshs      d
-                    leax      $6E0A,pcr
+                    leax      L6E0A,pcr
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $08,s
                     bra       L6A99
 
@@ -12170,11 +11632,11 @@ L6ABF               puls      pc,u
 L6AC1               pshs      u
                     ldd       $003D
                     bne       L6AD6
-                    leax      $6E23,pcr
+                    leax      L6E23,pcr
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $04,s
 L6AD6               ldd       $04,s
                     cmpd      #$0020
@@ -12188,7 +11650,7 @@ L6AE6               ldd       $04,s
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     bra       L6B27
 
@@ -12208,7 +11670,7 @@ L6AFB               ldd       $0064
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $04,s
 L6B27               clra
                     clrb
@@ -12224,7 +11686,7 @@ L6B34               pshs      u
                     pshs      x
                     ldd       $0064
                     pshs      d
-                    lbsr      L9A34
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L6B4B               pshs      u,d
@@ -12426,184 +11888,89 @@ L6CD5               ldb       $05,s
 L6CDA               clra
                     clrb
 L6CDC               puls      pc,u
-L6CDE               fcb       $62
-                    fcb       $61
-                    lsr       0,y
-                    com       $08,s
-                    fcb       $61
-                    fcb       $72
-                    fcb       $61
-                    com       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    neg       L0063
-                    clr       $0e,s
-                    com       $7461
-                    jmp       -$0C,s
-                    bra       $6D65
-                    ror       $6572
-                    ror       $0C,s
-                    clr       -$09,s
-                    neg       $0064
-                    clr       -$0b,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       $0066
-                    inc       $0f,s
-                    fcb       $61
-                    lsr       >$0074
-                    rol       L7065
-                    lsr       $05,s
-                    ror       0,x
-L6D13               com       $7461
-                    lsr       L6963
-                    neg       $0073
-                    rol       -$06,s
-                    fcb       $65
-                    clr       $06,s
-                    neg       $0069
-                    jmp       -$0C,s
-                    neg       $0069
+L6CDE               fcc       /bad character/
+                    fcb       $00
+L6CEC               fcc       /constant overflow/
+                    fcb       $00
+L6CFE               fcc       /double/
+                    fcb       $00
+L6D05               fcc       /float/
+                    fcb       $00
+L6D0B               fcc       /typedef/
+                    fcb       $00
+L6D13               fcc       /static/
+                    fcb       $00
+L6D1A               fcc       /sizeof/
+                    fcb       $00
+L6D21               rol       $0e,s
+                    lsr       >$0069
                     jmp       -$0C,s
                     neg       $0066
-                    inc       $0f,s
-                    fcb       $61
-                    lsr       >L0063
-                    asl       $01,s
-                    fcb       $72
-                    neg       $0073
-                    asl       $0f,s
-                    fcb       $72
-                    lsr       >L0061
-                    fcb       $75
-                    lsr       L6F00
-L6D3F               fcb       $65
-                    asl       $7465
-                    fcb       $72
-                    jmp       0,x
-
-L6D46               lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-                    neg       $0072
-                    fcb       $65
-                    asr       $09,s
-                    com       $7465
-                    fcb       $72
-                    neg       $0067
-                    clr       -$0C,s
-                    clr       0,x
-L6D5B               fcb       $72
-                    fcb       $65
-                    lsr       $7572
-                    jmp       0,x
-
+                    fcc       /loat/
+                    fcb       $00
+L6D2F               fcc       /char/
+                    fcb       $00
+L6D34               fcc       /short/
+                    fcb       $00
+L6D3A               fcc       /auto/
+                    fcb       $00
+L6D3F               fcc       /extern/
+                    fcb       $00
+L6D46               fcc       /direct/
+                    fcb       $00
+L6D4D               fcc       /register/
+                    fcb       $00
+L6D56               fcc       /goto/
+                    fcb       $00
+L6D5B               fcc       /return/
+                    fcb       $00
 L6D62               rol       $06,s
                     neg       $0077
-                    asl       $09,s
-                    inc       $05,s
-                    neg       L0065
-                    inc       -$0d,s
-                    fcb       $65
-                    neg       $0073
-                    asr       L6974
-                    com       $08,s
-                    neg       L0063
-                    fcb       $61
-                    com       L6500
-L6D7C               fcb       $62
-                    fcb       $72
-                    fcb       $65
-                    fcb       $61
-                    fcb       $6b
-                    neg       L0063
-                    clr       $0e,s
-                    lsr       L696E
-                    fcb       $75
-                    fcb       $65
+                    fcc       /hile/
+                    fcb       $00
+L6D6B               fcc       /else/
+                    fcb       $00
+L6D70               fcc       /switch/
+                    fcb       $00
+L6D77               fcc       /case/
+                    fcb       $00
+L6D7C               fcc       /break/
+                    fcb       $00
+L6D82               fcc       /continue/
+                    fcb       $00
+L6D8B               lsr       $0f,s
                     neg       $0064
-                    clr       0,x
-L6D8E               lsr       $05,s
-                    ror       $01,s
-                    fcb       $75
-                    inc       -$0C,s
-                    neg       $0066
-                    clr       -$0e,s
+                    fcc       /efault/
+                    fcb       $00
+L6D96               ror       $0f,s
+                    fcb       $72
                     neg       $0073
-                    lsr       L7275
-                    com       -$0C,s
-                    neg       L0075
-                    jmp       $09,s
-                    clr       $0e,s
-                    neg       L0075
-                    jmp       -$0d,s
-                    rol       $07,s
-                    jmp       $05,s
-                    lsr       0,x
-L6DB0               inc       $0f,s
-                    jmp       $07,s
-                    neg       L0065
-                    fcb       $72
-                    fcb       $72
-                    jmp       $0f,s
-                    neg       L006C
-                    com       L6565
-                    fcb       $6b
-                    neg       $006F
-                    fcb       $75
-                    lsr       $206F
-                    ror       0,y
-                    tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       >L0075
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    tst       $09,s
-                    jmp       $01,s
-                    lsr       $6564
-                    bra       L6E40
-                    asl       $01,s
-                    fcb       $72
-                    fcb       $61
-                    com       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L6E4A
-                    clr       $0e,s
-                    com       $7461
-                    jmp       -$0C,s
-                    neg       $0077
-                    bmi       L6DF2
-L6DF2               com       $01,s
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       L6E71
-                    lsr       L7269
-                    jmp       $07,s
-                    com       L2066
-                    rol       $0C,s
-                    fcb       $65
-                    neg       L0025
-                    com       $05,y
-                    lsr       0,x
-L6E0F               fcb       $75
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    tst       $09,s
-                    jmp       $01,s
-                    lsr       $6564
-                    bra       $6E90
-                    lsr       L7269
-L6E20               jmp       $07,s
-                    neg       $0020
-                    ror       $03,s
-                    com       0,y
-                    bhi       L6E2A
+                    fcc       /truct/
+                    fcb       $00
+L6DA1               fcc       /union/
+                    fcb       $00
+L6DA7               fcc       /unsigned/
+                    fcb       $00
+L6DB0               fcc       /long/
+                    fcb       $00
+L6DB5               fcc       /errno/
+                    fcb       $00
+L6DBB               fcc       /lseek/
+                    fcb       $00
+L6DC1               fcc       /out of memory/
+                    fcb       $00
+L6DCF               fcc       /unterminated character constant/
+                    fcb       $00
+L6DEF               asr       $2B00
+L6DF2               fcc       /can't open strings file/
+                    fcb       $00
+L6E0A               fcc       /%c%d/
+                    fcb       $00
+L6E0F               fcc       /unterminated string/
+                    fcb       $00
+L6E23               bra       $6E8B
+                    fcc       /cc "/
+                    fcb       $00
 L6E2A               bhi       $6E39
                     bra       L6E94
                     com       $02,s
@@ -12615,11 +11982,11 @@ L6E36               bhi       $6E45
                     fcb       $72
                     dec       $6220
                     bcs       $6EA4
-L6E40               tst       $0000
+                    tst       $0000
 L6E42               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
-L6E4A               ldu       $04,s
+                    lbsr      stkcheck
+                    ldu       $04,s
                     pshs      u
                     lbsr      L6EAC
                     leas      $02,s
@@ -12635,12 +12002,12 @@ L6E4A               ldu       $04,s
                     pshs      d
                     lbsr      L4623
                     leas      $08,s
-L6E71               ldd       #$0070
-L6E74               bra       L6EA8
+                    ldd       #$0070
+                    bra       L6EA8
 
 L6E76               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L7E9C
@@ -12662,7 +12029,7 @@ L6EA8               std       $06,u
 L6EAA               puls      pc,u
 L6EAC               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       ,u
                     bra       L6ED7
@@ -12672,7 +12039,7 @@ L6EBA               pshs      u
                     bra       L6ED3
 
 L6EC1               pshs      u
-                    lbsr      $3987
+                    lbsr      L3987
                     bra       L6ED3
 
 L6EC8               pshs      u
@@ -12694,14 +12061,14 @@ L6ED7               cmpx      #$0008
 L6EEA               puls      pc,u
 L6EEC               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     lbra      L6F5F
 
 L6EFB               pshs      u
                     ldd       #$0077
-L6F00               pshs      d
+                    pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$0075
@@ -12749,7 +12116,7 @@ L6F5B               std       $06,u
 L6F5F               cmpx      #$0037
                     lbeq      L6EFB
                     cmpx      #$0041
-L6F69               beq       L6F1D
+                    beq       L6F1D
                     cmpx      #$0071
                     beq       L6F81
                     cmpx      #$0070
@@ -12763,7 +12130,7 @@ L6F69               beq       L6F1D
 L6F81               puls      pc,u
 L6F83               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -12853,7 +12220,7 @@ L7028               ldd       $0a,u
 
 L7046               ldd       $0a,u
                     pshs      d
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       #$008F
                     pshs      d
@@ -12973,7 +12340,7 @@ L7176               tfr       u,d
                     puls      pc,u
 L717C               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -13035,7 +12402,7 @@ L71F7               ldd       $04,s
                     pshs      d
                     lbsr      L9754
                     std       ,s++
-L7200               bne       L7229
+                    bne       L7229
                     ldd       $04,s
                     pshs      d
                     lbsr      L6EAC
@@ -13056,7 +12423,7 @@ L7220               std       $06,x
 
 L7229               pshs      u
                     lbsr      L6E42
-L722E               leas      $02,s
+                    leas      $02,s
                     ldd       $04,s
                     pshs      d
                     lbsr      L6F83
@@ -13278,7 +12645,7 @@ L73E6               cmpx      #$0051
                     lbeq      L72EC
                     cmpx      #$005D
                     lbeq      L72EC
-                    cmpx      #$005C
+L7425               cmpx      #$005C
                     lbeq      L72EC
                     cmpx      #$005E
                     lbeq      L72EC
@@ -13300,7 +12667,7 @@ L73E6               cmpx      #$0051
                     lbeq      L735E
 L746B               cmpx      #$004E
                     lbeq      L7372
-L7472               cmpx      #$0053
+                    cmpx      #$0053
                     lbeq      L73AA
                     cmpx      #$004C
                     lbeq      L73AA
@@ -13321,7 +12688,7 @@ L7494               ldd       #$0070
 
 L749E               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       #$0000
                     bra       L74C2
 
@@ -13342,7 +12709,7 @@ L74C2               cmpu      #$000E
 
 L74CB               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       #$0001
@@ -13410,7 +12777,7 @@ L74CB               pshs      u
 
 L7567               pshs      u
                     ldd       #$FFAE
-L756C               lbsr      L010F
+L756C               lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -13466,7 +12833,7 @@ L75DF               leas      $06,s
                     puls      pc,u
 L75E3               pshs      u
                     ldd       #$FFB2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldd       $000F
                     std       ,s
@@ -13502,7 +12869,7 @@ L7627               ldd       ,u
                     cmpd      #$0006
                     bne       L7648
 L7637               pshs      u
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
@@ -13566,7 +12933,7 @@ L7680               ldx       $02,s
 
 L76BF               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $06,u
@@ -13609,7 +12976,7 @@ L7719               leas      $02,s
                     puls      pc,u
 L771D               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L774B
@@ -13635,7 +13002,7 @@ L774B               cmpx      #$0050
 
 L7759               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $12,x
                     cmpd      #$0002
@@ -13645,7 +13012,7 @@ L7759               pshs      u
 
 L7771               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L7790
@@ -13671,7 +13038,7 @@ L77A8               clra
 L77AA               puls      pc,u
 L77AC               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$80
@@ -13698,7 +13065,7 @@ L77AC               pshs      u
 L77E4               puls      pc,u
 L77E6               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -13864,7 +13231,7 @@ L792C               pshs      u
 
 L794A               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -13878,7 +13245,7 @@ L794A               pshs      u
                     addd      #$FFB0
                     std       $0a,s
                     ldd       ,u
-L796E               cmpd      #$0007
+                    cmpd      #$0007
                     bne       L7998
                     ldx       $0a,s
                     bra       L7989
@@ -14113,7 +13480,7 @@ L7B63               pshs      u
 
 L7B83               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$7f
@@ -14146,7 +13513,7 @@ L7BBC               ldd       #$0071
                     puls      pc,u
 L7BD2               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $0a,u
@@ -14296,7 +13663,7 @@ L7D15               leas      $04,s
                     puls      pc,u
 L7D19               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -14455,7 +13822,7 @@ L7E56               ldd       $0e,s
 
 L7E63               pshs      u
                     ldd       #$FFB4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     bsr       L7E9C
@@ -14479,7 +13846,7 @@ L7E95               ldd       #$0071
                     puls      pc,u
 L7E9C               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -14773,7 +14140,7 @@ L812E               leas      $08,s
                     puls      pc,u
 L8132               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$006F
                     beq       L814A
@@ -14786,45 +14153,21 @@ L814A               ldd       #$0001
 L814F               clra
                     clrb
 L8151               puls      pc,u
-L8153               lsr       L7261
-                    jmp       -$0d,s
-                    inc       $01,s
-                    lsr       $696F
-                    jmp       0,x
-
+L8153               fcc       /translation/
+                    fcb       $00
 L815F               bcs       $81D9
                     tst       $0000
-L8163               fcb       $62
-                    rol       $0e,s
-                    fcb       $61
-                    fcb       $72
-                    rol       $206F
-                    neg       L2E00
-L816E               rol       $0e,s
-                    lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-                    rol       $0f,s
-                    jmp       0,x
-
-L817A               rol       $0e,s
-                    lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-                    rol       $0f,s
-                    jmp       0,x
-
-L8186               asl       L2074
-                    fcb       $72
-                    fcb       $61
-                    jmp       -$0d,s
-                    inc       $01,s
-                    lsr       L6500
+L8163               fcc       /binary op./
+                    fcb       $00
+L816E               fcc       /indirection/
+                    fcb       $00
+L817A               fcc       /indirection/
+                    fcb       $00
+L8186               fcc       /x translate/
+                    fcb       $00
 L8192               pshs      u
                     ldd       #$FFA2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$14,s
                     bra       L81AD
 
@@ -14832,7 +14175,7 @@ L819F               leax      L925F,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
-                    lbsr      $5F26
+                    lbsr      L5F26
 L81AD               ldd       $003F
                     cmpd      #$002A
                     beq       L819F
@@ -14852,7 +14195,7 @@ L81AD               ldd       $003F
                     pshs      x
                     lbsr      L916F
                     leas      $02,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L843C
 
 L81E2               lbsr      L8B51
@@ -15082,7 +14425,7 @@ L83A3               ldd       $06,s
                     ldd       $06,s
                     cmpd      #$0003
                     bne       L83F4
-L83DF               leax      $9297,pcr
+L83DF               leax      L9297,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -15113,7 +14456,7 @@ L841C               leas      -$14,x
 L841F               ldd       $003F
                     cmpd      #$0030
                     bne       L842D
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L8228
 
 L842D               ldd       #$0028
@@ -15126,14 +14469,14 @@ L843C               leas      $14,s
                     puls      pc,u
 L8441               pshs      u
                     ldd       #$FFA4
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$12,s
                     lbsr      L8B51
                     std       $10,s
                     tfr       d,x
                     bra       L8469
 
-L8456               leax      $92AB,pcr
+L8456               leax      L92AB,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -15182,7 +14525,7 @@ L848E               ldd       $0a,s
                     ldd       $04,s
                     cmpd      #$000A
                     bne       L84CF
-L84C2               leax      $92BC,pcr
+L84C2               leax      L92BC,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -15243,7 +14586,7 @@ L851A               ldd       $04,s
 L853E               lbsr      L0443
                     bra       L8566
 
-L8543               leax      $92CB,pcr
+L8543               leax      L92CB,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -15265,7 +14608,7 @@ L8566               ldd       $003F
 L8571               ldd       $003F
                     cmpd      #$0030
                     bne       L857F
-                    lbsr      $5F26
+                    lbsr      L5F26
                     lbra      L848E
 
 L857F               ldd       #$0028
@@ -15278,14 +14621,14 @@ L857F               ldd       #$0028
 
 L8593               pshs      u
                     ldd       #$FF9E
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$12,s
                     lbsr      L8B51
                     std       $10,s
                     tfr       d,x
                     bra       L85BB
 
-L85A8               leax      $92DB,pcr
+L85A8               leax      L92DB,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -15450,7 +14793,7 @@ L870C               ldd       $12,s
 L871A               leas      $06,s
                     lbra      L87C3
 
-L871F               lbsr      $5F26
+L871F               lbsr      L5F26
                     ldd       $12,s
                     clra
                     andb      #$30
@@ -15461,7 +14804,7 @@ L871F               lbsr      $5F26
                     lbeq      L878A
                     ldd       #$0002
                     pshs      d
-                    lbsr      $0785
+                    lbsr      L0785
                     leas      $02,s
                     std       $0C,s
                     beq       L878A
@@ -15534,7 +14877,7 @@ L87C3               ldd       $003F
                     leas      $06,s
                     bra       L87D7
 
-L87CF               lbsr      $5F26
+L87CF               lbsr      L5F26
                     leas      $06,s
                     lbra      L85DE
 
@@ -15546,7 +14889,7 @@ L87E1               leas      $12,s
                     puls      pc,u
 L87E6               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       ,u
                     cmpd      $06,s
@@ -15557,7 +14900,7 @@ L87E6               pshs      u
                     ldd       $0a,u
                     cmpd      $08,s
                     beq       L8816
-L8806               leax      $92E9,pcr
+L8806               leax      L92E9,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -15568,7 +14911,7 @@ L8816               clra
                     puls      pc,u
 L881A               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$0010
                     bne       L886B
@@ -15605,7 +14948,7 @@ L886B               ldd       $04,s
                     puls      pc,u
 L886F               pshs      u
                     ldd       #$FFAC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       #$0001
                     std       $0031
@@ -15752,23 +15095,23 @@ L8992               clra
                     ldd       $003F
                     cmpd      #$FFFF
                     bne       L89B0
-                    leax      $92FE,pcr
+                    leax      L92FE,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
-L89B0               lbsr      $5F26
+L89B0               lbsr      L5F26
                     leas      $0a,s
                     puls      pc,u
 L89B7               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldd       $002B
                     std       $02,s
                     clra
                     clrb
                     std       $002B
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $0031
                     addd      #$0001
                     std       $0031
@@ -15885,12 +15228,12 @@ L8ABF               std       $000F
                     puls      pc,u
 L8AC5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     clra
                     clrb
                     std       [$06,s]
-L8AD4               lbsr      $5F26
+L8AD4               lbsr      L5F26
 L8AD7               ldd       $003F
                     cmpd      #$002E
                     lbeq      L8B45
@@ -15930,7 +15273,7 @@ L8B2C               clra
                     clrb
                     std       $10,u
                     stu       ,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L8B3B
 
 L8B38               lbsr      L924A
@@ -15945,14 +15288,14 @@ L8B45               ldd       #$002E
 
 L8B51               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     lbsr      L0641
                     std       -$02,s
                     beq       L8B9A
                     ldd       $0041
                     std       ,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0033
                     bne       L8B96
@@ -15973,7 +15316,7 @@ L8B89               cmpx      #$000F
                     beq       L8B7D
                     cmpx      #$000E
                     beq       L8B82
-L8B93               lbsr      $5F26
+L8B93               lbsr      L5F26
 L8B96               ldd       ,s
                     bra       L8B9C
 
@@ -15983,7 +15326,7 @@ L8B9C               leas      $02,s
                     puls      pc,u
 L8BA0               pshs      u
                     ldd       #$FF98
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$1a,s
                     clra
                     clrb
@@ -16003,7 +15346,7 @@ L8BA0               pshs      u
 
 L8BCC               ldd       #$0001
                     std       $02,s
-L8BD1               lbsr      $5F26
+L8BD1               lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0033
                     lbne      L8EE4
@@ -16015,7 +15358,7 @@ L8BD1               lbsr      $5F26
 L8BEA               ldd       #$0001
                     bra       L8C20
 
-L8BEF               lbsr      $5F26
+L8BEF               lbsr      L5F26
                     ldd       #$0004
                     std       ,s
                     ldd       $003F
@@ -16034,7 +15377,7 @@ L8C13               ldd       #$0006
 
 L8C1D               ldd       #$0004
 L8C20               std       ,s
-L8C22               lbsr      $5F26
+L8C22               lbsr      L5F26
                     lbra      L8EE4
 
 L8C28               clra
@@ -16052,7 +15395,7 @@ L8C2F               clra
                     clra
                     clrb
                     std       $18,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       L0021
                     addd      #$FFFF
                     std       L0021
@@ -16074,11 +15417,11 @@ L8C70               ldx       $18,s
                     ldd       $08,x
                     cmpd      #$0008
                     beq       L8C86
-                    leax      $931E,pcr
+                    leax      L931E,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
-L8C86               lbsr      $5F26
+L8C86               lbsr      L5F26
                     ldd       $003F
                     cmpd      #$0029
                     beq       L8CBC
@@ -16120,7 +15463,7 @@ L8CE5               ldd       L0021
                     clra
                     clrb
                     std       L0021
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $10,s
                     std       L0021
                     ldd       $003F
@@ -16179,7 +15522,7 @@ L8D5C               ldd       ,u
                     ldd       $06,u
                     cmpd      $1a,s
                     beq       L8D91
-L8D7F               leax      $9337,pcr
+L8D7F               leax      L9337,pcr
                     pshs      x
                     lbsr      L0450
                     bra       L8D8F
@@ -16190,7 +15533,7 @@ L8D8F               leas      $02,s
 L8D91               ldd       $12,s
                     cmpd      #$000A
                     bne       L8DA5
-                    leax      $934E,pcr
+                    leax      L934E,pcr
                     pshs      x
                     lbsr      L0450
                     leas      $02,s
@@ -16264,7 +15607,7 @@ L8E2F               ldd       $003F
 L8E37               leas      $04,s
                     bra       L8E43
 
-L8E3B               lbsr      $5F26
+L8E3B               lbsr      L5F26
                     leas      $04,s
                     lbra      L8D17
 
@@ -16323,7 +15666,7 @@ L8EBC               ldd       $003F
                     std       [$20,s]
                     ldd       $0a,u
                     std       [$22,s]
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       ,u
                     bra       L8EF0
 
@@ -16337,7 +15680,7 @@ L8EF0               leas      $1a,s
                     puls      pc,u
 L8EF5               pshs      u
                     ldd       #$FFAA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$0C,s
                     clra
                     clrb
@@ -16350,7 +15693,7 @@ L8F08               ldd       $0a,s
                     lbsr      L0688
                     leas      $02,s
                     std       $0a,s
-                    lbsr      $5F26
+                    lbsr      L5F26
 L8F16               ldd       $003F
                     cmpd      #$0042
                     beq       L8F08
@@ -16359,13 +15702,13 @@ L8F16               ldd       $003F
                     bne       L8F30
                     ldd       $0041
                     std       [$10,s]
-                    lbsr      $5F26
+                    lbsr      L5F26
                     bra       L8F6A
 
 L8F30               ldd       $003F
                     cmpd      #$002D
                     bne       L8F6A
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       $0031
                     addd      #$0001
                     std       $0031
@@ -16431,7 +15774,7 @@ L8FB4               ldd       $0a,s
                     rola
                     addd      #$0020
                     std       $0a,s
-                    lbsr      $5F26
+                    lbsr      L5F26
                     ldd       #$0004
                     pshs      d
                     lbsr      L6622
@@ -16488,7 +15831,7 @@ L9024               ldd       $0a,s
                     puls      pc,u
 L9035               pshs      u
                     ldd       #$FFBC
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
@@ -16514,7 +15857,7 @@ L905D               ldd       ,s
 
 L906B               pshs      u
                     ldd       #$FFB2
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       ,u
@@ -16582,7 +15925,7 @@ L90DD               std       $02,u
                     puls      pc,u
 L90F5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $08,s
                     leas      -$02,s
                     ldd       $06,s
@@ -16639,7 +15982,7 @@ L916A               ldd       $08,s
 
 L916F               pshs      u
                     ldd       #$FF74
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$40,s
                     ldu       [$44,s]
                     lbra      L922C
@@ -16659,7 +16002,7 @@ L9180               ldd       $10,u
                     ldd       #$0014
                     addd      ,s++
                     pshs      d
-                    leax      $9362,pcr
+                    leax      L9362,pcr
                     pshs      x
                     leax      $06,s
                     pshs      x
@@ -16726,195 +16069,57 @@ L922C               stu       -$02,s
                     puls      pc,u
 L923C               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leax      L9375,pcr
                     bra       L9256
 
 L924A               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
-                    leax      $938A,pcr
+                    lbsr      stkcheck
+                    leax      L938A,pcr
 L9256               pshs      x
                     lbsr      L0450
 L925B               leas      $02,s
                     puls      pc,u
-L925F               lsr       $6F6F
-                    bra       $92D1
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       $92CB
-                    fcb       $72
-                    fcb       $61
-                    com       $0b,s
-                    fcb       $65
-                    lsr       $7300
-L9271               ror       -$0b,s
-                    jmp       $03,s
-                    lsr       $696F
-                    jmp       0,y
-                    asl       $05,s
-                    fcb       $61
-                    lsr       $05,s
-                    fcb       $72
-                    bra       L92EF
-                    rol       -$0d,s
-                    com       L696E
-                    asr       0,x
-L9289               com       $746F
-                    fcb       $72
-                    fcb       $61
-                    asr       $05,s
-                    bra       L92F7
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $0066
-                    fcb       $75
-                    jmp       $03,s
-                    lsr       $696F
-                    jmp       0,y
-                    lsr       $7970
-                    fcb       $65
-                    bra       $930B
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L0061
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    bra       $9328
-                    lsr       $6F72
-                    fcb       $61
-                    asr       $05,s
-                    neg       L0061
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    bra       $932B
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $006E
-                    clr       -$0C,s
-                    bra       L9331
-                    jmp       0,y
-                    fcb       $61
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    neg       $0073
-                    lsr       $6F72
-                    fcb       $61
-                    asr       $05,s
-                    bra       $9349
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $0064
-                    fcb       $65
-                    com       $0C,s
-                    fcb       $61
-                    fcb       $72
-L92EF               fcb       $61
-                    lsr       $696F
-                    jmp       0,y
-                    tst       $09,s
-L92F7               com       $6D61
-                    lsr       L6368
-                    neg       $0066
-                    fcb       $75
-                    jmp       $03,s
-                    lsr       $696F
-                    jmp       0,y
-                    fcb       $75
-                    jmp       $06,s
-                    rol       $0e,s
-                    rol       -$0d,s
-                    asl       $05,s
-                    lsr       0,x
-L9312               jmp       $01,s
-                    tst       $05,s
-                    lsr       0,y
-                    lsr       $7769
-                    com       $05,s
-                    neg       $006E
-                    fcb       $61
-                    tst       $05,s
-                    bra       $9387
-                    inc       $01,s
-                    com       $6800
-L9329               com       L7472
-                    fcb       $75
-                    com       -$0C,s
-                    bra       $93A4
-
-L9331               rol       L6E74
-                    fcb       $61
-                    asl       >$0073
-                    lsr       L7275
-                    com       -$0C,s
-                    bra       $93AC
-                    fcb       $65
-                    tst       $02,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $93B3
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       L6368
-                    neg       L0075
-                    jmp       $04,s
-                    fcb       $65
-                    ror       $09,s
-                    jmp       $05,s
-                    lsr       0,y
-                    com       L7472
-                    fcb       $75
-                    com       -$0C,s
-                    fcb       $75
-                    fcb       $72
-                    fcb       $65
-                    neg       L006C
-                    fcb       $61
-                    fcb       $62
-                    fcb       $65
-                    inc       0,y
-                    fcb       $75
-                    jmp       $04,s
-                    fcb       $65
-                    ror       $09,s
-                    jmp       $05,s
-                    lsr       0,y
-                    abx
-                    bra       L9375
-
-L9375               com       $01,s
-                    jmp       $0e,s
-                    clr       -$0C,s
-                    bra       $93E2
-                    ror       $616C
-                    fcb       $75
-                    fcb       $61
-                    lsr       $6520
-                    com       $697A
-                    fcb       $65
-                    neg       $0069
-                    lsr       $05,s
-                    jmp       -$0C,s
-                    rol       $06,s
-                    rol       $05,s
-                    fcb       $72
-                    bra       L9403
-                    rol       -$0d,s
-                    com       L696E
-                    asr       0,x
+L925F               fcc       /too many brackets/
+                    fcb       $00
+L9271               fcc       /function header missing/
+                    fcb       $00
+L9289               fcc       /storage error/
+                    fcb       $00
+L9297               fcc       /function type error/
+                    fcb       $00
+L92AB               fcc       /argument storage/
+                    fcb       $00
+L92BC               fcc       /argument error/
+                    fcb       $00
+L92CB               fcc       /not an argument/
+                    fcb       $00
+L92DB               fcc       /storage error/
+                    fcb       $00
+L92E9               fcc       /declaration mismatch/
+                    fcb       $00
+L92FE               fcc       /function unfinished/
+                    fcb       $00
+L9312               fcc       /named twice/
+                    fcb       $00
+L931E               fcc       /name clash/
+                    fcb       $00
+L9329               fcc       /struct syntax/
+                    fcb       $00
+L9337               fcc       /struct member mismatch/
+                    fcb       $00
+L934E               fcc       /undefined structure/
+                    fcb       $00
+L9362               fcc       /label undefined : /
+                    fcb       $00
+L9375               fcc       /cannot evaluate size/
+                    fcb       $00
+L938A               fcc       /identifier missing/
+                    fcb       $00
 L939D               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
@@ -16963,7 +16168,7 @@ L93F2               ldd       ,s
 L93FC               ldd       #$0001
                     subd      $0e,s
                     pshs      d
-L9403               ldd       $0C,s
+                    ldd       $0C,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
@@ -17046,7 +16251,7 @@ L94A6               ldd       $06,u
                     bne       L94B0
                     ldu       $0a,u
 L94B0               pshs      u
-                    lbsr      $3987
+                    lbsr      L3987
                     leas      $02,s
                     ldd       ,u
                     pshs      d
@@ -17120,7 +16325,7 @@ L9573               leas      $04,s
                     puls      pc,u
 L9577               pshs      u
                     ldd       #$FFAE
-                    lbsr      L010F
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldd       $0a,x
@@ -17336,7 +16541,7 @@ L973E               ldd       $02,s
                     puls      pc,u
 L9754               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L9772
@@ -17357,7 +16562,7 @@ L9772               cmpx      #$0034
                     lbra      L998C
                     pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0034
@@ -17372,7 +16577,7 @@ L9772               cmpx      #$0034
 
 L97AE               pshs      u
                     ldd       #$FFB0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -17503,7 +16708,7 @@ L98ED               leas      $04,s
                     puls      pc,u
 L98F1               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L991B
 
@@ -17528,7 +16733,7 @@ L991B               cmpx      #$005A
                     puls      pc,u
 L9929               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L9947
 
@@ -17556,7 +16761,7 @@ L9947               cmpx      #$005A
                     puls      pc,u
 L9971               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010F
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -17657,7 +16862,7 @@ L9A1F               pshs      u
                     ldd       $06,s
                     bra       L9A45
 
-L9A34               pshs      u
+fprintf             pshs      u
                     ldd       $04,s
                     std       L0070
                     ldd       #$0001
@@ -17666,7 +16871,7 @@ L9A34               pshs      u
                     pshs      x
                     ldd       $08,s
 L9A45               pshs      d
-                    bsr       L9A6C
+                    bsr       doprnt
                     leas      $04,s
                     puls      pc,u
                     pshs      u
@@ -17678,13 +16883,13 @@ L9A45               pshs      d
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       L9A6C
+                    bsr       doprnt
                     leas      $04,s
                     clra
                     clrb
                     stb       [L0070,y]
                     puls      pc,u
-L9A6C               pshs      u
+doprnt              pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L9A84
@@ -20728,382 +19933,148 @@ LB33F               clra
 LB348               bcs       LB33F
                     clra
                     clrb
-LB34C               rts
+exit                rts
                     lbsr      LB358
                     lbsr      LA296
                     ldd       $02,s
                     os9       F$Exit
-LB358               rts
-                    neg       $0003
-                    neg       $0002
-                    rora
-                    fcb       $02
-                    ldx       $0000
-                    fcb       $01
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $000C
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       L008C
-                    com       -$0d,s
-                    lsr       L722E
-                    aslb
-                    aslb
-                    aslb
-                    aslb
-                    aslb
-                    neg       L0078
-                    bra       $B3F1
-                    asl       L7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-                    ror       $0083
-                    aslb
-                    tst       -$08,u
-                    neg       $5873
-                    aslb
-                    rol       L587F
-                    aslb
-                    anda      #$00
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $006D
-                    nega
-                    rol       0,x
-                    neg       L0054
-                    fcb       $41
-                    asl       $0d,y
-                    bgt       LB40F
-                    negb
-                    leax      $03,u
-                    fcb       $45
-                    comb
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    ble       $B406
-                    tstb
-                    asl       $5F64
-                    neg       L006A
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0b,y
-                    ror       $0C,y
-                    rolb
-                    dec       0,x
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-LB40F               dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    bvs       $B477
-                    bpl       $B465
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    rol       $0000
-                    neg       $0000
-                    tst       $000E
-                    neg       $0000
-                    neg       $000E
-                    inc       $0001
-                    jmp       $000F
-                    tst       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0003
-                    neg       $000A
-                    fcb       $02
-                    dec       $0003
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    asr       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    ror       $0000
-                    jmp       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0081
-                    bra       LB4AC
-
-LB4AC               neg       $0000
-                    neg       $0000
-                    neg       L0084
-                    asla
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $87
-                    dec       >$0000
-                    neg       $0000
-                    neg       $0000
-                    ora       #$1C
-                    nega
-                    neg       $0000
-                    neg       $0000
-                    neg       L008E
-                    coma
-                    negb
-                    neg       $0000
-                    neg       $0000
-                    neg       $0091
-                    lsr       L2400
-                    neg       $0000
-                    neg       $0000
-                    anda      L0018
-                    lda       L0080
-                    neg       $0000
-                    neg       $0000
-                    eora      L003E
-                    cmpx      L2000
-                    neg       $0000
-                    neg       $009B
-                    jmp       $0b,s
-                    bvc       LB4EE
-LB4EE               neg       $0000
-                    neg       L009E
-                    fcb       $15
-                    fcb       $02
-                    adcb      >$0000
-                    neg       $0000
-                    sbca      $0d,y
-                    asl       $EBC5
-                    cmpx      $02,s
-                    neg       $00C3
-                    rola
-                    sbcb      $C9CD
-                    lsr       $0067
-                    clra
-                    andb      0,x
-                    fcb       $02
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       $0020
-                    neg       $0040
-                    neg       L0080
-                    fcb       $01
-                    neg       $0002
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       $0020
-                    neg       $0040
-                    neg       $0027
-                    fcb       $10
-                    com       $00E8
-                    neg       $0064
-                    neg       $000A
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+* ------------------------------------------------------------------
+* LB358 - cc1-style init image for the c.comp work block (see _start).
+* First byte is an rts (the exit routine's stub); the table proper
+* follows: count1+block1 -> base, count2+block2 -> base+$78, then two
+* relocation directories.
+* ------------------------------------------------------------------
+LB358               rts                 exit rts stub / table anchor
+                    fdb       $0003     count1 - bytes copied to base
+                    fcb       $00,$02   block1
+                    fcb       $46
+                    fdb       $029E     count2 - bytes copied to base+$78
+* block2 - work block template ($29E bytes)
+                    fcb       $00,$01,$00,$02,$00,$00,$00,$00
+                    fcb       $00,$0C,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$8C
+                    fcc       /cstr.XXXXX/
+                    fcb       $00
+                    fcc       /x expected/
+                    fcb       $00,$06,$83
+                    fcc       /XmXpXsXyX/
+                    fcb       $7F
+                    fcb       $58
+                    fcb       $84,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00
+                    fcb       $6D,$40,$69
+                    fcb       $00,$00
+                    fcc       |TAh-.BP0CESkkkkkkkkkk/(]x_d|
+                    fcb       $00
+                    fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj+f,Yj/
+                    fcb       $00
+                    fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj)X*D/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$09,$00,$00,$00,$0D,$0E
+                    fcb       $00,$00,$00,$0E,$0C,$01,$0E,$0F
+                    fcb       $0D,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$03,$00,$0A,$02,$0A
+                    fcb       $03,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$07
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$06,$00,$0E
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $81
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$00,$00,$84
+                    fcb       $48
+                    fcb       $00,$00,$00,$00,$00,$00,$87
+                    fcb       $7A
+                    fcb       $00,$00,$00,$00,$00,$00,$8A,$1C
+                    fcb       $40
+                    fcb       $00,$00,$00,$00,$00,$8E
+                    fcb       $43,$50
+                    fcb       $00,$00,$00,$00,$00,$91
+                    fcb       $74,$24
+                    fcb       $00,$00,$00,$00,$00,$94,$18,$96
+                    fcb       $80,$00,$00,$00,$00,$98
+                    fcb       $3E
+                    fcb       $BC
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$9B
+                    fcb       $6E,$6B,$28
+                    fcb       $00,$00,$00,$00,$9E,$15,$02,$F9
+                    fcb       $00,$00,$00,$00,$A2
+                    fcb       $2D,$78
+                    fcb       $EB,$C5,$AC
+                    fcb       $62
+                    fcb       $00,$C3
+                    fcb       $49
+                    fcb       $F2,$C9,$CD,$04
+                    fcb       $67,$4F
+                    fcb       $E4,$00,$02,$00,$04,$00,$08,$00
+                    fcb       $10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00,$80,$01,$00,$02,$00,$04,$00
+                    fcb       $08,$00,$10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$01,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$02,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0006
-                    neg       L00B8
-                    neg       L00B6
-                    neg       L00B4
-                    neg       L00B2
-                    neg       L00B0
-                    neg       L00AE
-                    neg       $0003
-                    neg       L0094
-                    neg       L00AC
-                    neg       $0001
-                    com       $0e,y
-                    com       $0f,s
-                    tst       -$10,s
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00
+                    fdb       $0006     nreloc1
+* relocate by module base
+                    fdb       $00B8
+                    fdb       $00B6
+                    fdb       $00B4
+                    fdb       $00B2
+                    fdb       $00B0
+                    fdb       $00AE
+                    fdb       $0003     nreloc2
+* relocate by work base
+                    fdb       $0094
+                    fdb       $00AC
+                    fdb       $0001
+* trailing module name
+                    fcc       /c.comp/
 
                     emod
 eom                 equ       *

--- a/3rdparty/packages/ccompiler/c.link_dis.asm
+++ b/3rdparty/packages/ccompiler/c.link_dis.asm
@@ -4320,11 +4320,9 @@ L28AA               pshs      u
                     stx       $066d,y
                     stb       -$01,x
                     puls      pc,u
-L28BC               blt       L28F1
-                    leas      -$09,y
-                    pshu      y,x,dp
-                    neg       $0034
-                    nega
+L28BC               fcc       /-32768/
+                    fcb       $00
+L28C3               pshs      u
                     ldu       $04,s
                     leas      -$06,s
                     cmpu      #$0000

--- a/3rdparty/packages/ccompiler/c.link_dis.asm
+++ b/3rdparty/packages/ccompiler/c.link_dis.asm
@@ -5048,11 +5048,22 @@ L2EA1               cmpx      #$0064
                     lbeq      L2E84
                     bra       L2E93
                     puls      pc,u
+* ------------------------------------------------------------------
+* L2EB8/L2EC3 - reached ONLY via leax,pcr data pointers (never
+* branched or called), so the linear sweep decoded them as code.  They
+* read as a pair of function-pointer thunks: L2EB8 returns &L2EC3
+* in D; L2EC3 is strlen(4,s) - scan ldb,u+/bne for the NUL, length =
+* (end - start - 1).  But the leading "neg $34 / nega" ($00 $34 $40)
+* prologue would clobber DP $34 and A, which makes no sense as code, so
+* these may instead be data the sweep mis-framed.  Left as code: byte-
+* exact either way and the body reads as a genuine strlen.
+* ------------------------------------------------------------------
 L2EB8               neg       $0034
                     nega
                     leax      >L2EC3,pcr
                     tfr       x,d
                     puls      pc,u
+* L2EC3 - strlen routine (entered via the &L2EC3 pointer returned above):
 L2EC3               neg       $0034
                     nega
                     ldu       $04,s

--- a/3rdparty/packages/ccompiler/c.link_dis.asm
+++ b/3rdparty/packages/ccompiler/c.link_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $04
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       5646
 size                equ       .
@@ -17,32 +17,32 @@ name                equ       *
                     fcs       /c.link/
                     fcb       edition
 
-L0014               lda       ,y+
+copybytes           lda       ,y+
 L0016               sta       ,u+
 L0018               leax      -$01,x
-L001A               bne       L0014
+L001A               bne       copybytes
 L001C               rts
 
-start               pshs      y
+_start              pshs      y
                     pshs      u
                     clra
 L0022               clrb
 L0023               sta       ,u+
-L0025               decb
+                    decb
 L0026               bne       L0023
 L0028               ldx       ,s
 L002A               leau      ,x
 L002C               leax      $068e,x
 L0030               pshs      x
-L0032               leay      $3577,pcr
+L0032               leay      L3577,pcr
 L0036               ldx       ,y++
 L0038               beq       L003E
-L003A               bsr       L0014
+L003A               bsr       copybytes
 L003C               ldu       $02,s
 L003E               leau      >$0060,u
 L0042               ldx       ,y++
 L0044               beq       L0049
-L0046               bsr       L0014
+L0046               bsr       copybytes
 L0048               clra
 L0049               cmpu      ,s
 L004C               beq       L0052
@@ -61,7 +61,7 @@ L0065               lbsr      L0162
 L0068               leas      $04,s
                     puls      x
 L006C               stx       $021a,u
-L0070               sty       $01DA,u
+                    sty       $01DA,u
 L0075               ldd       #$0001
 L0078               std       $0216,u
                     leay      $01DC,u
@@ -129,92 +129,106 @@ L00FA               leax      $068e,y
 L0102               sts       $0218,y
                     sts       $0226,y
                     ldd       #$FF82
-                    leax      d,s
-L0111               cmpx      $0226,y
+L010F               leax      d,s
+                    cmpx      $0226,y
                     bcc       L0121
                     cmpx      $0224,y
                     bcs       L013B
                     stx       $0226,y
 L0121               rts
-L0122               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+
+L0122               bpl       $014E
+                    bpl       L0150
+                    bra       L017B
+                    lsrb
+                    fcb       $41
+                    coma
+                    fcb       $4B
+                    bra       $017D
+                    rorb
+                    fcb       $45,$52
+                    rora
+                    inca
+                    clra
+                    asrb
+                    bra       L0161
+                    bpl       $0163
+                    bpl       L0148
 L013B               leax      L0122,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
-                    os9       I$WritLn
+L0148               os9       I$WritLn
                     clr       ,-s
                     lbsr      L3571
-                    ldd       $0218,y
+L0150               ldd       $0218,y
                     subd      $0226,y
                     rts
                     ldd       $0226,y
                     subd      $0224,y
-                    rts
+L0161               rts
 
 L0162               pshs      x
                     leax      d,y
                     leax      d,x
-                    anda      $0034
-                    fcb       $10
-L016B               ldd       ,y++
+                    pshs      x
+L016A               ldd       ,y++
                     leax      d,u
                     ldd       ,x
                     addd      $02,s
-L0173               std       ,x
+                    std       ,x
                     cmpy      ,s
-                    bne       L016B
-L017A               leas      $04,s
-L017C               rts
-                    pshs      u
-                    ldd       #$FFB0
-                    lbsr      $0110
-                    leas      -$06,s
-                    leax      L1E00,pcr
-                    pshs      x
-                    lbsr      $353C
-                    leas      $02,s
-                    lbra      L033D
+                    bne       L016A
+                    leas      $04,s
+L017B               rts
 
-L0195               ldx       $0C,s
+L017C               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L010F
+                    leas      -$06,s
+                    leax      L1DFF,pcr
+                    pshs      x
+                    lbsr      L353B
+                    leas      $02,s
+                    lbra      L033C
+
+L0194               ldx       $0C,s
                     leax      $02,x
                     stx       $0C,s
                     ldu       ,x
                     ldb       ,u
                     cmpb      #$2d
-                    lbne      L0313
-                    lbra      L0305
+                    lbne      L0312
+                    lbra      L0304
 
-L01A8               ldb       ,u
+L01A7               ldb       ,u
                     sex
                     tfr       d,x
-                    lbra      L02BF
+                    lbra      L02BE
 
-L01B0               leau      $01,u
+L01AF               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    bne       L01C0
+                    bne       L01BF
                     leau      $01,u
                     tfr       u,d
                     std       $0273,y
-L01C0               ldd       $0271,y
-                    lbne      L02A1
+L01BF               ldd       $0271,y
+                    lbne      L02A0
                     pshs      u
-                    lbsr      L0D9E
+                    lbsr      L0D9D
                     leas      $02,s
                     std       $0271,y
-                    lbra      L02A1
+                    lbra      L02A0
 
-L01D6               leau      $01,u
+L01D5               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    bne       L0206
+                    bne       L0205
                     ldd       $000C
                     cmpd      #$0005
-                    bge       L0206
+                    bge       L0205
                     ldd       $000C
                     addd      #$0001
                     std       $000C
@@ -227,131 +241,131 @@ L01D6               leau      $01,u
                     pshs      u
                     ldd       #$0001
                     addd      ,s++
-                    std       [,s++]
-                    lbra      L02A1
+L0200               std       [,s++]
+                    lbra      L02A0
 
-L0206               pshs      u
-                    leax      $0DDE,pcr
+L0205               pshs      u
+                    leax      L0DDD,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $04,s
-                    lbra      L02A1
+                    lbra      L02A0
 
-L0216               ldd       #$0001
+L0215               ldd       #$0001
                     std       $000E
-                    lbra      L0305
+                    lbra      L0304
 
-L021E               ldd       #$0001
+L021D               ldd       #$0001
                     std       $0010
-                    lbra      L0305
+                    lbra      L0304
 
-L0226               leau      $01,u
+L0225               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    lbne      L02A1
+                    lbne      L02A0
                     leax      $01,u
                     stx       $0271,y
-                    lbra      L02A1
+                    lbra      L02A0
 
-L0239               leau      $01,u
+L0238               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    lbne      L02A1
+                    lbne      L02A0
                     pshs      u
                     ldd       #$0001
                     addd      ,s++
                     pshs      d
-                    lbsr      L302D
+                    lbsr      L302C
                     leas      $02,s
                     stb       $0270,y
-                    bra       L02A1
+                    bra       L02A0
 
-L0257               leau      $01,u
+L0256               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    bne       L027B
+                    bne       L027A
                     pshs      u
                     ldd       #$0001
                     addd      ,s++
                     pshs      d
-                    lbsr      $1B06
+                    lbsr      L1B05
                     leas      $02,s
                     std       ,s
                     cmpd      #$0100
-                    bcs       L02A1
+                    bcs       L02A0
                     ldd       ,s
                     std       L0032
-                    bra       L02A1
+                    bra       L02A0
 
-L027B               pshs      u
-                    leax      L0E18,pcr
+L027A               pshs      u
+                    leax      L0E17,pcr
                     pshs      x
-                    leax      L0DFE,pcr
+                    leax      L0DFD,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $06,s
-L028E               ldd       #$0001
-                    std       L0014
+L028D               ldd       #$0001
+                    std       copybytes
                     leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    bne       L02A1
+                    bne       L02A0
                     leax      $01,u
                     stx       $0275,y
-L02A1               leax      $06,s
-                    lbra      L030F
+L02A0               leax      $06,s
+                    lbra      L030E
 
-L02A6               ldd       #$0001
+L02A5               ldd       #$0001
                     std       L0016
-                    bra       L0305
+                    bra       L0304
 
-L02AD               ldb       ,u
+L02AC               ldb       ,u
                     sex
                     pshs      d
-                    leax      $0E25,pcr
+                    leax      L0E24,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $04,s
-                    bra       L0305
+                    bra       L0304
 
-L02BF               cmpx      #$006F
-                    lbeq      L01B0
+L02BE               cmpx      #$006F
+                    lbeq      L01AF
                     cmpx      #$006C
-                    lbeq      L01D6
+                    lbeq      L01D5
                     cmpx      #$006D
-                    lbeq      L0216
+                    lbeq      L0215
                     cmpx      #$0073
-                    lbeq      L021E
+                    lbeq      L021D
                     cmpx      #$006E
-                    lbeq      L0226
+                    lbeq      L0225
                     cmpx      #$0045
-                    lbeq      L0239
+                    lbeq      L0238
                     cmpx      #$0065
-                    lbeq      L0239
+                    lbeq      L0238
                     cmpx      #$004D
-                    lbeq      L0257
+                    lbeq      L0256
                     cmpx      #$0062
-                    lbeq      L028E
+                    lbeq      L028D
                     cmpx      #$0074
-                    beq       L02A6
-                    bra       L02AD
+                    beq       L02A5
+                    bra       L02AC
 
-L0305               leau      $01,u
+L0304               leau      $01,u
                     ldb       ,u
-                    lbne      L01A8
-                    bra       L033D
+                    lbne      L01A7
+                    bra       L033C
 
-L030F               leas      -$06,x
-                    bra       L033D
+L030E               leas      -$06,x
+                    bra       L033C
 
-L0313               ldd       $000A
+L0312               ldd       $000A
                     cmpd      #$001E
-                    bne       L0326
-                    leax      L0E38,pcr
+                    bne       L0325
+                    leax      L0E37,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $02,s
-L0326               ldd       $000A
+L0325               ldd       $000A
                     addd      #$0001
                     std       $000A
                     subd      #$0001
@@ -361,126 +375,126 @@ L0326               ldd       $000A
                     leax      d,x
                     ldd       [$0C,s]
                     std       ,x
-L033D               ldd       $0a,s
+L033C               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
-                    lbgt      L0195
-                    lbsr      L044B
-                    lbsr      L1D81
+                    lbgt      L0194
+                    lbsr      L044A
+                    lbsr      L1D80
                     std       -$02,s
-                    beq       L035D
-                    leax      $0E4E,pcr
+                    beq       L035C
+                    leax      L0E4D,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $02,s
-L035D               ldd       $0271,y
+L035C               ldd       $0271,y
                     pshs      d
-                    lbsr      $2EC5
+                    lbsr      $2EC4
                     leas      $02,s
                     std       L001A
-                    lbsr      L0928
-                    lbsr      L0A67
-                    ldd       L0014
-                    beq       L03A9
+                    lbsr      L0927
+                    lbsr      L0A66
+                    ldd       copybytes
+                    beq       L03A8
                     ldd       L0026
-                    bne       L037C
+                    bne       L037B
                     ldd       L002A
-                    beq       L0387
-L037C               leax      $0E64,pcr
+                    beq       L0386
+L037B               leax      L0E63,pcr
                     pshs      x
-                    lbsr      L0CE6
+                    lbsr      L0CE5
                     leas      $02,s
-L0387               ldd       L0022
-                    beq       L0396
-                    leax      L0E79,pcr
+L0386               ldd       L0022
+                    beq       L0395
+                    leax      L0E78,pcr
                     pshs      x
-                    lbsr      L0CE6
+                    lbsr      L0CE5
                     leas      $02,s
-L0396               ldd       L0016
-                    bne       L03A9
+L0395               ldd       L0016
+                    bne       L03A8
                     ldd       $001E
-                    beq       L03A9
-                    leax      L0E8C,pcr
+                    beq       L03A8
+                    leax      L0E8B,pcr
                     pshs      x
-                    lbsr      L0CE6
+                    lbsr      L0CE5
                     leas      $02,s
-L03A9               ldd       L0022
+L03A8               ldd       L0022
                     addd      L002A
                     cmpd      #$0100
-                    bls       L03C4
+                    bls       L03C3
                     ldd       L0022
                     addd      L002A
                     pshs      d
-                    leax      L0E9B,pcr
+                    leax      L0E9A,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $04,s
-L03C4               ldd       L0044
-                    beq       L03D3
-                    leax      $0EBE,pcr
+L03C3               ldd       L0044
+                    beq       L03D2
+                    leax      L0EBD,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $02,s
-L03D3               ldd       $0273,y
-                    bne       L03E4
-                    leax      L0EC9,pcr
+L03D2               ldd       $0273,y
+                    bne       L03E3
+                    leax      L0EC8,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $02,s
-L03E4               ldd       L0014
-                    lbeq      L0444
+L03E3               ldd       copybytes
+                    lbeq      L0443
                     ldd       $0275,y
-                    bne       L03FB
-                    leax      $0ED8,pcr
+                    bne       L03FA
+                    leax      L0ED7,pcr
                     pshs      x
-                    lbsr      L0CE6
-                    bra       L043D
+                    lbsr      L0CE5
+                    bra       L043C
 
-L03FB               leas      -$02,s
+L03FA               leas      -$02,s
                     ldd       $0275,y
                     pshs      d
                     ldd       $0275,y
                     pshs      d
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     std       ,s
-                    beq       L042C
+                    beq       L042B
                     ldx       ,s
                     ldd       $0a,x
                     clra
                     andb      #$07
                     cmpd      #$0004
-                    bne       L042C
+                    bne       L042B
                     ldx       ,s
                     ldd       $0C,x
                     std       L0030
-                    bra       L043D
+                    bra       L043C
 
-L042C               ldd       $0275,y
+L042B               ldd       $0275,y
                     pshs      d
-                    leax      $0EEC,pcr
+                    leax      L0EEB,pcr
                     pshs      x
-                    lbsr      L0CE6
+                    lbsr      L0CE5
                     leas      $04,s
-L043D               leas      $02,s
+L043C               leas      $02,s
                     ldd       #$2181
                     std       L0018
-L0444               lbsr      $1016
+L0443               lbsr      L1015
                     leas      $06,s
                     puls      pc,u
-L044B               pshs      u
+L044A               pshs      u
                     ldd       #$FF96
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$1e,s
                     ldd       $000A
-                    lbeq      L065B
+                    lbeq      L065A
                     clra
                     clrb
-                    lbra      L0595
+                    lbra      L0594
 
-L0461               ldd       ,s
+L0460               ldd       ,s
                     aslb
                     rola
                     leax      $022a,y
@@ -489,16 +503,16 @@ L0461               ldd       ,s
                     std       L0042
                     ldd       L0038
                     pshs      d
-                    leax      $0F07,pcr
+                    leax      L0F06,pcr
                     pshs      x
                     ldd       L0042
                     pshs      d
-                    lbsr      L22B9
+                    lbsr      L22B8
                     leas      $06,s
                     std       L0038
-                    bne       L0489
-                    lbsr      L0D2E
-L0489               ldd       $0003
+                    bne       L0488
+                    lbsr      L0D2D
+L0488               ldd       $0003
                     ldx       L0038
                     std       $0b,x
                     ldd       L0038
@@ -509,70 +523,71 @@ L0489               ldd       $0003
                     pshs      d
                     leax      $08,s
                     pshs      x
-                    lbsr      L232E
+                    lbsr      L232D
                     leas      $08,s
                     std       -$02,s
-                    bne       L04AD
-                    lbsr      L0D85
-L04AD               leax      $02,s
+                    bne       L04AC
+                    lbsr      L0D84
+L04AC               leax      $02,s
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       L04BD
+                    bsr       L04BC
                     fcb       $62
                     fcb       $CD
-                    bls       L0444
-L04BD               puls      x
-                    lbsr      $30E8
-                    beq       L04C9
-                    lbsr      L0D41
-                    bra       L0511
+                    fcb       $23
+                    fcb       $87
+L04BC               puls      x
+                    lbsr      L30E7
+                    beq       L04C8
+                    lbsr      L0D40
+                    bra       L0510
 
-L04C9               ldb       $08,s
-                    beq       L04D2
-                    lbsr      L0D53
-                    bra       L0511
+L04C8               ldb       $08,s
+                    beq       L04D1
+                    lbsr      L0D52
+                    bra       L0510
 
-L04D2               ldd       L0014
-                    beq       L04DF
+L04D1               ldd       copybytes
+                    beq       L04DE
                     ldd       $06,s
-                    beq       L0511
-                    lbsr      L0D1C
-                    bra       L0511
+                    beq       L0510
+                    lbsr      L0D1B
+                    bra       L0510
 
-L04DF               ldd       ,s
-                    beq       L04EC
+L04DE               ldd       ,s
+                    beq       L04EB
                     ldd       $06,s
-                    beq       L0511
-                    lbsr      L0D65
-                    bra       L0511
+                    beq       L0510
+                    lbsr      L0D64
+                    bra       L0510
 
-L04EC               ldd       $06,s
-                    bne       L0501
+L04EB               ldd       $06,s
+                    bne       L0500
                     ldd       L0042
                     pshs      d
-                    leax      $0F09,pcr
+                    leax      L0F08,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $04,s
-                    bra       L0505
+                    bra       L0504
 
-L0501               ldd       $06,s
+L0500               ldd       $06,s
                     std       L0018
-L0505               ldb       $0270,y
-                    bne       L0511
+L0504               ldb       $0270,y
+                    bne       L0510
                     ldb       $0e,s
                     stb       $0270,y
-L0511               clra
+L0510               clra
                     clrb
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    lbsr      L0660
+                    lbsr      L065F
                     leas      $04,s
                     ldd       ,s
-                    lbne      L0590
+                    lbne      L058F
                     leas      -$02,s
                     ldd       L003E
                     std       ,s
@@ -582,7 +597,7 @@ L0511               clra
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0B8C
+                    lbsr      L0B8B
                     leas      $06,s
                     ldd       #$0104
                     pshs      d
@@ -590,7 +605,7 @@ L0511               clra
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0B8C
+                    lbsr      L0B8B
                     leas      $06,s
                     ldd       #$0101
                     pshs      d
@@ -598,7 +613,7 @@ L0511               clra
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0B8C
+                    lbsr      L0B8B
                     leas      $06,s
                     ldd       #$0100
                     pshs      d
@@ -606,7 +621,7 @@ L0511               clra
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0B8C
+                    lbsr      L0B8B
                     leas      $06,s
                     ldd       #$0102
                     pshs      d
@@ -614,20 +629,20 @@ L0511               clra
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0B8C
+                    lbsr      L0B8B
                     leas      $06,s
                     leas      $02,s
-L0590               ldd       ,s
+L058F               ldd       ,s
                     addd      #$0001
-L0595               std       ,s
+L0594               std       ,s
                     ldd       ,s
                     cmpd      $000A
-                    lblt      L0461
+                    lblt      L0460
                     clra
                     clrb
-                    lbra      L064B
+                    lbra      L064A
 
-L05A5               ldd       ,s
+L05A4               ldd       ,s
                     aslb
                     rola
                     leax      $0266,y
@@ -636,62 +651,63 @@ L05A5               ldd       ,s
                     std       L0042
                     ldd       L0038
                     pshs      d
-                    lbsr      L2B74
+                    lbsr      L2B73
                     leas      $02,s
-                    leax      $0F23,pcr
+                    leax      L0F22,pcr
                     pshs      x
                     ldd       L0042
                     pshs      d
-                    lbsr      $229A
+                    lbsr      L2299
                     leas      $04,s
                     std       L0038
-                    lbne      L0629
-                    lbsr      L0D2E
-                    bra       L0629
+                    lbne      L0628
+                    lbsr      L0D2D
+                    bra       L0628
 
-L05D6               leax      $02,s
+L05D5               leax      $02,s
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       L05E6
+                    bsr       L05E5
                     fcb       $62
                     fcb       $CD
-                    bls       $056D
-L05E6               puls      x
-                    lbsr      $30E8
-                    beq       L05F2
-                    lbsr      L0D41
-                    bra       L061A
+                    fcb       $23
+                    fcb       $87
+L05E5               puls      x
+                    lbsr      L30E7
+                    beq       L05F1
+                    lbsr      L0D40
+                    bra       L0619
 
-L05F2               ldb       $08,s
-                    beq       L05FB
-                    lbsr      L0D53
-                    bra       L061A
+L05F1               ldb       $08,s
+                    beq       L05FA
+                    lbsr      L0D52
+                    bra       L0619
 
-L05FB               ldd       $06,s
-                    beq       L060D
-                    ldd       L0014
-                    beq       L0608
-                    lbsr      L0D1C
-                    bra       L061A
+L05FA               ldd       $06,s
+                    beq       L060C
+                    ldd       copybytes
+                    beq       L0607
+                    lbsr      L0D1B
+                    bra       L0619
 
-L0608               lbsr      L0D65
-                    bra       L061A
+L0607               lbsr      L0D64
+                    bra       L0619
 
-L060D               ldd       #$0001
+L060C               ldd       #$0001
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    bsr       L0660
+                    bsr       L065F
                     leas      $04,s
-L061A               leax      >$0060,y
+L0619               leax      >$0060,y
                     cmpx      >$0060,y
-                    bne       L0629
+                    bne       L0628
                     leax      $1e,s
-                    bra       L0658
+                    bra       L0657
 
-L0629               ldd       L0038
+L0628               ldd       L0038
                     pshs      d
                     ldd       #$0001
                     pshs      d
@@ -699,40 +715,40 @@ L0629               ldd       L0038
                     pshs      d
                     leax      $08,s
                     pshs      x
-                    lbsr      L232E
+                    lbsr      L232D
                     leas      $08,s
                     std       -$02,s
-                    lbne      L05D6
+                    lbne      L05D5
                     ldd       ,s
                     addd      #$0001
-L064B               std       ,s
+L064A               std       ,s
                     ldd       ,s
                     cmpd      $000C
-                    lblt      L05A5
-                    bra       L065B
+                    lblt      L05A4
+                    bra       L065A
 
-L0658               leas      -$1e,x
-L065B               leas      $1e,s
+L0657               leas      -$1e,x
+L065A               leas      $1e,s
                     puls      pc,u
-L0660               pshs      u
+L065F               pshs      u
                     ldd       #$FF8B
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$29,s
                     ldd       L003C
-                    bne       L067E
+                    bne       L067D
                     ldd       #$0031
                     pshs      d
-                    lbsr      $1C20
+                    lbsr      L1C1F
                     leas      $02,s
                     std       $27,s
-                    bra       L068B
+                    bra       L068A
 
-L067E               ldd       L003C
+L067D               ldd       L003C
                     std       $27,s
                     ldx       $27,s
                     ldd       $11,x
                     std       L003C
-L068B               clra
+L068A               clra
                     clrb
                     ldx       $27,s
                     std       $2d,x
@@ -743,31 +759,31 @@ L068B               clra
                     ldd       $27,s
                     std       $1b,s
                     ldd       #$0010
-                    bra       L06B9
+                    bra       L06B8
 
-L06A6               ldd       $23,s
+L06A5               ldd       $23,s
                     ldx       $1b,s
                     leax      $01,x
                     stx       $1b,s
                     stb       -$01,x
                     ldd       $21,s
                     addd      #$FFFF
-L06B9               std       $21,s
+L06B8               std       $21,s
                     ldd       $21,s
-                    ble       L06CF
+                    ble       L06CE
                     ldd       L0038
                     pshs      d
-                    lbsr      L2C97
+                    lbsr      L2C96
                     leas      $02,s
                     std       $23,s
-                    bne       L06A6
-L06CF               ldx       L0038
+                    bne       L06A5
+L06CE               ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L06DB
-                    lbsr      L0D85
-L06DB               clra
+                    beq       L06DA
+                    lbsr      L0D84
+L06DA               clra
                     clrb
                     stb       [$1b,s]
                     ldd       L0042
@@ -781,16 +797,16 @@ L06DB               clra
                     ldd       $2b,s
                     addd      #$0015
                     pshs      d
-                    lbsr      L30A0
+                    lbsr      L309F
                     leas      $06,s
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     std       $1f,s
-                    bra       L0750
+                    bra       L074F
 
-L0710               lbsr      L0BCD
+L070F               lbsr      L0BCC
                     std       $25,s
                     ldx       $27,s
                     ldd       $2d,x
@@ -801,51 +817,51 @@ L0710               lbsr      L0BCD
                     std       $2d,x
                     ldd       $25,s
                     pshs      d
-                    lbsr      L1DE1
+                    lbsr      L1DE0
                     leas      $02,s
                     ldd       L0038
                     pshs      d
-                    lbsr      L2C97
+                    lbsr      L2C96
                     leas      $02,s
                     ldx       $25,s
                     std       $0a,x
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     ldx       $25,s
                     std       $0C,x
-L0750               ldd       $1f,s
+L074F               ldd       $1f,s
                     addd      #$FFFF
                     std       $1f,s
                     subd      #$FFFF
-                    bne       L0710
+                    bne       L070F
                     ldd       $2f,s
-                    lbeq      L07DD
+                    lbeq      L07DC
                     ldx       $27,s
                     ldd       $2d,x
-                    bra       L0785
+                    bra       L0784
 
-L076D               ldd       #$0001
+L076C               ldd       #$0001
                     pshs      d
                     ldd       $27,s
                     pshs      d
-                    lbsr      $1B83
+                    lbsr      L1B82
                     leas      $04,s
                     std       -$02,s
-                    bne       L078D
+                    bne       L078C
                     ldx       $25,s
                     ldd       $0e,x
-L0785               std       $25,s
+L0784               std       $25,s
                     ldd       $25,s
-                    bne       L076D
-L078D               ldd       $25,s
-                    bne       L07DD
+                    bne       L076C
+L078C               ldd       $25,s
+                    bne       L07DC
                     leas      -$02,s
                     ldx       $29,s
                     ldd       $2d,x
                     pshs      d
-                    lbsr      L0CC8
+                    lbsr      L0CC7
                     leas      $02,s
                     std       ,s
                     ldd       $0001
@@ -856,14 +872,14 @@ L078D               ldd       $25,s
                     std       $0001
                     ldd       $29,s
                     pshs      d
-                    lbsr      L0BF1
+                    lbsr      L0BF0
                     leas      $02,s
-                    lbsr      L0C3C
+                    lbsr      L0C3B
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     std       ,s
-                    lbsr      L0C0F
+                    lbsr      L0C0E
                     leas      $02,s
                     ldd       L003C
                     ldx       $29,s
@@ -872,87 +888,87 @@ L078D               ldd       $25,s
                     std       L003C
                     leas      $2b,s
                     puls      pc,u
-L07DD               ldx       $27,s
+L07DC               ldx       $27,s
                     ldd       $2d,x
-                    bra       L0818
+                    bra       L0817
 
-L07E5               ldd       $25,s
+L07E4               ldd       $25,s
                     pshs      d
-                    lbsr      $1A57
+                    lbsr      L1A56
                     std       ,s++
-                    beq       L0813
+                    beq       L0812
                     ldd       $27,s
                     pshs      d
                     ldd       $27,s
                     pshs      d
-                    leax      $0F25,pcr
+                    leax      L0F24,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      L23D0
+                    lbsr      L23CF
                     leas      $08,s
                     ldd       L0044
                     addd      #$0001
                     std       L0044
-L0813               ldx       $25,s
+L0812               ldx       $25,s
                     ldd       $0e,x
-L0818               std       $25,s
+L0817               std       $25,s
                     ldd       $25,s
-                    bne       L07E5
+                    bne       L07E4
                     ldd       $0040
-                    bne       L082D
+                    bne       L082C
                     ldd       $27,s
                     std       $0040
                     std       L003E
-                    bra       L0837
+                    bra       L0836
 
-L082D               ldd       $27,s
+L082C               ldd       $27,s
                     ldx       $0040
                     std       $11,x
                     std       $0040
-L0837               ldx       $27,s
+L0836               ldx       $27,s
                     leax      $29,x
                     pshs      x
                     ldd       L0038
                     pshs      d
-                    lbsr      L2A1B
+                    lbsr      L2A1A
                     leas      $02,s
-                    lbsr      $314C
+                    lbsr      L314B
                     ldd       $27,s
                     pshs      d
-                    lbsr      L0BF1
+                    lbsr      L0BF0
                     leas      $02,s
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     std       $1f,s
-                    lbra      L08D2
+                    lbra      L08D1
 
-L0864               leax      $01,s
+L0863               leax      $01,s
                     pshs      x
-                    lbsr      L1DE1
+                    lbsr      L1DE0
                     leas      $02,s
                     leax      $01,s
                     pshs      x
                     leax      $03,s
                     pshs      x
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     std       $25,s
-                    beq       L088F
+                    beq       L088E
                     ldx       $25,s
                     ldd       $0a,x
                     ora       #$01
                     std       $0a,x
-                    bra       L08B5
+                    bra       L08B4
 
-L088F               leas      -$02,s
+L088E               leas      -$02,s
                     leax      $03,s
                     pshs      x
-                    lbsr      $1BD9
+                    lbsr      L1BD8
                     leas      $02,s
                     std       ,s
                     leax      $03,s
@@ -960,78 +976,78 @@ L088F               leas      -$02,s
                     ldd       $02,s
                     addd      #$0004
                     pshs      d
-                    lbsr      L2ED6
+                    lbsr      L2ED5
                     leas      $04,s
                     ldd       $29,s
                     ldx       ,s
                     std       $0e,x
                     leas      $02,s
-L08B5               ldx       $27,s
+L08B4               ldx       $27,s
                     ldd       $27,x
                     leax      $27,x
                     pshs      x,d
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     std       ,s
-                    lbsr      L0C7A
+                    lbsr      L0C79
                     leas      $02,s
                     addd      ,s++
                     std       [,s++]
-L08D2               ldd       $1f,s
+L08D1               ldd       $1f,s
                     addd      #$FFFF
                     std       $1f,s
                     subd      #$FFFF
-                    lbne      L0864
+                    lbne      L0863
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     std       $1f,s
                     ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L0915
-                    lbsr      L0D85
-                    bra       L0915
+                    beq       L0914
+                    lbsr      L0D84
+                    bra       L0914
 
-L08FC               ldx       $27,s
+L08FB               ldx       $27,s
                     ldd       $27,x
                     leax      $27,x
                     pshs      x,d
                     ldd       #$0001
                     pshs      d
-                    lbsr      L0C7A
+                    lbsr      L0C79
                     leas      $02,s
                     addd      ,s++
                     std       [,s++]
-L0915               ldd       $1f,s
+L0914               ldd       $1f,s
                     addd      #$FFFF
                     std       $1f,s
                     subd      #$FFFF
-                    bne       L08FC
+                    bne       L08FB
                     leas      $29,s
                     puls      pc,u
-L0928               pshs      u
+L0927               pshs      u
                     ldd       #$FFB6
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$02,s
                     clra
                     clrb
                     std       $0034
                     ldd       L003E
-                    lbra      L09DD
+                    lbra      L09DC
 
-L093B               ldx       ,s
+L093A               ldx       ,s
                     ldu       $2d,x
-                    lbra      L09D2
+                    lbra      L09D1
 
-L0943               ldd       $0a,u
+L0942               ldd       $0a,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      L09D0
+                    lbeq      L09CF
                     ldx       ,s
                     ldd       $13,x
                     ora       #$01
@@ -1083,146 +1099,146 @@ L0943               ldd       $0a,u
                     ldx       ,s
                     addd      $1b,x
                     cmpd      $0034
-                    bls       L09D8
+                    bls       L09D7
                     ldx       ,s
                     ldd       $1f,x
                     ldx       ,s
                     addd      $1b,x
                     std       $0034
-                    bra       L09D8
+                    bra       L09D7
 
-L09D0               ldu       $0e,u
-L09D2               stu       -$02,s
-                    lbne      L0943
-L09D8               ldx       ,s
+L09CF               ldu       $0e,u
+L09D1               stu       -$02,s
+                    lbne      L0942
+L09D7               ldx       ,s
                     ldd       $11,x
-L09DD               std       ,s
+L09DC               std       ,s
                     ldd       ,s
-                    lbne      L093B
+                    lbne      L093A
                     ldd       >$0070,y
                     pshs      d
                     ldd       >$0070,y
                     pshs      d
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L0A05
+                    beq       L0A04
                     ldd       $002E
                     std       $0C,u
-L0A05               ldd       >$0072,y
+L0A04               ldd       >$0072,y
                     pshs      d
                     ldd       >$0072,y
                     pshs      d
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L0A25
+                    beq       L0A24
                     ldd       L0026
                     std       $0C,u
-L0A25               ldd       >$0074,y
+L0A24               ldd       >$0074,y
                     pshs      d
                     ldd       >$0074,y
                     pshs      d
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L0A45
+                    beq       L0A44
                     ldd       $001E
                     std       $0C,u
-L0A45               ldd       >$0076,y
+L0A44               ldd       >$0076,y
                     pshs      d
                     ldd       >$0076,y
                     pshs      d
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L0A65
+                    beq       L0A64
                     ldd       L0022
                     std       $0C,u
-L0A65               puls      pc,u,x
-L0A67               pshs      u
+L0A64               puls      pc,u,x
+L0A66               pshs      u
                     ldd       #$FFB1
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$05,s
-                    lbsr      L0B65
+                    lbsr      L0B64
                     ldd       L003E
-                    lbra      L0B38
+                    lbra      L0B37
 
-L0A79               ldx       $03,s
+L0A78               ldx       $03,s
                     ldd       $13,x
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      L0B33
+                    lbeq      L0B32
                     ldx       $03,s
                     ldu       $2d,x
-                    lbra      L0AEC
+                    lbra      L0AEB
 
-L0A8F               ldd       $0a,u
+L0A8E               ldd       $0a,u
                     clra
                     andb      #$07
                     tfr       d,x
-                    bra       L0AD0
+                    bra       L0ACF
 
-L0A98               ldd       $0C,u
+L0A97               ldd       $0C,u
                     addd      L001C
-                    bra       L0AB4
+                    bra       L0AB3
 
-L0A9E               ldd       $0C,u
+L0A9D               ldd       $0C,u
                     addd      $0024
-                    bra       L0AB4
+                    bra       L0AB3
 
-L0AA4               ldd       $0C,u
+L0AA3               ldd       $0C,u
                     addd      $0020
-                    bra       L0AB4
+                    bra       L0AB3
 
-L0AAA               ldd       $0C,u
+L0AA9               ldd       $0C,u
                     addd      L0028
-                    bra       L0AB4
+                    bra       L0AB3
 
-L0AB0               ldd       $0C,u
+L0AAF               ldd       $0C,u
                     addd      L002C
-L0AB4               std       $0C,u
-                    bra       L0AEA
+L0AB3               std       $0C,u
+                    bra       L0AE9
 
-L0AB8               ldx       $03,s
+L0AB7               ldx       $03,s
                     ldd       $2f,x
                     pshs      d
                     ldd       $05,s
                     pshs      d
-                    leax      L0F49,pcr
+                    leax      L0F48,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $06,s
-                    bra       L0AEA
+                    bra       L0AE9
 
-L0AD0               stx       -$02,s
-                    beq       L0A98
+L0ACF               stx       -$02,s
+                    beq       L0A97
                     cmpx      #$0001
-                    beq       L0A9E
+                    beq       L0A9D
                     cmpx      #$0002
-                    beq       L0AA4
+                    beq       L0AA3
                     cmpx      #$0003
-                    beq       L0AAA
+                    beq       L0AA9
                     cmpx      #$0004
-                    beq       L0AB0
-                    bra       L0AB8
+                    beq       L0AAF
+                    bra       L0AB7
 
-L0AEA               ldu       $0e,u
-L0AEC               stu       -$02,s
-                    lbne      L0A8F
+L0AE9               ldu       $0e,u
+L0AEB               stu       -$02,s
+                    lbne      L0A8E
                     ldd       L001C
                     pshs      d
                     ldx       $05,s
@@ -1253,31 +1269,31 @@ L0AEC               stu       -$02,s
                     ldd       $1f,x
                     addd      ,s++
                     std       L002C
-L0B33               ldx       $03,s
+L0B32               ldx       $03,s
                     ldd       $11,x
-L0B38               std       $03,s
+L0B37               std       $03,s
                     ldd       $03,s
-                    lbne      L0A79
+                    lbne      L0A78
                     ldd       >$0078,y
                     pshs      d
                     ldd       >$0078,y
                     pshs      d
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L0B60
+                    beq       L0B5F
                     clra
                     clrb
                     std       $0C,u
-L0B60               bsr       L0B65
-                    lbra      L0CC4
+L0B5F               bsr       L0B64
+                    lbra      L0CC3
 
-L0B65               pshs      u
+L0B64               pshs      u
                     ldd       #$FFC0
-                    lbsr      $0110
+                    lbsr      L010F
                     clra
                     clrb
                     std       L0028
@@ -1294,11 +1310,11 @@ L0B65               pshs      u
                     addd      #$000E
                     std       L002C
                     puls      pc,u
-L0B8C               pshs      u
+L0B8B               pshs      u
                     ldd       #$FFB4
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$02,s
-                    bsr       L0BCD
+                    bsr       L0BCC
                     std       ,s
                     ldx       $06,s
                     ldd       $2d,x
@@ -1313,36 +1329,36 @@ L0B8C               pshs      u
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L2F4C
+                    lbsr      L2F4B
                     leas      $06,s
                     ldd       $0a,s
                     ldx       ,s
                     std       $0a,x
                     ldd       ,s
                     pshs      d
-                    lbsr      $1A57
+                    lbsr      L1A56
                     leas      $02,s
                     puls      pc,u,x
-L0BCD               pshs      u
+L0BCC               pshs      u
                     ldd       #$FFBA
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       $0001
-                    bne       L0BE7
+                    bne       L0BE6
                     ldd       #$0012
                     pshs      d
-                    lbsr      $1C20
+                    lbsr      L1C1F
                     leas      $02,s
                     tfr       d,u
-                    bra       L0BED
+                    bra       L0BEC
 
-L0BE7               ldu       $0001
+L0BE6               ldu       $0001
                     ldd       $0e,u
                     std       $0001
-L0BED               tfr       u,d
+L0BEC               tfr       u,d
                     puls      pc,u
-L0BF1               pshs      u
+L0BF0               pshs      u
                     ldd       #$FFB4
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       #$0001
                     pshs      d
                     ldx       $06,s
@@ -1351,65 +1367,65 @@ L0BF1               pshs      u
                     addd      $1d,x
                     ldx       $06,s
                     addd      $1b,x
-                    bra       L0C26
+                    bra       L0C25
 
-L0C0F               pshs      u
+L0C0E               pshs      u
                     ldd       #$FFB4
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       #$0001
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     ldd       #$0003
-                    lbsr      $3180
-L0C26               lbsr      $3141
+                    lbsr      L317F
+L0C25               lbsr      L3140
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
                     ldd       L0038
                     pshs      d
-                    lbsr      $28C4
+                    lbsr      $28C3
                     leas      $08,s
                     puls      pc,u
-L0C3C               pshs      u
+L0C3B               pshs      u
                     ldd       #$FFAE
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$0C,s
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     std       ,s
-                    bra       L0C6A
+                    bra       L0C69
 
-L0C53               leax      $02,s
+L0C52               leax      $02,s
                     pshs      x
-                    lbsr      L1DE1
+                    lbsr      L1DE0
                     leas      $02,s
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     std       ,s
-                    lbsr      L0C0F
+                    lbsr      L0C0E
                     leas      $02,s
-L0C6A               ldd       ,s
+L0C69               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bne       L0C53
+                    bne       L0C52
                     leas      $0C,s
                     puls      pc,u
-L0C7A               pshs      u
+L0C79               pshs      u
                     ldd       #$FFAF
-                    lbsr      $0110
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$05,s
                     clra
                     clrb
-                    bra       L0CB8
+                    bra       L0CB7
 
-L0C8A               ldd       L0038
+L0C89               ldd       L0038
                     pshs      d
                     ldd       #$0001
                     pshs      d
@@ -1417,424 +1433,213 @@ L0C8A               ldd       L0038
                     pshs      d
                     leax      $06,s
                     pshs      x
-                    lbsr      L232E
+                    lbsr      L232D
                     leas      $08,s
                     std       -$02,s
-                    bne       L0CA8
-                    lbsr      L0D85
-L0CA8               ldb       ,s
+                    bne       L0CA7
+                    lbsr      L0D84
+L0CA7               ldb       ,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    beq       L0CBA
+                    beq       L0CB9
                     ldd       $03,s
                     addd      #$0001
-L0CB8               std       $03,s
-L0CBA               tfr       u,d
+L0CB7               std       $03,s
+L0CB9               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    bne       L0C8A
+                    bne       L0C89
                     ldd       $03,s
-L0CC4               leas      $05,s
+L0CC3               leas      $05,s
                     puls      pc,u
-L0CC8               pshs      u
+L0CC7               pshs      u
                     ldd       #$FFBE
-                    lbsr      $0110
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     stu       ,s
                     stu       ,s
-                    bra       L0CDE
+                    bra       L0CDD
 
-L0CDA               stu       ,s
+L0CD9               stu       ,s
                     ldu       $0e,u
-L0CDE               stu       -$02,s
-                    bne       L0CDA
+L0CDD               stu       -$02,s
+                    bne       L0CD9
                     ldd       ,s
                     puls      pc,u,x
-L0CE6               pshs      u
+L0CE5               pshs      u
                     ldd       #$FFB6
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     leax      $00A3,y
                     pshs      x
-                    lbsr      L23D0
+                    lbsr      L23CF
                     leas      $06,s
                     leax      $00A3,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      L2A84
+                    lbsr      L2A83
                     leas      $04,s
-                    leax      $0F65,pcr
+                    leax      L0F64,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     puls      pc,u,x
-L0D1C               pshs      u
+L0D1B               pshs      u
                     ldd       #$FFBA
-                    lbsr      $0110
-                    leax      $0F76,pcr
+                    lbsr      L010F
+                    leax      L0F75,pcr
                     pshs      x
-                    bsr       L0CE6
+                    bsr       L0CE5
                     puls      pc,u,x
-L0D2E               pshs      u
+L0D2D               pshs      u
                     ldd       #$FFB8
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       L0042
                     pshs      d
-                    leax      L0F8A,pcr
-                    lbra      L0D95
+                    leax      L0F89,pcr
+                    lbra      L0D94
 
-L0D41               pshs      u
+L0D40               pshs      u
                     ldd       #$FFB8
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       L0042
                     pshs      d
-                    leax      L0F9A,pcr
-                    bra       L0D95
+                    leax      L0F99,pcr
+                    bra       L0D94
 
-L0D53               pshs      u
+L0D52               pshs      u
                     ldd       #$FFB8
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       L0042
                     pshs      d
-                    leax      $0FBB,pcr
-                    bra       L0D95
+                    leax      L0FBA,pcr
+                    bra       L0D94
 
-L0D65               pshs      u
+L0D64               pshs      u
                     ldd       #$FFB6
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       L0042
                     pshs      d
                     ldx       L003E
                     ldd       $2f,x
                     pshs      d
-                    leax      $0FD9,pcr
+                    leax      L0FD8,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $06,s
                     puls      pc,u
-L0D85               pshs      u
+L0D84               pshs      u
                     ldd       #$FFB8
-                    lbsr      $0110
+                    lbsr      L010F
                     ldd       L0042
                     pshs      d
-                    leax      $0FFA,pcr
-L0D95               pshs      x
-                    lbsr      $1AB6
+                    leax      L0FF9,pcr
+L0D94               pshs      x
+                    lbsr      L1AB5
                     leas      $04,s
                     puls      pc,u
-L0D9E               pshs      u
+L0D9D               pshs      u
                     ldd       #$FFBE
-                    lbsr      $0110
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     stu       ,s
-                    bra       L0DBA
+                    bra       L0DB9
 
-L0DAE               ldb       ,u
+L0DAD               ldb       ,u
                     cmpb      #$2f
-                    bne       L0DB8
+                    bne       L0DB7
                     leax      $01,u
                     stx       ,s
-L0DB8               leau      $01,u
-L0DBA               ldb       ,u
-                    bne       L0DAE
+L0DB7               leau      $01,u
+L0DB9               ldb       ,u
+                    bne       L0DAD
                     ldd       ,s
                     puls      pc,u,x
-                    fcb       $65
-                    lsr       $6578
-                    lsr       >L0065
-                    lsr       $01,s
-                    lsr       $6100
-                    fcb       $65
-                    jmp       $04,s
-                    neg       $0064
-                    neg       $7369
-                    dec       >$0062
-                    lsr       $6578
-                    lsr       >L0065
-                    fcb       $72,$72,$6f,$72,$20,$73,$70,$65
-                    fcb       $63,$69,$66,$79,$69,$6e,$67,$20
-                    fcb       $6C,$69,$62,$72,$61,$72,$79,$3a
-                    fcb       $20,$2d,$6C,$25,$73,$0d,$00
-L0DFE               fcb       $65,$72,$72,$6f,$72,$20,$73,$70
-                    fcb       $65,$63,$69,$66,$79,$69,$6e,$67
-                    fcb       $20,$25,$73,$20,$2d,$4d,$25,$73
-                    fcb       $0d,$00
-L0E18               tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       L2073
-                    rol       -$06,s
-                    fcb       $65
-                    abx
-                    neg       L0075
-                    jmp       $0b,s
-                    jmp       $0f,s
-                    asr       $6E20
-                    clr       -$10,s
-                    lsr       $696F
-                    jmp       0,y
-                    blt       L0E5B
-                    com       0,x
-L0E38               lsr       $6F6F
-                    bra       L0EAA
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       $0EB5
-                    clr       -$0b,s
-                    fcb       $72
-                    com       $05,s
-                    bra       $0EAF
-                    rol       $0C,s
-                    fcb       $65
-                    com       >L0075
-                    jmp       -$0e,s
-                    fcb       $65
-                    com       $6F6C
-                    ror       $6564
-                    bra       $0ECC
-                    fcb       $65
-L0E5B               ror       $05,s
-                    fcb       $72
-                    fcb       $65
-                    jmp       $03,s
-                    fcb       $65
-                    com       >$006E
-                    clr       0,y
-                    rol       $0e,s
-                    rol       -$0C,s
-                    bra       L0ED1
-                    fcb       $61
-                    lsr       $6120
-                    fcb       $61
-                    inc       $0C,s
-                    clr       -$09,s
-                    fcb       $65
-                    lsr       0,x
-L0E79               jmp       $0f,s
-                    bra       $0EE1
-                    neg       $2064
-                    fcb       $61
-                    lsr       $6120
-                    fcb       $61
-                    inc       $0C,s
-                    clr       -$09,s
-                    fcb       $65
-                    lsr       0,x
-L0E8C               jmp       $0f,s
-                    bra       $0F03
-                    lsr       $6174
-                    rol       $03,s
-                    bra       L0EFB
-                    fcb       $61
-                    lsr       $6100
-L0E9B               lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-                    bra       L0F13
-                    fcb       $61
-                    asr       $05,s
-                    bra       $0F09
-                    inc       $0C,s
-L0EAA               clr       $03,s
-                    fcb       $61
-                    lsr       $696F
-                    jmp       0,y
-                    rol       -$0d,s
-                    bra       L0EDB
-                    fcb       $75
-                    bra       $0F1B
-                    rol       $7465
-                    com       >$006E
-                    fcb       $61
-                    tst       $05,s
-                    bra       L0F27
-                    inc       $01,s
-                    com       $6800
-L0EC9               jmp       $0f,s
-                    bra       L0F3C
-                    fcb       $75
-                    lsr       $7075
-L0ED1               lsr       L2066
-                    rol       $0C,s
-                    fcb       $65
-                    neg       $006E
-                    clr       0,y
-L0EDB               fcb       $65
-                    jmp       -$0C,s
-                    fcb       $72
-                    rol       $2070
-                    clr       $09,s
-                    jmp       -$0C,s
-                    bra       $0F56
-                    fcb       $61
-                    tst       $05,s
-                    neg       L0065
-                    jmp       -$0C,s
-                    fcb       $72
-                    rol       $2070
-                    clr       $09,s
-                    jmp       -$0C,s
-                    bra       L0F20
-                    bcs       L0F6E
-L0EFB               beq       $0F1D
-                    jmp       $0f,s
-                    lsr       L2066
-                    clr       -$0b,s
-                    jmp       $04,s
-                    neg       $0072
-                    neg       $0027
-                    bcs       L0F7F
-                    beq       L0F2E
-                    com       $0f,s
-                    jmp       -$0C,s
-                    fcb       $61
-L0F13               rol       $0e,s
-                    com       L206E
-                    clr       0,y
-                    tst       $01,s
-                    rol       $0e,s
-                    inc       $09,s
-L0F20               jmp       $05,s
-                    neg       $0072
-                    neg       $0073
-                    fcb       $79
-L0F27               fcb       $6d,$62,$6f,$6C,$20,$61,$6C
-L0F2E               fcb       $72,$65,$61,$64,$79,$20,$64,$65
-                    fcb       $66,$69,$6e,$65,$64,$3a
-L0F3C               fcb       $20,$25,$2d,$38,$73,$20,$69,$6e
-                    fcb       $20,$25,$73,$0d,$00
-L0F49               fcb       $75
-                    jmp       $0b,s
-                    jmp       $0f,s
-                    asr       $6E20
-                    fcb       $65
-                    jmp       -$0C,s
-                    fcb       $72
-                    rol       $2074
-                    rol       $7065
-                    bra       $0FC6
-                    jmp       0,y
-                    bcs       L0FD4
-                    abx
-                    bcs       L0FD7
-                    neg       L0042
-                    fcb       $41
-                    comb
-                    rola
-                    coma
-                    leax      -$07,y
-                    bra       L0FD1
-
-L0F6E               clr       $0e,s
-                    ror       $0C,s
-                    rol       $03,s
-                    lsr       >$006E
-                    clr       0,y
-                    tst       $01,s
-                    rol       $0e,s
-                    inc       $09,s
-L0F7F               jmp       $05,s
-                    bra       $0FE4
-                    inc       $0C,s
-                    clr       -$09,s
-                    fcb       $65
-                    lsr       0,x
-L0F8A               com       $01,s
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       $0FBD
-                    bcs       L100B
-                    beq       L0F9A
-L0F9A               beq       $0FC1
-                    com       L2720
-                    rol       -$0d,s
-                    bra       L1011
-                    clr       -$0C,s
-                    bra       $1008
-                    bra       L101B
-                    fcb       $65
-                    inc       $0f,s
-                    com       $01,s
-                    lsr       $6162
-                    inc       $05,s
-                    bra       L1022
-                    clr       $04,s
-                    fcb       $75
-                    inc       $05,s
-                    neg       $0027
-                    bcs       L1031
-                    beq       $0FE0
-                    com       $0f,s
-                    jmp       -$0C,s
-                    fcb       $61
-                    rol       $0e,s
-                    com       $2061
-                    com       $7365
-                    tst       $02,s
-                    inc       -$07,s
-L0FD1               bra       L1038
-                    fcb       $72
-L0FD4               fcb       $72
-                    clr       -$0e,s
-L0FD7               com       >$006D
-                    fcb       $61
-                    rol       $0e,s
-                    inc       $09,s
-                    jmp       $05,s
-                    bra       $1049
-                    clr       -$0b,s
-                    jmp       $04,s
-                    bra       $1052
-                    jmp       0,y
-                    fcb       $62
-                    clr       -$0C,s
-                    asl       0,y
-                    bcs       L1065
-                    bra       $1055
-                    jmp       $04,s
-                    bra       $101D
-                    com       >L0065
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       $1073
-                    fcb       $65
-                    fcb       $61
-                    lsr       $09,s
-                    jmp       $07,s
-                    bra       L1072
-                    jmp       -$10,s
-L100B               fcb       $75
-                    lsr       L2066
-                    rol       $0C,s
-L1011               fcb       $65
-                    bra       $1039
-                    com       >$0034
-                    nega
+                    fcc       /etext/
+                    fcb       $00
+                    fcc       /edata/
+                    fcb       $00
+                    fcb       $65,$6E,$64
+                    fcb       $00
+                    fcc       /dpsiz/
+                    fcb       $00
+                    fcc       /btext/
+                    fcb       $00
+L0DDD               fcc       /error specifying library: -l%s/
+                    fcb       $0D,$00
+L0DFD               fcc       /error specifying %s -M%s/
+                    fcb       $0D,$00
+L0E17               fcc       /memory size:/
+                    fcb       $00
+L0E24               fcc       /unknown option -%c/
+                    fcb       $00
+L0E37               fcc       /too many source files/
+                    fcb       $00
+L0E4D               fcc       /unresolved references/
+                    fcb       $00
+L0E63               fcc       /no init data allowed/
+                    fcb       $00
+L0E78               fcc       /no dp data allowed/
+                    fcb       $00
+L0E8B               fcc       /no static data/
+                    fcb       $00
+L0E9A               fcc       /direct page allocation is %u bytes/
+                    fcb       $00
+L0EBD               fcc       /name clash/
+                    fcb       $00
+L0EC8               fcc       /no output file/
+                    fcb       $00
+L0ED7               fcc       /no entry point name/
+                    fcb       $00
+L0EEB               fcc       /entry point '%s' not found/
+                    fcb       $00
+L0F06               fcb       $72
+                    fcb       $00
+L0F08               fcc       /'%s' contains no mainline/
+                    fcb       $00
+L0F22               fcb       $72
+                    fcb       $00
+L0F24               fcc       /symbol already defined: %-8s in %s/
+                    fcb       $0D,$00
+L0F48               fcc       /unknown entry type in %s:%s/
+                    fcb       $00
+L0F64               fcc       /BASIC09 conflict/
+                    fcb       $00
+L0F75               fcc       /no mainline allowed/
+                    fcb       $00
+L0F89               fcc       /can't open '%s'/
+                    fcb       $00
+L0F99               fcc       /'%s' is not a relocatable module/
+                    fcb       $00
+L0FBA               fcc       /'%s' contains assembly errors/
+                    fcb       $00
+L0FD8               fcc       /mainline found in both %s and %s/
+                    fcb       $00
+L0FF9               fcc       /error reading input file %s/
+                    fcb       $00
+L1015               pshs      u
                     ldd       #$FFA5
-L101B               lbsr      $0110
+                    lbsr      L010F
                     leas      -$0f,s
                     ldd       $0034
-L1022               std       L0046
+                    std       L0046
                     pshs      d
-                    lbsr      $1C20
+                    lbsr      L1C1F
                     leas      $02,s
                     std       L0048
                     clra
                     clrb
                     std       L0046
-L1031               ldd       #$87CD
+                    ldd       #$87CD
                     std       $02,s
                     ldd       L001A
-L1038               addd      L0036
+                    addd      L0036
                     aslb
                     rola
                     addd      #$000D
@@ -1848,49 +1653,49 @@ L1038               addd      L0036
                     ldd       L0018
                     pshs      d
                     ldd       #$0008
-                    lbsr      $329E
+                    lbsr      L329D
                     stb       $08,s
                     ldd       L0018
                     clra
                     stb       $09,s
                     ldd       #$0008
                     pshs      d
-L1065               leax      $04,s
+                    leax      $04,s
                     pshs      x
-                    lbsr      $18C8
+                    lbsr      L18C7
                     leas      $04,s
                     stb       $0a,s
-                    ldd       L0014
-L1072               beq       L1078
+                    ldd       copybytes
+                    beq       L1077
                     ldd       L0030
-                    bra       L107F
+                    bra       L107E
 
-L1078               ldx       L003E
+L1077               ldx       L003E
                     ldd       $23,x
                     addd      L002C
-L107F               std       $0b,s
+L107E               std       $0b,s
                     ldd       L002A
                     addd      L0022
                     addd      L0026
                     addd      $001E
                     addd      L0032
                     std       $0d,s
-                    leax      $193F,pcr
+                    leax      L193E,pcr
                     pshs      x
                     ldd       $0273,y
                     pshs      d
-                    lbsr      $229A
+                    lbsr      L2299
                     leas      $04,s
                     std       L003A
-                    bne       L10B1
-                    bra       L10A6
+                    bne       L10B0
+                    bra       L10A5
 
-L10A4               leas      -$0f,x
-L10A6               leax      L1943,pcr
+L10A3               leas      -$0f,x
+L10A5               leax      L1942,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $02,s
-L10B1               ldd       #$0200
+L10B0               ldd       #$0200
                     ldx       L003A
                     std       $0b,x
                     ldd       $04,s
@@ -1898,20 +1703,20 @@ L10B1               ldd       #$0200
                     ldx       L003A
                     ldd       $08,x
                     pshs      d
-                    lbsr      $192C
+                    lbsr      L192B
                     leas      $04,s
                     std       -$02,s
-                    beq       L10CF
+                    beq       L10CE
                     leax      $0f,s
-                    bra       L10A4
+                    bra       L10A3
 
-L10CF               leax      >$0005,y
+L10CE               leax      >$0005,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
                     leax      $06,s
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
@@ -1921,16 +1726,16 @@ L10CF               leax      >$0005,y
                     pshs      d
                     leax      $08,s
                     pshs      x
-                    lbsr      L2374
+                    lbsr      L2373
                     leas      $08,s
-                    lbsr      $1908
+                    lbsr      L1907
                     ldd       $0271,y
                     std       ,s
-L1103               ldx       ,s
+L1102               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L1103
+                    bne       L1102
                     ldd       ,s
                     subd      #$0002
                     std       ,s
@@ -1944,29 +1749,29 @@ L1103               ldx       ,s
                     pshs      d
                     ldd       $0271,y
                     pshs      d
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       $0271,y
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      L23D0
+                    lbsr      L23CF
                     leas      $04,s
-                    lbsr      $1908
+                    lbsr      L1907
                     leax      >$0005,y
                     pshs      x
                     ldd       #$0001
                     pshs      d
                     leax      $0270,y
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
                     ldb       $0270,y
                     sex
                     pshs      d
-                    lbsr      L2A84
+                    lbsr      L2A83
                     leas      $04,s
                     ldb       [,s]
                     clra
@@ -1974,15 +1779,15 @@ L1103               ldx       ,s
                     stb       [,s]
                     ldd       L0036
                     pshs      d
-                    lbsr      L1F8A
+                    lbsr      L1F89
                     leas      $02,s
                     leax      $0377,y
                     pshs      x
                     ldd       L003A
                     pshs      d
-                    lbsr      L2A1B
+                    lbsr      L2A1A
                     leas      $02,s
-                    lbsr      $314C
+                    lbsr      L314B
                     leax      $037f,y
                     pshs      x
                     leax      $0377,y
@@ -1991,9 +1796,9 @@ L1103               ldx       ,s
                     ldd       ,x
                     pshs      d
                     ldd       $002E
-                    lbsr      $3141
-                    lbsr      L30BE
-                    lbsr      $314C
+                    lbsr      L3140
+                    lbsr      L30BD
+                    lbsr      L314B
                     leax      $037b,y
                     pshs      x
                     leax      $037f,y
@@ -2001,28 +1806,26 @@ L1103               ldx       ,s
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       L11BF
-                    neg       $0000
-                    neg       $0002
-L11BF               puls      x
-                    lbsr      L30BE
+                    bsr       L11BE
+                    fcb       $00,$00,$00,$02
+L11BE               puls      x
+                    lbsr      L30BD
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
                     ldd       L002A
-                    lbsr      $3141
-                    lbsr      L30BE
+                    lbsr      L3140
+                    lbsr      L30BD
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       L11E2
-                    neg       $0000
-                    neg       $0002
-L11E2               puls      x
-                    lbsr      L30BE
-                    lbsr      $314C
+                    bsr       L11E1
+                    fcb       $00,$00,$00,$02
+L11E1               puls      x
+                    lbsr      L30BD
+                    lbsr      L314B
                     leax      $0383,y
                     pshs      x
                     leax      $037b,y
@@ -2031,25 +1834,25 @@ L11E2               puls      x
                     ldd       ,x
                     pshs      d
                     ldd       L0026
-                    lbsr      $3141
-                    lbsr      L30BE
-                    lbsr      $314C
+                    lbsr      L3140
+                    lbsr      L30BD
+                    lbsr      L314B
                     ldd       L003E
-                    bra       L1222
+                    bra       L1221
 
-L120B               ldx       L0050
+L120A               ldx       L0050
                     ldd       $13,x
                     anda      #$01
                     clrb
                     std       -$02,s
-                    beq       L121D
-                    lbsr      L145E
-                    lbsr      $1908
-L121D               ldx       L0050
+                    beq       L121C
+                    lbsr      L145D
+                    lbsr      L1907
+L121C               ldx       L0050
                     ldd       $11,x
-L1222               std       L0050
+L1221               std       L0050
                     ldd       L0050
-                    bne       L120B
+                    bne       L120A
                     clra
                     clrb
                     pshs      d
@@ -2060,7 +1863,7 @@ L1222               std       L0050
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      $28C4
+                    lbsr      $28C3
                     leas      $08,s
                     leax      >$0005,y
                     pshs      x
@@ -2068,13 +1871,13 @@ L1222               std       L0050
                     pshs      d
                     leax      >$002a,y
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
                     ldd       L002A
                     pshs      d
-                    lbsr      L2B29
+                    lbsr      L2B28
                     leas      $04,s
                     leax      >$0005,y
                     pshs      x
@@ -2082,7 +1885,7 @@ L1222               std       L0050
                     pshs      d
                     leax      $0277,y
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
@@ -2092,30 +1895,30 @@ L1222               std       L0050
                     pshs      d
                     leax      $0277,y
                     pshs      x
-                    lbsr      L2374
+                    lbsr      L2373
                     leas      $08,s
-                    lbsr      $1908
+                    lbsr      L1907
                     leax      >$0005,y
                     pshs      x
                     ldd       #$0002
                     pshs      d
                     leax      >$0026,y
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
                     ldd       L0026
                     pshs      d
-                    lbsr      L2B29
+                    lbsr      L2B28
                     leas      $04,s
                     ldd       L0026
-                    beq       L12C4
+                    beq       L12C3
                     ldd       L0026
                     pshs      d
-                    lbsr      L13DC
+                    lbsr      L13DB
                     leas      $02,s
-L12C4               clra
+L12C3               clra
                     clrb
                     pshs      d
                     leax      $0383,y
@@ -2125,7 +1928,7 @@ L12C4               clra
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      $28C4
+                    lbsr      $28C3
                     leas      $08,s
                     leax      >$0005,y
                     pshs      x
@@ -2133,17 +1936,17 @@ L12C4               clra
                     pshs      d
                     leax      >$004e,y
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
                     ldd       L004E
                     pshs      d
-                    lbsr      L2B29
+                    lbsr      L2B28
                     leas      $04,s
                     ldd       L0052
                     pshs      d
-                    lbsr      L2092
+                    lbsr      L2091
                     leas      $02,s
                     leax      >$0005,y
                     pshs      x
@@ -2151,17 +1954,17 @@ L12C4               clra
                     pshs      d
                     leax      >$004C,y
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
                     ldd       L004C
                     pshs      d
-                    lbsr      L2B29
+                    lbsr      L2B28
                     leas      $04,s
                     ldd       L0054
                     pshs      d
-                    lbsr      L2092
+                    lbsr      L2091
                     leas      $02,s
                     leax      >$0005,y
                     pshs      x
@@ -2170,25 +1973,25 @@ L12C4               clra
                     pshs      d
                     ldd       $0271,y
                     pshs      d
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       $0271,y
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      L23D0
+                    lbsr      L23CF
                     leas      $04,s
                     ldd       L003A
                     pshs      d
                     clra
                     clrb
                     pshs      d
-                    lbsr      L2A84
+                    lbsr      L2A83
                     leas      $04,s
                     ldu       #$0000
-                    bra       L1389
+                    bra       L1388
 
-L136E               tfr       u,d
+L136D               tfr       u,d
                     leax      >$0005,y
                     leax      d,x
                     pshs      x
@@ -2201,8 +2004,8 @@ L136E               tfr       u,d
                     comb
                     stb       [,s++]
                     leau      $01,u
-L1389               cmpu      #$0003
-                    blt       L136E
+L1388               cmpu      #$0003
+                    blt       L136D
                     ldd       L003A
                     pshs      d
                     ldd       #$0001
@@ -2211,40 +2014,40 @@ L1389               cmpu      #$0003
                     pshs      d
                     leax      >$0005,y
                     pshs      x
-                    lbsr      L2374
+                    lbsr      L2373
                     leas      $08,s
-                    lbsr      $1908
+                    lbsr      L1907
                     ldd       L003A
                     pshs      d
-                    lbsr      L2B74
+                    lbsr      L2B73
                     leas      $02,s
                     ldd       $000E
-                    beq       L13BB
-                    lbsr      $1CAC
-L13BB               ldd       L0014
-                    beq       L13D8
+                    beq       L13BA
+                    lbsr      L1CAB
+L13BA               ldd       copybytes
+                    beq       L13D7
                     ldd       L0016
-                    beq       L13D8
+                    beq       L13D7
                     ldd       $001E
                     pshs      d
-                    leax      L195C,pcr
+                    leax      L195B,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      L23D0
+                    lbsr      L23CF
                     leas      $06,s
-L13D8               leas      $0f,s
+L13D7               leas      $0f,s
                     puls      pc,u
-L13DC               pshs      u
+L13DB               pshs      u
                     ldd       #$FF32
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      $FF7E,s
                     clra
                     clrb
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      L2A1B
+                    lbsr      L2A1A
                     leas      $02,s
                     ldd       $02,x
                     pshs      d
@@ -2252,29 +2055,29 @@ L13DC               pshs      u
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      $28C4
+                    lbsr      $28C3
                     leas      $08,s
-                    bra       L1437
+                    bra       L1436
 
-L1408               lbsr      $1908
+L1407               lbsr      L1907
                     ldd       ,s
                     cmpd      $0086,s
-                    ble       L141A
+                    ble       L1419
                     ldd       $0086,s
                     std       ,s
-L141A               leax      >$0005,y
+L1419               leax      >$0005,y
                     pshs      x
                     ldd       $02,s
                     pshs      d
                     leax      $06,s
                     pshs      x
-                    lbsr      $3492
+                    lbsr      L3491
                     leas      $06,s
                     ldd       $0086,s
                     subd      ,s
                     std       $0086,s
-L1437               ldd       $0086,s
-                    ble       L1458
+L1436               ldd       $0086,s
+                    ble       L1457
                     ldd       L003A
                     pshs      d
                     ldd       #$0080
@@ -2283,40 +2086,40 @@ L1437               ldd       $0086,s
                     pshs      d
                     leax      $08,s
                     pshs      x
-                    lbsr      L232E
+                    lbsr      L232D
                     leas      $08,s
                     std       ,s
-                    bne       L1408
-L1458               leas      $0082,s
+                    bne       L1407
+L1457               leas      $0082,s
                     puls      pc,u
-L145E               pshs      u
+L145D               pshs      u
                     ldd       #$FFA3
-                    lbsr      $0110
+                    lbsr      L010F
                     leas      -$07,s
                     ldd       $004A
                     ldx       L0050
                     cmpd      $2f,x
-                    beq       L14A0
+                    beq       L149F
                     ldd       L0038
                     pshs      d
-                    leax      L1982,pcr
+                    leax      L1981,pcr
                     pshs      x
                     ldx       L0050
                     ldd       $2f,x
                     std       $004A
                     pshs      d
-                    lbsr      L22B9
+                    lbsr      L22B8
                     leas      $06,s
                     std       L0038
-                    bne       L14A0
+                    bne       L149F
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    leax      L1984,pcr
+                    leax      L1983,pcr
                     pshs      x
-                    lbsr      $1AB6
+                    lbsr      L1AB5
                     leas      $04,s
-L14A0               clra
+L149F               clra
                     clrb
                     pshs      d
                     ldx       L0050
@@ -2327,7 +2130,7 @@ L14A0               clra
                     pshs      d
                     ldd       L0038
                     pshs      d
-                    lbsr      $28C4
+                    lbsr      $28C3
                     leas      $08,s
                     ldd       L0038
                     pshs      d
@@ -2342,70 +2145,70 @@ L14A0               clra
                     pshs      d
                     ldd       L0048
                     pshs      d
-                    lbsr      L232E
+                    lbsr      L232D
                     leas      $08,s
                     std       -$02,s
-                    bne       L14ED
+                    bne       L14EC
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    lbsr      $18F6
+                    lbsr      L18F5
                     leas      $02,s
-L14ED               ldd       L0038
+L14EC               ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     std       ,s
                     ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    lbeq      L15A6
+                    lbeq      L15A5
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    lbsr      $18F6
+                    lbsr      L18F5
                     leas      $02,s
-                    lbra      L15A6
+                    lbra      L15A5
 
-L1512               leas      -$0a,s
+L1511               leas      -$0a,s
                     leax      ,s
                     pshs      x
-                    lbsr      L1DE1
+                    lbsr      L1DE0
                     leas      $02,s
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     tfr       d,u
                     ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L153D
+                    beq       L153C
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    lbsr      $18F6
+                    lbsr      L18F5
                     leas      $02,s
-L153D               leax      ,s
+L153C               leax      ,s
                     pshs      x
                     leax      $02,s
                     pshs      x
-                    lbsr      $19F8
+                    lbsr      L19F7
                     std       ,s
-                    lbsr      $1A1D
+                    lbsr      L1A1C
                     leas      $04,s
                     std       $0f,s
-                    bne       L159C
+                    bne       L159B
                     leax      ,s
                     pshs      x
-                    leax      $199F,pcr
+                    leax      L199E,pcr
                     pshs      x
-                    lbsr      $1AB6
-                    bra       L159A
+                    lbsr      L1AB5
+                    bra       L1599
 
-L1562               ldd       L0038
+L1561               ldd       L0038
                     pshs      d
                     ldd       #$0001
                     pshs      d
@@ -2413,83 +2216,83 @@ L1562               ldd       L0038
                     pshs      d
                     leax      $12,s
                     pshs      x
-                    lbsr      L232E
+                    lbsr      L232D
                     leas      $08,s
                     ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L158F
+                    beq       L158E
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    lbsr      $18F6
+                    lbsr      L18F5
                     leas      $02,s
-L158F               ldd       $0f,s
+L158E               ldd       $0f,s
                     pshs      d
                     leax      $0e,s
                     pshs      x
-                    lbsr      $17A1
-L159A               leas      $04,s
-L159C               tfr       u,d
+                    lbsr      L17A0
+L1599               leas      $04,s
+L159B               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    bne       L1562
+                    bne       L1561
                     leas      $0a,s
-L15A6               ldd       ,s
+L15A5               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    lbne      L1512
+                    lbne      L1511
                     ldd       L0038
                     pshs      d
-                    lbsr      L2CF9
+                    lbsr      L2CF8
                     leas      $02,s
                     std       ,s
                     ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       $160F
+                    beq       L160E
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    lbsr      $18F6
+                    lbsr      L18F5
                     leas      $02,s
-                    bra       $160F
-                    ldd       L0038
-                    pshs      y,dp,a,cc
-                    ror       L00CC
-                    neg       $0001
+                    bra       L160E
+
+L15D5               ldd       L0038
+                    pshs      d
+                    ldd       #$0001
                     pshs      d
                     ldd       #$0003
                     pshs      d
                     leax      $08,s
                     pshs      x
-                    lbsr      $232F
+                    lbsr      L232D
                     leas      $08,s
                     ldx       L0038
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L1603
+                    beq       L1601
                     ldx       L0050
                     ldd       $2f,x
                     pshs      d
-                    lbsr      L18F7
+                    lbsr      L18F5
                     leas      $02,s
-L1603               clra
+L1601               clra
                     clrb
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    lbsr      L17A2
+                    lbsr      L17A0
                     leas      $04,s
-                    ldd       ,s
+L160E               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bne       $15D7
+                    bne       L15D5
                     leax      >$0005,y
                     pshs      x
                     ldx       L0050
@@ -2497,10 +2300,10 @@ L1603               clra
                     pshs      d
                     ldd       L0048
                     pshs      d
-                    lbsr      L3493
+                    lbsr      L3491
                     leas      $06,s
                     ldd       $005A
-                    bne       L164F
+                    bne       L164D
                     clra
                     clrb
                     pshs      d
@@ -2511,9 +2314,9 @@ L1603               clra
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      L28C5
+                    lbsr      $28C3
                     leas      $08,s
-L164F               ldd       L003A
+L164D               ldd       L003A
                     pshs      d
                     ldd       #$0001
                     pshs      d
@@ -2522,7 +2325,7 @@ L164F               ldd       L003A
                     pshs      d
                     ldd       L0048
                     pshs      d
-                    lbsr      $2375
+                    lbsr      L2373
                     leas      $08,s
                     leax      $0377,y
                     pshs      x
@@ -2532,12 +2335,12 @@ L164F               ldd       L003A
                     pshs      d
                     ldx       L0050
                     ldd       $1f,x
-                    lbsr      L3142
-                    lbsr      $30BF
-                    lbsr      L314D
+                    lbsr      L3140
+                    lbsr      L30BD
+                    lbsr      L314B
                     ldd       #$0001
                     std       $005A
-                    lbsr      L1909
+                    lbsr      L1907
                     clra
                     clrb
                     std       ,s
@@ -2545,9 +2348,9 @@ L164F               ldd       L003A
                     ldx       L0050
                     addd      $1f,x
                     tfr       d,u
-                    bra       L16B0
+                    bra       L16AE
 
-L169B               ldb       ,u+
+L1699               ldb       ,u+
                     ldx       >$007a,y
                     leax      $01,x
                     stx       >$007a,y
@@ -2555,13 +2358,13 @@ L169B               ldb       ,u+
                     ldd       ,s
                     addd      #$0001
                     std       ,s
-L16B0               ldd       ,s
+L16AE               ldd       ,s
                     ldx       L0050
                     cmpd      $1d,x
-                    bcs       L169B
+                    bcs       L1699
                     ldx       L0050
                     ldd       $1b,x
-                    lbeq      L1722
+                    lbeq      L1720
                     clra
                     clrb
                     pshs      d
@@ -2572,7 +2375,7 @@ L16B0               ldd       ,s
                     pshs      d
                     ldd       L003A
                     pshs      d
-                    lbsr      L28C5
+                    lbsr      $28C3
                     leas      $08,s
                     ldd       L003A
                     pshs      d
@@ -2587,7 +2390,7 @@ L16B0               ldd       ,s
                     ldx       L0050
                     addd      $1d,x
                     pshs      d
-                    lbsr      $2375
+                    lbsr      L2373
                     leas      $08,s
                     leax      $037b,y
                     pshs      x
@@ -2597,14 +2400,14 @@ L16B0               ldd       ,s
                     pshs      d
                     ldx       L0050
                     ldd       $1b,x
-                    lbsr      L3142
-                    lbsr      $30BF
-                    lbsr      L314D
-                    lbsr      L1909
+                    lbsr      L3140
+                    lbsr      L30BD
+                    lbsr      L314B
+                    lbsr      L1907
                     clra
                     clrb
                     std       $005A
-L1722               ldd       L001C
+L1720               ldd       L001C
                     pshs      d
                     ldx       L0050
                     ldd       $17,x
@@ -2659,11 +2462,11 @@ L1722               ldd       L001C
                     subd      $1f,x
                     ldx       L0050
                     std       $1f,x
-                    lbra      L18C5
+                    lbra      L18C3
 
-L17A2               pshs      u
+L17A0               pshs      u
                     ldd       #$FFB1
-                    lbsr      L0111
+                    lbsr      L010F
                     leas      -$07,s
                     ldx       $0b,s
                     ldd       $01,x
@@ -2672,7 +2475,7 @@ L17A2               pshs      u
                     ldb       [$0b,s]
                     stb       $02,s
                     ldd       $0d,s
-                    beq       L17DA
+                    beq       L17D8
                     ldx       $0d,s
                     ldd       $0C,x
                     std       $03,s
@@ -2682,68 +2485,68 @@ L17A2               pshs      u
                     ldb       $02,s
                     clra
                     andb      #$80
-                    lbeq      L1822
+                    lbeq      L1820
                     ldd       $03,s
                     subd      L002C
                     std       $03,s
-                    bra       L1822
+                    bra       L1820
 
-L17DA               ldb       $02,s
+L17D8               ldb       $02,s
                     stb       $01,s
                     clra
                     andb      #$07
                     tfr       d,x
-                    bra       L1808
+                    bra       L1806
 
-L17E5               ldd       L001C
-                    bra       L17F7
+L17E3               ldd       L001C
+                    bra       L17F5
 
-L17E9               ldd       $0024
-                    bra       L17F7
+L17E7               ldd       $0024
+                    bra       L17F5
 
-L17ED               ldd       $0020
-                    bra       L17F7
+L17EB               ldd       $0020
+                    bra       L17F5
 
-L17F1               ldd       L0028
-                    bra       L17F7
+L17EF               ldd       L0028
+                    bra       L17F5
 
-L17F5               ldd       L002C
-L17F7               std       $03,s
-                    bra       L1822
+L17F3               ldd       L002C
+L17F5               std       $03,s
+                    bra       L1820
 
-L17FB               leax      L19BE,pcr
+L17F9               leax      L19BC,pcr
                     pshs      x
-                    lbsr      L1AB7
+                    lbsr      L1AB5
                     leas      $02,s
-                    bra       L1822
+                    bra       L1820
 
-L1808               stx       -$02,s
-                    beq       L17E5
+L1806               stx       -$02,s
+                    beq       L17E3
                     cmpx      #$0001
-                    beq       L17E9
+                    beq       L17E7
                     cmpx      #$0002
-                    beq       L17ED
+                    beq       L17EB
                     cmpx      #$0003
-                    beq       L17F1
+                    beq       L17EF
                     cmpx      #$0004
-                    beq       L17F5
-                    bra       L17FB
+                    beq       L17F3
+                    bra       L17F9
 
-L1822               ldb       $02,s
+L1820               ldb       $02,s
                     clra
                     andb      #$40
-                    beq       L1831
+                    beq       L182F
                     ldd       $03,s
                     nega
                     negb
                     sbca      #$00
                     std       $03,s
-L1831               ldb       $02,s
+L182F               ldb       $02,s
                     clra
                     andb      #$30
                     stb       ,s
                     cmpb      #$20
-                    beq       L185D
+                    beq       L185B
                     ldd       $05,s
                     pshs      d
                     ldx       L0050
@@ -2753,265 +2556,198 @@ L1831               ldb       $02,s
                     ldb       ,s
                     clra
                     andb      #$10
-                    bne       L185D
+                    bne       L185B
                     ldd       $05,s
                     pshs      d
                     ldx       L0050
                     ldd       $1d,x
                     addd      ,s++
                     std       $05,s
-L185D               ldb       $02,s
+L185B               ldb       $02,s
                     clra
                     andb      #$08
-                    beq       L186F
+                    beq       L186D
                     ldb       [$05,s]
                     sex
                     addd      $03,s
                     stb       [$05,s]
-                    bra       L1877
+                    bra       L1875
 
-L186F               ldd       [$05,s]
+L186D               ldd       [$05,s]
                     addd      $03,s
                     std       [$05,s]
-L1877               ldb       ,s
+L1875               ldb       ,s
                     cmpb      #$20
-                    beq       L18C5
+                    beq       L18C3
                     ldb       ,s
                     clra
                     andb      #$10
-                    beq       L1888
+                    beq       L1886
                     ldd       L0028
-                    bra       L188A
+                    bra       L1888
 
-L1888               ldd       $0024
-L188A               ldx       $0b,s
+L1886               ldd       $0024
+L1888               ldx       $0b,s
                     addd      $01,x
                     tfr       d,u
                     ldb       $01,s
                     clra
                     andb      #$07
                     cmpd      #$0004
-                    bne       L18B1
+                    bne       L18AF
                     pshs      u
                     leax      >$0052,y
                     pshs      x
-                    lbsr      $200F
+                    lbsr      L200D
                     leas      $04,s
                     ldd       L004E
                     addd      #$0001
                     std       L004E
-                    bra       L18C5
+                    bra       L18C3
 
-L18B1               pshs      u
+L18AF               pshs      u
                     leax      >$0054,y
                     pshs      x
-                    lbsr      $200F
+                    lbsr      L200D
                     leas      $04,s
                     ldd       L004C
                     addd      #$0001
                     std       L004C
-L18C5               leas      $07,s
+L18C3               leas      $07,s
                     puls      pc,u
-                    pshs      u
+L18C7               pshs      u
                     ldd       #$FFBC
-                    lbsr      L0111
+                    lbsr      L010F
                     ldu       $04,s
                     leas      -$02,s
                     ldd       #$FFFF
-                    bra       L18E5
+                    bra       L18E3
 
-L18DA               ldd       ,s
+L18D8               ldd       ,s
                     pshs      d
                     ldb       ,u+
                     sex
                     eora      ,s+
                     eorb      ,s+
-L18E5               std       ,s
+L18E3               std       ,s
                     ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L18DA
+                    bne       L18D8
                     ldd       ,s
                     puls      pc,u,x
-L18F7               pshs      u
+L18F5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0111
+                    lbsr      L010F
                     ldd       $04,s
                     pshs      d
-                    leax      $19CD,pcr
-                    bra       L1924
+                    leax      L19CB,pcr
+                    bra       L1922
 
-L1909               pshs      u
+L1907               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0111
+                    lbsr      L010F
                     ldx       L003A
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L192B
+                    beq       L1929
                     ldd       $0273,y
                     pshs      d
-                    leax      $19E3,pcr
-L1924               pshs      x
-                    lbsr      L1AB7
+                    leax      L19E1,pcr
+L1922               pshs      x
+                    lbsr      L1AB5
                     leas      $04,s
-L192B               puls      pc,u
-                    pshs      u,x,d
+L1929               puls      pc,u
+L192B               pshs      u,x,d
                     lda       $09,s
                     ldb       #$02
                     ldx       #$0000
                     ldu       $0a,s
                     os9       I$SetStt
                     puls      u,x,d
-                    lbra      L3568
-                    asr       $782B
-L1943               neg       L0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $2063
-                    fcb       $72
-                    fcb       $65
-                    fcb       $61
-                    lsr       $6520
-                    clr       -$0b,s
-                    lsr       $7075
-                    lsr       L2066
-                    rol       $0C,s
-                    fcb       $65
-L195C               neg       L0042
-                    fcb       $41,$53,$49,$43,$30,$39,$20,$73
-                    fcb       $74,$61,$74,$69,$63,$20,$64,$61
-                    fcb       $74,$61,$20,$73,$69,$7a,$65,$20
-                    fcb       $69,$73,$20,$25,$64,$20,$62,$79
-                    fcb       $74,$65,$73,$0d
-L1982               neg       $0072
-L1984               neg       L0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $2072
-                    fcb       $65
-                    clr       -$10,s
-                    fcb       $65
-                    jmp       0,y
-                    rol       $0e,s
-                    neg       $7574
-                    bra       L19FF
-                    rol       $0C,s
-                    fcb       $65
-                    bra       $19C3
-                    com       >$0073
-                    rol       $6D62
-                    clr       $0C,s
-                    bra       $19CD
-                    com       L206E
-                    clr       -$0C,s
-                    bra       $1A15
-                    clr       -$0b,s
-                    jmp       $04,s
-                    bra       L1A1E
-                    jmp       0,y
-                    com       $0f,s
-                    lsr       $07,s
-                    fcb       $65
-                    jmp       0,x
-L19BE               fcb       $72
-                    fcb       $65
-                    ror       0,y
-                    lsr       $7970
-                    fcb       $65
-                    bra       $1A2D
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L0065
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       $1A46
-                    fcb       $65
-                    fcb       $61
-                    lsr       $09,s
-                    jmp       $07,s
-                    bra       L1A42
-                    rol       $0C,s
-                    fcb       $65
-                    bra       $1A06
-                    com       >L0065
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       $1A61
-                    fcb       $72
-                    rol       -$0C,s
-                    rol       $0e,s
-                    asr       0,y
-                    ror       $09,s
-                    inc       $05,s
-                    bra       L1A1C
-                    com       >$0034
-                    nega
+                    lbra      L3566
+L193E               fcb       $77,$78,$2B
+                    fcb       $00
+L1942               fcc       /can't create output file/
+                    fcb       $00
+L195B               fcc       /BASIC09 static data size is %d bytes/
+                    fcb       $0D,$00
+L1981               fcb       $72
+                    fcb       $00
+L1983               fcc       /can't reopen input file %s/
+                    fcb       $00
+L199E               fcc       /symbol %s not found in codgen/
+                    fcb       $00
+L19BC               fcc       /ref type error/
+                    fcb       $00
+L19CB               fcc       /error reading file %s/
+                    fcb       $00
+L19E1               fcc       /error writing file %s/
+                    fcb       $00
+L19F7               pshs      u
                     ldu       $04,s
                     leas      -$02,s
-L19FF               clra
+                    clra
                     clrb
-                    bra       L1A0C
+                    bra       L1A0A
 
-L1A03               ldd       ,s
+L1A01               ldd       ,s
                     pshs      d
                     ldb       ,u+
                     sex
                     addd      ,s++
-L1A0C               std       ,s
+L1A0A               std       ,s
                     ldb       ,u
-                    bne       L1A03
+                    bne       L1A01
                     ldd       ,s
                     pshs      d
                     ldd       #$0173
-                    lbsr      L31D4
-L1A1C               puls      pc,u,x
-L1A1E               pshs      u
+                    lbsr      L31D2
+                    puls      pc,u,x
+L1A1C               pshs      u
                     ldd       $04,s
                     aslb
                     rola
                     leax      $0387,y
                     leax      d,x
                     ldu       ,x
-                    bra       L1A50
+                    bra       L1A4E
 
-L1A2E               ldb       [$06,s]
+L1A2C               ldb       [$06,s]
                     sex
                     pshs      d
                     ldb       ,u
                     sex
                     cmpd      ,s++
-                    bne       L1A4D
+                    bne       L1A4B
                     pshs      u
                     ldd       $08,s
                     pshs      d
-L1A42               lbsr      $2F1C
+                    lbsr      L2F1A
                     leas      $04,s
                     std       -$02,s
-                    lbeq      L1C1D
-L1A4D               ldu       $10,u
-L1A50               stu       -$02,s
-                    bne       L1A2E
+                    lbeq      L1C1B
+L1A4B               ldu       $10,u
+L1A4E               stu       -$02,s
+                    bne       L1A2C
                     clra
                     clrb
                     puls      pc,u
-                    pshs      u,d
+L1A56               pshs      u,d
                     ldd       $06,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      $19F9
+                    lbsr      L19F7
                     leas      $02,s
                     std       $02,s
                     pshs      d
-                    lbsr      L1A1E
+                    lbsr      L1A1C
                     leas      $04,s
                     std       -$02,s
-                    bne       L1AB0
+                    bne       L1AAE
                     ldd       ,s
                     aslb
                     rola
@@ -3032,29 +2768,29 @@ L1A50               stu       -$02,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L1B84
+                    lbsr      L1B82
                     leas      $04,s
                     std       -$02,s
-                    beq       L1AAC
+                    beq       L1AAA
                     ldx       $06,s
                     ldd       $0a,x
                     ora       #$01
                     std       $0a,x
-L1AAC               clra
+L1AAA               clra
                     clrb
-                    bra       L1AB3
+                    bra       L1AB1
 
-L1AB0               ldd       #$0001
-L1AB3               puls      pc,u,x
+L1AAE               ldd       #$0001
+L1AB1               puls      pc,u,x
                     puls      pc,u,x
-L1AB7               pshs      u,d
+L1AB5               pshs      u,d
                     ldd       $0228,y
                     std       ,s
-                    leax      $1E2E,pcr
+                    leax      L1E2C,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      $23D1
+                    lbsr      L23CF
                     leas      $04,s
                     ldd       $0C,s
                     pshs      d
@@ -3066,35 +2802,35 @@ L1AB7               pshs      u,d
                     pshs      d
                     leax      $00A3,y
                     pshs      x
-                    lbsr      $23D1
+                    lbsr      L23CF
                     leas      $0a,s
-                    leax      $1E3D,pcr
+                    leax      L1E3B,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      $23D1
+                    lbsr      L23CF
                     leas      $04,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L356D
+                    lbsr      L356B
                     leas      $02,s
                     puls      pc,u,x
-                    pshs      u
+L1B05               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
-                    bra       L1B24
+                    bra       L1B22
 
-L1B11               ldd       ,s
+L1B0F               ldd       ,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L3181
+                    lbsr      L317F
                     pshs      d
                     ldd       $04,s
                     addd      #$FFD0
                     addd      ,s++
-L1B24               std       ,s
+L1B22               std       ,s
                     ldb       ,u+
                     sex
                     std       $02,s
@@ -3103,25 +2839,25 @@ L1B24               std       ,s
                     ldb       ,x
                     clra
                     andb      #$08
-                    bne       L1B11
+                    bne       L1B0F
                     ldd       $02,s
                     cmpd      #$006B
-                    beq       L1B48
+                    beq       L1B46
                     ldd       $02,s
                     cmpd      #$004B
-                    bne       L1B54
-L1B48               ldd       ,s
+                    bne       L1B52
+L1B46               ldd       ,s
                     pshs      d
                     ldd       #$0004
-                    lbsr      L3181
+                    lbsr      L317F
                     std       ,s
-L1B54               ldd       ,s
+L1B52               ldd       ,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      L32C2
+                    lbsr      L32C0
                     leas      $04,s
                     puls      pc,u
-L1B62               pshs      u
+L1B60               pshs      u
                     ldu       $04,s
                     ldd       ,u
                     std       [$02,u]
@@ -3131,168 +2867,169 @@ L1B62               pshs      u
                     leax      >$0060,y
                     pshs      x
                     cmpu      ,s++
-                    beq       L1B82
+                    beq       L1B80
                     ldd       L005C
                     std       ,u
                     stu       L005C
-L1B82               puls      pc,u
-L1B84               pshs      u,d
+L1B80               puls      pc,u
+L1B82               pshs      u,d
                     clra
                     clrb
                     std       ,s
                     ldu       >$0060,y
-                    bra       L1BCB
+                    bra       L1BC9
 
-L1B90               ldb       $04,u
+L1B8E               ldb       $04,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    bne       L1BC9
+                    bne       L1BC7
                     ldd       $06,s
                     pshs      d
                     pshs      u
                     ldd       #$0004
                     addd      ,s++
                     pshs      d
-                    lbsr      $2F1C
+                    lbsr      L2F1A
                     leas      $04,s
                     std       -$02,s
-                    bne       L1BC9
+                    bne       L1BC7
                     ldd       $08,s
-                    beq       L1BBC
+                    beq       L1BBA
                     tfr       u,d
                     puls      pc,u,x
-L1BBC               ldd       ,u
+L1BBA               ldd       ,u
                     std       ,s
                     pshs      u
-                    lbsr      L1B62
+                    lbsr      L1B60
                     leas      $02,s
                     ldu       ,s
-L1BC9               ldu       ,u
-L1BCB               leax      >$0060,y
+L1BC7               ldu       ,u
+L1BC9               leax      >$0060,y
                     pshs      x
                     cmpu      ,s++
-                    bne       L1B90
+                    bne       L1B8E
                     ldd       ,s
                     puls      pc,u,x
-                    pshs      u
+L1BD8               pshs      u
                     ldd       #$0001
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L1B84
+                    lbsr      L1B82
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    bne       L1C1D
+                    bne       L1C1B
                     ldd       L005C
-                    beq       L1BFC
+                    beq       L1BFA
                     ldu       L005C
                     ldd       ,u
                     std       L005C
-                    bra       L1C07
+                    bra       L1C05
 
-L1BFC               ldd       #$0010
+L1BFA               ldd       #$0010
                     pshs      d
-                    bsr       L1C21
+                    bsr       L1C1F
                     leas      $02,s
                     tfr       d,u
-L1C07               leax      >$0060,y
+L1C05               leax      >$0060,y
                     stx       $02,u
                     ldd       >$0060,y
                     std       ,u
                     ldx       >$0060,y
                     stu       $02,x
                     stu       >$0060,y
-L1C1D               tfr       u,d
+L1C1B               tfr       u,d
                     puls      pc,u
-L1C21               pshs      u,d
+L1C1F               pshs      u,d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L34B9
+                    lbsr      L34B7
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L1C5A
+                    bne       L1C58
                     ldd       L0046
-                    beq       L1C4D
+                    beq       L1C4B
                     ldd       L0046
                     pshs      d
-                    leax      $1E3F,pcr
+                    leax      L1E3D,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      $23D1
+                    lbsr      L23CF
                     leas      $06,s
-L1C4D               leax      L1E5A,pcr
+L1C4B               leax      L1E58,pcr
                     pshs      x
-                    lbsr      L1AB7
+                    lbsr      L1AB5
                     leas      $02,s
-                    bra       L1C5E
+                    bra       L1C5C
 
-L1C5A               ldd       ,s
+L1C58               ldd       ,s
                     puls      pc,u,x
-L1C5E               puls      pc,u,x
-                    pshs      u
+L1C5C               puls      pc,u,x
+L1C5E               pshs      u
                     ldd       $04,s
                     clra
                     andb      #$07
                     tfr       d,x
-                    bra       L1C91
+                    bra       L1C8F
 
-L1C6B               leax      $1E68,pcr
-                    bra       L1C8D
+L1C69               leax      L1E66,pcr
+                    bra       L1C8B
 
-L1C71               leax      L1E6D,pcr
-                    bra       L1C8D
+L1C6F               leax      L1E6B,pcr
+                    bra       L1C8B
 
-L1C77               leax      $1E72,pcr
-                    bra       L1C8D
+L1C75               leax      L1E70,pcr
+                    bra       L1C8B
 
-L1C7D               leax      $1E77,pcr
-                    bra       L1C8D
+L1C7B               leax      L1E75,pcr
+                    bra       L1C8B
 
-L1C83               leax      $1E7C,pcr
-                    bra       L1C8D
+L1C81               leax      L1E7A,pcr
+                    bra       L1C8B
 
-L1C89               leax      $1E81,pcr
-L1C8D               tfr       x,d
+L1C87               leax      L1E7F,pcr
+L1C8B               tfr       x,d
                     puls      pc,u
-L1C91               cmpx      #$0004
-                    beq       L1C6B
+L1C8F               cmpx      #$0004
+                    beq       L1C69
                     stx       -$02,s
-                    beq       L1C71
+                    beq       L1C6F
                     cmpx      #$0001
-                    beq       L1C77
+                    beq       L1C75
                     cmpx      #$0002
-                    beq       L1C7D
+                    beq       L1C7B
                     cmpx      #$0003
-                    beq       L1C83
-                    bra       L1C89
+                    beq       L1C81
+                    bra       L1C87
                     puls      pc,u
-                    pshs      u,d
+L1CAB               pshs      u,d
                     ldd       $0273,y
                     pshs      d
                     ldd       $0271,y
                     pshs      d
-                    leax      L1E85,pcr
+                    leax      L1E83,pcr
                     pshs      x
-                    lbsr      $23BF
+                    lbsr      L23BD
                     leas      $06,s
-                    leax      $1EA3,pcr
+                    leax      L1EA1,pcr
                     pshs      x
-                    lbsr      $22ED
+                    lbsr      L22EB
                     leas      $02,s
                     ldd       L003E
-                    lbra      $1D4E
-                    ldx       ,s
+                    lbra      L1D4C
+
+L1CD4               ldx       ,s
                     ldd       $13,x
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      $1D49
+                    lbeq      L1D47
                     ldx       ,s
                     ldd       $2f,x
                     pshs      d
@@ -3313,39 +3050,38 @@ L1C91               cmpx      #$0004
                     pshs      d
                     ldd       $0C,s
                     pshs      d
-                    leax      L1ED5,pcr
+                    leax      L1ED3,pcr
                     pshs      x
-                    lbsr      $23BF
+                    lbsr      L23BD
                     leas      $10,s
                     ldd       $0010
-                    beq       $1D49
-                    fcb       $02
+                    beq       L1D47
                     ldx       ,s
                     ldu       $2d,x
-                    bra       L1D46
+                    bra       L1D43
 
-L1D2A               ldd       $0C,u
+L1D27               ldd       $0C,u
                     pshs      d
                     ldd       $0a,u
                     pshs      d
-                    lbsr      $1C61
+                    lbsr      L1C5E
                     std       ,s
                     pshs      u
-                    leax      L1EFB,pcr
+                    leax      L1EF8,pcr
                     pshs      x
-                    lbsr      L23C0
+                    lbsr      L23BD
                     leas      $08,s
                     ldu       $0e,u
-L1D46               stu       -$02,s
-                    bne       L1D2A
-                    ldx       ,s
+L1D43               stu       -$02,s
+                    bne       L1D27
+L1D47               ldx       ,s
                     ldd       $11,x
-                    std       ,s
+L1D4C               std       ,s
                     ldd       ,s
-                    lbne      $1CD7
-                    leax      L1F0E,pcr
+                    lbne      L1CD4
+                    leax      L1F0B,pcr
                     pshs      x
-                    lbsr      L22EE
+                    lbsr      L22EB
                     leas      $02,s
                     ldd       L0022
                     pshs      d
@@ -3357,25 +3093,25 @@ L1D46               stu       -$02,s
                     pshs      d
                     ldd       $002E
                     pshs      d
-                    leax      $1F31,pcr
+                    leax      L1F2E,pcr
                     pshs      x
-                    lbsr      L23C0
+                    lbsr      L23BD
                     leas      $0C,s
-L1D81               puls      pc,u,x
-                    pshs      u
+                    puls      pc,u,x
+L1D80               pshs      u
                     leax      >$0060,y
                     cmpx      >$0060,y
-                    beq       L1DDD
-                    leax      L1F5D,pcr
+                    beq       L1DDA
+                    leax      L1F5A,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      L23D2
+                    lbsr      L23CF
                     leas      $04,s
                     ldu       >$0060,y
-                    bra       L1DCD
+                    bra       L1DCA
 
-L1DA6               ldx       $0e,u
+L1DA3               ldx       $0e,u
                     ldd       $2f,x
                     pshs      d
                     ldd       $0e,u
@@ -3384,213 +3120,113 @@ L1DA6               ldx       $0e,u
                     ldd       #$0004
                     addd      ,s++
                     pshs      d
-                    leax      $1F75,pcr
+                    leax      L1F72,pcr
                     pshs      x
                     leax      $00A3,y
                     pshs      x
-                    lbsr      L23D2
+                    lbsr      L23CF
                     leas      $0a,s
                     ldu       ,u
-L1DCD               leax      >$0060,y
+L1DCA               leax      >$0060,y
                     pshs      x
                     cmpu      ,s++
-                    bne       L1DA6
+                    bne       L1DA3
                     ldd       #$0001
                     puls      pc,u
-L1DDD               clra
+L1DDA               clra
                     clrb
                     puls      pc,u
-L1DE1               puls      pc,u
-                    pshs      u
+                    puls      pc,u
+L1DE0               pshs      u
                     ldu       $04,s
                     leas      -$02,s
-                    bra       L1DEF
+                    bra       L1DEC
 
-L1DEB               ldd       ,s
+L1DE8               ldd       ,s
                     stb       ,u+
-L1DEF               ldd       L0038
+L1DEC               ldd       L0038
                     pshs      d
-                    lbsr      L2C99
+                    lbsr      L2C96
                     leas      $02,s
                     std       ,s
-                    bne       L1DEB
+                    bne       L1DE8
                     clra
                     clrb
                     stb       ,u
-L1E00               puls      pc,u,x
-                    pshs      u,d
+                    puls      pc,u,x
+L1DFF               pshs      u,d
                     ldd       $0228,y
                     std       ,s
                     ldd       L003A
-                    beq       L1E22
+                    beq       L1E1F
                     ldd       L003A
                     pshs      d
-                    lbsr      L2B76
+                    lbsr      L2B73
                     leas      $02,s
                     ldd       $0273,y
                     pshs      d
-                    lbsr      L33B2
+                    lbsr      L33AF
                     leas      $02,s
-L1E22               ldd       $0228,y
+L1E1F               ldd       $0228,y
                     pshs      d
-                    lbsr      L356E
+                    lbsr      L356B
                     leas      $02,s
                     puls      pc,u,x
-                    inc       $09,s
-                    jmp       $0b,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L1E9D
-                    fcb       $61
-                    lsr       $616C
-                    abx
-                    bra       L1E3E
-
-L1E3E               tst       $0000
-                    fcb       $6e,$65,$65,$64,$20,$25,$64,$20
-                    fcb       $62,$79,$74,$65,$73,$20,$66,$6f
-                    fcb       $72,$20,$6C,$69,$6e,$6b,$62,$75
-                    fcb       $66,$0d
-L1E5A               neg       $006F
-                    fcb       $75
-                    lsr       $206F
-                    ror       0,y
-                    tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       >L0063
-                    clr       $04,s
-                    fcb       $65
-L1E6D               neg       L0075
-                    lsr       $01,s
-                    lsr       >$0069
-                    lsr       $01,s
-                    lsr       >L0075
-                    lsr       -$10,s
-                    lsr       0,x
-                    rol       $04,s
-                    neg       $6400
-                    swi
-                    swi
-                    swi
-
-L1E85               neg       L004C
-                    rol       $0e,s
-                    fcb       $6b
-                    fcb       $61
-                    asr       $05,s
-                    bra       $1EFC
-                    fcb       $61
-                    neg       L2066
-                    clr       -$0e,s
-                    bra       L1EBC
-                    com       L2020
-                    rora
-                    rol       $0C,s
-L1E9D               fcb       $65
-                    bra       L1ECD
-                    bra       L1EC7
-                    com       >$000D
-                    tst       $0053
-                    fcb       $65,$63,$74,$69,$6f,$6e,$20,$20
-                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $43,$6f,$64,$65,$20
-L1EBC               fcb       $49,$44,$61,$74,$20,$55,$44,$61
-                    fcb       $74,$20,$49
-L1EC7               fcb       $44,$70,$44,$20,$55,$44
-L1ECD               fcb       $70,$44,$20,$46,$69,$6C,$65
-                    fcb       $0d
-L1ED5               neg       L0025
-                    fcb       $2d,$31,$36,$73,$20,$25,$30,$34
-                    fcb       $78,$20,$25,$30,$34,$78,$20,$25
-                    fcb       $30,$34,$78,$20,$25,$30,$32,$78
-                    fcb       $20,$20,$20,$25,$30,$32,$78,$20
-                    fcb       $25,$73,$0d,$00
-L1EFB               bra       $1F1D
-                    bra       $1F1F
-                    bra       $1F26
-                    blt       L1F3C
-                    com       $2025
-                    com       $2025
-                    leax      -$0C,y
-                    asl       $0D00
-L1F0E               bra       L1F30
-                    bra       L1F32
-                    bra       L1F34
-                    bra       L1F36
-                    bra       L1F38
-                    bra       L1F3A
-                    bra       L1F3C
-                    bra       L1F3E
-
-L1F1E               bra       L1F4D
-
-L1F20               blt       L1F4F
-                    blt       L1F44
-                    blt       $1F53
-                    blt       $1F55
-                    bra       L1F57
-                    blt       L1F59
-                    blt       $1F4E
-                    blt       L1F5D
-L1F30               neg       $0020
-L1F32               bra       L1F54
-
-L1F34               bra       $1F56
-
-L1F36               bra       $1F58
-
-L1F38               bra       $1F5A
-
-L1F3A               bra       $1F5C
-
-L1F3C               bra       L1F5E
-
-L1F3E               bra       L1F60
-                    bra       L1F62
-                    bcs       L1F74
-L1F44               pshs      u,y,x,dp
-                    bra       L1F6D
-                    leax      -$0C,y
-                    asl       $2025
-L1F4D               leax      -$0C,y
-L1F4F               asl       $2025
-                    leax      -$0e,y
-L1F54               asl       L2020
-L1F57               bcs       L1F89
-L1F59               leas      -$08,s
-                    tst       $0000
-L1F5D               fcb       $55
-L1F5E               fcb       $6e,$72
-L1F60               fcb       $65,$73
-L1F62               fcb       $6f,$6C,$76,$65,$64,$20,$72,$65
-                    fcb       $66,$65,$72
-L1F6D               fcb       $65,$6e,$63,$65,$73,$3a,$0d
-L1F74               neg       $0020
-                    fcb       $25,$2d,$31,$36,$73,$20,$25,$2d
-                    fcb       $31,$36,$73,$20,$69,$6e,$20,$25
-                    fcb       $2d,$31,$36
-L1F89               fcb       $73
-L1F8A               fcb       $0d,$00
-                    pshs      u
+L1E2C               fcc       /linker fatal: /
+                    fcb       $00
+L1E3B               fcb       $0D,$00
+L1E3D               fcc       /need %d bytes for linkbuf/
+                    fcb       $0D,$00
+L1E58               fcc       /out of memory/
+                    fcb       $00
+L1E66               fcc       /code/
+                    fcb       $00
+L1E6B               fcc       /udat/
+                    fcb       $00
+L1E70               fcc       /idat/
+                    fcb       $00
+L1E75               fcc       /udpd/
+                    fcb       $00
+L1E7A               fcc       /idpd/
+                    fcb       $00
+L1E7F               fcb       $3F,$3F,$3F
+                    fcb       $00
+L1E83               fcc       /Linkage map for %s  File - %s/
+                    fcb       $00
+L1EA1               fcb       $0D,$0D
+                    fcc       /Section          Code IDat UDat IDpD UDpD File/
+                    fcb       $0D,$00
+L1ED3               fcc       /%-16s %04x %04x %04x %02x   %02x %s/
+                    fcb       $0D,$00
+L1EF8               fcc       /     %-9s %s %04x/
+                    fcb       $0D,$00
+L1F0B               fcc       /                 ---- ---- ---- --/
+                    fcb       $00
+L1F2E               fcc       /                 %04x %04x %04x %02x  %02x/
+                    fcb       $0D,$00
+L1F5A               fcc       /Unresolved references:/
+                    fcb       $0D,$00
+L1F72               fcc       / %-16s %-16s in %-16s/
+                    fcb       $0D,$00
+L1F89               pshs      u
                     ldu       >$005C,y
-                    bra       L1F9D
+                    bra       L1F9A
 
-L1F94               ldu       ,u
+L1F91               ldu       ,u
                     ldd       $04,s
                     subd      #$0007
                     std       $04,s
-L1F9D               ldd       $04,s
-                    ble       L1FA5
+L1F9A               ldd       $04,s
+                    ble       L1FA2
                     stu       -$02,s
-                    bne       L1F94
-L1FA5               ldd       $04,s
-                    beq       L1FCC
-                    bra       L1FC8
+                    bne       L1F91
+L1FA2               ldd       $04,s
+                    beq       L1FC9
+                    bra       L1FC5
 
-L1FAB               ldd       #$0010
+L1FA8               ldd       #$0010
                     pshs      d
-                    lbsr      $1C22
+                    lbsr      L1C1F
                     leas      $02,s
                     tfr       d,u
                     ldd       >$005C,y
@@ -3599,50 +3235,50 @@ L1FAB               ldd       #$0010
                     ldd       $04,s
                     subd      #$0007
                     std       $04,s
-L1FC8               ldd       $04,s
-                    bgt       L1FAB
-L1FCC               puls      pc,u
-L1FCE               pshs      u
+L1FC5               ldd       $04,s
+                    bgt       L1FA8
+L1FC9               puls      pc,u
+L1FCB               pshs      u
                     ldu       $04,s
-                    bra       L1FD9
+                    bra       L1FD6
 
-L1FD4               ldd       #$FFFF
+L1FD1               ldd       #$FFFF
                     std       ,u++
-L1FD9               ldd       $06,s
+L1FD6               ldd       $06,s
                     addd      #$FFFF
                     std       $06,s
                     subd      #$FFFF
-                    bgt       L1FD4
+                    bgt       L1FD1
                     puls      pc,u
-L1FE7               pshs      u
+L1FE4               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     clra
                     clrb
                     std       ,s
-                    bra       L2004
+                    bra       L2001
 
-L1FF3               ldd       ,u
-                    bge       L1FFB
+L1FF0               ldd       ,u
+                    bge       L1FF8
                     tfr       u,d
                     puls      pc,u,x
-L1FFB               ldd       ,s
+L1FF8               ldd       ,s
                     addd      #$0001
                     std       ,s
                     leau      $02,u
-L2004               ldd       ,s
+L2001               ldd       ,s
                     cmpd      #$0007
-                    blt       L1FF3
+                    blt       L1FF0
                     clra
                     clrb
                     puls      pc,u,x
-                    pshs      u,d
+L200D               pshs      u,d
                     ldd       [$06,s]
-                    bne       L203E
+                    bne       L203B
                     ldd       >$005C,y
                     std       [$06,s]
                     ldx       $06,s
-L2020               ldd       [,x]
+                    ldd       [,x]
                     std       >$005C,y
                     clra
                     clrb
@@ -3653,30 +3289,30 @@ L2020               ldd       [,x]
                     ldd       [$08,s]
                     addd      #$0002
                     pshs      d
-                    lbsr      L1FCE
+                    lbsr      L1FCB
                     leas      $04,s
-L203E               ldd       [$06,s]
+L203B               ldd       [$06,s]
                     addd      #$0002
                     pshs      d
-                    lbsr      L1FE7
+                    lbsr      L1FE4
                     leas      $02,s
                     std       ,s
-                    bne       L208E
+                    bne       L208B
                     ldd       >$005C,y
-                    bne       L2060
-                    leax      L2134,pcr
+                    bne       L205D
+                    leax      L2131,pcr
                     pshs      x
-                    lbsr      $1AB8
-                    bra       L208C
+                    lbsr      L1AB5
+                    bra       L2089
 
-L2060               leas      -$02,s
+L205D               leas      -$02,s
                     ldd       >$005C,y
-L2066               std       ,s
+                    std       ,s
                     ldd       [,s]
                     std       >$005C,y
-L206E               ldd       [$08,s]
+                    ldd       [$08,s]
                     std       [,s]
-L2073               ldd       ,s
+                    ldd       ,s
                     std       [$08,s]
                     ldd       #$0007
                     pshs      d
@@ -3684,49 +3320,49 @@ L2073               ldd       ,s
                     addd      #$0002
                     std       $04,s
                     pshs      d
-                    lbsr      L1FCE
+                    lbsr      L1FCB
                     leas      $04,s
-L208C               leas      $02,s
-L208E               ldd       $08,s
+L2089               leas      $02,s
+L208B               ldd       $08,s
                     std       [,s]
-L2092               puls      pc,u,x
-                    pshs      u
+                    puls      pc,u,x
+L2091               pshs      u
                     ldu       $04,s
                     leas      -$04,s
-                    bra       L20CF
+                    bra       L20CC
 
-L209C               clra
+L2099               clra
                     clrb
                     std       $02,s
                     leax      $02,u
                     stx       ,s
-                    bra       L20C5
+                    bra       L20C2
 
-L20A6               ldd       [,s]
+L20A3               ldd       [,s]
                     cmpd      #$FFFF
-                    beq       L20CD
+                    beq       L20CA
                     ldx       ,s
                     leax      $02,x
                     stx       ,s
                     ldd       -$02,x
                     pshs      d
-                    bsr       L20D9
+                    bsr       L20D6
                     leas      $02,s
-                    bra       L20BE
+                    bra       L20BB
 
-L20BE               ldd       $02,s
+L20BB               ldd       $02,s
                     addd      #$0001
                     std       $02,s
-L20C5               ldd       $02,s
+L20C2               ldd       $02,s
                     cmpd      #$0007
-                    blt       L20A6
-L20CD               ldu       ,u
-L20CF               stu       -$02,s
-                    bne       L209C
-                    bsr       L20F6
+                    blt       L20A3
+L20CA               ldu       ,u
+L20CC               stu       -$02,s
+                    bne       L2099
+                    bsr       L20F3
                     leas      $04,s
                     puls      pc,u
-L20D9               pshs      u
+L20D6               pshs      u
                     ldd       $04,s
                     ldx       $0008
                     leax      $02,x
@@ -3736,17 +3372,17 @@ L20D9               pshs      u
                     addd      #$0002
                     std       $005E
                     cmpd      #$0100
-                    blt       L20F4
-                    bsr       L20F6
-L20F4               puls      pc,u
-L20F6               pshs      u
+                    blt       L20F1
+                    bsr       L20F3
+L20F1               puls      pc,u
+L20F3               pshs      u
                     leax      >$0005,y
                     pshs      x
                     ldd       $005E
                     pshs      d
                     leax      $0277,y
                     pshs      x
-                    lbsr      L3494
+                    lbsr      L3491
                     leas      $06,s
                     ldd       L003A
                     pshs      d
@@ -3756,85 +3392,78 @@ L20F6               pshs      u
                     pshs      d
                     leax      $0277,y
                     pshs      x
-                    lbsr      L2376
+                    lbsr      L2373
                     leas      $08,s
-                    lbsr      $190A
+                    lbsr      L1907
                     leax      $0277,y
                     stx       $0008
                     clra
                     clrb
                     std       $005E
                     puls      pc,u
-L2134               clr       -$0b,s
-                    lsr       $206F
-                    ror       0,y
-                    lsr       -$0e,s
-                    fcb       $65
-                    ror       0,y
-                    jmp       $0f,s
-                    lsr       $05,s
-                    com       >$0034
-                    nega
+L2131               fcc       /out of dref nodes/
+                    fcb       $00
+L2143               pshs      u
                     leau      $0089,y
-L214C               ldd       $06,u
+L2149               ldd       $06,u
                     clra
                     andb      #$03
-                    lbeq      L21BD
+                    lbeq      L21BA
                     leau      $0d,u
                     pshs      u
                     leax      $0159,y
                     cmpx      ,s++
-                    bhi       L214C
+                    bhi       L2149
                     ldd       #$00C8
                     std       $0228,y
-                    lbra      L21C1
+                    lbra      L21BE
                     puls      pc,u
-L216D               pshs      u
+L216A               pshs      u
                     ldu       $08,s
-                    bne       L2177
-                    bsr       $2146
+                    bne       L2174
+                    bsr       L2143
                     tfr       d,u
-L2177               stu       -$02,s
-                    beq       L21C1
+L2174               stu       -$02,s
+                    beq       L21BE
                     ldd       $04,s
                     std       $08,u
                     ldx       $06,s
-L2181               ldb       $01,x
+                    ldb       $01,x
                     cmpb      #$2b
-                    beq       L218F
+                    beq       L218C
                     ldx       $06,s
                     ldb       $02,x
                     cmpb      #$2b
-                    bne       L2195
-L218F               ldd       $06,u
+                    bne       L2192
+L218C               ldd       $06,u
                     orb       #$03
-                    bra       L21B3
+                    bra       L21B0
 
-L2195               ldd       $06,u
+L2192               ldd       $06,u
                     pshs      d
                     ldb       [$08,s]
                     cmpb      #$72
-                    beq       L21A7
+                    beq       L21A4
                     ldb       [$08,s]
                     cmpb      #$64
-                    bne       L21AC
-L21A7               ldd       #$0001
-                    bra       L21AF
+                    bne       L21A9
+L21A4               ldd       #$0001
+                    bra       L21AC
 
-L21AC               ldd       #$0002
-L21AF               ora       ,s+
+L21A9               ldd       #$0002
+L21AC               ora       ,s+
                     orb       ,s+
-L21B3               std       $06,u
+L21B0               std       $06,u
                     ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
-L21BD               tfr       u,d
+L21BA               tfr       u,d
                     puls      pc,u
-L21C1               clra
+L21BE               clra
                     clrb
                     puls      pc,u
-L21C5               pshs      u
+L21C2               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -3844,51 +3473,51 @@ L21C5               pshs      u
                     ldb       $01,x
                     sex
                     tfr       d,x
-                    bra       L21F6
+                    bra       L21F3
 
-L21D8               ldx       $0a,s
+L21D5               ldx       $0a,s
                     ldb       $02,x
                     cmpb      #$2b
-                    bne       L21E5
+                    bne       L21E2
                     ldd       #$0007
-                    bra       L21ED
+                    bra       L21EA
 
-L21E5               ldd       #$0004
-                    bra       L21ED
+L21E2               ldd       #$0004
+                    bra       L21EA
 
-L21EA               ldd       #$0003
-L21ED               std       ,s
-                    bra       L2206
+L21E7               ldd       #$0003
+L21EA               std       ,s
+                    bra       L2203
 
-L21F1               leax      $04,s
-                    lbra      L225E
+L21EE               leax      $04,s
+                    lbra      L225B
 
-L21F6               stx       -$02,s
-                    beq       L2206
+L21F3               stx       -$02,s
+                    beq       L2203
                     cmpx      #$0078
-                    beq       L21D8
+                    beq       L21D5
                     cmpx      #$002B
-                    beq       L21EA
-                    bra       L21F1
+                    beq       L21E7
+                    bra       L21EE
 
-L2206               ldb       [$0a,s]
+L2203               ldb       [$0a,s]
                     sex
                     tfr       d,x
-                    lbra      L226B
+                    lbra      L2268
 
-L220F               ldd       ,s
+L220C               ldd       ,s
                     orb       #$01
-                    bra       L2251
+                    bra       L224E
 
-L2215               ldd       ,s
+L2212               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      L334D
+                    lbsr      L334A
                     leas      $04,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L2240
+                    beq       L223D
                     ldd       #$0002
                     pshs      d
                     clra
@@ -3897,45 +3526,45 @@ L2215               ldd       ,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L3421
+                    lbsr      L341E
                     leas      $08,s
-                    bra       L2285
+                    bra       L2282
 
-L2240               ldd       ,s
+L223D               ldd       ,s
                     orb       #$0b
                     pshs      d
                     pshs      u
-                    lbsr      L336E
-                    bra       L2258
+                    lbsr      L336B
+                    bra       L2255
 
-L224D               ldd       ,s
+L224A               ldd       ,s
                     orb       #$81
-L2251               pshs      d
+L224E               pshs      d
                     pshs      u
-                    lbsr      L334D
-L2258               leas      $04,s
+                    lbsr      L334A
+L2255               leas      $04,s
                     std       $02,s
-                    bra       L2285
+                    bra       L2282
 
-L225E               leas      -$04,x
-L2260               ldd       #$00CB
+L225B               leas      -$04,x
+L225D               ldd       #$00CB
                     std       $0228,y
                     clra
                     clrb
-                    bra       L2287
+                    bra       L2284
 
-L226B               cmpx      #$0072
-                    lbeq      L220F
+L2268               cmpx      #$0072
+                    lbeq      L220C
                     cmpx      #$0061
-                    lbeq      L2215
+                    lbeq      L2212
                     cmpx      #$0077
-                    beq       L2240
+                    beq       L223D
                     cmpx      #$0064
-                    beq       L224D
-                    bra       L2260
+                    beq       L224A
+                    bra       L225D
 
-L2285               ldd       $02,s
-L2287               leas      $04,s
+L2282               ldd       $02,s
+L2284               leas      $04,s
                     puls      pc,u
                     pshs      u
                     clra
@@ -3945,172 +3574,174 @@ L2287               leas      $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbra      L22E7
-                    pshs      u
+                    lbra      L22E4
+
+L2299               pshs      u
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L21C5
+                    lbsr      L21C2
                     leas      $04,s
                     tfr       d,u
                     cmpu      #$FFFF
-                    bne       L22B7
+                    bne       L22B4
                     clra
                     clrb
-                    bra       L22EC
+                    bra       L22E9
 
-L22B7               clra
+L22B4               clra
                     clrb
-L22B9               bra       L22DF
-                    pshs      u
+                    bra       L22DC
+
+L22B8               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      L2B76
+                    lbsr      L2B73
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L21C5
+                    lbsr      L21C2
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    bge       L22DD
+                    bge       L22DA
                     clra
                     clrb
-                    bra       L22EC
+                    bra       L22E9
 
-L22DD               ldd       $08,s
-L22DF               pshs      d
+L22DA               ldd       $08,s
+L22DC               pshs      d
                     ldd       $08,s
                     pshs      d
                     pshs      u
-L22E7               lbsr      L216D
+L22E4               lbsr      L216A
                     leas      $06,s
-L22EC               puls      pc,u
-L22EE               pshs      u
+L22E9               puls      pc,u
+L22EB               pshs      u
                     leax      $0096,y
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    bsr       L2310
+                    bsr       L230D
                     leas      $04,s
                     leax      $0096,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      L2A86
+                    lbsr      L2A83
                     leas      $04,s
                     puls      pc,u
-L2310               pshs      u
+L230D               pshs      u
                     ldu       $04,s
                     leas      -$01,s
-                    bra       L2326
+                    bra       L2323
 
-L2318               ldd       $07,s
+L2315               ldd       $07,s
                     pshs      d
                     ldb       $02,s
                     sex
                     pshs      d
-                    lbsr      L2A86
+                    lbsr      L2A83
                     leas      $04,s
-L2326               ldb       ,u+
+L2323               ldb       ,u+
                     stb       ,s
-                    bne       L2318
+                    bne       L2315
                     leas      $01,s
-L232E               puls      pc,u
-                    pshs      u
+                    puls      pc,u
+L232D               pshs      u
                     ldu       $04,s
                     leas      -$06,s
                     clra
                     clrb
-                    bra       L2367
+                    bra       L2364
 
-L233A               ldd       $0C,s
+L2337               ldd       $0C,s
                     std       $04,s
-                    bra       L2356
+                    bra       L2353
 
-L2340               ldd       $10,s
+L233D               ldd       $10,s
                     pshs      d
-                    lbsr      L2C99
+                    lbsr      L2C96
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    beq       L2370
+                    beq       L236D
                     ldd       ,s
                     stb       ,u+
-L2356               ldd       $04,s
+L2353               ldd       $04,s
                     addd      #$FFFF
                     std       $04,s
                     subd      #$FFFF
-                    bgt       L2340
+                    bgt       L233D
                     ldd       $02,s
                     addd      #$0001
-L2367               std       $02,s
+L2364               std       $02,s
                     ldd       $02,s
                     cmpd      $0e,s
-                    blt       L233A
-L2370               ldd       $02,s
+                    blt       L2337
+L236D               ldd       $02,s
                     leas      $06,s
-L2374               puls      pc,u
-L2376               pshs      u
+                    puls      pc,u
+L2373               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
-                    bra       L23B1
+                    bra       L23AE
 
-L2380               clra
+L237D               clra
                     clrb
                     std       ,s
-                    bra       L239D
+                    bra       L239A
 
-L2386               ldd       $0e,s
+L2383               ldd       $0e,s
                     pshs      d
                     ldb       ,u+
                     sex
                     pshs      d
-                    lbsr      L2A86
+                    lbsr      L2A83
                     leas      $04,s
                     ldx       $0e,s
                     ldd       $06,x
                     clra
                     andb      #$20
-                    bne       L23BA
-L239D               ldd       ,s
+                    bne       L23B7
+L239A               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      $0a,s
-                    blt       L2386
+                    blt       L2383
                     ldd       $02,s
                     addd      #$0001
-L23B1               std       $02,s
+L23AE               std       $02,s
                     ldd       $02,s
                     cmpd      $0C,s
-                    blt       L2380
-L23BA               ldd       $02,s
+                    blt       L237D
+L23B7               ldd       $02,s
                     leas      $04,s
                     puls      pc,u
-L23C0               pshs      u
+L23BD               pshs      u
                     leax      $0096,y
                     stx       $066d,y
                     leax      $06,s
                     pshs      x
                     ldd       $06,s
-L23D0               bra       L23E0
+                    bra       L23DD
 
-L23D2               pshs      u
+L23CF               pshs      u
                     ldd       $04,s
                     std       $066d,y
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
-L23E0               pshs      d
-                    leax      L289A,pcr
+L23DD               pshs      d
+                    leax      L2897,pcr
                     pshs      x
-                    bsr       L2412
+                    bsr       L240F
                     leas      $06,s
                     puls      pc,u
                     pshs      u
@@ -4120,31 +3751,31 @@ L23E0               pshs      d
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    leax      L28AD,pcr
+                    leax      L28AA,pcr
                     pshs      x
-                    bsr       L2412
+                    bsr       L240F
                     leas      $06,s
                     clra
                     clrb
                     stb       [$066d,y]
                     ldd       $04,s
                     puls      pc,u
-L2412               pshs      u
+L240F               pshs      u
                     ldu       $06,s
                     leas      -$0b,s
-                    bra       L242A
+                    bra       L2427
 
-L241A               ldb       $08,s
-                    lbeq      L265B
+L2417               ldb       $08,s
+                    lbeq      L2658
                     ldb       $08,s
                     sex
                     pshs      d
                     jsr       [$11,s]
                     leas      $02,s
-L242A               ldb       ,u+
+L2427               ldb       ,u+
                     stb       $08,s
                     cmpb      #$25
-                    bne       L241A
+                    bne       L2417
                     ldb       ,u+
                     stb       $08,s
                     clra
@@ -4153,30 +3784,30 @@ L242A               ldb       ,u+
                     std       $06,s
                     ldb       $08,s
                     cmpb      #$2d
-                    bne       L244F
+                    bne       L244C
                     ldd       #$0001
                     std       $0683,y
                     ldb       ,u+
                     stb       $08,s
-                    bra       L2455
+                    bra       L2452
 
-L244F               clra
+L244C               clra
                     clrb
                     std       $0683,y
-L2455               ldb       $08,s
+L2452               ldb       $08,s
                     cmpb      #$30
-                    bne       L2460
+                    bne       L245D
                     ldd       #$0030
-                    bra       L2463
+                    bra       L2460
 
-L2460               ldd       #$0020
-L2463               std       $0685,y
-                    bra       L2483
+L245D               ldd       #$0020
+L2460               std       $0685,y
+                    bra       L2480
 
-L2469               ldd       $06,s
+L2466               ldd       $06,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L3182
+                    lbsr      L317F
                     pshs      d
                     ldb       $0a,s
                     sex
@@ -4185,32 +3816,32 @@ L2469               ldd       $06,s
                     std       $06,s
                     ldb       ,u+
                     stb       $08,s
-L2483               ldb       $08,s
+L2480               ldb       $08,s
                     sex
                     leax      $015a,y
                     leax      d,x
                     ldb       ,x
                     clra
                     andb      #$08
-                    bne       L2469
+                    bne       L2466
                     ldb       $08,s
                     cmpb      #$2e
-                    bne       L24CC
+                    bne       L24C9
                     ldd       #$0001
                     std       $04,s
-                    bra       L24B6
+                    bra       L24B3
 
-L24A0               ldd       $02,s
+L249D               ldd       $02,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L3182
+                    lbsr      L317F
                     pshs      d
                     ldb       $0a,s
                     sex
                     addd      #$FFD0
                     addd      ,s++
                     std       $02,s
-L24B6               ldb       ,u+
+L24B3               ldb       ,u+
                     stb       $08,s
                     ldb       $08,s
                     sex
@@ -4219,39 +3850,39 @@ L24B6               ldb       ,u+
                     ldb       ,x
                     clra
                     andb      #$08
-                    bne       L24A0
-                    bra       L24D0
+                    bne       L249D
+                    bra       L24CD
 
-L24CC               clra
+L24C9               clra
                     clrb
                     std       $04,s
-L24D0               ldb       $08,s
+L24CD               ldb       $08,s
                     sex
                     tfr       d,x
-                    lbra      L25FE
+                    lbra      L25FB
 
-L24D8               ldd       $06,s
+L24D5               ldd       $06,s
                     pshs      d
                     ldx       $15,s
                     leax      $02,x
                     stx       $15,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L265F
-                    bra       L2500
+                    lbsr      L265C
+                    bra       L24FD
 
-L24ED               ldd       $06,s
+L24EA               ldd       $06,s
                     pshs      d
                     ldx       $15,s
                     leax      $02,x
                     stx       $15,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L2720
-L2500               std       ,s
-                    lbra      L25E4
+                    lbsr      L271D
+L24FD               std       ,s
+                    lbra      L25E1
 
-L2505               ldd       $06,s
+L2502               ldd       $06,s
                     pshs      d
                     ldb       $0a,s
                     sex
@@ -4266,10 +3897,10 @@ L2505               ldd       $06,s
                     stx       $17,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L2766
-                    lbra      L25E0
+                    lbsr      L2763
+                    lbra      L25DD
 
-L252B               ldd       $06,s
+L2528               ldd       $06,s
                     pshs      d
                     ldx       $15,s
                     leax      $02,x
@@ -4278,14 +3909,14 @@ L252B               ldd       $06,s
                     pshs      d
                     leax      $066f,y
                     pshs      x
-                    lbsr      L26A7
-                    lbra      L25E0
+                    lbsr      L26A4
+                    lbra      L25DD
 
-L2547               ldd       $04,s
-                    bne       L2550
+L2544               ldd       $04,s
+                    bne       L254D
                     ldd       #$0006
                     std       $02,s
-L2550               ldd       $06,s
+L254D               ldd       $06,s
                     pshs      d
                     leax      $15,s
                     pshs      x
@@ -4294,38 +3925,38 @@ L2550               ldd       $06,s
                     ldb       $0e,s
                     sex
                     pshs      d
-                    lbsr      $2EBC
+                    lbsr      $2EB9
                     leas      $06,s
-                    lbra      L25E2
+                    lbra      L25DF
 
-L256A               ldx       $13,s
+L2567               ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
-                    lbra      L25F4
+                    lbra      L25F1
 
-L2577               ldx       $13,s
+L2574               ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
                     std       $09,s
                     ldd       $04,s
-                    beq       L25BF
+                    beq       L25BC
                     ldd       $09,s
                     std       $04,s
-                    bra       L2599
+                    bra       L2596
 
-L258D               ldb       [$09,s]
-                    beq       L25A5
+L258A               ldb       [$09,s]
+                    beq       L25A2
                     ldd       $09,s
                     addd      #$0001
                     std       $09,s
-L2599               ldd       $02,s
+L2596               ldd       $02,s
                     addd      #$FFFF
                     std       $02,s
                     subd      #$FFFF
-                    bne       L258D
-L25A5               ldd       $06,s
+                    bne       L258A
+L25A2               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
                     subd      $06,s
@@ -4334,105 +3965,105 @@ L25A5               ldd       $06,s
                     pshs      d
                     ldd       $15,s
                     pshs      d
-                    lbsr      L27D1
+                    lbsr      L27CE
                     leas      $08,s
-                    bra       L25EE
+                    bra       L25EB
 
-L25BF               ldd       $06,s
+L25BC               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
-                    bra       L25E2
+                    bra       L25DF
 
-L25C7               ldb       ,u+
+L25C4               ldb       ,u+
                     stb       $08,s
-                    bra       L25CF
+                    bra       L25CC
                     leas      -$0b,x
-L25CF               ldd       $06,s
+L25CC               ldd       $06,s
                     pshs      d
                     leax      $15,s
                     pshs      x
                     ldb       $0C,s
                     sex
                     pshs      d
-                    lbsr      L2E7E
-L25E0               leas      $04,s
-L25E2               pshs      d
-L25E4               ldd       $13,s
+                    lbsr      L2E7B
+L25DD               leas      $04,s
+L25DF               pshs      d
+L25E1               ldd       $13,s
                     pshs      d
-                    lbsr      L2833
+                    lbsr      L2830
                     leas      $06,s
-L25EE               lbra      L242A
+L25EB               lbra      L2427
 
-L25F1               ldb       $08,s
+L25EE               ldb       $08,s
                     sex
-L25F4               pshs      d
+L25F1               pshs      d
                     jsr       [$11,s]
                     leas      $02,s
-                    lbra      L242A
+                    lbra      L2427
 
-L25FE               cmpx      #$0064
-                    lbeq      L24D8
+L25FB               cmpx      #$0064
+                    lbeq      L24D5
                     cmpx      #$006F
-                    lbeq      L24ED
+                    lbeq      L24EA
                     cmpx      #$0078
-                    lbeq      L2505
+                    lbeq      L2502
                     cmpx      #$0058
-                    lbeq      L2505
+                    lbeq      L2502
                     cmpx      #$0075
-                    lbeq      L252B
+                    lbeq      L2528
                     cmpx      #$0066
-                    lbeq      L2547
+                    lbeq      L2544
                     cmpx      #$0065
-                    lbeq      L2547
+                    lbeq      L2544
                     cmpx      #$0067
-                    lbeq      L2547
+                    lbeq      L2544
                     cmpx      #$0045
-                    lbeq      L2547
+                    lbeq      L2544
                     cmpx      #$0047
-                    lbeq      L2547
+                    lbeq      L2544
                     cmpx      #$0063
-                    lbeq      L256A
+                    lbeq      L2567
                     cmpx      #$0073
-                    lbeq      L2577
+                    lbeq      L2574
                     cmpx      #$006C
-                    lbeq      L25C7
-                    bra       L25F1
+                    lbeq      L25C4
+                    bra       L25EE
 
-L265B               leas      $0b,s
+L2658               leas      $0b,s
                     puls      pc,u
-L265F               pshs      u,d
+L265C               pshs      u,d
                     leax      $066f,y
                     stx       ,s
                     ldd       $06,s
-                    bge       L2693
+                    bge       L2690
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-                    bge       L2688
-                    leax      L28BF,pcr
+                    bge       L2685
+                    leax      L28BC,pcr
                     pshs      x
                     leax      $066f,y
                     pshs      x
-                    lbsr      L2ED8
+                    lbsr      L2ED5
                     leas      $04,s
                     puls      pc,u,x
-L2688               ldd       #$002D
+L2685               ldd       #$002D
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L2693               ldd       $06,s
+L2690               ldd       $06,s
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    bsr       L26A7
+                    bsr       L26A4
                     leas      $04,s
                     leax      $066f,y
                     tfr       x,d
                     puls      pc,u,x
-L26A7               pshs      u,y,x,d
+L26A4               pshs      u,y,x,d
                     ldu       $0a,s
                     clra
                     clrb
@@ -4440,48 +4071,48 @@ L26A7               pshs      u,y,x,d
                     clra
                     clrb
                     std       ,s
-                    bra       L26C4
+                    bra       L26C1
 
-L26B5               ldd       ,s
+L26B2               ldd       ,s
                     addd      #$0001
                     std       ,s
                     ldd       $0C,s
                     subd      >$007C,y
                     std       $0C,s
-L26C4               ldd       $0C,s
-                    blt       L26B5
+L26C1               ldd       $0C,s
+                    blt       L26B2
                     leax      >$007C,y
                     stx       $04,s
-                    bra       L2706
+                    bra       L2703
 
-L26D0               ldd       ,s
+L26CD               ldd       ,s
                     addd      #$0001
                     std       ,s
-L26D7               ldd       $0C,s
+L26D4               ldd       $0C,s
                     subd      [$04,s]
                     std       $0C,s
-                    bge       L26D0
+                    bge       L26CD
                     ldd       $0C,s
                     addd      [$04,s]
                     std       $0C,s
                     ldd       ,s
-                    beq       L26F0
+                    beq       L26ED
                     ldd       #$0001
                     std       $02,s
-L26F0               ldd       $02,s
-                    beq       L26FB
+L26ED               ldd       $02,s
+                    beq       L26F8
                     ldd       ,s
                     addd      #$0030
                     stb       ,u+
-L26FB               clra
+L26F8               clra
                     clrb
                     std       ,s
                     ldd       $04,s
                     addd      #$0002
                     std       $04,s
-L2706               ldd       $04,s
+L2703               ldd       $04,s
                     cmpd      $0084,y
-                    bne       L26D7
+                    bne       L26D4
                     ldd       $0C,s
                     addd      #$0030
                     stb       ,u+
@@ -4491,11 +4122,11 @@ L2706               ldd       $04,s
                     ldd       $0a,s
                     leas      $06,s
                     puls      pc,u
-L2720               pshs      u,d
+L271D               pshs      u,d
                     leax      $066f,y
                     stx       ,s
                     leau      $0679,y
-L272C               ldd       $06,s
+L2729               ldd       $06,s
                     clra
                     andb      #$07
                     addd      #$0030
@@ -4508,48 +4139,48 @@ L272C               ldd       $06,s
                     lsra
                     rorb
                     std       $06,s
-                    bne       L272C
-                    bra       L274E
+                    bne       L2729
+                    bra       L274B
 
-L2744               ldb       ,u
+L2741               ldb       ,u
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L274E               leau      -$01,u
+L274B               leau      -$01,u
                     pshs      u
                     leax      $0679,y
                     cmpx      ,s++
-                    bls       L2744
+                    bls       L2741
                     clra
                     clrb
                     stb       [,s]
                     leax      $066f,y
                     tfr       x,d
                     puls      pc,u,x
-L2766               pshs      u,x,d
+L2763               pshs      u,x,d
                     leax      $066f,y
                     stx       $02,s
                     leau      $0679,y
-L2772               ldd       $08,s
+L276F               ldd       $08,s
                     clra
                     andb      #$0f
                     std       ,s
                     pshs      d
                     ldd       $02,s
                     cmpd      #$0009
-                    ble       L2794
+                    ble       L2791
                     ldd       $0C,s
-                    beq       L278C
+                    beq       L2789
                     ldd       #$0041
-                    bra       L278F
+                    bra       L278C
 
-L278C               ldd       #$0061
-L278F               addd      #$FFF6
-                    bra       L2797
+L2789               ldd       #$0061
+L278C               addd      #$FFF6
+                    bra       L2794
 
-L2794               ldd       #$0030
-L2797               addd      ,s++
+L2791               ldd       #$0030
+L2794               addd      ,s++
                     stb       ,u+
                     ldd       $08,s
                     lsra
@@ -4562,76 +4193,76 @@ L2797               addd      ,s++
                     rorb
                     anda      #$0f
                     std       $08,s
-                    bne       L2772
-                    bra       L27B7
+                    bne       L276F
+                    bra       L27B4
 
-L27AD               ldb       ,u
+L27AA               ldb       ,u
                     ldx       $02,s
                     leax      $01,x
                     stx       $02,s
                     stb       -$01,x
-L27B7               leau      -$01,u
+L27B4               leau      -$01,u
                     pshs      u
                     leax      $0679,y
                     cmpx      ,s++
-                    bls       L27AD
+                    bls       L27AA
                     clra
                     clrb
                     stb       [$02,s]
                     leax      $066f,y
                     tfr       x,d
-                    lbra      L28A9
+                    lbra      L28A6
 
-L27D1               pshs      u
+L27CE               pshs      u
                     ldu       $06,s
                     ldd       $0a,s
                     subd      $08,s
                     std       $0a,s
                     ldd       $0683,y
-                    bne       L2806
-                    bra       L27EE
+                    bne       L2803
+                    bra       L27EB
 
-L27E3               ldd       $0685,y
+L27E0               ldd       $0685,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-L27EE               ldd       $0a,s
+L27EB               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    bgt       L27E3
-                    bra       L2806
+                    bgt       L27E0
+                    bra       L2803
 
-L27FC               ldb       ,u+
+L27F9               ldb       ,u+
                     sex
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-L2806               ldd       $08,s
+L2803               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L27FC
+                    bne       L27F9
                     ldd       $0683,y
-                    beq       L2831
-                    bra       L2825
+                    beq       L282E
+                    bra       L2822
 
-L281A               ldd       $0685,y
+L2817               ldd       $0685,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-L2825               ldd       $0a,s
+L2822               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    bgt       L281A
-L2831               puls      pc,u
-L2833               pshs      u
+                    bgt       L2817
+L282E               puls      pc,u
+L2830               pshs      u
                     ldu       $06,s
                     ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      $2EC7
+                    lbsr      $2EC4
                     leas      $02,s
                     nega
                     negb
@@ -4639,89 +4270,89 @@ L2833               pshs      u
                     addd      ,s++
                     std       $08,s
                     ldd       $0683,y
-                    bne       L2875
-                    bra       L285D
+                    bne       L2872
+                    bra       L285A
 
-L2852               ldd       $0685,y
+L284F               ldd       $0685,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-L285D               ldd       $08,s
+L285A               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bgt       L2852
-                    bra       L2875
+                    bgt       L284F
+                    bra       L2872
 
-L286B               ldb       ,u+
+L2868               ldb       ,u+
                     sex
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-L2875               ldb       ,u
-                    bne       L286B
+L2872               ldb       ,u
+                    bne       L2868
                     ldd       $0683,y
-                    beq       L2898
-                    bra       L288C
+                    beq       L2895
+                    bra       L2889
 
-L2881               ldd       $0685,y
+L287E               ldd       $0685,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-L288C               ldd       $08,s
+L2889               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bgt       L2881
-L2898               puls      pc,u
-L289A               pshs      u
+                    bgt       L287E
+L2895               puls      pc,u
+L2897               pshs      u
                     ldd       $066d,y
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L2A86
-L28A9               leas      $04,s
+                    lbsr      L2A83
+L28A6               leas      $04,s
                     puls      pc,u
-L28AD               pshs      u
+L28AA               pshs      u
                     ldd       $04,s
                     ldx       $066d,y
                     leax      $01,x
                     stx       $066d,y
                     stb       -$01,x
                     puls      pc,u
-L28BF               blt       L28F4
+L28BC               blt       L28F1
                     leas      -$09,y
                     pshu      y,x,dp
-L28C5               neg       $0034
+                    neg       $0034
                     nega
                     ldu       $04,s
                     leas      -$06,s
                     cmpu      #$0000
-                    beq       L28D9
+                    beq       L28D6
                     ldd       $06,u
                     clra
                     andb      #$03
-                    bne       L28DF
-L28D9               ldd       #$FFFF
-                    lbra      L2A02
+                    bne       L28DC
+L28D6               ldd       #$FFFF
+                    lbra      L29FF
 
-L28DF               ldd       $06,u
+L28DC               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L28F2
+                    bne       L28EF
                     pshs      u
-                    lbsr      L2DEE
+                    lbsr      L2DEB
                     leas      $02,s
-                    lbra      L29C8
+                    lbra      L29C5
 
-L28F2               ldd       $06,u
-L28F4               anda      #$01
+L28EF               ldd       $06,u
+L28F1               anda      #$01
                     clrb
                     std       -$02,s
-                    beq       L2911
+                    beq       L290E
                     pshs      u
-                    lbsr      L2BAF
+                    lbsr      L2BAC
                     leas      $02,s
                     ldd       $06,u
                     anda      #$FE
@@ -4729,31 +4360,31 @@ L28F4               anda      #$01
                     ldd       $02,u
                     addd      $0b,u
                     std       $04,u
-                    lbra      L29C6
+                    lbra      L29C3
 
-L2911               ldd       ,u
+L290E               ldd       ,u
                     cmpd      $04,u
-                    lbcc      L29C8
+                    lbcc      L29C5
                     leax      $02,s
                     pshs      x
                     leax      $0e,s
-                    lbsr      L314E
+                    lbsr      L314B
                     ldx       $10,s
-                    lbra      L2995
+                    lbra      L2992
 
-L2929               leax      $02,s
+L2926               leax      $02,s
                     pshs      x
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
                     pshs      u
-                    lbsr      L2A1D
+                    lbsr      L2A1A
                     leas      $02,s
-                    lbsr      L30D5
-                    lbsr      L314E
-L2942               ldd       $0b,u
-                    lbsr      L3135
+                    lbsr      L30D2
+                    lbsr      L314B
+L293F               ldd       $0b,u
+                    lbsr      L3132
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
@@ -4763,42 +4394,41 @@ L2942               ldd       $0b,u
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       L295F
-                    neg       $0000
-                    neg       $0000
-L295F               puls      x
-                    lbsr      L30EA
-                    bge       L296D
+                    bsr       L295C
+                    fcb       $00,$00,$00,$00
+L295C               puls      x
+                    lbsr      L30E7
+                    bge       L296A
                     leax      $06,s
-                    lbsr      L310E
-                    bra       L296F
+                    lbsr      L310B
+                    bra       L296C
 
-L296D               leax      $06,s
-L296F               lbsr      L30EA
-                    blt       L29A2
+L296A               leax      $06,s
+L296C               lbsr      L30E7
+                    blt       L299F
                     ldd       $04,s
                     addd      ,u
                     std       ,s
                     cmpd      $02,u
-                    bcs       L29A2
+                    bcs       L299F
                     ldd       ,s
                     cmpd      $04,u
-                    bcc       L29A2
+                    bcc       L299F
                     ldd       ,s
                     std       ,u
                     ldd       $06,u
                     andb      #$EF
                     std       $06,u
-                    lbra      L2A00
-                    bra       L29A2
+                    lbra      L29FD
+                    bra       L299F
 
-L2995               stx       -$02,s
-                    lbeq      L2929
+L2992               stx       -$02,s
+                    lbeq      L2926
                     cmpx      #$0001
-                    lbeq      L2942
-L29A2               ldd       $10,s
+                    lbeq      L293F
+L299F               ldd       $10,s
                     cmpd      #$0001
-                    bne       L29C4
+                    bne       L29C1
                     leax      $0C,s
                     pshs      x
                     ldd       $02,x
@@ -4807,12 +4437,12 @@ L29A2               ldd       $10,s
                     pshs      d
                     ldd       $04,u
                     subd      ,u
-                    lbsr      L3135
-                    lbsr      L30D5
-                    lbsr      L314E
-L29C4               ldd       $04,u
-L29C6               std       ,u
-L29C8               ldd       $06,u
+                    lbsr      L3132
+                    lbsr      L30D2
+                    lbsr      L314B
+L29C1               ldd       $04,u
+L29C3               std       ,u
+L29C5               ldd       $06,u
                     andb      #$EF
                     std       $06,u
                     ldd       $10,s
@@ -4824,23 +4454,23 @@ L29C8               ldd       $06,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3421
+                    lbsr      L341E
                     leas      $08,s
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $29F4
-                    stu       $FFFF
-                    stu       $3510
-                    lbsr      L30EA
-                    bne       L2A00
+                    bsr       L29F1
+                    fcb       $FF,$FF,$FF,$FF
+L29F1               puls      x
+                    lbsr      L30E7
+                    bne       L29FD
                     ldd       #$FFFF
-                    bra       L2A02
+                    bra       L29FF
 
-L2A00               clra
+L29FD               clra
                     clrb
-L2A02               leas      $06,s
+L29FF               leas      $06,s
                     puls      pc,u
                     pshs      u
                     clra
@@ -4852,32 +4482,32 @@ L2A02               leas      $06,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      $28C6
+                    lbsr      $28C3
                     leas      $08,s
-L2A1B               puls      pc,u
-L2A1D               pshs      u
+                    puls      pc,u
+L2A1A               pshs      u
                     ldu       $04,s
-                    beq       L2A2A
+                    beq       L2A27
                     ldd       $06,u
                     clra
                     andb      #$03
-                    bne       L2A3D
-L2A2A               bsr       $2A30
-                    stu       $FFFF
-                    stu       $3510
+                    bne       L2A3A
+L2A27               bsr       L2A2D
+                    fcb       $FF,$FF,$FF,$FF
+L2A2D               puls      x
                     leau      $021C,y
                     pshs      u
-                    lbsr      L314E
+                    lbsr      L314B
                     puls      pc,u
-L2A3D               ldd       $06,u
+L2A3A               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L2A4D
+                    bne       L2A4A
                     pshs      u
-                    lbsr      L2DEE
+                    lbsr      L2DEB
                     leas      $02,s
-L2A4D               ldd       #$0001
+L2A4A               ldd       #$0001
                     pshs      d
                     clra
                     clrb
@@ -4885,7 +4515,7 @@ L2A4D               ldd       #$0001
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3421
+                    lbsr      L341E
                     leas      $08,s
                     ldd       $02,x
                     pshs      d
@@ -4895,36 +4525,36 @@ L2A4D               ldd       #$0001
                     anda      #$01
                     clrb
                     std       -$02,s
-                    beq       L2A76
+                    beq       L2A73
                     ldd       $02,u
-                    bra       L2A78
+                    bra       L2A75
 
-L2A76               ldd       $04,u
-L2A78               pshs      d
+L2A73               ldd       $04,u
+L2A75               pshs      d
                     ldd       ,u
                     subd      ,s++
-                    lbsr      L3135
-                    lbsr      L30C0
-L2A84               puls      pc,u
-L2A86               pshs      u
+                    lbsr      L3132
+                    lbsr      L30BD
+                    puls      pc,u
+L2A83               pshs      u
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$22
                     cmpd      #$8002
-                    beq       L2AAA
+                    beq       L2AA7
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    lbne      L2BC0
+                    lbne      L2BBD
                     pshs      u
-                    lbsr      L2DEE
+                    lbsr      L2DEB
                     leas      $02,s
-L2AAA               ldd       $06,u
+L2AA7               ldd       $06,u
                     clra
                     andb      #$04
-                    beq       L2AE6
+                    beq       L2AE3
                     ldd       #$0001
                     pshs      d
                     leax      $07,s
@@ -4934,31 +4564,31 @@ L2AAA               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2ACB
-                    leax      L3411,pcr
-                    bra       L2ACF
+                    beq       L2AC8
+                    leax      L340E,pcr
+                    bra       L2ACC
 
-L2ACB               leax      L33F8,pcr
-L2ACF               tfr       x,d
+L2AC8               leax      L33F5,pcr
+L2ACC               tfr       x,d
                     tfr       d,x
                     jsr       ,x
                     leas      $06,s
                     cmpd      #$FFFF
-                    bne       L2B27
+                    bne       L2B24
                     ldd       $06,u
                     orb       #$20
                     std       $06,u
-                    lbra      L2BC0
+                    lbra      L2BBD
 
-L2AE6               ldd       $06,u
+L2AE3               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L2AF6
+                    bne       L2AF3
                     pshs      u
-                    lbsr      L2BDB
+                    lbsr      L2BD8
                     leas      $02,s
-L2AF6               ldd       ,u
+L2AF3               ldd       ,u
                     addd      #$0001
                     std       ,u
                     subd      #$0001
@@ -4967,122 +4597,122 @@ L2AF6               ldd       ,u
                     stb       ,x
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L2B1C
+                    bcc       L2B19
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2B27
+                    beq       L2B24
                     ldd       $04,s
                     cmpd      #$000D
-                    bne       L2B27
-L2B1C               pshs      u
-                    lbsr      L2BDB
+                    bne       L2B24
+L2B19               pshs      u
+                    lbsr      L2BD8
                     std       ,s++
-                    lbne      L2BC0
-L2B27               ldd       $04,s
-L2B29               puls      pc,u
-                    pshs      u
+                    lbne      L2BBD
+L2B24               ldd       $04,s
+                    puls      pc,u
+L2B28               pshs      u
                     ldu       $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
                     ldd       #$0008
-                    lbsr      L32AC
+                    lbsr      L32A9
                     pshs      d
-                    lbsr      L2A86
+                    lbsr      L2A83
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      L2A86
-                    lbra      L2C95
+                    lbsr      L2A83
+                    lbra      L2C92
 
-L2B4E               pshs      u,d
+L2B4B               pshs      u,d
                     leau      $0089,y
                     clra
                     clrb
                     std       ,s
-                    bra       L2B64
+                    bra       L2B61
 
-L2B5A               tfr       u,d
+L2B57               tfr       u,d
                     leau      $0d,u
                     pshs      d
-                    bsr       L2B76
+                    bsr       L2B73
                     leas      $02,s
-L2B64               ldd       ,s
+L2B61               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0010
-                    blt       L2B5A
-L2B74               puls      pc,u,x
-L2B76               pshs      u
+                    blt       L2B57
+                    puls      pc,u,x
+L2B73               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     cmpu      #$0000
-                    beq       L2B86
+                    beq       L2B83
                     ldd       $06,u
-                    bne       L2B8B
-L2B86               ldd       #$FFFF
+                    bne       L2B88
+L2B83               ldd       #$FFFF
                     puls      pc,u,x
-L2B8B               ldd       $06,u
+L2B88               ldd       $06,u
                     clra
                     andb      #$02
-                    beq       L2B9A
+                    beq       L2B97
                     pshs      u
-                    bsr       L2BAF
+                    bsr       L2BAC
                     leas      $02,s
-                    bra       L2B9C
+                    bra       L2B99
 
-L2B9A               clra
+L2B97               clra
                     clrb
-L2B9C               std       ,s
+L2B99               std       ,s
                     ldd       $08,u
                     pshs      d
-                    lbsr      L335C
+                    lbsr      L3359
                     leas      $02,s
                     clra
                     clrb
                     std       $06,u
                     ldd       ,s
                     puls      pc,u,x
-L2BAF               pshs      u
+L2BAC               pshs      u
                     ldu       $04,s
-                    beq       L2BC0
+                    beq       L2BBD
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    beq       L2BC5
-L2BC0               ldd       #$FFFF
+                    beq       L2BC2
+L2BBD               ldd       #$FFFF
                     puls      pc,u
-L2BC5               ldd       $06,u
+L2BC2               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L2BD5
+                    bne       L2BD2
                     pshs      u
-                    lbsr      L2DEE
+                    lbsr      L2DEB
                     leas      $02,s
-L2BD5               pshs      u
-                    bsr       L2BDB
+L2BD2               pshs      u
+                    bsr       L2BD8
                     puls      pc,u,x
-L2BDB               pshs      u
+L2BD8               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L2C0D
+                    bne       L2C0A
                     ldd       ,u
                     cmpd      $04,u
-                    beq       L2C0D
+                    beq       L2C0A
                     clra
                     clrb
                     pshs      d
                     pshs      u
-                    lbsr      L2A1D
+                    lbsr      L2A1A
                     leas      $02,s
                     ldd       $02,x
                     pshs      d
@@ -5090,70 +4720,70 @@ L2BDB               pshs      u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3421
+                    lbsr      L341E
                     leas      $08,s
-L2C0D               ldd       ,u
+L2C0A               ldd       ,u
                     subd      $02,u
                     std       $02,s
-                    lbeq      L2C85
+                    lbeq      L2C82
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      L2C85
+                    lbeq      L2C82
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2C5C
+                    beq       L2C59
                     ldd       $02,u
-                    bra       L2C54
+                    bra       L2C51
 
-L2C2D               ldd       $02,s
+L2C2A               ldd       $02,s
                     pshs      d
                     ldd       ,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3411
+                    lbsr      L340E
                     leas      $06,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L2C4A
+                    bne       L2C47
                     leax      $04,s
-                    bra       L2C74
+                    bra       L2C71
 
-L2C4A               ldd       $02,s
+L2C47               ldd       $02,s
                     subd      ,s
                     std       $02,s
                     ldd       ,u
                     addd      ,s
-L2C54               std       ,u
+L2C51               std       ,u
                     ldd       $02,s
-                    bne       L2C2D
-                    bra       L2C85
+                    bne       L2C2A
+                    bra       L2C82
 
-L2C5C               ldd       $02,s
+L2C59               ldd       $02,s
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L33F8
+                    lbsr      L33F5
                     leas      $06,s
                     cmpd      $02,s
-                    beq       L2C85
-                    bra       L2C76
+                    beq       L2C82
+                    bra       L2C73
 
-L2C74               leas      -$04,x
-L2C76               ldd       $06,u
+L2C71               leas      -$04,x
+L2C73               ldd       $06,u
                     orb       #$20
                     std       $06,u
                     ldd       $04,u
                     std       ,u
                     ldd       #$FFFF
-                    bra       L2C95
+                    bra       L2C92
 
-L2C85               ldd       $06,u
+L2C82               ldd       $06,u
                     ora       #$01
                     std       $06,u
                     ldd       $02,u
@@ -5162,19 +4792,19 @@ L2C85               ldd       $06,u
                     std       $04,u
                     clra
                     clrb
-L2C95               leas      $04,s
-L2C97               puls      pc,u
-L2C99               pshs      u
+L2C92               leas      $04,s
+                    puls      pc,u
+L2C96               pshs      u
                     ldu       $04,s
-                    beq       L2CE5
+                    beq       L2CE2
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L2CE5
+                    bne       L2CE2
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L2CC0
+                    bcc       L2CBD
                     ldd       ,u
                     addd      #$0001
                     std       ,u
@@ -5182,94 +4812,94 @@ L2C99               pshs      u
                     tfr       d,x
                     ldb       ,x
                     clra
-                    bra       L2CC7
+                    bra       L2CC4
 
-L2CC0               pshs      u
-                    lbsr      L2D34
+L2CBD               pshs      u
+                    lbsr      L2D31
                     leas      $02,s
-L2CC7               puls      pc,u
+L2CC4               puls      pc,u
                     pshs      u
                     ldu       $06,s
-                    beq       L2CE5
+                    beq       L2CE2
                     ldd       $06,u
                     clra
                     andb      #$01
-                    beq       L2CE5
+                    beq       L2CE2
                     ldd       $04,s
                     cmpd      #$FFFF
-                    beq       L2CE5
+                    beq       L2CE2
                     ldd       ,u
                     cmpd      $02,u
-                    bhi       L2CEA
-L2CE5               ldd       #$FFFF
+                    bhi       L2CE7
+L2CE2               ldd       #$FFFF
                     puls      pc,u
-L2CEA               ldd       ,u
+L2CE7               ldd       ,u
                     addd      #$FFFF
                     std       ,u
                     tfr       d,x
                     ldd       $04,s
                     stb       ,x
                     ldd       $04,s
-L2CF9               puls      pc,u
-                    pshs      u
+                    puls      pc,u
+L2CF8               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
-                    lbsr      L2C99
+                    lbsr      L2C96
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L2D1F
+                    beq       L2D1C
                     pshs      u
-                    lbsr      L2C99
+                    lbsr      L2C96
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L2D24
-L2D1F               ldd       #$FFFF
-                    bra       L2D30
+                    bne       L2D21
+L2D1C               ldd       #$FFFF
+                    bra       L2D2D
 
-L2D24               ldd       $02,s
+L2D21               ldd       $02,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      L32C3
+                    lbsr      L32C0
                     addd      ,s
-L2D30               leas      $04,s
+L2D2D               leas      $04,s
                     puls      pc,u
-L2D34               pshs      u
+L2D31               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$31
                     cmpd      #$8001
-                    beq       L2D5D
+                    beq       L2D5A
                     ldd       $06,u
                     clra
                     andb      #$31
                     cmpd      #$0001
-                    beq       L2D56
+                    beq       L2D53
                     ldd       #$FFFF
                     puls      pc,u,x
-L2D56               pshs      u
-                    lbsr      L2DEE
+L2D53               pshs      u
+                    lbsr      L2DEB
                     leas      $02,s
-L2D5D               leax      $0089,y
+L2D5A               leax      $0089,y
                     pshs      x
                     cmpu      ,s++
-                    bne       L2D7A
+                    bne       L2D77
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2D7A
+                    beq       L2D77
                     leax      $0096,y
                     pshs      x
-                    lbsr      L2BAF
+                    lbsr      L2BAC
                     leas      $02,s
-L2D7A               ldd       $06,u
+L2D77               ldd       $06,u
                     clra
                     andb      #$08
-                    beq       L2DA6
+                    beq       L2DA3
                     ldd       $0b,u
                     pshs      d
                     ldd       $02,u
@@ -5279,42 +4909,42 @@ L2D7A               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2D9A
-                    leax      L33E8,pcr
-                    bra       L2D9E
+                    beq       L2D97
+                    leax      L33E5,pcr
+                    bra       L2D9B
 
-L2D9A               leax      L33C7,pcr
-L2D9E               tfr       x,d
+L2D97               leax      L33C4,pcr
+L2D9B               tfr       x,d
                     tfr       d,x
                     jsr       ,x
-                    bra       L2DB8
+                    bra       L2DB5
 
-L2DA6               ldd       #$0001
+L2DA3               ldd       #$0001
                     pshs      d
                     leax      $0a,u
                     stx       $02,u
                     pshs      x
                     ldd       $08,u
                     pshs      d
-                    lbsr      L33C7
-L2DB8               leas      $06,s
+                    lbsr      L33C4
+L2DB5               leas      $06,s
                     std       ,s
                     ldd       ,s
-                    bgt       L2DDB
+                    bgt       L2DD8
                     ldd       $06,u
                     pshs      d
                     ldd       $02,s
-                    beq       L2DCD
+                    beq       L2DCA
                     ldd       #$0020
-                    bra       L2DD0
+                    bra       L2DCD
 
-L2DCD               ldd       #$0010
-L2DD0               ora       ,s+
+L2DCA               ldd       #$0010
+L2DCD               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     ldd       #$FFFF
                     puls      pc,u,x
-L2DDB               ldd       $02,u
+L2DD8               ldd       $02,u
                     addd      #$0001
                     std       ,u
                     ldd       $02,u
@@ -5323,12 +4953,12 @@ L2DDB               ldd       $02,u
                     ldb       [$02,u]
                     clra
                     puls      pc,u,x
-L2DEE               pshs      u
+L2DEB               pshs      u
                     ldu       $04,s
                     ldd       $06,u
                     clra
                     andb      #$C0
-                    bne       L2E26
+                    bne       L2E23
                     leas      -$20,s
                     leax      ,s
                     pshs      x
@@ -5337,114 +4967,114 @@ L2DEE               pshs      u
                     clra
                     clrb
                     pshs      d
-                    lbsr      L32DE
+                    lbsr      L32DB
                     leas      $06,s
                     ldd       $06,u
                     pshs      d
                     ldb       $02,s
-                    bne       L2E1A
+                    bne       L2E17
                     ldd       #$0040
-                    bra       L2E1D
+                    bra       L2E1A
 
-L2E1A               ldd       #$0080
-L2E1D               ora       ,s+
+L2E17               ldd       #$0080
+L2E1A               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     leas      $20,s
-L2E26               ldd       $06,u
+L2E23               ldd       $06,u
                     ora       #$80
                     std       $06,u
                     clra
                     andb      #$0C
-                    beq       L2E33
+                    beq       L2E30
                     puls      pc,u
-L2E33               ldd       $0b,u
-                    bne       L2E48
+L2E30               ldd       $0b,u
+                    bne       L2E45
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2E43
+                    beq       L2E40
                     ldd       #$0080
-                    bra       L2E46
+                    bra       L2E43
 
-L2E43               ldd       #$0100
-L2E46               std       $0b,u
-L2E48               ldd       $02,u
-                    bne       L2E5D
+L2E40               ldd       #$0100
+L2E43               std       $0b,u
+L2E45               ldd       $02,u
+                    bne       L2E5A
                     ldd       $0b,u
                     pshs      d
-                    lbsr      L3511
+                    lbsr      L350E
                     leas      $02,s
                     std       $02,u
                     cmpd      #$FFFF
-                    beq       L2E65
-L2E5D               ldd       $06,u
+                    beq       L2E62
+L2E5A               ldd       $06,u
                     orb       #$08
                     std       $06,u
-                    bra       L2E74
+                    bra       L2E71
 
-L2E65               ldd       $06,u
+L2E62               ldd       $06,u
                     orb       #$04
                     std       $06,u
                     leax      $0a,u
                     stx       $02,u
                     ldd       #$0001
                     std       $0b,u
-L2E74               ldd       $02,u
+L2E71               ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
                     puls      pc,u
-L2E7E               pshs      u
+L2E7B               pshs      u
                     ldb       $05,s
                     sex
                     tfr       d,x
-                    bra       L2EA4
+                    bra       L2EA1
 
-L2E87               ldd       [$06,s]
+L2E84               ldd       [$06,s]
                     addd      #$0004
                     std       [$06,s]
-                    leax      >L2EBB,pcr
-                    bra       L2EA0
+                    leax      >L2EB8,pcr
+                    bra       L2E9D
 
-L2E96               ldb       $05,s
+L2E93               ldb       $05,s
                     stb       $0087,y
                     leax      $0086,y
-L2EA0               tfr       x,d
+L2E9D               tfr       x,d
                     puls      pc,u
-L2EA4               cmpx      #$0064
-                    beq       L2E87
+L2EA1               cmpx      #$0064
+                    beq       L2E84
                     cmpx      #$006F
-                    lbeq      L2E87
+                    lbeq      L2E84
                     cmpx      #$0078
-                    lbeq      L2E87
-                    bra       L2E96
+                    lbeq      L2E84
+                    bra       L2E93
                     puls      pc,u
-L2EBB               neg       $0034
+L2EB8               neg       $0034
                     nega
-                    leax      >L2EC6,pcr
+                    leax      >L2EC3,pcr
                     tfr       x,d
                     puls      pc,u
-L2EC6               neg       $0034
+L2EC3               neg       $0034
                     nega
                     ldu       $04,s
-L2ECB               ldb       ,u+
-                    bne       L2ECB
+L2EC8               ldb       ,u+
+                    bne       L2EC8
                     tfr       u,d
                     subd      $04,s
                     addd      #$FFFF
-L2ED6               puls      pc,u
-L2ED8               pshs      u
+                    puls      pc,u
+L2ED5               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L2EE2               ldb       ,u+
+L2EDF               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L2EE2
+                    bne       L2EDF
                     ldd       $06,s
                     puls      pc,u,x
                     pshs      u
@@ -5452,157 +5082,157 @@ L2EE2               ldb       ,u+
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L2EFC               ldx       ,s
+L2EF9               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L2EFC
+                    bne       L2EF9
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-L2F0D               ldb       ,u+
+L2F0A               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L2F0D
+                    bne       L2F0A
                     ldd       $06,s
                     puls      pc,u,x
-                    pshs      u
+L2F1A               pshs      u
                     ldu       $04,s
-                    bra       L2F33
+                    bra       L2F30
 
-L2F23               ldx       $06,s
+L2F20               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       L2F31
+                    bne       L2F2E
                     clra
                     clrb
                     puls      pc,u
-L2F31               leau      $01,u
-L2F33               ldb       ,u
+L2F2E               leau      $01,u
+L2F30               ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       L2F23
+                    beq       L2F20
                     ldb       [$06,s]
                     sex
                     pshs      d
                     ldb       ,u
                     sex
                     subd      ,s++
-L2F4C               puls      pc,u
-                    pshs      u
+                    puls      pc,u
+L2F4B               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L2F58               ldd       $0a,s
+L2F55               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       L2F7C
+                    ble       L2F79
                     ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L2F58
-                    bra       L2F7C
+                    bne       L2F55
+                    bra       L2F79
 
-L2F72               clra
+L2F6F               clra
                     clrb
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L2F7C               ldd       $0a,s
+L2F79               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    bgt       L2F72
+                    bgt       L2F6F
                     ldd       $06,s
                     puls      pc,u,x
                     pshs      u
                     ldu       $04,s
-                    bra       L2FA2
+                    bra       L2F9F
 
-L2F92               ldx       $06,s
+L2F8F               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       L2FA0
+                    bne       L2F9D
                     clra
                     clrb
                     puls      pc,u
-L2FA0               leau      $01,u
-L2FA2               ldd       $08,s
+L2F9D               leau      $01,u
+L2F9F               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    ble       L2FBC
+                    ble       L2FB9
                     ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       L2F92
-L2FBC               ldd       $08,s
-                    bge       L2FC4
+                    beq       L2F8F
+L2FB9               ldd       $08,s
+                    bge       L2FC1
                     clra
                     clrb
-                    bra       L2FCF
+                    bra       L2FCC
 
-L2FC4               ldb       [$06,s]
+L2FC1               ldb       [$06,s]
                     sex
                     pshs      d
                     ldb       ,u
                     sex
                     subd      ,s++
-L2FCF               puls      pc,u
+L2FCC               puls      pc,u
                     pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L2FDB               ldx       ,s
+L2FD8               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L2FDB
+                    bne       L2FD8
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-L2FEC               ldd       $0a,s
+L2FE9               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       L3004
+                    ble       L3001
                     ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L2FEC
-L3004               ldd       $0a,s
-                    bge       L300C
+                    bne       L2FE9
+L3001               ldd       $0a,s
+                    bge       L3009
                     clra
                     clrb
                     stb       [,s]
-L300C               ldd       $06,s
+L3009               ldd       $06,s
                     puls      pc,u,x
                     pshs      u
                     ldu       $04,s
-L3014               ldx       $06,s
+L3011               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
                     stb       ,u+
-                    bgt       L3014
+                    bgt       L3011
                     ldb       -$01,u
                     clra
                     andb      #$7f
@@ -5611,122 +5241,122 @@ L3014               ldx       $06,s
                     clrb
                     stb       ,u
                     ldd       $04,s
-L302D               puls      pc,u
-                    pshs      u
+                    puls      pc,u
+L302C               pshs      u
                     ldu       $04,s
                     leas      -$05,s
                     clra
                     clrb
                     std       $01,s
-L3039               ldb       ,u+
+L3036               ldb       ,u+
                     stb       ,s
                     cmpb      #$20
-                    beq       L3039
+                    beq       L3036
                     ldb       ,s
                     cmpb      #$09
-                    lbeq      L3039
+                    lbeq      L3036
                     ldb       ,s
                     cmpb      #$2d
-                    bne       L3054
+                    bne       L3051
                     ldd       #$0001
-                    bra       L3056
+                    bra       L3053
 
-L3054               clra
+L3051               clra
                     clrb
-L3056               std       $03,s
+L3053               std       $03,s
                     ldb       ,s
                     cmpb      #$2d
-                    beq       L307C
+                    beq       L3079
                     ldb       ,s
                     cmpb      #$2b
-                    bne       L3080
-                    bra       L307C
+                    bne       L307D
+                    bra       L3079
 
-L3066               ldd       $01,s
+L3063               ldd       $01,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L3182
+                    lbsr      L317F
                     pshs      d
                     ldb       $02,s
                     sex
                     addd      ,s++
                     addd      #$FFD0
                     std       $01,s
-L307C               ldb       ,u+
+L3079               ldb       ,u+
                     stb       ,s
-L3080               ldb       ,s
+L307D               ldb       ,s
                     sex
                     leax      $015a,y
                     leax      d,x
                     ldb       ,x
                     clra
                     andb      #$08
-                    bne       L3066
+                    bne       L3063
                     ldd       $03,s
-                    beq       L309C
+                    beq       L3099
                     ldd       $01,s
                     nega
                     negb
                     sbca      #$00
-                    bra       L309E
+                    bra       L309B
 
-L309C               ldd       $01,s
-L309E               leas      $05,s
-L30A0               puls      pc,u
-                    pshs      u
+L3099               ldd       $01,s
+L309B               leas      $05,s
+                    puls      pc,u
+L309F               pshs      u
                     ldu       $04,s
-                    bra       L30B2
+                    bra       L30AF
 
-L30A8               ldx       $06,s
+L30A5               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
                     stb       ,u+
-L30B2               ldd       $08,s
+L30AF               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bgt       L30A8
-L30BE               puls      pc,u
-L30C0               ldd       $04,s
+                    bgt       L30A5
+                    puls      pc,u
+L30BD               ldd       $04,s
                     addd      $02,x
                     std       $021e,y
                     ldd       $02,s
                     adcb      $01,x
                     adca      ,x
                     std       $021C,y
-                    lbra      L3164
+                    lbra      L3161
 
-L30D5               ldd       $04,s
+L30D2               ldd       $04,s
                     subd      $02,x
                     std       $021e,y
                     ldd       $02,s
                     sbcb      $01,x
                     sbca      ,x
                     std       $021C,y
-                    lbra      L3164
+                    lbra      L3161
 
-L30EA               ldd       $02,s
+L30E7               ldd       $02,s
                     cmpd      ,x
-                    bne       L3103
+                    bne       L3100
                     ldd       $04,s
                     cmpd      $02,x
-                    beq       L3103
-                    bcs       L3100
+                    beq       L3100
+                    bcs       L30FD
                     lda       #$01
                     andcc     #$FE
-                    bra       L3103
+                    bra       L3100
 
-L3100               clra
+L30FD               clra
                     cmpa      #$01
-L3103               pshs      cc
+L3100               pshs      cc
                     ldd       $01,s
                     std       $05,s
                     puls      cc
                     leas      $04,s
                     rts
 
-L310E               lbsr      L3173
+L310B               lbsr      L3170
                     ldd       #$0000
                     subd      $02,x
                     std       $02,x
@@ -5746,20 +5376,21 @@ L310E               lbsr      L3173
                     std       $02,x
                     rts
 
-L3135               leax      $021C,y
+L3132               leax      $021C,y
                     std       $02,x
                     tfr       a,b
                     sex
                     tfr       a,b
                     std       ,x
-L3142               rts
-                    leax      $021C,y
+                    rts
+
+L3140               leax      $021C,y
                     std       $02,x
                     clr       ,x
                     clr       $01,x
-L314D               rts
+                    rts
 
-L314E               pshs      y
+L314B               pshs      y
                     ldy       $04,s
                     ldd       ,x
                     std       ,y
@@ -5771,7 +5402,7 @@ L314E               pshs      y
                     std       ,s
                     rts
 
-L3164               tfr       cc,a
+L3161               tfr       cc,a
                     puls      x
                     stx       $02,s
                     leas      $02,s
@@ -5779,17 +5410,17 @@ L3164               tfr       cc,a
                     tfr       a,cc
                     rts
 
-L3173               ldd       ,x
+L3170               ldd       ,x
                     std       $021C,y
                     ldd       $02,x
                     leax      $021C,y
                     std       $02,x
-L3181               rts
+                    rts
 
-L3182               tsta
-                    bne       L3197
+L317F               tsta
+                    bne       L3194
                     tst       $02,s
-                    bne       L3197
+                    bne       L3194
                     lda       $03,s
                     mul
                     ldx       ,s
@@ -5797,7 +5428,7 @@ L3182               tsta
                     ldx       #$0000
                     std       ,s
                     puls      pc,d
-L3197               pshs      d
+L3194               pshs      d
                     ldd       #$0000
                     pshs      d
                     pshs      d
@@ -5810,16 +5441,16 @@ L3197               pshs      d
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L31B4
+                    bcc       L31B1
                     inc       ,s
-L31B4               lda       $04,s
+L31B1               lda       $04,s
                     ldb       $09,s
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L31C1
+                    bcc       L31BE
                     inc       ,s
-L31C1               lda       $04,s
+L31BE               lda       $04,s
                     ldb       $08,s
                     mul
                     addd      ,s
@@ -5829,101 +5460,102 @@ L31C1               lda       $04,s
                     ldx       ,s
                     ldd       $02,s
                     leas      $08,s
-L31D4               rts
-                    clr       $0687,y
-                    leax      >L321D,pcr
+                    rts
+
+L31D2               clr       $0687,y
+                    leax      >L321A,pcr
                     stx       $0688,y
-                    bra       L31F7
-                    leax      >L3236,pcr
+                    bra       L31F4
+                    leax      >L3233,pcr
                     stx       $0688,y
                     clr       $0687,y
                     tst       $02,s
-                    bpl       L31F7
+                    bpl       L31F4
                     inc       $0687,y
-L31F7               subd      #$0000
-                    bne       L3202
+L31F4               subd      #$0000
+                    bne       L31FF
                     puls      x
                     ldd       ,s++
                     jmp       ,x
 
-L3202               ldx       $02,s
+L31FF               ldx       $02,s
                     pshs      x
                     jsr       [$0688,y]
                     ldd       ,s
                     std       $02,s
                     tfr       x,d
                     tst       $0687,y
-                    beq       L321A
+                    beq       L3217
                     nega
                     negb
                     sbca      #$00
-L321A               std       ,s++
+L3217               std       ,s++
                     rts
 
-L321D               subd      #$0000
-                    beq       L322C
+L321A               subd      #$0000
+                    beq       L3229
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
-                    bra       L325A
+                    bra       L3257
 
-L322C               puls      d
+L3229               puls      d
                     std       ,s
                     ldd       #$002D
-                    lbra      L32CF
+                    lbra      L32CC
 
-L3236               subd      #$0000
-                    beq       L322C
+L3233               subd      #$0000
+                    beq       L3229
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
                     tsta
-                    bpl       L324E
+                    bpl       L324B
                     nega
                     negb
                     sbca      #$00
                     inc       $01,s
                     std       $02,s
-L324E               ldd       $06,s
-                    bpl       L325A
+L324B               ldd       $06,s
+                    bpl       L3257
                     nega
                     negb
                     sbca      #$00
                     com       $01,s
                     std       $06,s
-L325A               lda       #$01
-L325C               inca
+L3257               lda       #$01
+L3259               inca
                     asl       $03,s
                     rol       $02,s
-                    bpl       L325C
+                    bpl       L3259
                     sta       ,s
                     ldd       $06,s
                     clr       $06,s
                     clr       $07,s
-L326B               subd      $02,s
-                    bcc       L3275
+L3268               subd      $02,s
+                    bcc       L3272
                     addd      $02,s
                     andcc     #$FE
-                    bra       L3277
+                    bra       L3274
 
-L3275               orcc      #$01
-L3277               rol       $07,s
+L3272               orcc      #$01
+L3274               rol       $07,s
                     rol       $06,s
                     lsr       $02,s
                     ror       $03,s
                     dec       ,s
-                    bne       L326B
+                    bne       L3268
                     std       $02,s
                     tst       $01,s
-                    beq       L3291
+                    beq       L328E
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-L3291               ldx       $04,s
+L328E               ldx       $04,s
                     ldd       $06,s
                     std       $04,s
                     stx       $06,s
@@ -5931,64 +5563,65 @@ L3291               ldx       $04,s
                     ldd       $04,s
                     leas      $06,s
                     rts
-                    tstb
-                    beq       L32B6
-L32A3               asr       $02,s
-                    ror       $03,s
-                    decb
-                    bne       L32A3
-                    bra       L32B6
 
-L32AC               tstb
-                    beq       L32B6
-L32AF               lsr       $02,s
+L329D               tstb
+                    beq       L32B3
+L32A0               asr       $02,s
                     ror       $03,s
                     decb
-                    bne       L32AF
-L32B6               ldd       $02,s
+                    bne       L32A0
+                    bra       L32B3
+
+L32A9               tstb
+                    beq       L32B3
+L32AC               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L32AC
+L32B3               ldd       $02,s
                     pshs      d
                     ldd       $02,s
                     std       $04,s
                     ldd       ,s
                     leas      $04,s
-L32C2               rts
+                    rts
 
-L32C3               tstb
-                    beq       L32B6
-L32C6               asl       $03,s
+L32C0               tstb
+                    beq       L32B3
+L32C3               asl       $03,s
                     rol       $02,s
                     decb
-                    bne       L32C6
-                    bra       L32B6
+                    bne       L32C3
+                    bra       L32B3
 
-L32CF               std       $0228,y
+L32CC               std       $0228,y
                     pshs      y,b
                     os9       F$ID
                     puls      y,b
                     os9       F$Send
                     rts
 
-L32DE               lda       $05,s
+L32DB               lda       $05,s
                     ldb       $03,s
-                    beq       L3311
+                    beq       L330E
                     cmpb      #$01
-                    beq       L3313
+                    beq       L3310
                     cmpb      #$06
-                    beq       L3313
+                    beq       L3310
                     cmpb      #$02
-                    beq       L32F9
+                    beq       L32F6
                     cmpb      #$05
-                    beq       L32F9
+                    beq       L32F6
                     ldb       #$D0
-                    lbra      L3560
+                    lbra      L355D
 
-L32F9               pshs      u
+L32F6               pshs      u
                     os9       I$GetStt
-                    bcc       L3305
+                    bcc       L3302
                     puls      u
-                    lbra      L3560
+                    lbra      L355D
 
-L3305               stx       [$08,s]
+L3302               stx       [$08,s]
                     ldx       $08,s
                     stu       $02,x
                     puls      u
@@ -5996,189 +5629,188 @@ L3305               stx       [$08,s]
                     clrb
                     rts
 
-L3311               ldx       $06,s
-L3313               os9       I$GetStt
-                    lbra      L3569
+L330E               ldx       $06,s
+L3310               os9       I$GetStt
+                    lbra      L3566
                     lda       $05,s
                     ldb       $03,s
-                    beq       L3328
+                    beq       L3325
                     cmpb      #$02
-                    beq       L3330
+                    beq       L332D
                     ldb       #$D0
-                    lbra      L3560
+                    lbra      L355D
 
-L3328               ldx       $06,s
+L3325               ldx       $06,s
                     os9       I$SetStt
-                    lbra      L3569
+                    lbra      L3566
 
-L3330               pshs      u
+L332D               pshs      u
                     ldx       $08,s
                     ldu       $0a,s
                     os9       I$SetStt
                     puls      u
-                    lbra      L3569
+                    lbra      L3566
                     ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    bcs       L334A
+                    bcs       L3347
                     os9       I$Close
-L334A               lbra      L3569
+L3347               lbra      L3566
 
-L334D               ldx       $02,s
+L334A               ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    lbcs      L3560
+                    lbcs      L355D
                     tfr       a,b
                     clra
                     rts
 
-L335C               lda       $03,s
+L3359               lda       $03,s
                     os9       I$Close
-                    lbra      L3569
+                    lbra      L3566
                     ldx       $02,s
                     ldb       $05,s
                     os9       I$MakDir
-                    lbra      L3569
+                    lbra      L3566
 
-L336E               ldx       $02,s
+L336B               ldx       $02,s
                     ldb       $05,s
                     tfr       b,a
                     anda      #$07
                     os9       I$Create
-                    bcs       L337F
-L337B               tfr       a,b
+                    bcs       L337C
+L3378               tfr       a,b
                     clra
                     rts
 
-L337F               cmpb      #$DA
-                    lbne      L3560
+L337C               cmpb      #$DA
+                    lbne      L355D
                     lda       $05,s
                     bita      #$80
-                    lbne      L3560
+                    lbne      L355D
                     anda      #$07
                     ldx       $02,s
                     os9       I$Open
-                    lbcs      L3560
+                    lbcs      L355D
                     pshs      u,a
                     ldx       #$0000
                     leau      ,x
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-                    bcc       L337B
+                    bcc       L3378
                     pshs      b
                     os9       I$Close
                     puls      b
-                    lbra      L3560
+                    lbra      L355D
 
-L33B2               ldx       $02,s
+L33AF               ldx       $02,s
                     os9       I$Delete
-                    lbra      L3569
+                    lbra      L3566
                     lda       $03,s
                     os9       I$Dup
-                    lbcs      L3560
+                    lbcs      L355D
                     tfr       a,b
                     clra
                     rts
 
-L33C7               pshs      y
+L33C4               pshs      y
                     ldx       $06,s
                     lda       $05,s
                     ldy       $08,s
                     pshs      y
                     os9       I$Read
-L33D5               bcc       L33E4
+L33D2               bcc       L33E1
                     cmpb      #$D3
-                    bne       L33DF
+                    bne       L33DC
                     clra
                     clrb
                     puls      pc,y,x
-L33DF               puls      y,x
-                    lbra      L3560
+L33DC               puls      y,x
+                    lbra      L355D
 
-L33E4               tfr       y,d
+L33E1               tfr       y,d
                     puls      pc,y,x
-L33E8               pshs      y
+L33E5               pshs      y
                     lda       $05,s
                     ldx       $06,s
                     ldy       $08,s
                     pshs      y
                     os9       I$ReadLn
-                    bra       L33D5
+                    bra       L33D2
 
-L33F8               pshs      y
+L33F5               pshs      y
                     ldy       $08,s
-                    beq       L340D
+                    beq       L340A
                     lda       $05,s
                     ldx       $06,s
                     os9       I$Write
-L3406               bcc       L340D
+L3403               bcc       L340A
                     puls      y
-                    lbra      L3560
+                    lbra      L355D
 
-L340D               tfr       y,d
+L340A               tfr       y,d
                     puls      pc,y
-L3411               pshs      y
+L340E               pshs      y
                     ldy       $08,s
-                    beq       L340D
+                    beq       L340A
                     lda       $05,s
                     ldx       $06,s
                     os9       I$WritLn
-                    bra       L3406
+                    bra       L3403
 
-L3421               pshs      u
+L341E               pshs      u
                     ldd       $0a,s
-                    bne       L342F
+                    bne       L342C
                     ldu       #$0000
                     ldx       #$0000
-                    bra       L3463
+                    bra       L3460
 
-L342F               cmpd      #$0001
-                    beq       L345A
+L342C               cmpd      #$0001
+                    beq       L3457
                     cmpd      #$0002
-                    beq       L344F
+                    beq       L344C
                     ldb       #$F7
-L343D               clra
+L343A               clra
                     std       $0228,y
                     ldd       #$FFFF
                     leax      $021C,y
                     std       ,x
                     std       $02,x
                     puls      pc,u
-L344F               lda       $05,s
+L344C               lda       $05,s
                     ldb       #$02
                     os9       I$GetStt
-                    bcs       L343D
-                    bra       L3463
+                    bcs       L343A
+                    bra       L3460
 
-L345A               lda       $05,s
+L3457               lda       $05,s
                     ldb       #$05
                     os9       I$GetStt
-                    bcs       L343D
-L3463               tfr       u,d
+                    bcs       L343A
+L3460               tfr       u,d
                     addd      $08,s
                     std       $021e,y
                     tfr       d,u
                     tfr       x,d
                     adcb      $07,s
                     adca      $06,s
-                    bmi       L343D
+                    bmi       L343A
                     tfr       d,x
                     std       $021C,y
                     lda       $05,s
                     os9       I$Seek
-                    bcs       L343D
+                    bcs       L343A
                     leax      $021C,y
                     puls      pc,u
                     rts
                     ldx       #$0000
                     clrb
                     os9       F$Sleep
-                    lbra      L3560
+                    lbra      L355D
+                    rts
 
-L3493               rts
-
-L3494               pshs      u,y
+L3491               pshs      u,y
                     ldx       $06,s
                     ldy       $08,s
                     ldu       $0a,s
@@ -6187,34 +5819,35 @@ L3494               pshs      u,y
                     lda       $03,s
                     ldb       $05,s
                     os9       F$Perr
-                    lbcs      L3560
+                    lbcs      L355D
                     rts
                     ldx       $02,s
                     os9       F$Sleep
-                    lbcs      L3560
+                    lbcs      L355D
                     tfr       x,d
-L34B9               rts
-                    ldd       $021a,y
+                    rts
+
+L34B7               ldd       $021a,y
                     pshs      d
                     ldd       $04,s
                     cmpd      $068a,y
-                    bcs       L34EE
+                    bcs       L34EB
                     addd      $021a,y
                     pshs      y
                     subd      ,s
                     os9       F$Mem
                     tfr       y,d
                     puls      y
-                    bcc       L34E0
+                    bcc       L34DD
                     ldd       #$FFFF
                     leas      $02,s
                     rts
 
-L34E0               std       $021a,y
+L34DD               std       $021a,y
                     addd      $068a,y
                     subd      ,s
                     std       $068a,y
-L34EE               leas      $02,s
+L34EB               leas      $02,s
                     ldd       $068a,y
                     pshs      d
                     subd      $04,s
@@ -6224,309 +5857,108 @@ L34EE               leas      $02,s
                     pshs      d
                     clra
                     ldx       ,s
-L3507               sta       ,x+
+L3504               sta       ,x+
                     cmpx      $021a,y
-                    bcs       L3507
+                    bcs       L3504
                     puls      pc,d
-L3511               ldd       $02,s
+L350E               ldd       $02,s
                     addd      $0224,y
-                    bcs       L353A
+                    bcs       L3537
                     cmpd      $0226,y
-                    bcc       L353A
+                    bcc       L3537
                     pshs      d
                     ldx       $0224,y
                     clra
-L3527               cmpx      ,s
-                    bcc       L352F
+L3524               cmpx      ,s
+                    bcc       L352C
                     sta       ,x+
-                    bra       L3527
+                    bra       L3524
 
-L352F               ldd       $0224,y
+L352C               ldd       $0224,y
                     puls      x
                     stx       $0224,y
                     rts
 
-L353A               ldd       #$FFFF
+L3537               ldd       #$FFFF
                     rts
-                    pshs      u
+
+L353B               pshs      u
                     tfr       y,u
                     ldx       $04,s
                     stx       $068C,y
-                    leax      >L3554,pcr
+                    leax      >L3551,pcr
                     os9       F$Icpt
                     puls      u
-                    lbra      L3569
+                    lbra      L3566
 
-L3554               tfr       u,y
+L3551               tfr       u,y
                     clra
                     pshs      d
                     jsr       [$068C,y]
                     leas      $02,s
                     rti
 
-L3560               clra
+L355D               clra
                     std       $0228,y
                     ldd       #$FFFF
-L3568               rts
+                    rts
 
-L3569               bcs       L3560
-L356B               clra
+L3566               bcs       L355D
+                    clra
                     clrb
-L356D               rts
+                    rts
 
-L356E               lbsr      L3579
-L3571               lbsr      L2B4E
-                    ldd       $02,s
+L356B               lbsr      L3576
+                    lbsr      L2B4B
+L3571               ldd       $02,s
                     os9       F$Exit
-L3579               rts
-                    neg       $000A
-                    neg       $0000
-                    neg       $0004
-                    neg       $00FF
-                    stu       $FF02
-                    asr       L017A
-                    neg       $0060
-                    neg       $0060
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    tst       $00C1
-                    tst       $00C7
-                    tst       $00CD
-                    tst       $00D1
-                    tst       $00D7
-                    fcb       $02
-                    asr       $2710
-                    com       $00E8
-                    neg       $0064
-                    neg       $000A
-                    neg       L0084
-                    inc       -$08,s
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+L3576               rts
+* ------------------------------------------------------------------
+* L3577 - cc1-style init image for the work block (see _start):
+* rts stub + count/block table + relocation dirs + module-name string.
+* ------------------------------------------------------------------
+L3577               fcb       $00,$0A,$00,$00,$00,$04,$00,$FF,$FF,$FF,$02
+                    fcb       $77
                     fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $7A
+                    fcb       $00
+                    fcb       $60
+                    fcb       $00
+                    fcb       $60
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$0D,$C1,$0D,$C7,$0D,$CD,$0D,$D1,$0D,$D7,$02
+                    fcc       /w'/
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$84
+                    fcc       /lx/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00,$01,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$02,$00,$01,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    leax      0,y
-                    bra       L36C6
-                    bra       L36C8
-                    bra       L36CA
-                    bra       L36CC
-                    bra       L36CE
-                    bra       L36D0
-                    bra       L36D2
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    bra       $36DE
-                    bra       $36E0
-                    bra       $36E2
-                    bra       L3706
-                    fcb       $42
-                    fcb       $42
-L36C6               fcb       $42
-                    fcb       $42
-L36C8               fcb       $42
-                    fcb       $02
-L36CA               fcb       $02
-                    fcb       $02
-L36CC               fcb       $02
-                    fcb       $02
-L36CE               fcb       $02
-                    fcb       $02
-L36D0               fcb       $02
-                    fcb       $02
-L36D2               fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    bra       L36FF
-                    bra       L3701
-                    bra       $3703
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    bra       $371F
-
-L36FF               bra       $3721
-L3701               fcb       $01
-                    neg       $0005
-                    neg       L0078
-L3706               neg       $0076
-                    neg       $0074
-                    neg       $0072
-                    neg       L0070
-                    neg       $0005
-                    neg       $0062
-                    neg       $0060
-                    neg       $007A
-                    neg       $0008
-                    neg       L0084
-                    com       $0e,y
-                    inc       $09,s
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$01,$01,$01,$01,$01,$01,$01,$01,$01,$11,$11,$01,$11,$11,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01
+                    fcc       /0               HHHHH/
+                    fcc       /HHHHH       BBBBBB/
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02
+                    fcc       /      DDDDDD/
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04
+                    fcc       /    /
+                    fcb       $01,$00,$05,$00
+                    fcb       $78
+                    fcb       $00
+                    fcb       $76
+                    fcb       $00
+                    fcb       $74
+                    fcb       $00
+                    fcb       $72
+                    fcb       $00
+                    fcb       $70
+                    fcb       $00,$05,$00
+                    fcb       $62
+                    fcb       $00
+                    fcb       $60
+                    fcb       $00
+                    fcb       $7A
+                    fcb       $00,$08,$00,$84
+                    fcc       /c.link/
+                    fcb       $00
 
                     emod
 eom                 equ       *

--- a/3rdparty/packages/ccompiler/c.link_dis.asm
+++ b/3rdparty/packages/ccompiler/c.link_dis.asm
@@ -1,0 +1,6533 @@
+                    nam       c.link
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $04
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       5646
+size                equ       .
+
+name                equ       *
+                    fcs       /c.link/
+                    fcb       edition
+
+L0014               lda       ,y+
+L0016               sta       ,u+
+L0018               leax      -$01,x
+L001A               bne       L0014
+L001C               rts
+
+start               pshs      y
+                    pshs      u
+                    clra
+L0022               clrb
+L0023               sta       ,u+
+L0025               decb
+L0026               bne       L0023
+L0028               ldx       ,s
+L002A               leau      ,x
+L002C               leax      $068e,x
+L0030               pshs      x
+L0032               leay      $3577,pcr
+L0036               ldx       ,y++
+L0038               beq       L003E
+L003A               bsr       L0014
+L003C               ldu       $02,s
+L003E               leau      >$0060,u
+L0042               ldx       ,y++
+L0044               beq       L0049
+L0046               bsr       L0014
+L0048               clra
+L0049               cmpu      ,s
+L004C               beq       L0052
+L004E               sta       ,u+
+L0050               bra       L0049
+
+L0052               ldu       $02,s
+L0054               ldd       ,y++
+                    beq       L005F
+L0058               leax      >$0000,pcr
+L005C               lbsr      L0162
+L005F               ldd       ,y++
+L0061               beq       L0068
+L0063               leax      ,u
+L0065               lbsr      L0162
+L0068               leas      $04,s
+                    puls      x
+L006C               stx       $021a,u
+L0070               sty       $01DA,u
+L0075               ldd       #$0001
+L0078               std       $0216,u
+                    leay      $01DC,u
+L0080               leax      ,s
+                    lda       ,x+
+L0084               ldb       $0217,u
+                    cmpb      #$1d
+                    beq       L00E0
+L008C               cmpa      #$0d
+                    beq       L00E0
+                    cmpa      #$20
+                    beq       L0098
+                    cmpa      #$2C
+                    bne       L009C
+L0098               lda       ,x+
+                    bra       L008C
+
+L009C               cmpa      #$22
+                    beq       L00A4
+                    cmpa      #$27
+                    bne       L00C2
+L00A4               stx       ,y++
+                    inc       $0217,u
+                    pshs      a
+L00AC               lda       ,x+
+                    cmpa      #$0d
+                    beq       L00B6
+                    cmpa      ,s
+                    bne       L00AC
+L00B6               puls      b
+                    clr       -$01,x
+                    cmpa      #$0d
+                    beq       L00E0
+                    lda       ,x+
+                    bra       L0084
+
+L00C2               leax      -$01,x
+                    stx       ,y++
+                    leax      $01,x
+L00C8               inc       $0217,u
+L00CC               cmpa      #$0d
+                    beq       L00DC
+                    cmpa      #$20
+                    beq       L00DC
+                    cmpa      #$2C
+                    beq       L00DC
+                    lda       ,x+
+                    bra       L00CC
+
+L00DC               clr       -$01,x
+                    bra       L0084
+
+L00E0               leax      $01DA,u
+                    pshs      x
+                    ldd       $0216,u
+                    pshs      d
+                    leay      ,u
+                    bsr       L00FA
+                    lbsr      L017C
+                    clr       ,-s
+                    clr       ,-s
+                    lbsr      L356B
+L00FA               leax      $068e,y
+                    stx       $0224,y
+L0102               sts       $0218,y
+                    sts       $0226,y
+                    ldd       #$FF82
+                    leax      d,s
+L0111               cmpx      $0226,y
+                    bcc       L0121
+                    cmpx      $0224,y
+                    bcs       L013B
+                    stx       $0226,y
+L0121               rts
+L0122               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L013B               leax      L0122,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clr       ,-s
+                    lbsr      L3571
+                    ldd       $0218,y
+                    subd      $0226,y
+                    rts
+                    ldd       $0226,y
+                    subd      $0224,y
+                    rts
+
+L0162               pshs      x
+                    leax      d,y
+                    leax      d,x
+                    anda      $0034
+                    fcb       $10
+L016B               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+L0173               std       ,x
+                    cmpy      ,s
+                    bne       L016B
+L017A               leas      $04,s
+L017C               rts
+                    pshs      u
+                    ldd       #$FFB0
+                    lbsr      $0110
+                    leas      -$06,s
+                    leax      L1E00,pcr
+                    pshs      x
+                    lbsr      $353C
+                    leas      $02,s
+                    lbra      L033D
+
+L0195               ldx       $0C,s
+                    leax      $02,x
+                    stx       $0C,s
+                    ldu       ,x
+                    ldb       ,u
+                    cmpb      #$2d
+                    lbne      L0313
+                    lbra      L0305
+
+L01A8               ldb       ,u
+                    sex
+                    tfr       d,x
+                    lbra      L02BF
+
+L01B0               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L01C0
+                    leau      $01,u
+                    tfr       u,d
+                    std       $0273,y
+L01C0               ldd       $0271,y
+                    lbne      L02A1
+                    pshs      u
+                    lbsr      L0D9E
+                    leas      $02,s
+                    std       $0271,y
+                    lbra      L02A1
+
+L01D6               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L0206
+                    ldd       $000C
+                    cmpd      #$0005
+                    bge       L0206
+                    ldd       $000C
+                    addd      #$0001
+                    std       $000C
+                    subd      #$0001
+                    aslb
+                    rola
+                    leax      $0266,y
+                    leax      d,x
+                    pshs      x
+                    pshs      u
+                    ldd       #$0001
+                    addd      ,s++
+                    std       [,s++]
+                    lbra      L02A1
+
+L0206               pshs      u
+                    leax      $0DDE,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $04,s
+                    lbra      L02A1
+
+L0216               ldd       #$0001
+                    std       $000E
+                    lbra      L0305
+
+L021E               ldd       #$0001
+                    std       $0010
+                    lbra      L0305
+
+L0226               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    lbne      L02A1
+                    leax      $01,u
+                    stx       $0271,y
+                    lbra      L02A1
+
+L0239               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    lbne      L02A1
+                    pshs      u
+                    ldd       #$0001
+                    addd      ,s++
+                    pshs      d
+                    lbsr      L302D
+                    leas      $02,s
+                    stb       $0270,y
+                    bra       L02A1
+
+L0257               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L027B
+                    pshs      u
+                    ldd       #$0001
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $1B06
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$0100
+                    bcs       L02A1
+                    ldd       ,s
+                    std       L0032
+                    bra       L02A1
+
+L027B               pshs      u
+                    leax      L0E18,pcr
+                    pshs      x
+                    leax      L0DFE,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $06,s
+L028E               ldd       #$0001
+                    std       L0014
+                    leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L02A1
+                    leax      $01,u
+                    stx       $0275,y
+L02A1               leax      $06,s
+                    lbra      L030F
+
+L02A6               ldd       #$0001
+                    std       L0016
+                    bra       L0305
+
+L02AD               ldb       ,u
+                    sex
+                    pshs      d
+                    leax      $0E25,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $04,s
+                    bra       L0305
+
+L02BF               cmpx      #$006F
+                    lbeq      L01B0
+                    cmpx      #$006C
+                    lbeq      L01D6
+                    cmpx      #$006D
+                    lbeq      L0216
+                    cmpx      #$0073
+                    lbeq      L021E
+                    cmpx      #$006E
+                    lbeq      L0226
+                    cmpx      #$0045
+                    lbeq      L0239
+                    cmpx      #$0065
+                    lbeq      L0239
+                    cmpx      #$004D
+                    lbeq      L0257
+                    cmpx      #$0062
+                    lbeq      L028E
+                    cmpx      #$0074
+                    beq       L02A6
+                    bra       L02AD
+
+L0305               leau      $01,u
+                    ldb       ,u
+                    lbne      L01A8
+                    bra       L033D
+
+L030F               leas      -$06,x
+                    bra       L033D
+
+L0313               ldd       $000A
+                    cmpd      #$001E
+                    bne       L0326
+                    leax      L0E38,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $02,s
+L0326               ldd       $000A
+                    addd      #$0001
+                    std       $000A
+                    subd      #$0001
+                    aslb
+                    rola
+                    leax      $022a,y
+                    leax      d,x
+                    ldd       [$0C,s]
+                    std       ,x
+L033D               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    lbgt      L0195
+                    lbsr      L044B
+                    lbsr      L1D81
+                    std       -$02,s
+                    beq       L035D
+                    leax      $0E4E,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $02,s
+L035D               ldd       $0271,y
+                    pshs      d
+                    lbsr      $2EC5
+                    leas      $02,s
+                    std       L001A
+                    lbsr      L0928
+                    lbsr      L0A67
+                    ldd       L0014
+                    beq       L03A9
+                    ldd       L0026
+                    bne       L037C
+                    ldd       L002A
+                    beq       L0387
+L037C               leax      $0E64,pcr
+                    pshs      x
+                    lbsr      L0CE6
+                    leas      $02,s
+L0387               ldd       L0022
+                    beq       L0396
+                    leax      L0E79,pcr
+                    pshs      x
+                    lbsr      L0CE6
+                    leas      $02,s
+L0396               ldd       L0016
+                    bne       L03A9
+                    ldd       $001E
+                    beq       L03A9
+                    leax      L0E8C,pcr
+                    pshs      x
+                    lbsr      L0CE6
+                    leas      $02,s
+L03A9               ldd       L0022
+                    addd      L002A
+                    cmpd      #$0100
+                    bls       L03C4
+                    ldd       L0022
+                    addd      L002A
+                    pshs      d
+                    leax      L0E9B,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $04,s
+L03C4               ldd       L0044
+                    beq       L03D3
+                    leax      $0EBE,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $02,s
+L03D3               ldd       $0273,y
+                    bne       L03E4
+                    leax      L0EC9,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $02,s
+L03E4               ldd       L0014
+                    lbeq      L0444
+                    ldd       $0275,y
+                    bne       L03FB
+                    leax      $0ED8,pcr
+                    pshs      x
+                    lbsr      L0CE6
+                    bra       L043D
+
+L03FB               leas      -$02,s
+                    ldd       $0275,y
+                    pshs      d
+                    ldd       $0275,y
+                    pshs      d
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    std       ,s
+                    beq       L042C
+                    ldx       ,s
+                    ldd       $0a,x
+                    clra
+                    andb      #$07
+                    cmpd      #$0004
+                    bne       L042C
+                    ldx       ,s
+                    ldd       $0C,x
+                    std       L0030
+                    bra       L043D
+
+L042C               ldd       $0275,y
+                    pshs      d
+                    leax      $0EEC,pcr
+                    pshs      x
+                    lbsr      L0CE6
+                    leas      $04,s
+L043D               leas      $02,s
+                    ldd       #$2181
+                    std       L0018
+L0444               lbsr      $1016
+                    leas      $06,s
+                    puls      pc,u
+L044B               pshs      u
+                    ldd       #$FF96
+                    lbsr      $0110
+                    leas      -$1e,s
+                    ldd       $000A
+                    lbeq      L065B
+                    clra
+                    clrb
+                    lbra      L0595
+
+L0461               ldd       ,s
+                    aslb
+                    rola
+                    leax      $022a,y
+                    leax      d,x
+                    ldd       ,x
+                    std       L0042
+                    ldd       L0038
+                    pshs      d
+                    leax      $0F07,pcr
+                    pshs      x
+                    ldd       L0042
+                    pshs      d
+                    lbsr      L22B9
+                    leas      $06,s
+                    std       L0038
+                    bne       L0489
+                    lbsr      L0D2E
+L0489               ldd       $0003
+                    ldx       L0038
+                    std       $0b,x
+                    ldd       L0038
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$001C
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    lbsr      L232E
+                    leas      $08,s
+                    std       -$02,s
+                    bne       L04AD
+                    lbsr      L0D85
+L04AD               leax      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L04BD
+                    fcb       $62
+                    fcb       $CD
+                    bls       L0444
+L04BD               puls      x
+                    lbsr      $30E8
+                    beq       L04C9
+                    lbsr      L0D41
+                    bra       L0511
+
+L04C9               ldb       $08,s
+                    beq       L04D2
+                    lbsr      L0D53
+                    bra       L0511
+
+L04D2               ldd       L0014
+                    beq       L04DF
+                    ldd       $06,s
+                    beq       L0511
+                    lbsr      L0D1C
+                    bra       L0511
+
+L04DF               ldd       ,s
+                    beq       L04EC
+                    ldd       $06,s
+                    beq       L0511
+                    lbsr      L0D65
+                    bra       L0511
+
+L04EC               ldd       $06,s
+                    bne       L0501
+                    ldd       L0042
+                    pshs      d
+                    leax      $0F09,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $04,s
+                    bra       L0505
+
+L0501               ldd       $06,s
+                    std       L0018
+L0505               ldb       $0270,y
+                    bne       L0511
+                    ldb       $0e,s
+                    stb       $0270,y
+L0511               clra
+                    clrb
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L0660
+                    leas      $04,s
+                    ldd       ,s
+                    lbne      L0590
+                    leas      -$02,s
+                    ldd       L003E
+                    std       ,s
+                    ldd       #$0104
+                    pshs      d
+                    ldd       >$0070,y
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0B8C
+                    leas      $06,s
+                    ldd       #$0104
+                    pshs      d
+                    ldd       >$0078,y
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0B8C
+                    leas      $06,s
+                    ldd       #$0101
+                    pshs      d
+                    ldd       >$0072,y
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0B8C
+                    leas      $06,s
+                    ldd       #$0100
+                    pshs      d
+                    ldd       >$0074,y
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0B8C
+                    leas      $06,s
+                    ldd       #$0102
+                    pshs      d
+                    ldd       >$0076,y
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0B8C
+                    leas      $06,s
+                    leas      $02,s
+L0590               ldd       ,s
+                    addd      #$0001
+L0595               std       ,s
+                    ldd       ,s
+                    cmpd      $000A
+                    lblt      L0461
+                    clra
+                    clrb
+                    lbra      L064B
+
+L05A5               ldd       ,s
+                    aslb
+                    rola
+                    leax      $0266,y
+                    leax      d,x
+                    ldd       ,x
+                    std       L0042
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2B74
+                    leas      $02,s
+                    leax      $0F23,pcr
+                    pshs      x
+                    ldd       L0042
+                    pshs      d
+                    lbsr      $229A
+                    leas      $04,s
+                    std       L0038
+                    lbne      L0629
+                    lbsr      L0D2E
+                    bra       L0629
+
+L05D6               leax      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L05E6
+                    fcb       $62
+                    fcb       $CD
+                    bls       $056D
+L05E6               puls      x
+                    lbsr      $30E8
+                    beq       L05F2
+                    lbsr      L0D41
+                    bra       L061A
+
+L05F2               ldb       $08,s
+                    beq       L05FB
+                    lbsr      L0D53
+                    bra       L061A
+
+L05FB               ldd       $06,s
+                    beq       L060D
+                    ldd       L0014
+                    beq       L0608
+                    lbsr      L0D1C
+                    bra       L061A
+
+L0608               lbsr      L0D65
+                    bra       L061A
+
+L060D               ldd       #$0001
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    bsr       L0660
+                    leas      $04,s
+L061A               leax      >$0060,y
+                    cmpx      >$0060,y
+                    bne       L0629
+                    leax      $1e,s
+                    bra       L0658
+
+L0629               ldd       L0038
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$001C
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    lbsr      L232E
+                    leas      $08,s
+                    std       -$02,s
+                    lbne      L05D6
+                    ldd       ,s
+                    addd      #$0001
+L064B               std       ,s
+                    ldd       ,s
+                    cmpd      $000C
+                    lblt      L05A5
+                    bra       L065B
+
+L0658               leas      -$1e,x
+L065B               leas      $1e,s
+                    puls      pc,u
+L0660               pshs      u
+                    ldd       #$FF8B
+                    lbsr      $0110
+                    leas      -$29,s
+                    ldd       L003C
+                    bne       L067E
+                    ldd       #$0031
+                    pshs      d
+                    lbsr      $1C20
+                    leas      $02,s
+                    std       $27,s
+                    bra       L068B
+
+L067E               ldd       L003C
+                    std       $27,s
+                    ldx       $27,s
+                    ldd       $11,x
+                    std       L003C
+L068B               clra
+                    clrb
+                    ldx       $27,s
+                    std       $2d,x
+                    clra
+                    clrb
+                    ldx       $27,s
+                    std       $27,x
+                    ldd       $27,s
+                    std       $1b,s
+                    ldd       #$0010
+                    bra       L06B9
+
+L06A6               ldd       $23,s
+                    ldx       $1b,s
+                    leax      $01,x
+                    stx       $1b,s
+                    stb       -$01,x
+                    ldd       $21,s
+                    addd      #$FFFF
+L06B9               std       $21,s
+                    ldd       $21,s
+                    ble       L06CF
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2C97
+                    leas      $02,s
+                    std       $23,s
+                    bne       L06A6
+L06CF               ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L06DB
+                    lbsr      L0D85
+L06DB               clra
+                    clrb
+                    stb       [$1b,s]
+                    ldd       L0042
+                    ldx       $27,s
+                    std       $2f,x
+                    ldd       #$0010
+                    pshs      d
+                    ldd       $2f,s
+                    addd      #$000C
+                    pshs      d
+                    ldd       $2b,s
+                    addd      #$0015
+                    pshs      d
+                    lbsr      L30A0
+                    leas      $06,s
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    std       $1f,s
+                    bra       L0750
+
+L0710               lbsr      L0BCD
+                    std       $25,s
+                    ldx       $27,s
+                    ldd       $2d,x
+                    ldx       $25,s
+                    std       $0e,x
+                    ldd       $25,s
+                    ldx       $27,s
+                    std       $2d,x
+                    ldd       $25,s
+                    pshs      d
+                    lbsr      L1DE1
+                    leas      $02,s
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2C97
+                    leas      $02,s
+                    ldx       $25,s
+                    std       $0a,x
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    ldx       $25,s
+                    std       $0C,x
+L0750               ldd       $1f,s
+                    addd      #$FFFF
+                    std       $1f,s
+                    subd      #$FFFF
+                    bne       L0710
+                    ldd       $2f,s
+                    lbeq      L07DD
+                    ldx       $27,s
+                    ldd       $2d,x
+                    bra       L0785
+
+L076D               ldd       #$0001
+                    pshs      d
+                    ldd       $27,s
+                    pshs      d
+                    lbsr      $1B83
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L078D
+                    ldx       $25,s
+                    ldd       $0e,x
+L0785               std       $25,s
+                    ldd       $25,s
+                    bne       L076D
+L078D               ldd       $25,s
+                    bne       L07DD
+                    leas      -$02,s
+                    ldx       $29,s
+                    ldd       $2d,x
+                    pshs      d
+                    lbsr      L0CC8
+                    leas      $02,s
+                    std       ,s
+                    ldd       $0001
+                    ldx       ,s
+                    std       $0e,x
+                    ldx       $29,s
+                    ldd       $0e,x
+                    std       $0001
+                    ldd       $29,s
+                    pshs      d
+                    lbsr      L0BF1
+                    leas      $02,s
+                    lbsr      L0C3C
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    std       ,s
+                    lbsr      L0C0F
+                    leas      $02,s
+                    ldd       L003C
+                    ldx       $29,s
+                    std       $11,x
+                    ldd       $29,s
+                    std       L003C
+                    leas      $2b,s
+                    puls      pc,u
+L07DD               ldx       $27,s
+                    ldd       $2d,x
+                    bra       L0818
+
+L07E5               ldd       $25,s
+                    pshs      d
+                    lbsr      $1A57
+                    std       ,s++
+                    beq       L0813
+                    ldd       $27,s
+                    pshs      d
+                    ldd       $27,s
+                    pshs      d
+                    leax      $0F25,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      L23D0
+                    leas      $08,s
+                    ldd       L0044
+                    addd      #$0001
+                    std       L0044
+L0813               ldx       $25,s
+                    ldd       $0e,x
+L0818               std       $25,s
+                    ldd       $25,s
+                    bne       L07E5
+                    ldd       $0040
+                    bne       L082D
+                    ldd       $27,s
+                    std       $0040
+                    std       L003E
+                    bra       L0837
+
+L082D               ldd       $27,s
+                    ldx       $0040
+                    std       $11,x
+                    std       $0040
+L0837               ldx       $27,s
+                    leax      $29,x
+                    pshs      x
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2A1B
+                    leas      $02,s
+                    lbsr      $314C
+                    ldd       $27,s
+                    pshs      d
+                    lbsr      L0BF1
+                    leas      $02,s
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    std       $1f,s
+                    lbra      L08D2
+
+L0864               leax      $01,s
+                    pshs      x
+                    lbsr      L1DE1
+                    leas      $02,s
+                    leax      $01,s
+                    pshs      x
+                    leax      $03,s
+                    pshs      x
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    std       $25,s
+                    beq       L088F
+                    ldx       $25,s
+                    ldd       $0a,x
+                    ora       #$01
+                    std       $0a,x
+                    bra       L08B5
+
+L088F               leas      -$02,s
+                    leax      $03,s
+                    pshs      x
+                    lbsr      $1BD9
+                    leas      $02,s
+                    std       ,s
+                    leax      $03,s
+                    pshs      x
+                    ldd       $02,s
+                    addd      #$0004
+                    pshs      d
+                    lbsr      L2ED6
+                    leas      $04,s
+                    ldd       $29,s
+                    ldx       ,s
+                    std       $0e,x
+                    leas      $02,s
+L08B5               ldx       $27,s
+                    ldd       $27,x
+                    leax      $27,x
+                    pshs      x,d
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    std       ,s
+                    lbsr      L0C7A
+                    leas      $02,s
+                    addd      ,s++
+                    std       [,s++]
+L08D2               ldd       $1f,s
+                    addd      #$FFFF
+                    std       $1f,s
+                    subd      #$FFFF
+                    lbne      L0864
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    std       $1f,s
+                    ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L0915
+                    lbsr      L0D85
+                    bra       L0915
+
+L08FC               ldx       $27,s
+                    ldd       $27,x
+                    leax      $27,x
+                    pshs      x,d
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L0C7A
+                    leas      $02,s
+                    addd      ,s++
+                    std       [,s++]
+L0915               ldd       $1f,s
+                    addd      #$FFFF
+                    std       $1f,s
+                    subd      #$FFFF
+                    bne       L08FC
+                    leas      $29,s
+                    puls      pc,u
+L0928               pshs      u
+                    ldd       #$FFB6
+                    lbsr      $0110
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       $0034
+                    ldd       L003E
+                    lbra      L09DD
+
+L093B               ldx       ,s
+                    ldu       $2d,x
+                    lbra      L09D2
+
+L0943               ldd       $0a,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L09D0
+                    ldx       ,s
+                    ldd       $13,x
+                    ora       #$01
+                    std       $13,x
+                    ldd       $001E
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $17,x
+                    addd      ,s++
+                    std       $001E
+                    ldd       L0022
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $19,x
+                    addd      ,s++
+                    std       L0022
+                    ldd       L0026
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $1b,x
+                    addd      ,s++
+                    std       L0026
+                    ldd       L002A
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $1d,x
+                    addd      ,s++
+                    std       L002A
+                    ldd       L0032
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $21,x
+                    addd      ,s++
+                    std       L0032
+                    ldd       $002E
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $1f,x
+                    addd      ,s++
+                    std       $002E
+                    ldd       L0036
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $27,x
+                    addd      ,s++
+                    std       L0036
+                    ldx       ,s
+                    ldd       $1f,x
+                    ldx       ,s
+                    addd      $1b,x
+                    cmpd      $0034
+                    bls       L09D8
+                    ldx       ,s
+                    ldd       $1f,x
+                    ldx       ,s
+                    addd      $1b,x
+                    std       $0034
+                    bra       L09D8
+
+L09D0               ldu       $0e,u
+L09D2               stu       -$02,s
+                    lbne      L0943
+L09D8               ldx       ,s
+                    ldd       $11,x
+L09DD               std       ,s
+                    ldd       ,s
+                    lbne      L093B
+                    ldd       >$0070,y
+                    pshs      d
+                    ldd       >$0070,y
+                    pshs      d
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0A05
+                    ldd       $002E
+                    std       $0C,u
+L0A05               ldd       >$0072,y
+                    pshs      d
+                    ldd       >$0072,y
+                    pshs      d
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0A25
+                    ldd       L0026
+                    std       $0C,u
+L0A25               ldd       >$0074,y
+                    pshs      d
+                    ldd       >$0074,y
+                    pshs      d
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0A45
+                    ldd       $001E
+                    std       $0C,u
+L0A45               ldd       >$0076,y
+                    pshs      d
+                    ldd       >$0076,y
+                    pshs      d
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0A65
+                    ldd       L0022
+                    std       $0C,u
+L0A65               puls      pc,u,x
+L0A67               pshs      u
+                    ldd       #$FFB1
+                    lbsr      $0110
+                    leas      -$05,s
+                    lbsr      L0B65
+                    ldd       L003E
+                    lbra      L0B38
+
+L0A79               ldx       $03,s
+                    ldd       $13,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L0B33
+                    ldx       $03,s
+                    ldu       $2d,x
+                    lbra      L0AEC
+
+L0A8F               ldd       $0a,u
+                    clra
+                    andb      #$07
+                    tfr       d,x
+                    bra       L0AD0
+
+L0A98               ldd       $0C,u
+                    addd      L001C
+                    bra       L0AB4
+
+L0A9E               ldd       $0C,u
+                    addd      $0024
+                    bra       L0AB4
+
+L0AA4               ldd       $0C,u
+                    addd      $0020
+                    bra       L0AB4
+
+L0AAA               ldd       $0C,u
+                    addd      L0028
+                    bra       L0AB4
+
+L0AB0               ldd       $0C,u
+                    addd      L002C
+L0AB4               std       $0C,u
+                    bra       L0AEA
+
+L0AB8               ldx       $03,s
+                    ldd       $2f,x
+                    pshs      d
+                    ldd       $05,s
+                    pshs      d
+                    leax      L0F49,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $06,s
+                    bra       L0AEA
+
+L0AD0               stx       -$02,s
+                    beq       L0A98
+                    cmpx      #$0001
+                    beq       L0A9E
+                    cmpx      #$0002
+                    beq       L0AA4
+                    cmpx      #$0003
+                    beq       L0AAA
+                    cmpx      #$0004
+                    beq       L0AB0
+                    bra       L0AB8
+
+L0AEA               ldu       $0e,u
+L0AEC               stu       -$02,s
+                    lbne      L0A8F
+                    ldd       L001C
+                    pshs      d
+                    ldx       $05,s
+                    ldd       $17,x
+                    addd      ,s++
+                    std       L001C
+                    ldd       $0024
+                    pshs      d
+                    ldx       $05,s
+                    ldd       $1b,x
+                    addd      ,s++
+                    std       $0024
+                    ldd       $0020
+                    pshs      d
+                    ldx       $05,s
+                    ldd       $19,x
+                    addd      ,s++
+                    std       $0020
+                    ldd       L0028
+                    pshs      d
+                    ldx       $05,s
+                    ldd       $1d,x
+                    addd      ,s++
+                    std       L0028
+                    ldd       L002C
+                    pshs      d
+                    ldx       $05,s
+                    ldd       $1f,x
+                    addd      ,s++
+                    std       L002C
+L0B33               ldx       $03,s
+                    ldd       $11,x
+L0B38               std       $03,s
+                    ldd       $03,s
+                    lbne      L0A79
+                    ldd       >$0078,y
+                    pshs      d
+                    ldd       >$0078,y
+                    pshs      d
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0B60
+                    clra
+                    clrb
+                    std       $0C,u
+L0B60               bsr       L0B65
+                    lbra      L0CC4
+
+L0B65               pshs      u
+                    ldd       #$FFC0
+                    lbsr      $0110
+                    clra
+                    clrb
+                    std       L0028
+                    ldd       L0028
+                    addd      L002A
+                    std       $0020
+                    ldd       $0020
+                    addd      L0022
+                    std       $0024
+                    ldd       $0024
+                    addd      L0026
+                    std       L001C
+                    ldd       L001A
+                    addd      #$000E
+                    std       L002C
+                    puls      pc,u
+L0B8C               pshs      u
+                    ldd       #$FFB4
+                    lbsr      $0110
+                    leas      -$02,s
+                    bsr       L0BCD
+                    std       ,s
+                    ldx       $06,s
+                    ldd       $2d,x
+                    ldx       ,s
+                    std       $0e,x
+                    ldd       ,s
+                    ldx       $06,s
+                    std       $2d,x
+                    ldd       #$0009
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L2F4C
+                    leas      $06,s
+                    ldd       $0a,s
+                    ldx       ,s
+                    std       $0a,x
+                    ldd       ,s
+                    pshs      d
+                    lbsr      $1A57
+                    leas      $02,s
+                    puls      pc,u,x
+L0BCD               pshs      u
+                    ldd       #$FFBA
+                    lbsr      $0110
+                    ldd       $0001
+                    bne       L0BE7
+                    ldd       #$0012
+                    pshs      d
+                    lbsr      $1C20
+                    leas      $02,s
+                    tfr       d,u
+                    bra       L0BED
+
+L0BE7               ldu       $0001
+                    ldd       $0e,u
+                    std       $0001
+L0BED               tfr       u,d
+                    puls      pc,u
+L0BF1               pshs      u
+                    ldd       #$FFB4
+                    lbsr      $0110
+                    ldd       #$0001
+                    pshs      d
+                    ldx       $06,s
+                    ldd       $1f,x
+                    ldx       $06,s
+                    addd      $1d,x
+                    ldx       $06,s
+                    addd      $1b,x
+                    bra       L0C26
+
+L0C0F               pshs      u
+                    ldd       #$FFB4
+                    lbsr      $0110
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0003
+                    lbsr      $3180
+L0C26               lbsr      $3141
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L0038
+                    pshs      d
+                    lbsr      $28C4
+                    leas      $08,s
+                    puls      pc,u
+L0C3C               pshs      u
+                    ldd       #$FFAE
+                    lbsr      $0110
+                    leas      -$0C,s
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    std       ,s
+                    bra       L0C6A
+
+L0C53               leax      $02,s
+                    pshs      x
+                    lbsr      L1DE1
+                    leas      $02,s
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    std       ,s
+                    lbsr      L0C0F
+                    leas      $02,s
+L0C6A               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bne       L0C53
+                    leas      $0C,s
+                    puls      pc,u
+L0C7A               pshs      u
+                    ldd       #$FFAF
+                    lbsr      $0110
+                    ldu       $04,s
+                    leas      -$05,s
+                    clra
+                    clrb
+                    bra       L0CB8
+
+L0C8A               ldd       L0038
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0003
+                    pshs      d
+                    leax      $06,s
+                    pshs      x
+                    lbsr      L232E
+                    leas      $08,s
+                    std       -$02,s
+                    bne       L0CA8
+                    lbsr      L0D85
+L0CA8               ldb       ,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L0CBA
+                    ldd       $03,s
+                    addd      #$0001
+L0CB8               std       $03,s
+L0CBA               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bne       L0C8A
+                    ldd       $03,s
+L0CC4               leas      $05,s
+                    puls      pc,u
+L0CC8               pshs      u
+                    ldd       #$FFBE
+                    lbsr      $0110
+                    ldu       $04,s
+                    leas      -$02,s
+                    stu       ,s
+                    stu       ,s
+                    bra       L0CDE
+
+L0CDA               stu       ,s
+                    ldu       $0e,u
+L0CDE               stu       -$02,s
+                    bne       L0CDA
+                    ldd       ,s
+                    puls      pc,u,x
+L0CE6               pshs      u
+                    ldd       #$FFB6
+                    lbsr      $0110
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      L23D0
+                    leas      $06,s
+                    leax      $00A3,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L2A84
+                    leas      $04,s
+                    leax      $0F65,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    puls      pc,u,x
+L0D1C               pshs      u
+                    ldd       #$FFBA
+                    lbsr      $0110
+                    leax      $0F76,pcr
+                    pshs      x
+                    bsr       L0CE6
+                    puls      pc,u,x
+L0D2E               pshs      u
+                    ldd       #$FFB8
+                    lbsr      $0110
+                    ldd       L0042
+                    pshs      d
+                    leax      L0F8A,pcr
+                    lbra      L0D95
+
+L0D41               pshs      u
+                    ldd       #$FFB8
+                    lbsr      $0110
+                    ldd       L0042
+                    pshs      d
+                    leax      L0F9A,pcr
+                    bra       L0D95
+
+L0D53               pshs      u
+                    ldd       #$FFB8
+                    lbsr      $0110
+                    ldd       L0042
+                    pshs      d
+                    leax      $0FBB,pcr
+                    bra       L0D95
+
+L0D65               pshs      u
+                    ldd       #$FFB6
+                    lbsr      $0110
+                    ldd       L0042
+                    pshs      d
+                    ldx       L003E
+                    ldd       $2f,x
+                    pshs      d
+                    leax      $0FD9,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $06,s
+                    puls      pc,u
+L0D85               pshs      u
+                    ldd       #$FFB8
+                    lbsr      $0110
+                    ldd       L0042
+                    pshs      d
+                    leax      $0FFA,pcr
+L0D95               pshs      x
+                    lbsr      $1AB6
+                    leas      $04,s
+                    puls      pc,u
+L0D9E               pshs      u
+                    ldd       #$FFBE
+                    lbsr      $0110
+                    ldu       $04,s
+                    leas      -$02,s
+                    stu       ,s
+                    bra       L0DBA
+
+L0DAE               ldb       ,u
+                    cmpb      #$2f
+                    bne       L0DB8
+                    leax      $01,u
+                    stx       ,s
+L0DB8               leau      $01,u
+L0DBA               ldb       ,u
+                    bne       L0DAE
+                    ldd       ,s
+                    puls      pc,u,x
+                    fcb       $65
+                    lsr       $6578
+                    lsr       >L0065
+                    lsr       $01,s
+                    lsr       $6100
+                    fcb       $65
+                    jmp       $04,s
+                    neg       $0064
+                    neg       $7369
+                    dec       >$0062
+                    lsr       $6578
+                    lsr       >L0065
+                    fcb       $72,$72,$6f,$72,$20,$73,$70,$65
+                    fcb       $63,$69,$66,$79,$69,$6e,$67,$20
+                    fcb       $6C,$69,$62,$72,$61,$72,$79,$3a
+                    fcb       $20,$2d,$6C,$25,$73,$0d,$00
+L0DFE               fcb       $65,$72,$72,$6f,$72,$20,$73,$70
+                    fcb       $65,$63,$69,$66,$79,$69,$6e,$67
+                    fcb       $20,$25,$73,$20,$2d,$4d,$25,$73
+                    fcb       $0d,$00
+L0E18               tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       L2073
+                    rol       -$06,s
+                    fcb       $65
+                    abx
+                    neg       L0075
+                    jmp       $0b,s
+                    jmp       $0f,s
+                    asr       $6E20
+                    clr       -$10,s
+                    lsr       $696F
+                    jmp       0,y
+                    blt       L0E5B
+                    com       0,x
+L0E38               lsr       $6F6F
+                    bra       L0EAA
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       $0EB5
+                    clr       -$0b,s
+                    fcb       $72
+                    com       $05,s
+                    bra       $0EAF
+                    rol       $0C,s
+                    fcb       $65
+                    com       >L0075
+                    jmp       -$0e,s
+                    fcb       $65
+                    com       $6F6C
+                    ror       $6564
+                    bra       $0ECC
+                    fcb       $65
+L0E5B               ror       $05,s
+                    fcb       $72
+                    fcb       $65
+                    jmp       $03,s
+                    fcb       $65
+                    com       >$006E
+                    clr       0,y
+                    rol       $0e,s
+                    rol       -$0C,s
+                    bra       L0ED1
+                    fcb       $61
+                    lsr       $6120
+                    fcb       $61
+                    inc       $0C,s
+                    clr       -$09,s
+                    fcb       $65
+                    lsr       0,x
+L0E79               jmp       $0f,s
+                    bra       $0EE1
+                    neg       $2064
+                    fcb       $61
+                    lsr       $6120
+                    fcb       $61
+                    inc       $0C,s
+                    clr       -$09,s
+                    fcb       $65
+                    lsr       0,x
+L0E8C               jmp       $0f,s
+                    bra       $0F03
+                    lsr       $6174
+                    rol       $03,s
+                    bra       L0EFB
+                    fcb       $61
+                    lsr       $6100
+L0E9B               lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+                    bra       L0F13
+                    fcb       $61
+                    asr       $05,s
+                    bra       $0F09
+                    inc       $0C,s
+L0EAA               clr       $03,s
+                    fcb       $61
+                    lsr       $696F
+                    jmp       0,y
+                    rol       -$0d,s
+                    bra       L0EDB
+                    fcb       $75
+                    bra       $0F1B
+                    rol       $7465
+                    com       >$006E
+                    fcb       $61
+                    tst       $05,s
+                    bra       L0F27
+                    inc       $01,s
+                    com       $6800
+L0EC9               jmp       $0f,s
+                    bra       L0F3C
+                    fcb       $75
+                    lsr       $7075
+L0ED1               lsr       L2066
+                    rol       $0C,s
+                    fcb       $65
+                    neg       $006E
+                    clr       0,y
+L0EDB               fcb       $65
+                    jmp       -$0C,s
+                    fcb       $72
+                    rol       $2070
+                    clr       $09,s
+                    jmp       -$0C,s
+                    bra       $0F56
+                    fcb       $61
+                    tst       $05,s
+                    neg       L0065
+                    jmp       -$0C,s
+                    fcb       $72
+                    rol       $2070
+                    clr       $09,s
+                    jmp       -$0C,s
+                    bra       L0F20
+                    bcs       L0F6E
+L0EFB               beq       $0F1D
+                    jmp       $0f,s
+                    lsr       L2066
+                    clr       -$0b,s
+                    jmp       $04,s
+                    neg       $0072
+                    neg       $0027
+                    bcs       L0F7F
+                    beq       L0F2E
+                    com       $0f,s
+                    jmp       -$0C,s
+                    fcb       $61
+L0F13               rol       $0e,s
+                    com       L206E
+                    clr       0,y
+                    tst       $01,s
+                    rol       $0e,s
+                    inc       $09,s
+L0F20               jmp       $05,s
+                    neg       $0072
+                    neg       $0073
+                    fcb       $79
+L0F27               fcb       $6d,$62,$6f,$6C,$20,$61,$6C
+L0F2E               fcb       $72,$65,$61,$64,$79,$20,$64,$65
+                    fcb       $66,$69,$6e,$65,$64,$3a
+L0F3C               fcb       $20,$25,$2d,$38,$73,$20,$69,$6e
+                    fcb       $20,$25,$73,$0d,$00
+L0F49               fcb       $75
+                    jmp       $0b,s
+                    jmp       $0f,s
+                    asr       $6E20
+                    fcb       $65
+                    jmp       -$0C,s
+                    fcb       $72
+                    rol       $2074
+                    rol       $7065
+                    bra       $0FC6
+                    jmp       0,y
+                    bcs       L0FD4
+                    abx
+                    bcs       L0FD7
+                    neg       L0042
+                    fcb       $41
+                    comb
+                    rola
+                    coma
+                    leax      -$07,y
+                    bra       L0FD1
+
+L0F6E               clr       $0e,s
+                    ror       $0C,s
+                    rol       $03,s
+                    lsr       >$006E
+                    clr       0,y
+                    tst       $01,s
+                    rol       $0e,s
+                    inc       $09,s
+L0F7F               jmp       $05,s
+                    bra       $0FE4
+                    inc       $0C,s
+                    clr       -$09,s
+                    fcb       $65
+                    lsr       0,x
+L0F8A               com       $01,s
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       $0FBD
+                    bcs       L100B
+                    beq       L0F9A
+L0F9A               beq       $0FC1
+                    com       L2720
+                    rol       -$0d,s
+                    bra       L1011
+                    clr       -$0C,s
+                    bra       $1008
+                    bra       L101B
+                    fcb       $65
+                    inc       $0f,s
+                    com       $01,s
+                    lsr       $6162
+                    inc       $05,s
+                    bra       L1022
+                    clr       $04,s
+                    fcb       $75
+                    inc       $05,s
+                    neg       $0027
+                    bcs       L1031
+                    beq       $0FE0
+                    com       $0f,s
+                    jmp       -$0C,s
+                    fcb       $61
+                    rol       $0e,s
+                    com       $2061
+                    com       $7365
+                    tst       $02,s
+                    inc       -$07,s
+L0FD1               bra       L1038
+                    fcb       $72
+L0FD4               fcb       $72
+                    clr       -$0e,s
+L0FD7               com       >$006D
+                    fcb       $61
+                    rol       $0e,s
+                    inc       $09,s
+                    jmp       $05,s
+                    bra       $1049
+                    clr       -$0b,s
+                    jmp       $04,s
+                    bra       $1052
+                    jmp       0,y
+                    fcb       $62
+                    clr       -$0C,s
+                    asl       0,y
+                    bcs       L1065
+                    bra       $1055
+                    jmp       $04,s
+                    bra       $101D
+                    com       >L0065
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       $1073
+                    fcb       $65
+                    fcb       $61
+                    lsr       $09,s
+                    jmp       $07,s
+                    bra       L1072
+                    jmp       -$10,s
+L100B               fcb       $75
+                    lsr       L2066
+                    rol       $0C,s
+L1011               fcb       $65
+                    bra       $1039
+                    com       >$0034
+                    nega
+                    ldd       #$FFA5
+L101B               lbsr      $0110
+                    leas      -$0f,s
+                    ldd       $0034
+L1022               std       L0046
+                    pshs      d
+                    lbsr      $1C20
+                    leas      $02,s
+                    std       L0048
+                    clra
+                    clrb
+                    std       L0046
+L1031               ldd       #$87CD
+                    std       $02,s
+                    ldd       L001A
+L1038               addd      L0036
+                    aslb
+                    rola
+                    addd      #$000D
+                    addd      $002E
+                    addd      L0026
+                    addd      L002A
+                    addd      #$000D
+                    std       $04,s
+                    ldd       #$000D
+                    std       $06,s
+                    ldd       L0018
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      $329E
+                    stb       $08,s
+                    ldd       L0018
+                    clra
+                    stb       $09,s
+                    ldd       #$0008
+                    pshs      d
+L1065               leax      $04,s
+                    pshs      x
+                    lbsr      $18C8
+                    leas      $04,s
+                    stb       $0a,s
+                    ldd       L0014
+L1072               beq       L1078
+                    ldd       L0030
+                    bra       L107F
+
+L1078               ldx       L003E
+                    ldd       $23,x
+                    addd      L002C
+L107F               std       $0b,s
+                    ldd       L002A
+                    addd      L0022
+                    addd      L0026
+                    addd      $001E
+                    addd      L0032
+                    std       $0d,s
+                    leax      $193F,pcr
+                    pshs      x
+                    ldd       $0273,y
+                    pshs      d
+                    lbsr      $229A
+                    leas      $04,s
+                    std       L003A
+                    bne       L10B1
+                    bra       L10A6
+
+L10A4               leas      -$0f,x
+L10A6               leax      L1943,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $02,s
+L10B1               ldd       #$0200
+                    ldx       L003A
+                    std       $0b,x
+                    ldd       $04,s
+                    pshs      d
+                    ldx       L003A
+                    ldd       $08,x
+                    pshs      d
+                    lbsr      $192C
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L10CF
+                    leax      $0f,s
+                    bra       L10A4
+
+L10CF               leax      >$0005,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    leax      $06,s
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$000D
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    lbsr      L2374
+                    leas      $08,s
+                    lbsr      $1908
+                    ldd       $0271,y
+                    std       ,s
+L1103               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L1103
+                    ldd       ,s
+                    subd      #$0002
+                    std       ,s
+                    ldb       [,s]
+                    sex
+                    orb       #$80
+                    stb       [,s]
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       L001A
+                    pshs      d
+                    ldd       $0271,y
+                    pshs      d
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       $0271,y
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L23D0
+                    leas      $04,s
+                    lbsr      $1908
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       #$0001
+                    pshs      d
+                    leax      $0270,y
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldb       $0270,y
+                    sex
+                    pshs      d
+                    lbsr      L2A84
+                    leas      $04,s
+                    ldb       [,s]
+                    clra
+                    andb      #$7f
+                    stb       [,s]
+                    ldd       L0036
+                    pshs      d
+                    lbsr      L1F8A
+                    leas      $02,s
+                    leax      $0377,y
+                    pshs      x
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L2A1B
+                    leas      $02,s
+                    lbsr      $314C
+                    leax      $037f,y
+                    pshs      x
+                    leax      $0377,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $002E
+                    lbsr      $3141
+                    lbsr      L30BE
+                    lbsr      $314C
+                    leax      $037b,y
+                    pshs      x
+                    leax      $037f,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L11BF
+                    neg       $0000
+                    neg       $0002
+L11BF               puls      x
+                    lbsr      L30BE
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L002A
+                    lbsr      $3141
+                    lbsr      L30BE
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L11E2
+                    neg       $0000
+                    neg       $0002
+L11E2               puls      x
+                    lbsr      L30BE
+                    lbsr      $314C
+                    leax      $0383,y
+                    pshs      x
+                    leax      $037b,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L0026
+                    lbsr      $3141
+                    lbsr      L30BE
+                    lbsr      $314C
+                    ldd       L003E
+                    bra       L1222
+
+L120B               ldx       L0050
+                    ldd       $13,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L121D
+                    lbsr      L145E
+                    lbsr      $1908
+L121D               ldx       L0050
+                    ldd       $11,x
+L1222               std       L0050
+                    ldd       L0050
+                    bne       L120B
+                    clra
+                    clrb
+                    pshs      d
+                    leax      $037f,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      $28C4
+                    leas      $08,s
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       #$0002
+                    pshs      d
+                    leax      >$002a,y
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       L002A
+                    pshs      d
+                    lbsr      L2B29
+                    leas      $04,s
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       L002A
+                    pshs      d
+                    leax      $0277,y
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       L002A
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    leax      $0277,y
+                    pshs      x
+                    lbsr      L2374
+                    leas      $08,s
+                    lbsr      $1908
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       #$0002
+                    pshs      d
+                    leax      >$0026,y
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       L0026
+                    pshs      d
+                    lbsr      L2B29
+                    leas      $04,s
+                    ldd       L0026
+                    beq       L12C4
+                    ldd       L0026
+                    pshs      d
+                    lbsr      L13DC
+                    leas      $02,s
+L12C4               clra
+                    clrb
+                    pshs      d
+                    leax      $0383,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      $28C4
+                    leas      $08,s
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       #$0002
+                    pshs      d
+                    leax      >$004e,y
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       L004E
+                    pshs      d
+                    lbsr      L2B29
+                    leas      $04,s
+                    ldd       L0052
+                    pshs      d
+                    lbsr      L2092
+                    leas      $02,s
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       #$0002
+                    pshs      d
+                    leax      >$004C,y
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       L004C
+                    pshs      d
+                    lbsr      L2B29
+                    leas      $04,s
+                    ldd       L0054
+                    pshs      d
+                    lbsr      L2092
+                    leas      $02,s
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       L001A
+                    addd      #$0001
+                    pshs      d
+                    ldd       $0271,y
+                    pshs      d
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       $0271,y
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L23D0
+                    leas      $04,s
+                    ldd       L003A
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L2A84
+                    leas      $04,s
+                    ldu       #$0000
+                    bra       L1389
+
+L136E               tfr       u,d
+                    leax      >$0005,y
+                    leax      d,x
+                    pshs      x
+                    tfr       u,d
+                    leax      >$0005,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    coma
+                    comb
+                    stb       [,s++]
+                    leau      $01,u
+L1389               cmpu      #$0003
+                    blt       L136E
+                    ldd       L003A
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0003
+                    pshs      d
+                    leax      >$0005,y
+                    pshs      x
+                    lbsr      L2374
+                    leas      $08,s
+                    lbsr      $1908
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L2B74
+                    leas      $02,s
+                    ldd       $000E
+                    beq       L13BB
+                    lbsr      $1CAC
+L13BB               ldd       L0014
+                    beq       L13D8
+                    ldd       L0016
+                    beq       L13D8
+                    ldd       $001E
+                    pshs      d
+                    leax      L195C,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      L23D0
+                    leas      $06,s
+L13D8               leas      $0f,s
+                    puls      pc,u
+L13DC               pshs      u
+                    ldd       #$FF32
+                    lbsr      $0110
+                    leas      $FF7E,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L2A1B
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      $28C4
+                    leas      $08,s
+                    bra       L1437
+
+L1408               lbsr      $1908
+                    ldd       ,s
+                    cmpd      $0086,s
+                    ble       L141A
+                    ldd       $0086,s
+                    std       ,s
+L141A               leax      >$0005,y
+                    pshs      x
+                    ldd       $02,s
+                    pshs      d
+                    leax      $06,s
+                    pshs      x
+                    lbsr      $3492
+                    leas      $06,s
+                    ldd       $0086,s
+                    subd      ,s
+                    std       $0086,s
+L1437               ldd       $0086,s
+                    ble       L1458
+                    ldd       L003A
+                    pshs      d
+                    ldd       #$0080
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    lbsr      L232E
+                    leas      $08,s
+                    std       ,s
+                    bne       L1408
+L1458               leas      $0082,s
+                    puls      pc,u
+L145E               pshs      u
+                    ldd       #$FFA3
+                    lbsr      $0110
+                    leas      -$07,s
+                    ldd       $004A
+                    ldx       L0050
+                    cmpd      $2f,x
+                    beq       L14A0
+                    ldd       L0038
+                    pshs      d
+                    leax      L1982,pcr
+                    pshs      x
+                    ldx       L0050
+                    ldd       $2f,x
+                    std       $004A
+                    pshs      d
+                    lbsr      L22B9
+                    leas      $06,s
+                    std       L0038
+                    bne       L14A0
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    leax      L1984,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    leas      $04,s
+L14A0               clra
+                    clrb
+                    pshs      d
+                    ldx       L0050
+                    leax      $29,x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L0038
+                    pshs      d
+                    lbsr      $28C4
+                    leas      $08,s
+                    ldd       L0038
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1f,x
+                    ldx       L0050
+                    addd      $1d,x
+                    ldx       L0050
+                    addd      $1b,x
+                    pshs      d
+                    ldd       L0048
+                    pshs      d
+                    lbsr      L232E
+                    leas      $08,s
+                    std       -$02,s
+                    bne       L14ED
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    lbsr      $18F6
+                    leas      $02,s
+L14ED               ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    std       ,s
+                    ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    lbeq      L15A6
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    lbsr      $18F6
+                    leas      $02,s
+                    lbra      L15A6
+
+L1512               leas      -$0a,s
+                    leax      ,s
+                    pshs      x
+                    lbsr      L1DE1
+                    leas      $02,s
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    tfr       d,u
+                    ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L153D
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    lbsr      $18F6
+                    leas      $02,s
+L153D               leax      ,s
+                    pshs      x
+                    leax      $02,s
+                    pshs      x
+                    lbsr      $19F8
+                    std       ,s
+                    lbsr      $1A1D
+                    leas      $04,s
+                    std       $0f,s
+                    bne       L159C
+                    leax      ,s
+                    pshs      x
+                    leax      $199F,pcr
+                    pshs      x
+                    lbsr      $1AB6
+                    bra       L159A
+
+L1562               ldd       L0038
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0003
+                    pshs      d
+                    leax      $12,s
+                    pshs      x
+                    lbsr      L232E
+                    leas      $08,s
+                    ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L158F
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    lbsr      $18F6
+                    leas      $02,s
+L158F               ldd       $0f,s
+                    pshs      d
+                    leax      $0e,s
+                    pshs      x
+                    lbsr      $17A1
+L159A               leas      $04,s
+L159C               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bne       L1562
+                    leas      $0a,s
+L15A6               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    lbne      L1512
+                    ldd       L0038
+                    pshs      d
+                    lbsr      L2CF9
+                    leas      $02,s
+                    std       ,s
+                    ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       $160F
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    lbsr      $18F6
+                    leas      $02,s
+                    bra       $160F
+                    ldd       L0038
+                    pshs      y,dp,a,cc
+                    ror       L00CC
+                    neg       $0001
+                    pshs      d
+                    ldd       #$0003
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    lbsr      $232F
+                    leas      $08,s
+                    ldx       L0038
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L1603
+                    ldx       L0050
+                    ldd       $2f,x
+                    pshs      d
+                    lbsr      L18F7
+                    leas      $02,s
+L1603               clra
+                    clrb
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L17A2
+                    leas      $04,s
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bne       $15D7
+                    leax      >$0005,y
+                    pshs      x
+                    ldx       L0050
+                    ldd       $1f,x
+                    pshs      d
+                    ldd       L0048
+                    pshs      d
+                    lbsr      L3493
+                    leas      $06,s
+                    ldd       $005A
+                    bne       L164F
+                    clra
+                    clrb
+                    pshs      d
+                    leax      $0377,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L28C5
+                    leas      $08,s
+L164F               ldd       L003A
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1f,x
+                    pshs      d
+                    ldd       L0048
+                    pshs      d
+                    lbsr      $2375
+                    leas      $08,s
+                    leax      $0377,y
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1f,x
+                    lbsr      L3142
+                    lbsr      $30BF
+                    lbsr      L314D
+                    ldd       #$0001
+                    std       $005A
+                    lbsr      L1909
+                    clra
+                    clrb
+                    std       ,s
+                    ldd       L0048
+                    ldx       L0050
+                    addd      $1f,x
+                    tfr       d,u
+                    bra       L16B0
+
+L169B               ldb       ,u+
+                    ldx       >$007a,y
+                    leax      $01,x
+                    stx       >$007a,y
+                    stb       -$01,x
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L16B0               ldd       ,s
+                    ldx       L0050
+                    cmpd      $1d,x
+                    bcs       L169B
+                    ldx       L0050
+                    ldd       $1b,x
+                    lbeq      L1722
+                    clra
+                    clrb
+                    pshs      d
+                    leax      $037b,y
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L28C5
+                    leas      $08,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1b,x
+                    pshs      d
+                    ldd       L0048
+                    ldx       L0050
+                    addd      $1f,x
+                    ldx       L0050
+                    addd      $1d,x
+                    pshs      d
+                    lbsr      $2375
+                    leas      $08,s
+                    leax      $037b,y
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1b,x
+                    lbsr      L3142
+                    lbsr      $30BF
+                    lbsr      L314D
+                    lbsr      L1909
+                    clra
+                    clrb
+                    std       $005A
+L1722               ldd       L001C
+                    pshs      d
+                    ldx       L0050
+                    ldd       $17,x
+                    addd      ,s++
+                    std       L001C
+                    ldd       $0020
+                    pshs      d
+                    ldx       L0050
+                    ldd       $19,x
+                    addd      ,s++
+                    std       $0020
+                    ldd       $0024
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1b,x
+                    addd      ,s++
+                    std       $0024
+                    ldd       L0028
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1d,x
+                    addd      ,s++
+                    std       L0028
+                    ldd       L002C
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1f,x
+                    addd      ,s++
+                    std       L002C
+                    ldd       L001C
+                    ldx       L0050
+                    subd      $17,x
+                    ldx       L0050
+                    std       $17,x
+                    ldd       $0020
+                    ldx       L0050
+                    subd      $19,x
+                    ldx       L0050
+                    std       $19,x
+                    ldd       $0024
+                    ldx       L0050
+                    subd      $1b,x
+                    ldx       L0050
+                    std       $1b,x
+                    ldd       L0028
+                    ldx       L0050
+                    subd      $1d,x
+                    ldx       L0050
+                    std       $1d,x
+                    ldd       L002C
+                    ldx       L0050
+                    subd      $1f,x
+                    ldx       L0050
+                    std       $1f,x
+                    lbra      L18C5
+
+L17A2               pshs      u
+                    ldd       #$FFB1
+                    lbsr      L0111
+                    leas      -$07,s
+                    ldx       $0b,s
+                    ldd       $01,x
+                    addd      L0048
+                    std       $05,s
+                    ldb       [$0b,s]
+                    stb       $02,s
+                    ldd       $0d,s
+                    beq       L17DA
+                    ldx       $0d,s
+                    ldd       $0C,x
+                    std       $03,s
+                    ldx       $0d,s
+                    ldd       $0a,x
+                    stb       $01,s
+                    ldb       $02,s
+                    clra
+                    andb      #$80
+                    lbeq      L1822
+                    ldd       $03,s
+                    subd      L002C
+                    std       $03,s
+                    bra       L1822
+
+L17DA               ldb       $02,s
+                    stb       $01,s
+                    clra
+                    andb      #$07
+                    tfr       d,x
+                    bra       L1808
+
+L17E5               ldd       L001C
+                    bra       L17F7
+
+L17E9               ldd       $0024
+                    bra       L17F7
+
+L17ED               ldd       $0020
+                    bra       L17F7
+
+L17F1               ldd       L0028
+                    bra       L17F7
+
+L17F5               ldd       L002C
+L17F7               std       $03,s
+                    bra       L1822
+
+L17FB               leax      L19BE,pcr
+                    pshs      x
+                    lbsr      L1AB7
+                    leas      $02,s
+                    bra       L1822
+
+L1808               stx       -$02,s
+                    beq       L17E5
+                    cmpx      #$0001
+                    beq       L17E9
+                    cmpx      #$0002
+                    beq       L17ED
+                    cmpx      #$0003
+                    beq       L17F1
+                    cmpx      #$0004
+                    beq       L17F5
+                    bra       L17FB
+
+L1822               ldb       $02,s
+                    clra
+                    andb      #$40
+                    beq       L1831
+                    ldd       $03,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $03,s
+L1831               ldb       $02,s
+                    clra
+                    andb      #$30
+                    stb       ,s
+                    cmpb      #$20
+                    beq       L185D
+                    ldd       $05,s
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1f,x
+                    addd      ,s++
+                    std       $05,s
+                    ldb       ,s
+                    clra
+                    andb      #$10
+                    bne       L185D
+                    ldd       $05,s
+                    pshs      d
+                    ldx       L0050
+                    ldd       $1d,x
+                    addd      ,s++
+                    std       $05,s
+L185D               ldb       $02,s
+                    clra
+                    andb      #$08
+                    beq       L186F
+                    ldb       [$05,s]
+                    sex
+                    addd      $03,s
+                    stb       [$05,s]
+                    bra       L1877
+
+L186F               ldd       [$05,s]
+                    addd      $03,s
+                    std       [$05,s]
+L1877               ldb       ,s
+                    cmpb      #$20
+                    beq       L18C5
+                    ldb       ,s
+                    clra
+                    andb      #$10
+                    beq       L1888
+                    ldd       L0028
+                    bra       L188A
+
+L1888               ldd       $0024
+L188A               ldx       $0b,s
+                    addd      $01,x
+                    tfr       d,u
+                    ldb       $01,s
+                    clra
+                    andb      #$07
+                    cmpd      #$0004
+                    bne       L18B1
+                    pshs      u
+                    leax      >$0052,y
+                    pshs      x
+                    lbsr      $200F
+                    leas      $04,s
+                    ldd       L004E
+                    addd      #$0001
+                    std       L004E
+                    bra       L18C5
+
+L18B1               pshs      u
+                    leax      >$0054,y
+                    pshs      x
+                    lbsr      $200F
+                    leas      $04,s
+                    ldd       L004C
+                    addd      #$0001
+                    std       L004C
+L18C5               leas      $07,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       #$FFBC
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       #$FFFF
+                    bra       L18E5
+
+L18DA               ldd       ,s
+                    pshs      d
+                    ldb       ,u+
+                    sex
+                    eora      ,s+
+                    eorb      ,s+
+L18E5               std       ,s
+                    ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L18DA
+                    ldd       ,s
+                    puls      pc,u,x
+L18F7               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0111
+                    ldd       $04,s
+                    pshs      d
+                    leax      $19CD,pcr
+                    bra       L1924
+
+L1909               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0111
+                    ldx       L003A
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L192B
+                    ldd       $0273,y
+                    pshs      d
+                    leax      $19E3,pcr
+L1924               pshs      x
+                    lbsr      L1AB7
+                    leas      $04,s
+L192B               puls      pc,u
+                    pshs      u,x,d
+                    lda       $09,s
+                    ldb       #$02
+                    ldx       #$0000
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u,x,d
+                    lbra      L3568
+                    asr       $782B
+L1943               neg       L0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $2063
+                    fcb       $72
+                    fcb       $65
+                    fcb       $61
+                    lsr       $6520
+                    clr       -$0b,s
+                    lsr       $7075
+                    lsr       L2066
+                    rol       $0C,s
+                    fcb       $65
+L195C               neg       L0042
+                    fcb       $41,$53,$49,$43,$30,$39,$20,$73
+                    fcb       $74,$61,$74,$69,$63,$20,$64,$61
+                    fcb       $74,$61,$20,$73,$69,$7a,$65,$20
+                    fcb       $69,$73,$20,$25,$64,$20,$62,$79
+                    fcb       $74,$65,$73,$0d
+L1982               neg       $0072
+L1984               neg       L0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $2072
+                    fcb       $65
+                    clr       -$10,s
+                    fcb       $65
+                    jmp       0,y
+                    rol       $0e,s
+                    neg       $7574
+                    bra       L19FF
+                    rol       $0C,s
+                    fcb       $65
+                    bra       $19C3
+                    com       >$0073
+                    rol       $6D62
+                    clr       $0C,s
+                    bra       $19CD
+                    com       L206E
+                    clr       -$0C,s
+                    bra       $1A15
+                    clr       -$0b,s
+                    jmp       $04,s
+                    bra       L1A1E
+                    jmp       0,y
+                    com       $0f,s
+                    lsr       $07,s
+                    fcb       $65
+                    jmp       0,x
+L19BE               fcb       $72
+                    fcb       $65
+                    ror       0,y
+                    lsr       $7970
+                    fcb       $65
+                    bra       $1A2D
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L0065
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       $1A46
+                    fcb       $65
+                    fcb       $61
+                    lsr       $09,s
+                    jmp       $07,s
+                    bra       L1A42
+                    rol       $0C,s
+                    fcb       $65
+                    bra       $1A06
+                    com       >L0065
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       $1A61
+                    fcb       $72
+                    rol       -$0C,s
+                    rol       $0e,s
+                    asr       0,y
+                    ror       $09,s
+                    inc       $05,s
+                    bra       L1A1C
+                    com       >$0034
+                    nega
+                    ldu       $04,s
+                    leas      -$02,s
+L19FF               clra
+                    clrb
+                    bra       L1A0C
+
+L1A03               ldd       ,s
+                    pshs      d
+                    ldb       ,u+
+                    sex
+                    addd      ,s++
+L1A0C               std       ,s
+                    ldb       ,u
+                    bne       L1A03
+                    ldd       ,s
+                    pshs      d
+                    ldd       #$0173
+                    lbsr      L31D4
+L1A1C               puls      pc,u,x
+L1A1E               pshs      u
+                    ldd       $04,s
+                    aslb
+                    rola
+                    leax      $0387,y
+                    leax      d,x
+                    ldu       ,x
+                    bra       L1A50
+
+L1A2E               ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    cmpd      ,s++
+                    bne       L1A4D
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+L1A42               lbsr      $2F1C
+                    leas      $04,s
+                    std       -$02,s
+                    lbeq      L1C1D
+L1A4D               ldu       $10,u
+L1A50               stu       -$02,s
+                    bne       L1A2E
+                    clra
+                    clrb
+                    puls      pc,u
+                    pshs      u,d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $19F9
+                    leas      $02,s
+                    std       $02,s
+                    pshs      d
+                    lbsr      L1A1E
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L1AB0
+                    ldd       ,s
+                    aslb
+                    rola
+                    leax      $0387,y
+                    leax      d,x
+                    ldd       ,x
+                    ldx       $06,s
+                    std       $10,x
+                    ldd       ,s
+                    aslb
+                    rola
+                    leax      $0387,y
+                    leax      d,x
+                    ldd       $06,s
+                    std       ,x
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L1B84
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L1AAC
+                    ldx       $06,s
+                    ldd       $0a,x
+                    ora       #$01
+                    std       $0a,x
+L1AAC               clra
+                    clrb
+                    bra       L1AB3
+
+L1AB0               ldd       #$0001
+L1AB3               puls      pc,u,x
+                    puls      pc,u,x
+L1AB7               pshs      u,d
+                    ldd       $0228,y
+                    std       ,s
+                    leax      $1E2E,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      $23D1
+                    leas      $04,s
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      $23D1
+                    leas      $0a,s
+                    leax      $1E3D,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      $23D1
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L356D
+                    leas      $02,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L1B24
+
+L1B11               ldd       ,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L3181
+                    pshs      d
+                    ldd       $04,s
+                    addd      #$FFD0
+                    addd      ,s++
+L1B24               std       ,s
+                    ldb       ,u+
+                    sex
+                    std       $02,s
+                    leax      $015a,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L1B11
+                    ldd       $02,s
+                    cmpd      #$006B
+                    beq       L1B48
+                    ldd       $02,s
+                    cmpd      #$004B
+                    bne       L1B54
+L1B48               ldd       ,s
+                    pshs      d
+                    ldd       #$0004
+                    lbsr      L3181
+                    std       ,s
+L1B54               ldd       ,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      L32C2
+                    leas      $04,s
+                    puls      pc,u
+L1B62               pshs      u
+                    ldu       $04,s
+                    ldd       ,u
+                    std       [$02,u]
+                    ldd       $02,u
+                    ldx       ,u
+                    std       $02,x
+                    leax      >$0060,y
+                    pshs      x
+                    cmpu      ,s++
+                    beq       L1B82
+                    ldd       L005C
+                    std       ,u
+                    stu       L005C
+L1B82               puls      pc,u
+L1B84               pshs      u,d
+                    clra
+                    clrb
+                    std       ,s
+                    ldu       >$0060,y
+                    bra       L1BCB
+
+L1B90               ldb       $04,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    bne       L1BC9
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0004
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $2F1C
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L1BC9
+                    ldd       $08,s
+                    beq       L1BBC
+                    tfr       u,d
+                    puls      pc,u,x
+L1BBC               ldd       ,u
+                    std       ,s
+                    pshs      u
+                    lbsr      L1B62
+                    leas      $02,s
+                    ldu       ,s
+L1BC9               ldu       ,u
+L1BCB               leax      >$0060,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L1B90
+                    ldd       ,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L1B84
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L1C1D
+                    ldd       L005C
+                    beq       L1BFC
+                    ldu       L005C
+                    ldd       ,u
+                    std       L005C
+                    bra       L1C07
+
+L1BFC               ldd       #$0010
+                    pshs      d
+                    bsr       L1C21
+                    leas      $02,s
+                    tfr       d,u
+L1C07               leax      >$0060,y
+                    stx       $02,u
+                    ldd       >$0060,y
+                    std       ,u
+                    ldx       >$0060,y
+                    stu       $02,x
+                    stu       >$0060,y
+L1C1D               tfr       u,d
+                    puls      pc,u
+L1C21               pshs      u,d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L34B9
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L1C5A
+                    ldd       L0046
+                    beq       L1C4D
+                    ldd       L0046
+                    pshs      d
+                    leax      $1E3F,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      $23D1
+                    leas      $06,s
+L1C4D               leax      L1E5A,pcr
+                    pshs      x
+                    lbsr      L1AB7
+                    leas      $02,s
+                    bra       L1C5E
+
+L1C5A               ldd       ,s
+                    puls      pc,u,x
+L1C5E               puls      pc,u,x
+                    pshs      u
+                    ldd       $04,s
+                    clra
+                    andb      #$07
+                    tfr       d,x
+                    bra       L1C91
+
+L1C6B               leax      $1E68,pcr
+                    bra       L1C8D
+
+L1C71               leax      L1E6D,pcr
+                    bra       L1C8D
+
+L1C77               leax      $1E72,pcr
+                    bra       L1C8D
+
+L1C7D               leax      $1E77,pcr
+                    bra       L1C8D
+
+L1C83               leax      $1E7C,pcr
+                    bra       L1C8D
+
+L1C89               leax      $1E81,pcr
+L1C8D               tfr       x,d
+                    puls      pc,u
+L1C91               cmpx      #$0004
+                    beq       L1C6B
+                    stx       -$02,s
+                    beq       L1C71
+                    cmpx      #$0001
+                    beq       L1C77
+                    cmpx      #$0002
+                    beq       L1C7D
+                    cmpx      #$0003
+                    beq       L1C83
+                    bra       L1C89
+                    puls      pc,u
+                    pshs      u,d
+                    ldd       $0273,y
+                    pshs      d
+                    ldd       $0271,y
+                    pshs      d
+                    leax      L1E85,pcr
+                    pshs      x
+                    lbsr      $23BF
+                    leas      $06,s
+                    leax      $1EA3,pcr
+                    pshs      x
+                    lbsr      $22ED
+                    leas      $02,s
+                    ldd       L003E
+                    lbra      $1D4E
+                    ldx       ,s
+                    ldd       $13,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      $1D49
+                    ldx       ,s
+                    ldd       $2f,x
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $19,x
+                    pshs      d
+                    ldx       $04,s
+                    ldd       $1d,x
+                    pshs      d
+                    ldx       $06,s
+                    ldd       $17,x
+                    pshs      d
+                    ldx       $08,s
+                    ldd       $1b,x
+                    pshs      d
+                    ldx       $0a,s
+                    ldd       $1f,x
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    leax      L1ED5,pcr
+                    pshs      x
+                    lbsr      $23BF
+                    leas      $10,s
+                    ldd       $0010
+                    beq       $1D49
+                    fcb       $02
+                    ldx       ,s
+                    ldu       $2d,x
+                    bra       L1D46
+
+L1D2A               ldd       $0C,u
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      $1C61
+                    std       ,s
+                    pshs      u
+                    leax      L1EFB,pcr
+                    pshs      x
+                    lbsr      L23C0
+                    leas      $08,s
+                    ldu       $0e,u
+L1D46               stu       -$02,s
+                    bne       L1D2A
+                    ldx       ,s
+                    ldd       $11,x
+                    std       ,s
+                    ldd       ,s
+                    lbne      $1CD7
+                    leax      L1F0E,pcr
+                    pshs      x
+                    lbsr      L22EE
+                    leas      $02,s
+                    ldd       L0022
+                    pshs      d
+                    ldd       L002A
+                    pshs      d
+                    ldd       $001E
+                    pshs      d
+                    ldd       L0026
+                    pshs      d
+                    ldd       $002E
+                    pshs      d
+                    leax      $1F31,pcr
+                    pshs      x
+                    lbsr      L23C0
+                    leas      $0C,s
+L1D81               puls      pc,u,x
+                    pshs      u
+                    leax      >$0060,y
+                    cmpx      >$0060,y
+                    beq       L1DDD
+                    leax      L1F5D,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      L23D2
+                    leas      $04,s
+                    ldu       >$0060,y
+                    bra       L1DCD
+
+L1DA6               ldx       $0e,u
+                    ldd       $2f,x
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    pshs      u
+                    ldd       #$0004
+                    addd      ,s++
+                    pshs      d
+                    leax      $1F75,pcr
+                    pshs      x
+                    leax      $00A3,y
+                    pshs      x
+                    lbsr      L23D2
+                    leas      $0a,s
+                    ldu       ,u
+L1DCD               leax      >$0060,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L1DA6
+                    ldd       #$0001
+                    puls      pc,u
+L1DDD               clra
+                    clrb
+                    puls      pc,u
+L1DE1               puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    bra       L1DEF
+
+L1DEB               ldd       ,s
+                    stb       ,u+
+L1DEF               ldd       L0038
+                    pshs      d
+                    lbsr      L2C99
+                    leas      $02,s
+                    std       ,s
+                    bne       L1DEB
+                    clra
+                    clrb
+                    stb       ,u
+L1E00               puls      pc,u,x
+                    pshs      u,d
+                    ldd       $0228,y
+                    std       ,s
+                    ldd       L003A
+                    beq       L1E22
+                    ldd       L003A
+                    pshs      d
+                    lbsr      L2B76
+                    leas      $02,s
+                    ldd       $0273,y
+                    pshs      d
+                    lbsr      L33B2
+                    leas      $02,s
+L1E22               ldd       $0228,y
+                    pshs      d
+                    lbsr      L356E
+                    leas      $02,s
+                    puls      pc,u,x
+                    inc       $09,s
+                    jmp       $0b,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L1E9D
+                    fcb       $61
+                    lsr       $616C
+                    abx
+                    bra       L1E3E
+
+L1E3E               tst       $0000
+                    fcb       $6e,$65,$65,$64,$20,$25,$64,$20
+                    fcb       $62,$79,$74,$65,$73,$20,$66,$6f
+                    fcb       $72,$20,$6C,$69,$6e,$6b,$62,$75
+                    fcb       $66,$0d
+L1E5A               neg       $006F
+                    fcb       $75
+                    lsr       $206F
+                    ror       0,y
+                    tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       >L0063
+                    clr       $04,s
+                    fcb       $65
+L1E6D               neg       L0075
+                    lsr       $01,s
+                    lsr       >$0069
+                    lsr       $01,s
+                    lsr       >L0075
+                    lsr       -$10,s
+                    lsr       0,x
+                    rol       $04,s
+                    neg       $6400
+                    swi
+                    swi
+                    swi
+
+L1E85               neg       L004C
+                    rol       $0e,s
+                    fcb       $6b
+                    fcb       $61
+                    asr       $05,s
+                    bra       $1EFC
+                    fcb       $61
+                    neg       L2066
+                    clr       -$0e,s
+                    bra       L1EBC
+                    com       L2020
+                    rora
+                    rol       $0C,s
+L1E9D               fcb       $65
+                    bra       L1ECD
+                    bra       L1EC7
+                    com       >$000D
+                    tst       $0053
+                    fcb       $65,$63,$74,$69,$6f,$6e,$20,$20
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $43,$6f,$64,$65,$20
+L1EBC               fcb       $49,$44,$61,$74,$20,$55,$44,$61
+                    fcb       $74,$20,$49
+L1EC7               fcb       $44,$70,$44,$20,$55,$44
+L1ECD               fcb       $70,$44,$20,$46,$69,$6C,$65
+                    fcb       $0d
+L1ED5               neg       L0025
+                    fcb       $2d,$31,$36,$73,$20,$25,$30,$34
+                    fcb       $78,$20,$25,$30,$34,$78,$20,$25
+                    fcb       $30,$34,$78,$20,$25,$30,$32,$78
+                    fcb       $20,$20,$20,$25,$30,$32,$78,$20
+                    fcb       $25,$73,$0d,$00
+L1EFB               bra       $1F1D
+                    bra       $1F1F
+                    bra       $1F26
+                    blt       L1F3C
+                    com       $2025
+                    com       $2025
+                    leax      -$0C,y
+                    asl       $0D00
+L1F0E               bra       L1F30
+                    bra       L1F32
+                    bra       L1F34
+                    bra       L1F36
+                    bra       L1F38
+                    bra       L1F3A
+                    bra       L1F3C
+                    bra       L1F3E
+
+L1F1E               bra       L1F4D
+
+L1F20               blt       L1F4F
+                    blt       L1F44
+                    blt       $1F53
+                    blt       $1F55
+                    bra       L1F57
+                    blt       L1F59
+                    blt       $1F4E
+                    blt       L1F5D
+L1F30               neg       $0020
+L1F32               bra       L1F54
+
+L1F34               bra       $1F56
+
+L1F36               bra       $1F58
+
+L1F38               bra       $1F5A
+
+L1F3A               bra       $1F5C
+
+L1F3C               bra       L1F5E
+
+L1F3E               bra       L1F60
+                    bra       L1F62
+                    bcs       L1F74
+L1F44               pshs      u,y,x,dp
+                    bra       L1F6D
+                    leax      -$0C,y
+                    asl       $2025
+L1F4D               leax      -$0C,y
+L1F4F               asl       $2025
+                    leax      -$0e,y
+L1F54               asl       L2020
+L1F57               bcs       L1F89
+L1F59               leas      -$08,s
+                    tst       $0000
+L1F5D               fcb       $55
+L1F5E               fcb       $6e,$72
+L1F60               fcb       $65,$73
+L1F62               fcb       $6f,$6C,$76,$65,$64,$20,$72,$65
+                    fcb       $66,$65,$72
+L1F6D               fcb       $65,$6e,$63,$65,$73,$3a,$0d
+L1F74               neg       $0020
+                    fcb       $25,$2d,$31,$36,$73,$20,$25,$2d
+                    fcb       $31,$36,$73,$20,$69,$6e,$20,$25
+                    fcb       $2d,$31,$36
+L1F89               fcb       $73
+L1F8A               fcb       $0d,$00
+                    pshs      u
+                    ldu       >$005C,y
+                    bra       L1F9D
+
+L1F94               ldu       ,u
+                    ldd       $04,s
+                    subd      #$0007
+                    std       $04,s
+L1F9D               ldd       $04,s
+                    ble       L1FA5
+                    stu       -$02,s
+                    bne       L1F94
+L1FA5               ldd       $04,s
+                    beq       L1FCC
+                    bra       L1FC8
+
+L1FAB               ldd       #$0010
+                    pshs      d
+                    lbsr      $1C22
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       >$005C,y
+                    std       ,u
+                    stu       >$005C,y
+                    ldd       $04,s
+                    subd      #$0007
+                    std       $04,s
+L1FC8               ldd       $04,s
+                    bgt       L1FAB
+L1FCC               puls      pc,u
+L1FCE               pshs      u
+                    ldu       $04,s
+                    bra       L1FD9
+
+L1FD4               ldd       #$FFFF
+                    std       ,u++
+L1FD9               ldd       $06,s
+                    addd      #$FFFF
+                    std       $06,s
+                    subd      #$FFFF
+                    bgt       L1FD4
+                    puls      pc,u
+L1FE7               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L2004
+
+L1FF3               ldd       ,u
+                    bge       L1FFB
+                    tfr       u,d
+                    puls      pc,u,x
+L1FFB               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    leau      $02,u
+L2004               ldd       ,s
+                    cmpd      #$0007
+                    blt       L1FF3
+                    clra
+                    clrb
+                    puls      pc,u,x
+                    pshs      u,d
+                    ldd       [$06,s]
+                    bne       L203E
+                    ldd       >$005C,y
+                    std       [$06,s]
+                    ldx       $06,s
+L2020               ldd       [,x]
+                    std       >$005C,y
+                    clra
+                    clrb
+                    ldx       $06,s
+                    std       [,x]
+                    ldd       #$0007
+                    pshs      d
+                    ldd       [$08,s]
+                    addd      #$0002
+                    pshs      d
+                    lbsr      L1FCE
+                    leas      $04,s
+L203E               ldd       [$06,s]
+                    addd      #$0002
+                    pshs      d
+                    lbsr      L1FE7
+                    leas      $02,s
+                    std       ,s
+                    bne       L208E
+                    ldd       >$005C,y
+                    bne       L2060
+                    leax      L2134,pcr
+                    pshs      x
+                    lbsr      $1AB8
+                    bra       L208C
+
+L2060               leas      -$02,s
+                    ldd       >$005C,y
+L2066               std       ,s
+                    ldd       [,s]
+                    std       >$005C,y
+L206E               ldd       [$08,s]
+                    std       [,s]
+L2073               ldd       ,s
+                    std       [$08,s]
+                    ldd       #$0007
+                    pshs      d
+                    ldd       [$0a,s]
+                    addd      #$0002
+                    std       $04,s
+                    pshs      d
+                    lbsr      L1FCE
+                    leas      $04,s
+L208C               leas      $02,s
+L208E               ldd       $08,s
+                    std       [,s]
+L2092               puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    bra       L20CF
+
+L209C               clra
+                    clrb
+                    std       $02,s
+                    leax      $02,u
+                    stx       ,s
+                    bra       L20C5
+
+L20A6               ldd       [,s]
+                    cmpd      #$FFFF
+                    beq       L20CD
+                    ldx       ,s
+                    leax      $02,x
+                    stx       ,s
+                    ldd       -$02,x
+                    pshs      d
+                    bsr       L20D9
+                    leas      $02,s
+                    bra       L20BE
+
+L20BE               ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+L20C5               ldd       $02,s
+                    cmpd      #$0007
+                    blt       L20A6
+L20CD               ldu       ,u
+L20CF               stu       -$02,s
+                    bne       L209C
+                    bsr       L20F6
+                    leas      $04,s
+                    puls      pc,u
+L20D9               pshs      u
+                    ldd       $04,s
+                    ldx       $0008
+                    leax      $02,x
+                    stx       $0008
+                    std       -$02,x
+                    ldd       $005E
+                    addd      #$0002
+                    std       $005E
+                    cmpd      #$0100
+                    blt       L20F4
+                    bsr       L20F6
+L20F4               puls      pc,u
+L20F6               pshs      u
+                    leax      >$0005,y
+                    pshs      x
+                    ldd       $005E
+                    pshs      d
+                    leax      $0277,y
+                    pshs      x
+                    lbsr      L3494
+                    leas      $06,s
+                    ldd       L003A
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $005E
+                    pshs      d
+                    leax      $0277,y
+                    pshs      x
+                    lbsr      L2376
+                    leas      $08,s
+                    lbsr      $190A
+                    leax      $0277,y
+                    stx       $0008
+                    clra
+                    clrb
+                    std       $005E
+                    puls      pc,u
+L2134               clr       -$0b,s
+                    lsr       $206F
+                    ror       0,y
+                    lsr       -$0e,s
+                    fcb       $65
+                    ror       0,y
+                    jmp       $0f,s
+                    lsr       $05,s
+                    com       >$0034
+                    nega
+                    leau      $0089,y
+L214C               ldd       $06,u
+                    clra
+                    andb      #$03
+                    lbeq      L21BD
+                    leau      $0d,u
+                    pshs      u
+                    leax      $0159,y
+                    cmpx      ,s++
+                    bhi       L214C
+                    ldd       #$00C8
+                    std       $0228,y
+                    lbra      L21C1
+                    puls      pc,u
+L216D               pshs      u
+                    ldu       $08,s
+                    bne       L2177
+                    bsr       $2146
+                    tfr       d,u
+L2177               stu       -$02,s
+                    beq       L21C1
+                    ldd       $04,s
+                    std       $08,u
+                    ldx       $06,s
+L2181               ldb       $01,x
+                    cmpb      #$2b
+                    beq       L218F
+                    ldx       $06,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L2195
+L218F               ldd       $06,u
+                    orb       #$03
+                    bra       L21B3
+
+L2195               ldd       $06,u
+                    pshs      d
+                    ldb       [$08,s]
+                    cmpb      #$72
+                    beq       L21A7
+                    ldb       [$08,s]
+                    cmpb      #$64
+                    bne       L21AC
+L21A7               ldd       #$0001
+                    bra       L21AF
+
+L21AC               ldd       #$0002
+L21AF               ora       ,s+
+                    orb       ,s+
+L21B3               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+L21BD               tfr       u,d
+                    puls      pc,u
+L21C1               clra
+                    clrb
+                    puls      pc,u
+L21C5               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $0a,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L21F6
+
+L21D8               ldx       $0a,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L21E5
+                    ldd       #$0007
+                    bra       L21ED
+
+L21E5               ldd       #$0004
+                    bra       L21ED
+
+L21EA               ldd       #$0003
+L21ED               std       ,s
+                    bra       L2206
+
+L21F1               leax      $04,s
+                    lbra      L225E
+
+L21F6               stx       -$02,s
+                    beq       L2206
+                    cmpx      #$0078
+                    beq       L21D8
+                    cmpx      #$002B
+                    beq       L21EA
+                    bra       L21F1
+
+L2206               ldb       [$0a,s]
+                    sex
+                    tfr       d,x
+                    lbra      L226B
+
+L220F               ldd       ,s
+                    orb       #$01
+                    bra       L2251
+
+L2215               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      L334D
+                    leas      $04,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L2240
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L3421
+                    leas      $08,s
+                    bra       L2285
+
+L2240               ldd       ,s
+                    orb       #$0b
+                    pshs      d
+                    pshs      u
+                    lbsr      L336E
+                    bra       L2258
+
+L224D               ldd       ,s
+                    orb       #$81
+L2251               pshs      d
+                    pshs      u
+                    lbsr      L334D
+L2258               leas      $04,s
+                    std       $02,s
+                    bra       L2285
+
+L225E               leas      -$04,x
+L2260               ldd       #$00CB
+                    std       $0228,y
+                    clra
+                    clrb
+                    bra       L2287
+
+L226B               cmpx      #$0072
+                    lbeq      L220F
+                    cmpx      #$0061
+                    lbeq      L2215
+                    cmpx      #$0077
+                    beq       L2240
+                    cmpx      #$0064
+                    beq       L224D
+                    bra       L2260
+
+L2285               ldd       $02,s
+L2287               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      L22E7
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L21C5
+                    leas      $04,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L22B7
+                    clra
+                    clrb
+                    bra       L22EC
+
+L22B7               clra
+                    clrb
+L22B9               bra       L22DF
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L2B76
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L21C5
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L22DD
+                    clra
+                    clrb
+                    bra       L22EC
+
+L22DD               ldd       $08,s
+L22DF               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+L22E7               lbsr      L216D
+                    leas      $06,s
+L22EC               puls      pc,u
+L22EE               pshs      u
+                    leax      $0096,y
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    bsr       L2310
+                    leas      $04,s
+                    leax      $0096,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L2A86
+                    leas      $04,s
+                    puls      pc,u
+L2310               pshs      u
+                    ldu       $04,s
+                    leas      -$01,s
+                    bra       L2326
+
+L2318               ldd       $07,s
+                    pshs      d
+                    ldb       $02,s
+                    sex
+                    pshs      d
+                    lbsr      L2A86
+                    leas      $04,s
+L2326               ldb       ,u+
+                    stb       ,s
+                    bne       L2318
+                    leas      $01,s
+L232E               puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$06,s
+                    clra
+                    clrb
+                    bra       L2367
+
+L233A               ldd       $0C,s
+                    std       $04,s
+                    bra       L2356
+
+L2340               ldd       $10,s
+                    pshs      d
+                    lbsr      L2C99
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    beq       L2370
+                    ldd       ,s
+                    stb       ,u+
+L2356               ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    subd      #$FFFF
+                    bgt       L2340
+                    ldd       $02,s
+                    addd      #$0001
+L2367               std       $02,s
+                    ldd       $02,s
+                    cmpd      $0e,s
+                    blt       L233A
+L2370               ldd       $02,s
+                    leas      $06,s
+L2374               puls      pc,u
+L2376               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L23B1
+
+L2380               clra
+                    clrb
+                    std       ,s
+                    bra       L239D
+
+L2386               ldd       $0e,s
+                    pshs      d
+                    ldb       ,u+
+                    sex
+                    pshs      d
+                    lbsr      L2A86
+                    leas      $04,s
+                    ldx       $0e,s
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    bne       L23BA
+L239D               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      $0a,s
+                    blt       L2386
+                    ldd       $02,s
+                    addd      #$0001
+L23B1               std       $02,s
+                    ldd       $02,s
+                    cmpd      $0C,s
+                    blt       L2380
+L23BA               ldd       $02,s
+                    leas      $04,s
+                    puls      pc,u
+L23C0               pshs      u
+                    leax      $0096,y
+                    stx       $066d,y
+                    leax      $06,s
+                    pshs      x
+                    ldd       $06,s
+L23D0               bra       L23E0
+
+L23D2               pshs      u
+                    ldd       $04,s
+                    std       $066d,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L23E0               pshs      d
+                    leax      L289A,pcr
+                    pshs      x
+                    bsr       L2412
+                    leas      $06,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $04,s
+                    std       $066d,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    leax      L28AD,pcr
+                    pshs      x
+                    bsr       L2412
+                    leas      $06,s
+                    clra
+                    clrb
+                    stb       [$066d,y]
+                    ldd       $04,s
+                    puls      pc,u
+L2412               pshs      u
+                    ldu       $06,s
+                    leas      -$0b,s
+                    bra       L242A
+
+L241A               ldb       $08,s
+                    lbeq      L265B
+                    ldb       $08,s
+                    sex
+                    pshs      d
+                    jsr       [$11,s]
+                    leas      $02,s
+L242A               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    bne       L241A
+                    ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L244F
+                    ldd       #$0001
+                    std       $0683,y
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L2455
+
+L244F               clra
+                    clrb
+                    std       $0683,y
+L2455               ldb       $08,s
+                    cmpb      #$30
+                    bne       L2460
+                    ldd       #$0030
+                    bra       L2463
+
+L2460               ldd       #$0020
+L2463               std       $0685,y
+                    bra       L2483
+
+L2469               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L3182
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+L2483               ldb       $08,s
+                    sex
+                    leax      $015a,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L2469
+                    ldb       $08,s
+                    cmpb      #$2e
+                    bne       L24CC
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L24B6
+
+L24A0               ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L3182
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+L24B6               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $015a,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L24A0
+                    bra       L24D0
+
+L24CC               clra
+                    clrb
+                    std       $04,s
+L24D0               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L25FE
+
+L24D8               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L265F
+                    bra       L2500
+
+L24ED               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L2720
+L2500               std       ,s
+                    lbra      L25E4
+
+L2505               ldd       $06,s
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    leax      $015a,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$02
+                    pshs      d
+                    ldx       $17,s
+                    leax      $02,x
+                    stx       $17,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L2766
+                    lbra      L25E0
+
+L252B               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    leax      $066f,y
+                    pshs      x
+                    lbsr      L26A7
+                    lbra      L25E0
+
+L2547               ldd       $04,s
+                    bne       L2550
+                    ldd       #$0006
+                    std       $02,s
+L2550               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    ldb       $0e,s
+                    sex
+                    pshs      d
+                    lbsr      $2EBC
+                    leas      $06,s
+                    lbra      L25E2
+
+L256A               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    lbra      L25F4
+
+L2577               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L25BF
+                    ldd       $09,s
+                    std       $04,s
+                    bra       L2599
+
+L258D               ldb       [$09,s]
+                    beq       L25A5
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+L2599               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L258D
+L25A5               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $15,s
+                    pshs      d
+                    lbsr      L27D1
+                    leas      $08,s
+                    bra       L25EE
+
+L25BF               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    bra       L25E2
+
+L25C7               ldb       ,u+
+                    stb       $08,s
+                    bra       L25CF
+                    leas      -$0b,x
+L25CF               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldb       $0C,s
+                    sex
+                    pshs      d
+                    lbsr      L2E7E
+L25E0               leas      $04,s
+L25E2               pshs      d
+L25E4               ldd       $13,s
+                    pshs      d
+                    lbsr      L2833
+                    leas      $06,s
+L25EE               lbra      L242A
+
+L25F1               ldb       $08,s
+                    sex
+L25F4               pshs      d
+                    jsr       [$11,s]
+                    leas      $02,s
+                    lbra      L242A
+
+L25FE               cmpx      #$0064
+                    lbeq      L24D8
+                    cmpx      #$006F
+                    lbeq      L24ED
+                    cmpx      #$0078
+                    lbeq      L2505
+                    cmpx      #$0058
+                    lbeq      L2505
+                    cmpx      #$0075
+                    lbeq      L252B
+                    cmpx      #$0066
+                    lbeq      L2547
+                    cmpx      #$0065
+                    lbeq      L2547
+                    cmpx      #$0067
+                    lbeq      L2547
+                    cmpx      #$0045
+                    lbeq      L2547
+                    cmpx      #$0047
+                    lbeq      L2547
+                    cmpx      #$0063
+                    lbeq      L256A
+                    cmpx      #$0073
+                    lbeq      L2577
+                    cmpx      #$006C
+                    lbeq      L25C7
+                    bra       L25F1
+
+L265B               leas      $0b,s
+                    puls      pc,u
+L265F               pshs      u,d
+                    leax      $066f,y
+                    stx       ,s
+                    ldd       $06,s
+                    bge       L2693
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+                    bge       L2688
+                    leax      L28BF,pcr
+                    pshs      x
+                    leax      $066f,y
+                    pshs      x
+                    lbsr      L2ED8
+                    leas      $04,s
+                    puls      pc,u,x
+L2688               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L2693               ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L26A7
+                    leas      $04,s
+                    leax      $066f,y
+                    tfr       x,d
+                    puls      pc,u,x
+L26A7               pshs      u,y,x,d
+                    ldu       $0a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L26C4
+
+L26B5               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      >$007C,y
+                    std       $0C,s
+L26C4               ldd       $0C,s
+                    blt       L26B5
+                    leax      >$007C,y
+                    stx       $04,s
+                    bra       L2706
+
+L26D0               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L26D7               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    bge       L26D0
+                    ldd       $0C,s
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L26F0
+                    ldd       #$0001
+                    std       $02,s
+L26F0               ldd       $02,s
+                    beq       L26FB
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L26FB               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+L2706               ldd       $04,s
+                    cmpd      $0084,y
+                    bne       L26D7
+                    ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $06,s
+                    puls      pc,u
+L2720               pshs      u,d
+                    leax      $066f,y
+                    stx       ,s
+                    leau      $0679,y
+L272C               ldd       $06,s
+                    clra
+                    andb      #$07
+                    addd      #$0030
+                    stb       ,u+
+                    ldd       $06,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    std       $06,s
+                    bne       L272C
+                    bra       L274E
+
+L2744               ldb       ,u
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L274E               leau      -$01,u
+                    pshs      u
+                    leax      $0679,y
+                    cmpx      ,s++
+                    bls       L2744
+                    clra
+                    clrb
+                    stb       [,s]
+                    leax      $066f,y
+                    tfr       x,d
+                    puls      pc,u,x
+L2766               pshs      u,x,d
+                    leax      $066f,y
+                    stx       $02,s
+                    leau      $0679,y
+L2772               ldd       $08,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L2794
+                    ldd       $0C,s
+                    beq       L278C
+                    ldd       #$0041
+                    bra       L278F
+
+L278C               ldd       #$0061
+L278F               addd      #$FFF6
+                    bra       L2797
+
+L2794               ldd       #$0030
+L2797               addd      ,s++
+                    stb       ,u+
+                    ldd       $08,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $08,s
+                    bne       L2772
+                    bra       L27B7
+
+L27AD               ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+L27B7               leau      -$01,u
+                    pshs      u
+                    leax      $0679,y
+                    cmpx      ,s++
+                    bls       L27AD
+                    clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $066f,y
+                    tfr       x,d
+                    lbra      L28A9
+
+L27D1               pshs      u
+                    ldu       $06,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       $0a,s
+                    ldd       $0683,y
+                    bne       L2806
+                    bra       L27EE
+
+L27E3               ldd       $0685,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L27EE               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L27E3
+                    bra       L2806
+
+L27FC               ldb       ,u+
+                    sex
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L2806               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L27FC
+                    ldd       $0683,y
+                    beq       L2831
+                    bra       L2825
+
+L281A               ldd       $0685,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L2825               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L281A
+L2831               puls      pc,u
+L2833               pshs      u
+                    ldu       $06,s
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $2EC7
+                    leas      $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    addd      ,s++
+                    std       $08,s
+                    ldd       $0683,y
+                    bne       L2875
+                    bra       L285D
+
+L2852               ldd       $0685,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L285D               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L2852
+                    bra       L2875
+
+L286B               ldb       ,u+
+                    sex
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L2875               ldb       ,u
+                    bne       L286B
+                    ldd       $0683,y
+                    beq       L2898
+                    bra       L288C
+
+L2881               ldd       $0685,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L288C               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L2881
+L2898               puls      pc,u
+L289A               pshs      u
+                    ldd       $066d,y
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L2A86
+L28A9               leas      $04,s
+                    puls      pc,u
+L28AD               pshs      u
+                    ldd       $04,s
+                    ldx       $066d,y
+                    leax      $01,x
+                    stx       $066d,y
+                    stb       -$01,x
+                    puls      pc,u
+L28BF               blt       L28F4
+                    leas      -$09,y
+                    pshu      y,x,dp
+L28C5               neg       $0034
+                    nega
+                    ldu       $04,s
+                    leas      -$06,s
+                    cmpu      #$0000
+                    beq       L28D9
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L28DF
+L28D9               ldd       #$FFFF
+                    lbra      L2A02
+
+L28DF               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L28F2
+                    pshs      u
+                    lbsr      L2DEE
+                    leas      $02,s
+                    lbra      L29C8
+
+L28F2               ldd       $06,u
+L28F4               anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L2911
+                    pshs      u
+                    lbsr      L2BAF
+                    leas      $02,s
+                    ldd       $06,u
+                    anda      #$FE
+                    std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    lbra      L29C6
+
+L2911               ldd       ,u
+                    cmpd      $04,u
+                    lbcc      L29C8
+                    leax      $02,s
+                    pshs      x
+                    leax      $0e,s
+                    lbsr      L314E
+                    ldx       $10,s
+                    lbra      L2995
+
+L2929               leax      $02,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    pshs      u
+                    lbsr      L2A1D
+                    leas      $02,s
+                    lbsr      L30D5
+                    lbsr      L314E
+L2942               ldd       $0b,u
+                    lbsr      L3135
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    leax      $06,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L295F
+                    neg       $0000
+                    neg       $0000
+L295F               puls      x
+                    lbsr      L30EA
+                    bge       L296D
+                    leax      $06,s
+                    lbsr      L310E
+                    bra       L296F
+
+L296D               leax      $06,s
+L296F               lbsr      L30EA
+                    blt       L29A2
+                    ldd       $04,s
+                    addd      ,u
+                    std       ,s
+                    cmpd      $02,u
+                    bcs       L29A2
+                    ldd       ,s
+                    cmpd      $04,u
+                    bcc       L29A2
+                    ldd       ,s
+                    std       ,u
+                    ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    lbra      L2A00
+                    bra       L29A2
+
+L2995               stx       -$02,s
+                    lbeq      L2929
+                    cmpx      #$0001
+                    lbeq      L2942
+L29A2               ldd       $10,s
+                    cmpd      #$0001
+                    bne       L29C4
+                    leax      $0C,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $04,u
+                    subd      ,u
+                    lbsr      L3135
+                    lbsr      L30D5
+                    lbsr      L314E
+L29C4               ldd       $04,u
+L29C6               std       ,u
+L29C8               ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    ldd       $10,s
+                    pshs      d
+                    leax      $0e,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3421
+                    leas      $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       $29F4
+                    stu       $FFFF
+                    stu       $3510
+                    lbsr      L30EA
+                    bne       L2A00
+                    ldd       #$FFFF
+                    bra       L2A02
+
+L2A00               clra
+                    clrb
+L2A02               leas      $06,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      $28C6
+                    leas      $08,s
+L2A1B               puls      pc,u
+L2A1D               pshs      u
+                    ldu       $04,s
+                    beq       L2A2A
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L2A3D
+L2A2A               bsr       $2A30
+                    stu       $FFFF
+                    stu       $3510
+                    leau      $021C,y
+                    pshs      u
+                    lbsr      L314E
+                    puls      pc,u
+L2A3D               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L2A4D
+                    pshs      u
+                    lbsr      L2DEE
+                    leas      $02,s
+L2A4D               ldd       #$0001
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3421
+                    leas      $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L2A76
+                    ldd       $02,u
+                    bra       L2A78
+
+L2A76               ldd       $04,u
+L2A78               pshs      d
+                    ldd       ,u
+                    subd      ,s++
+                    lbsr      L3135
+                    lbsr      L30C0
+L2A84               puls      pc,u
+L2A86               pshs      u
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       L2AAA
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    lbne      L2BC0
+                    pshs      u
+                    lbsr      L2DEE
+                    leas      $02,s
+L2AAA               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       L2AE6
+                    ldd       #$0001
+                    pshs      d
+                    leax      $07,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2ACB
+                    leax      L3411,pcr
+                    bra       L2ACF
+
+L2ACB               leax      L33F8,pcr
+L2ACF               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       L2B27
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      L2BC0
+
+L2AE6               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L2AF6
+                    pshs      u
+                    lbsr      L2BDB
+                    leas      $02,s
+L2AF6               ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L2B1C
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2B27
+                    ldd       $04,s
+                    cmpd      #$000D
+                    bne       L2B27
+L2B1C               pshs      u
+                    lbsr      L2BDB
+                    std       ,s++
+                    lbne      L2BC0
+L2B27               ldd       $04,s
+L2B29               puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      L32AC
+                    pshs      d
+                    lbsr      L2A86
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2A86
+                    lbra      L2C95
+
+L2B4E               pshs      u,d
+                    leau      $0089,y
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L2B64
+
+L2B5A               tfr       u,d
+                    leau      $0d,u
+                    pshs      d
+                    bsr       L2B76
+                    leas      $02,s
+L2B64               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    blt       L2B5A
+L2B74               puls      pc,u,x
+L2B76               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       L2B86
+                    ldd       $06,u
+                    bne       L2B8B
+L2B86               ldd       #$FFFF
+                    puls      pc,u,x
+L2B8B               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       L2B9A
+                    pshs      u
+                    bsr       L2BAF
+                    leas      $02,s
+                    bra       L2B9C
+
+L2B9A               clra
+                    clrb
+L2B9C               std       ,s
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L335C
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $06,u
+                    ldd       ,s
+                    puls      pc,u,x
+L2BAF               pshs      u
+                    ldu       $04,s
+                    beq       L2BC0
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       L2BC5
+L2BC0               ldd       #$FFFF
+                    puls      pc,u
+L2BC5               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L2BD5
+                    pshs      u
+                    lbsr      L2DEE
+                    leas      $02,s
+L2BD5               pshs      u
+                    bsr       L2BDB
+                    puls      pc,u,x
+L2BDB               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L2C0D
+                    ldd       ,u
+                    cmpd      $04,u
+                    beq       L2C0D
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L2A1D
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3421
+                    leas      $08,s
+L2C0D               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      L2C85
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L2C85
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2C5C
+                    ldd       $02,u
+                    bra       L2C54
+
+L2C2D               ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3411
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L2C4A
+                    leax      $04,s
+                    bra       L2C74
+
+L2C4A               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+L2C54               std       ,u
+                    ldd       $02,s
+                    bne       L2C2D
+                    bra       L2C85
+
+L2C5C               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L33F8
+                    leas      $06,s
+                    cmpd      $02,s
+                    beq       L2C85
+                    bra       L2C76
+
+L2C74               leas      -$04,x
+L2C76               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       L2C95
+
+L2C85               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+L2C95               leas      $04,s
+L2C97               puls      pc,u
+L2C99               pshs      u
+                    ldu       $04,s
+                    beq       L2CE5
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L2CE5
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L2CC0
+                    ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldb       ,x
+                    clra
+                    bra       L2CC7
+
+L2CC0               pshs      u
+                    lbsr      L2D34
+                    leas      $02,s
+L2CC7               puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    beq       L2CE5
+                    ldd       $06,u
+                    clra
+                    andb      #$01
+                    beq       L2CE5
+                    ldd       $04,s
+                    cmpd      #$FFFF
+                    beq       L2CE5
+                    ldd       ,u
+                    cmpd      $02,u
+                    bhi       L2CEA
+L2CE5               ldd       #$FFFF
+                    puls      pc,u
+L2CEA               ldd       ,u
+                    addd      #$FFFF
+                    std       ,u
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       $04,s
+L2CF9               puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      L2C99
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L2D1F
+                    pshs      u
+                    lbsr      L2C99
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L2D24
+L2D1F               ldd       #$FFFF
+                    bra       L2D30
+
+L2D24               ldd       $02,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      L32C3
+                    addd      ,s
+L2D30               leas      $04,s
+                    puls      pc,u
+L2D34               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$31
+                    cmpd      #$8001
+                    beq       L2D5D
+                    ldd       $06,u
+                    clra
+                    andb      #$31
+                    cmpd      #$0001
+                    beq       L2D56
+                    ldd       #$FFFF
+                    puls      pc,u,x
+L2D56               pshs      u
+                    lbsr      L2DEE
+                    leas      $02,s
+L2D5D               leax      $0089,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L2D7A
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2D7A
+                    leax      $0096,y
+                    pshs      x
+                    lbsr      L2BAF
+                    leas      $02,s
+L2D7A               ldd       $06,u
+                    clra
+                    andb      #$08
+                    beq       L2DA6
+                    ldd       $0b,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2D9A
+                    leax      L33E8,pcr
+                    bra       L2D9E
+
+L2D9A               leax      L33C7,pcr
+L2D9E               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    bra       L2DB8
+
+L2DA6               ldd       #$0001
+                    pshs      d
+                    leax      $0a,u
+                    stx       $02,u
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L33C7
+L2DB8               leas      $06,s
+                    std       ,s
+                    ldd       ,s
+                    bgt       L2DDB
+                    ldd       $06,u
+                    pshs      d
+                    ldd       $02,s
+                    beq       L2DCD
+                    ldd       #$0020
+                    bra       L2DD0
+
+L2DCD               ldd       #$0010
+L2DD0               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    ldd       #$FFFF
+                    puls      pc,u,x
+L2DDB               ldd       $02,u
+                    addd      #$0001
+                    std       ,u
+                    ldd       $02,u
+                    addd      ,s
+                    std       $04,u
+                    ldb       [$02,u]
+                    clra
+                    puls      pc,u,x
+L2DEE               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       L2E26
+                    leas      -$20,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L32DE
+                    leas      $06,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       L2E1A
+                    ldd       #$0040
+                    bra       L2E1D
+
+L2E1A               ldd       #$0080
+L2E1D               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $20,s
+L2E26               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       L2E33
+                    puls      pc,u
+L2E33               ldd       $0b,u
+                    bne       L2E48
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2E43
+                    ldd       #$0080
+                    bra       L2E46
+
+L2E43               ldd       #$0100
+L2E46               std       $0b,u
+L2E48               ldd       $02,u
+                    bne       L2E5D
+                    ldd       $0b,u
+                    pshs      d
+                    lbsr      L3511
+                    leas      $02,s
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       L2E65
+L2E5D               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       L2E74
+
+L2E65               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+L2E74               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    puls      pc,u
+L2E7E               pshs      u
+                    ldb       $05,s
+                    sex
+                    tfr       d,x
+                    bra       L2EA4
+
+L2E87               ldd       [$06,s]
+                    addd      #$0004
+                    std       [$06,s]
+                    leax      >L2EBB,pcr
+                    bra       L2EA0
+
+L2E96               ldb       $05,s
+                    stb       $0087,y
+                    leax      $0086,y
+L2EA0               tfr       x,d
+                    puls      pc,u
+L2EA4               cmpx      #$0064
+                    beq       L2E87
+                    cmpx      #$006F
+                    lbeq      L2E87
+                    cmpx      #$0078
+                    lbeq      L2E87
+                    bra       L2E96
+                    puls      pc,u
+L2EBB               neg       $0034
+                    nega
+                    leax      >L2EC6,pcr
+                    tfr       x,d
+                    puls      pc,u
+L2EC6               neg       $0034
+                    nega
+                    ldu       $04,s
+L2ECB               ldb       ,u+
+                    bne       L2ECB
+                    tfr       u,d
+                    subd      $04,s
+                    addd      #$FFFF
+L2ED6               puls      pc,u
+L2ED8               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L2EE2               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L2EE2
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L2EFC               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L2EFC
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L2F0D               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L2F0D
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+                    bra       L2F33
+
+L2F23               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L2F31
+                    clra
+                    clrb
+                    puls      pc,u
+L2F31               leau      $01,u
+L2F33               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L2F23
+                    ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+L2F4C               puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L2F58               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L2F7C
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L2F58
+                    bra       L2F7C
+
+L2F72               clra
+                    clrb
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L2F7C               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L2F72
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+                    bra       L2FA2
+
+L2F92               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L2FA0
+                    clra
+                    clrb
+                    puls      pc,u
+L2FA0               leau      $01,u
+L2FA2               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    ble       L2FBC
+                    ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L2F92
+L2FBC               ldd       $08,s
+                    bge       L2FC4
+                    clra
+                    clrb
+                    bra       L2FCF
+
+L2FC4               ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+L2FCF               puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L2FDB               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L2FDB
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L2FEC               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L3004
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L2FEC
+L3004               ldd       $0a,s
+                    bge       L300C
+                    clra
+                    clrb
+                    stb       [,s]
+L300C               ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+L3014               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    stb       ,u+
+                    bgt       L3014
+                    ldb       -$01,u
+                    clra
+                    andb      #$7f
+                    stb       -$01,u
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $04,s
+L302D               puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$05,s
+                    clra
+                    clrb
+                    std       $01,s
+L3039               ldb       ,u+
+                    stb       ,s
+                    cmpb      #$20
+                    beq       L3039
+                    ldb       ,s
+                    cmpb      #$09
+                    lbeq      L3039
+                    ldb       ,s
+                    cmpb      #$2d
+                    bne       L3054
+                    ldd       #$0001
+                    bra       L3056
+
+L3054               clra
+                    clrb
+L3056               std       $03,s
+                    ldb       ,s
+                    cmpb      #$2d
+                    beq       L307C
+                    ldb       ,s
+                    cmpb      #$2b
+                    bne       L3080
+                    bra       L307C
+
+L3066               ldd       $01,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L3182
+                    pshs      d
+                    ldb       $02,s
+                    sex
+                    addd      ,s++
+                    addd      #$FFD0
+                    std       $01,s
+L307C               ldb       ,u+
+                    stb       ,s
+L3080               ldb       ,s
+                    sex
+                    leax      $015a,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L3066
+                    ldd       $03,s
+                    beq       L309C
+                    ldd       $01,s
+                    nega
+                    negb
+                    sbca      #$00
+                    bra       L309E
+
+L309C               ldd       $01,s
+L309E               leas      $05,s
+L30A0               puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    bra       L30B2
+
+L30A8               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    stb       ,u+
+L30B2               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L30A8
+L30BE               puls      pc,u
+L30C0               ldd       $04,s
+                    addd      $02,x
+                    std       $021e,y
+                    ldd       $02,s
+                    adcb      $01,x
+                    adca      ,x
+                    std       $021C,y
+                    lbra      L3164
+
+L30D5               ldd       $04,s
+                    subd      $02,x
+                    std       $021e,y
+                    ldd       $02,s
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       $021C,y
+                    lbra      L3164
+
+L30EA               ldd       $02,s
+                    cmpd      ,x
+                    bne       L3103
+                    ldd       $04,s
+                    cmpd      $02,x
+                    beq       L3103
+                    bcs       L3100
+                    lda       #$01
+                    andcc     #$FE
+                    bra       L3103
+
+L3100               clra
+                    cmpa      #$01
+L3103               pshs      cc
+                    ldd       $01,s
+                    std       $05,s
+                    puls      cc
+                    leas      $04,s
+                    rts
+
+L310E               lbsr      L3173
+                    ldd       #$0000
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       ,x
+                    rts
+                    ldd       ,x
+                    coma
+                    comb
+                    std       $021C,y
+                    ldd       $02,x
+                    coma
+                    comb
+                    leax      $021C,y
+                    std       $02,x
+                    rts
+
+L3135               leax      $021C,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+L3142               rts
+                    leax      $021C,y
+                    std       $02,x
+                    clr       ,x
+                    clr       $01,x
+L314D               rts
+
+L314E               pshs      y
+                    ldy       $04,s
+                    ldd       ,x
+                    std       ,y
+                    ldd       $02,x
+                    std       $02,y
+                    puls      x
+                    exg       y,x
+                    puls      d
+                    std       ,s
+                    rts
+
+L3164               tfr       cc,a
+                    puls      x
+                    stx       $02,s
+                    leas      $02,s
+                    leax      $021C,y
+                    tfr       a,cc
+                    rts
+
+L3173               ldd       ,x
+                    std       $021C,y
+                    ldd       $02,x
+                    leax      $021C,y
+                    std       $02,x
+L3181               rts
+
+L3182               tsta
+                    bne       L3197
+                    tst       $02,s
+                    bne       L3197
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+L3197               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L31B4
+                    inc       ,s
+L31B4               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L31C1
+                    inc       ,s
+L31C1               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+L31D4               rts
+                    clr       $0687,y
+                    leax      >L321D,pcr
+                    stx       $0688,y
+                    bra       L31F7
+                    leax      >L3236,pcr
+                    stx       $0688,y
+                    clr       $0687,y
+                    tst       $02,s
+                    bpl       L31F7
+                    inc       $0687,y
+L31F7               subd      #$0000
+                    bne       L3202
+                    puls      x
+                    ldd       ,s++
+                    jmp       ,x
+
+L3202               ldx       $02,s
+                    pshs      x
+                    jsr       [$0688,y]
+                    ldd       ,s
+                    std       $02,s
+                    tfr       x,d
+                    tst       $0687,y
+                    beq       L321A
+                    nega
+                    negb
+                    sbca      #$00
+L321A               std       ,s++
+                    rts
+
+L321D               subd      #$0000
+                    beq       L322C
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    bra       L325A
+
+L322C               puls      d
+                    std       ,s
+                    ldd       #$002D
+                    lbra      L32CF
+
+L3236               subd      #$0000
+                    beq       L322C
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    tsta
+                    bpl       L324E
+                    nega
+                    negb
+                    sbca      #$00
+                    inc       $01,s
+                    std       $02,s
+L324E               ldd       $06,s
+                    bpl       L325A
+                    nega
+                    negb
+                    sbca      #$00
+                    com       $01,s
+                    std       $06,s
+L325A               lda       #$01
+L325C               inca
+                    asl       $03,s
+                    rol       $02,s
+                    bpl       L325C
+                    sta       ,s
+                    ldd       $06,s
+                    clr       $06,s
+                    clr       $07,s
+L326B               subd      $02,s
+                    bcc       L3275
+                    addd      $02,s
+                    andcc     #$FE
+                    bra       L3277
+
+L3275               orcc      #$01
+L3277               rol       $07,s
+                    rol       $06,s
+                    lsr       $02,s
+                    ror       $03,s
+                    dec       ,s
+                    bne       L326B
+                    std       $02,s
+                    tst       $01,s
+                    beq       L3291
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+L3291               ldx       $04,s
+                    ldd       $06,s
+                    std       $04,s
+                    stx       $06,s
+                    ldx       $02,s
+                    ldd       $04,s
+                    leas      $06,s
+                    rts
+                    tstb
+                    beq       L32B6
+L32A3               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L32A3
+                    bra       L32B6
+
+L32AC               tstb
+                    beq       L32B6
+L32AF               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L32AF
+L32B6               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+                    leas      $04,s
+L32C2               rts
+
+L32C3               tstb
+                    beq       L32B6
+L32C6               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       L32C6
+                    bra       L32B6
+
+L32CF               std       $0228,y
+                    pshs      y,b
+                    os9       F$ID
+                    puls      y,b
+                    os9       F$Send
+                    rts
+
+L32DE               lda       $05,s
+                    ldb       $03,s
+                    beq       L3311
+                    cmpb      #$01
+                    beq       L3313
+                    cmpb      #$06
+                    beq       L3313
+                    cmpb      #$02
+                    beq       L32F9
+                    cmpb      #$05
+                    beq       L32F9
+                    ldb       #$D0
+                    lbra      L3560
+
+L32F9               pshs      u
+                    os9       I$GetStt
+                    bcc       L3305
+                    puls      u
+                    lbra      L3560
+
+L3305               stx       [$08,s]
+                    ldx       $08,s
+                    stu       $02,x
+                    puls      u
+                    clra
+                    clrb
+                    rts
+
+L3311               ldx       $06,s
+L3313               os9       I$GetStt
+                    lbra      L3569
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       L3328
+                    cmpb      #$02
+                    beq       L3330
+                    ldb       #$D0
+                    lbra      L3560
+
+L3328               ldx       $06,s
+                    os9       I$SetStt
+                    lbra      L3569
+
+L3330               pshs      u
+                    ldx       $08,s
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u
+                    lbra      L3569
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    bcs       L334A
+                    os9       I$Close
+L334A               lbra      L3569
+
+L334D               ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    lbcs      L3560
+                    tfr       a,b
+                    clra
+                    rts
+
+L335C               lda       $03,s
+                    os9       I$Close
+                    lbra      L3569
+                    ldx       $02,s
+                    ldb       $05,s
+                    os9       I$MakDir
+                    lbra      L3569
+
+L336E               ldx       $02,s
+                    ldb       $05,s
+                    tfr       b,a
+                    anda      #$07
+                    os9       I$Create
+                    bcs       L337F
+L337B               tfr       a,b
+                    clra
+                    rts
+
+L337F               cmpb      #$DA
+                    lbne      L3560
+                    lda       $05,s
+                    bita      #$80
+                    lbne      L3560
+                    anda      #$07
+                    ldx       $02,s
+                    os9       I$Open
+                    lbcs      L3560
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+                    bcc       L337B
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+                    lbra      L3560
+
+L33B2               ldx       $02,s
+                    os9       I$Delete
+                    lbra      L3569
+                    lda       $03,s
+                    os9       I$Dup
+                    lbcs      L3560
+                    tfr       a,b
+                    clra
+                    rts
+
+L33C7               pshs      y
+                    ldx       $06,s
+                    lda       $05,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$Read
+L33D5               bcc       L33E4
+                    cmpb      #$D3
+                    bne       L33DF
+                    clra
+                    clrb
+                    puls      pc,y,x
+L33DF               puls      y,x
+                    lbra      L3560
+
+L33E4               tfr       y,d
+                    puls      pc,y,x
+L33E8               pshs      y
+                    lda       $05,s
+                    ldx       $06,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$ReadLn
+                    bra       L33D5
+
+L33F8               pshs      y
+                    ldy       $08,s
+                    beq       L340D
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$Write
+L3406               bcc       L340D
+                    puls      y
+                    lbra      L3560
+
+L340D               tfr       y,d
+                    puls      pc,y
+L3411               pshs      y
+                    ldy       $08,s
+                    beq       L340D
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$WritLn
+                    bra       L3406
+
+L3421               pshs      u
+                    ldd       $0a,s
+                    bne       L342F
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       L3463
+
+L342F               cmpd      #$0001
+                    beq       L345A
+                    cmpd      #$0002
+                    beq       L344F
+                    ldb       #$F7
+L343D               clra
+                    std       $0228,y
+                    ldd       #$FFFF
+                    leax      $021C,y
+                    std       ,x
+                    std       $02,x
+                    puls      pc,u
+L344F               lda       $05,s
+                    ldb       #$02
+                    os9       I$GetStt
+                    bcs       L343D
+                    bra       L3463
+
+L345A               lda       $05,s
+                    ldb       #$05
+                    os9       I$GetStt
+                    bcs       L343D
+L3463               tfr       u,d
+                    addd      $08,s
+                    std       $021e,y
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       L343D
+                    tfr       d,x
+                    std       $021C,y
+                    lda       $05,s
+                    os9       I$Seek
+                    bcs       L343D
+                    leax      $021C,y
+                    puls      pc,u
+                    rts
+                    ldx       #$0000
+                    clrb
+                    os9       F$Sleep
+                    lbra      L3560
+
+L3493               rts
+
+L3494               pshs      u,y
+                    ldx       $06,s
+                    ldy       $08,s
+                    ldu       $0a,s
+                    os9       F$CRC
+                    puls      pc,u,y
+                    lda       $03,s
+                    ldb       $05,s
+                    os9       F$Perr
+                    lbcs      L3560
+                    rts
+                    ldx       $02,s
+                    os9       F$Sleep
+                    lbcs      L3560
+                    tfr       x,d
+L34B9               rts
+                    ldd       $021a,y
+                    pshs      d
+                    ldd       $04,s
+                    cmpd      $068a,y
+                    bcs       L34EE
+                    addd      $021a,y
+                    pshs      y
+                    subd      ,s
+                    os9       F$Mem
+                    tfr       y,d
+                    puls      y
+                    bcc       L34E0
+                    ldd       #$FFFF
+                    leas      $02,s
+                    rts
+
+L34E0               std       $021a,y
+                    addd      $068a,y
+                    subd      ,s
+                    std       $068a,y
+L34EE               leas      $02,s
+                    ldd       $068a,y
+                    pshs      d
+                    subd      $04,s
+                    std       $068a,y
+                    ldd       $021a,y
+                    subd      ,s++
+                    pshs      d
+                    clra
+                    ldx       ,s
+L3507               sta       ,x+
+                    cmpx      $021a,y
+                    bcs       L3507
+                    puls      pc,d
+L3511               ldd       $02,s
+                    addd      $0224,y
+                    bcs       L353A
+                    cmpd      $0226,y
+                    bcc       L353A
+                    pshs      d
+                    ldx       $0224,y
+                    clra
+L3527               cmpx      ,s
+                    bcc       L352F
+                    sta       ,x+
+                    bra       L3527
+
+L352F               ldd       $0224,y
+                    puls      x
+                    stx       $0224,y
+                    rts
+
+L353A               ldd       #$FFFF
+                    rts
+                    pshs      u
+                    tfr       y,u
+                    ldx       $04,s
+                    stx       $068C,y
+                    leax      >L3554,pcr
+                    os9       F$Icpt
+                    puls      u
+                    lbra      L3569
+
+L3554               tfr       u,y
+                    clra
+                    pshs      d
+                    jsr       [$068C,y]
+                    leas      $02,s
+                    rti
+
+L3560               clra
+                    std       $0228,y
+                    ldd       #$FFFF
+L3568               rts
+
+L3569               bcs       L3560
+L356B               clra
+                    clrb
+L356D               rts
+
+L356E               lbsr      L3579
+L3571               lbsr      L2B4E
+                    ldd       $02,s
+                    os9       F$Exit
+L3579               rts
+                    neg       $000A
+                    neg       $0000
+                    neg       $0004
+                    neg       $00FF
+                    stu       $FF02
+                    asr       L017A
+                    neg       $0060
+                    neg       $0060
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    tst       $00C1
+                    tst       $00C7
+                    tst       $00CD
+                    tst       $00D1
+                    tst       $00D7
+                    fcb       $02
+                    asr       $2710
+                    com       $00E8
+                    neg       $0064
+                    neg       $000A
+                    neg       L0084
+                    inc       -$08,s
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    leax      0,y
+                    bra       L36C6
+                    bra       L36C8
+                    bra       L36CA
+                    bra       L36CC
+                    bra       L36CE
+                    bra       L36D0
+                    bra       L36D2
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    bra       $36DE
+                    bra       $36E0
+                    bra       $36E2
+                    bra       L3706
+                    fcb       $42
+                    fcb       $42
+L36C6               fcb       $42
+                    fcb       $42
+L36C8               fcb       $42
+                    fcb       $02
+L36CA               fcb       $02
+                    fcb       $02
+L36CC               fcb       $02
+                    fcb       $02
+L36CE               fcb       $02
+                    fcb       $02
+L36D0               fcb       $02
+                    fcb       $02
+L36D2               fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    bra       L36FF
+                    bra       L3701
+                    bra       $3703
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    bra       $371F
+
+L36FF               bra       $3721
+L3701               fcb       $01
+                    neg       $0005
+                    neg       L0078
+L3706               neg       $0076
+                    neg       $0074
+                    neg       $0072
+                    neg       L0070
+                    neg       $0005
+                    neg       $0062
+                    neg       $0060
+                    neg       $007A
+                    neg       $0008
+                    neg       L0084
+                    com       $0e,y
+                    inc       $09,s
+
+                    emod
+eom                 equ       *
+                    end

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $04
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       5127
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.opt/
                     fcb       edition
 
-L0013               lda       ,y+
+copybytes           lda       ,y+
 L0015               sta       ,u+
 L0017               leax      -$01,x
-L0019               bne       L0013
+L0019               bne       copybytes
 L001B               rts
 
-start               pshs      y
+_start              pshs      y
 L001E               pshs      u
 L0020               clra
 L0021               clrb
@@ -37,12 +37,12 @@ L002F               pshs      x
 L0031               leay      L27DC,pcr
 L0035               ldx       ,y++
 L0037               beq       L003D
-L0039               bsr       L0013
+L0039               bsr       copybytes
 L003B               ldu       $02,s
 L003D               leau      >$0023,u
 L0041               ldx       ,y++
 L0043               beq       L0048
-L0045               bsr       L0013
+L0045               bsr       copybytes
 L0047               clra
 L0048               cmpu      ,s
 L004B               beq       L0051
@@ -119,12 +119,12 @@ L00DF               leax      $0515,u
                     ldd       $0551,u
 L00E9               pshs      d
                     leay      ,u
-L00ED               bsr       L00F9
-                    lbsr      L017B
+L00ED               bsr       stkinit
+                    lbsr      main
                     clr       ,-s
 L00F4               clr       ,-s
-                    lbsr      L27D0
-L00F9               leax      $0887,y
+                    lbsr      exit
+stkinit             leax      $0887,y
                     stx       $055f,y
                     sts       $0553,y
                     sts       $0561,y
@@ -167,7 +167,7 @@ L0169               ldd       ,y++
 L0178               leas      $04,s
                     rts
 
-L017B               pshs      u
+main                pshs      u
                     leas      -$08,s
                     leax      $0445,y
                     stx       $0565,y
@@ -314,7 +314,7 @@ L02AB               ldd       $0567,y
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $04,s
                     ldd       $0009
                     pshs      d
@@ -322,7 +322,7 @@ L02AB               ldd       $0567,y
                     pshs      x
 L02E2               leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       L0019
                     pshs      d
@@ -339,7 +339,7 @@ L02FA               pshs      d
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $0a,s
                     ldd       $0009
                     pshs      d
@@ -354,7 +354,7 @@ L02FA               pshs      d
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $08,s
                     ldd       L001B
                     aslb
@@ -386,7 +386,7 @@ L02FA               pshs      d
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $0a,s
                     leas      $04,s
 L037E               leas      $08,s
@@ -528,7 +528,7 @@ L04A8               leax      $0080,s
                     pshs      x
                     ldd       $0567,y
 L04B8               pshs      d
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L0625
 
@@ -676,7 +676,7 @@ L05CB               ldb       $69,s
 L0612               ldd       $0009
                     addd      #$0001
                     std       $0009
-                    ldd       L0013
+                    ldd       copybytes
                     cmpd      >$0025,y
                     blt       L0625
                     lbsr      L0D20
@@ -706,7 +706,7 @@ L0660               bsr       L0671
                     bra       L0667
 
 L0664               lbsr      L0D20
-L0667               ldd       L0013
+L0667               ldd       copybytes
                     bne       L0664
                     leas      $00E4,s
                     puls      pc,u
@@ -721,13 +721,13 @@ L0671               pshs      u
                     bra       L0688
 
 L0681               lbsr      L0D20
-L0684               ldd       L0013
+L0684               ldd       copybytes
                     bne       L0681
 L0688               leax      L07A3,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $04,s
                     clra
                     clrb
@@ -1125,7 +1125,7 @@ L0A7C               pshs      u
                     clrb
                     std       $001D
                     std       $001F
-                    std       L0013
+                    std       copybytes
                     puls      pc,u
 L0A92               pshs      u
                     leas      -$0a,s
@@ -1183,9 +1183,9 @@ L0AEB               ldd       $04,s
                     stu       [$02,x]
                     ldx       $0e,s
                     stu       $02,x
-                    ldd       L0013
+                    ldd       copybytes
                     addd      #$0001
-                    std       L0013
+                    std       copybytes
                     leax      $08,u
                     stx       $06,s
                     ldb       ,x
@@ -1461,7 +1461,7 @@ L0D62               ldd       ,s
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $06,s
                     ldx       ,s
                     ldd       $0a,x
@@ -1525,7 +1525,7 @@ L0DF6               tfr       x,d
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $0a,s
                     bra       L0E42
 
@@ -1537,7 +1537,7 @@ L0E0D               pshs      u
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $06,s
                     ldb       [$13,u]
                     beq       L0E42
@@ -1547,7 +1547,7 @@ L0E0D               pshs      u
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $06,s
 L0E42               ldd       $0567,y
                     pshs      d
@@ -1697,9 +1697,9 @@ L0F65               std       ,s
                     ldd       $001D
                     std       ,u
                     stu       $001D
-                    ldd       L0013
+                    ldd       copybytes
                     addd      #$FFFF
-                    std       L0013
+                    std       copybytes
 L0F83               leas      $02,s
                     puls      pc,u
 L0F87               pshs      u,x,d
@@ -2719,7 +2719,7 @@ L1814               pshs      u
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $04,s
                     ldd       $0a,s
                     pshs      d
@@ -2731,7 +2731,7 @@ L1814               pshs      u
 L1835               pshs      d
                     leax      $045f,y
                     pshs      x
-                    lbsr      L1ABE
+                    lbsr      fprintf
                     leas      $0a,s
                     leax      $045f,y
                     pshs      x
@@ -2741,7 +2741,7 @@ L1835               pshs      d
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      L27D0
+                    lbsr      exit
 L185A               leas      $02,s
                     puls      pc,u
 L185E               fcc       /memory overflow/
@@ -3038,7 +3038,7 @@ L1AA8               leas      $04,s
                     ldd       $06,s
                     bra       L1ACC
 
-L1ABE               pshs      u
+fprintf             pshs      u
                     ldd       $04,s
                     std       $086b,y
                     leax      $08,s
@@ -3047,7 +3047,7 @@ L1ABE               pshs      u
 L1ACC               pshs      d
                     leax      L1F86,pcr
                     pshs      x
-                    bsr       L1AFE
+                    bsr       doprnt
                     leas      $06,s
                     puls      pc,u
 L1ADA               pshs      u
@@ -3059,14 +3059,14 @@ L1ADA               pshs      u
                     pshs      d
                     leax      L1F99,pcr
                     pshs      x
-                    bsr       L1AFE
+                    bsr       doprnt
                     leas      $06,s
                     clra
                     clrb
                     stb       [$086b,y]
                     ldd       $04,s
                     puls      pc,u
-L1AFE               pshs      u
+doprnt              pshs      u
                     ldu       $06,s
                     leas      -$0b,s
 L1B04               ldb       ,u+
@@ -4639,25 +4639,25 @@ L27CB               bcs       L27C2
                     clrb
                     rts
 
-L27D0               lbsr      L27DB
+exit                lbsr      L27DB
                     lbsr      L207A
 L27D6               ldd       $02,s
                     os9       F$Exit
 L27DB               rts
 
-L27DC               neg       $0007
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0004
-                    sbcb      >$0000
-                    fcb       $01
-                    bge       L27FC
+* ------------------------------------------------------------------
+* L27DC - cc1-style init image for the work block (see _start):
+* rts stub + count/block table + relocation dirs + module-name string.
+* ------------------------------------------------------------------
+L27DC               fcb       $00,$07,$00,$00,$00,$00,$00,$00 init table / work-block image
+                    fcb       $00,$04,$F2,$00,$00,$01
+                    fcb       $2C
+                    fcb       $10
                     fcb       $52
                     fcb       $10
                     fcb       $55
                     fcb       $10
-                    aslb
+                    fcb       $58
                     fcb       $10
                     fcb       $5B
                     fcb       $10
@@ -4665,41 +4665,51 @@ L27DC               neg       $0007
                     fcb       $10
                     fcb       $61
                     fcb       $10
-                    lsr       -$10,x
-                    asr       -$10,x
-L27FC               dec       -$10,x
-                    tst       -$10,x
-                    neg       $1073
+                    fcb       $64
                     fcb       $10
-                    ror       L1079
+                    fcb       $67
                     fcb       $10
-                    inc       L107F
+                    fcb       $6A
                     fcb       $10
-                    sbca      #$10
-                    bita      #$64
-                    neg       $0078
-                    neg       $0079
-                    neg       $0075
-                    neg       L0064
-                    bge       L2892
-                    neg       L0064
-                    bge       L2897
-                    neg       L0064
-                    bge       L2897
-                    neg       L0064
-                    fcc       /,x,u/
+                    fcb       $6D
+                    fcb       $10
+                    fcb       $70
+                    fcb       $10
+                    fcb       $73
+                    fcb       $10
+                    fcb       $76
+                    fcb       $10
+                    fcb       $79
+                    fcb       $10
+                    fcb       $7C
+                    fcb       $10,$7F,$10,$82,$10,$85
+                    fcb       $64
+                    fcb       $00
+                    fcb       $78
+                    fcb       $00
+                    fcb       $79
+                    fcb       $00
+                    fcb       $75
+                    fcb       $00
+                    fcb       $64,$2C,$78
+                    fcb       $00
+                    fcb       $64,$2C,$79
+                    fcb       $00
+                    fcb       $64,$2C,$75
+                    fcb       $00
+                    fcc       /d,x,u/
                     fcb       $00
                     fcc       /d,x,y,u/
                     fcb       $00
                     fcc       /x,u,pc/
                     fcb       $00
-                    rol       $2C64
-                    neg       $0079
-                    bge       L28B4
-                    neg       $0075
-                    bge       L28A7
-                    neg       $0075
-                    fcb       $2C,$70,$63
+                    fcb       $79,$2C,$64
+                    fcb       $00
+                    fcb       $79,$2C,$75
+                    fcb       $00
+                    fcb       $75,$2C,$64
+                    fcb       $00
+                    fcc       /u,pc/
                     fcb       $00
                     fcc       /clra/
                     fcb       $00
@@ -4713,761 +4723,428 @@ L27FC               dec       -$10,x
                     fcb       $00
                     fcc       /cmpu/
                     fcb       $00
-                    inc       $04,s
-                    fcb       $62
-                    neg       $006C
-                    lsr       $04,s
-                    neg       $006C
-                    lsr       -$08,s
-                    neg       $006C
-                    lsr       -$07,s
-                    neg       $006C
-                    lsr       -$0b,s
-                    neg       $0073
-                    lsr       $6200
-                    com       $7464
-                    neg       $0073
-                    lsr       $7800
-                    com       $7479
-                    neg       $0073
-                    lsr       $7500
-                    fcb       $70,$73,$68
-L2892               fcb       $73
+                    fcb       $6C,$64,$62
                     fcb       $00
-                    fcb       $70,$75,$6C
-L2897               fcb       $73
+                    fcb       $6C,$64,$64
+                    fcb       $00
+                    fcb       $6C,$64,$78
+                    fcb       $00
+                    fcb       $6C,$64,$79
+                    fcb       $00
+                    fcb       $6C,$64,$75
+                    fcb       $00
+                    fcb       $73,$74,$62
+                    fcb       $00
+                    fcb       $73,$74,$64
+                    fcb       $00
+                    fcb       $73,$74,$78
+                    fcb       $00
+                    fcb       $73,$74,$79
+                    fcb       $00
+                    fcb       $73,$74,$75
+                    fcb       $00
+                    fcc       /pshs/
+                    fcb       $00
+                    fcc       /puls/
                     fcb       $00
                     fcc       /leax/
                     fcb       $00
                     fcc       /leay/
                     fcb       $00
                     fcc       /leau/
-L28A7               fcb       $00
+                    fcb       $00
                     fcc       /leas/
                     fcb       $00
-                    com       $6578
-                    neg       L0074
-                    ror       -$0e,s
-L28B4               neg       $0023
-                    leax      0,x
-                    leas      $0C,y
-                    asl       >L0031
-                    bge       $2937
-                    neg       $0030
-                    bge       $293B
-                    neg       $002D
-                    leay      $0C,y
-                    asl       >$002D
-                    leas      $0C,y
-                    asl       >$0032
-                    bge       L294A
-                    neg       L0031
-                    bge       L294E
-                    neg       $0030
-                    bge       L2952
-                    neg       $002D
-                    leay      $0C,y
-                    rol       >$002D
-                    leas      $0C,y
-                    rol       >$0032
-                    bge       L295C
-                    neg       L0031
-                    bge       L2960
-                    neg       $0030
-                    bge       L2964
-                    neg       $002D
-                    leay      $0C,y
-                    fcb       $75
-                    neg       $002D
-                    leas      $0C,y
-                    fcb       $75
-                    neg       $0032
-                    bge       L2970
-                    neg       $0030
-                    bge       L2974
-                    neg       $002D
-                    leas      $0C,y
-                    com       >$0023
-                    cwai      #$00
-                    neg       $0002
-                    neg       L00BB
-                    neg       $0000
-                    neg       $00A7
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00BF
-                    neg       $0000
-                    neg       L00AB
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00B7
-                    neg       $0000
-                    neg       L00A3
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       $00A7
-                    neg       $0000
-                    neg       L00BB
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-L294A               neg       $0002
-                    neg       L00AB
-L294E               neg       $0000
-                    neg       L00BF
-L2952               neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0001
-L295C               neg       L00ED
-                    neg       L0074
-L2960               neg       L00CB
-                    neg       L004B
-L2964               neg       $0002
-                    neg       L004F
-                    neg       $0000
-                    neg       $0001
-                    neg       L00ED
-                    neg       $007C
-L2970               neg       L00CB
-                    neg       L004B
-L2974               neg       $0002
-                    neg       L0051
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L004D
-                    neg       L00CB
-                    neg       L004B
-                    neg       $0001
-                    neg       L0053
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       L00CB
-                    neg       L004B
-                    neg       $0001
-                    neg       L005B
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L004F
-                    neg       L00CB
-                    neg       L004B
-                    neg       $0001
-                    neg       L0057
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       L00CB
-                    neg       L004F
-                    neg       $0001
-                    neg       $0078
-                    neg       $0000
-                    neg       $0002
-                    neg       $00A7
-                    neg       $0000
-                    neg       L008F
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00AB
-                    neg       $0000
-                    neg       $0094
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00AF
-                    neg       $0000
-                    neg       L0099
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00B3
-                    neg       $0000
-                    neg       $009E
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00C3
-                    neg       $0000
-                    neg       L0099
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00C7
-                    neg       $0000
-                    neg       $009E
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00A3
-                    neg       $0000
-                    neg       L00B7
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0001
-                    neg       L00E9
-                    neg       $0000
-                    neg       $0085
-                    neg       $0000
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0002
-                    neg       L00D5
-                    neg       $00F8
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    fcb       $02
-                    lbsr      $D349
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    jmp       $0000
-                    neg       $0001
-                    lbra      $2A58
-                    lbsr      $D759
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    bcc       L2A61
-L2A61               neg       $0001
-                    bge       L2A65
-L2A65               fcb       $02
-                    lbsr      $DB69
-                    neg       $0000
-                    fcb       $02
-                    neg       L00D5
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    ldd       >$0002
-                    lbsr      $DF79
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    lbra      L2A82
-L2A82               fcb       $01
-                    nop
-                    neg       $0002
-                    lbsr      $E389
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    bge       L2A91
-L2A91               neg       $0001
-                    bvc       L2A95
-L2A95               fcb       $02
-                    lbsr      $E799
-                    neg       $0000
-                    fcb       $02
-                    neg       L00D5
-                    neg       L00F4
-                    neg       $0000
-                    fcb       $01,$05
-                    neg       $0002
-                    lbsr      $EBA9
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    dec       $0000
-                    neg       $0001
-                    fcb       $1B
-                    neg       $0002
-                    lbsr      $F0B9
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    bra       L2AC1
-
-L2AC1               neg       $0001
-                    leay      0,x
-                    fcb       $02
-                    lbsr      $F5C9
-                    neg       $0000
-                    fcb       $02
-                    neg       L00D5
-                    fcb       $01,$05
-                    neg       $0000
-                    neg       $00FC
-                    neg       $0002
-                    lbsr      $FAD9
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01,$1B
-                    neg       $0000
-                    fcb       $01
-                    nop
-                    neg       $0002
-                    lbsr      $FFE9
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    leay      0,x
-                    neg       $0001
-                    bvc       L2AF5
-L2AF5               fcb       $02
-                    lbsr      L04F9
-                    neg       $0000
-                    fcb       $02
-                    neg       L00E9
-                    neg       $0000
-                    neg       L008F
-                    fcb       $01
-                    coma
-                    neg       $008A
-                    neg       $0002
-                    neg       $0000
-                    neg       $0002
-                    neg       $0085
-                    neg       $0000
-                    neg       L008F
-                    fcb       $01
-                    coma
-                    neg       $008A
-                    neg       $0002
-                    neg       $0000
-                    neg       $0002
-                    neg       $00E4
-                    fcb       $01
-                    fcb       $36
+                    fcb       $73,$65,$78
                     fcb       $00
-                    adda      $013E
-                    neg       $0002
-                    lbsr      L0A29
-                    neg       $0000
-L2B2B               fcb       $02
-                    neg       $00E4
-                    fcb       $01
-                    fcb       $36
+                    fcb       $74,$66,$72
                     fcb       $00
-                    addb      #$00
+                    fcb       $23,$30
+                    fcb       $00
+                    fcb       $32,$2C,$78
+                    fcb       $00
+                    fcb       $31,$2C,$78
+                    fcb       $00
+                    fcb       $30,$2C,$78
+                    fcb       $00
+                    fcc       /-1,x/
+                    fcb       $00
+                    fcc       /-2,x/
+                    fcb       $00
+                    fcb       $32,$2C,$79
+                    fcb       $00
+                    fcb       $31,$2C,$79
+                    fcb       $00
+                    fcb       $30,$2C,$79
+                    fcb       $00
+                    fcc       /-1,y/
+                    fcb       $00
+                    fcc       /-2,y/
+                    fcb       $00
+                    fcb       $32,$2C,$75
+                    fcb       $00
+                    fcb       $31,$2C,$75
+                    fcb       $00
+                    fcb       $30,$2C,$75
+                    fcb       $00
+                    fcc       /-1,u/
+                    fcb       $00
+                    fcc       /-2,u/
+                    fcb       $00
+                    fcb       $32,$2C,$73
+                    fcb       $00
+                    fcb       $30,$2C,$73
+                    fcb       $00
+                    fcc       /-2,s/
+                    fcb       $00
+                    fcb       $23,$3C
+                    fcb       $00,$00,$02,$00,$BB,$00,$00,$00
+                    fcb       $A7,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$BF,$00,$00,$00
+                    fcb       $AB,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$B7,$00,$00,$00
+                    fcb       $A3,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$A7,$00,$00,$00
+                    fcb       $BB,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$AB,$00,$00,$00
+                    fcb       $BF,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$01,$00,$ED,$00
+                    fcb       $74
+                    fcb       $00,$CB,$00
                     fcb       $4B
-                    neg       L00BB
-                    fcb       $01
-                    abx
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       $00E4
-                    fcb       $01
+                    fcb       $00,$02,$00
+                    fcb       $4F
+                    fcb       $00,$00,$00,$01,$00,$ED,$00
+                    fcb       $7C
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$02,$00
+                    fcb       $51
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $4D
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$01,$00
+                    fcb       $53
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$01,$00
+                    fcb       $5B
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $4F
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$01,$00
+                    fcb       $57
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$CB,$00
+                    fcb       $4F
+                    fcb       $00,$01,$00
+                    fcb       $78
+                    fcb       $00,$00,$00,$02,$00,$A7,$00,$00
+                    fcb       $00,$8F,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$AB,$00,$00
+                    fcb       $00,$94,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$AF,$00,$00
+                    fcb       $00,$99,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$B3,$00,$00
+                    fcb       $00,$9E,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$C3,$00,$00
+                    fcb       $00,$99,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$C7,$00,$00
+                    fcb       $00,$9E,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$A3,$00,$00
+                    fcb       $00,$B7,$00,$01,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$01,$00,$E9,$00,$00
+                    fcb       $00,$85,$00,$00,$00,$02,$00,$00
+                    fcb       $00,$00,$00,$02,$00,$D5,$00,$F8
+                    fcb       $00,$00,$01,$00,$00,$02,$17,$A9
+                    fcb       $00,$00,$00,$02,$00,$DA,$01,$0E
+                    fcb       $00,$00,$01,$16,$00,$02,$17,$AD
+                    fcb       $00,$00,$00,$02,$00,$DF,$01
+                    fcb       $24
+                    fcb       $00,$00,$01
+                    fcb       $2C
+                    fcb       $00,$02,$17,$B1,$00,$00,$00,$02
+                    fcb       $00,$D5,$01,$00,$00,$00,$00,$FC
+                    fcb       $00,$02,$17,$B5,$00,$00,$00,$02
+                    fcb       $00,$DA,$01,$16,$00,$00,$01,$12
+                    fcb       $00,$02,$17,$B9,$00,$00,$00,$02
+                    fcb       $00,$DF,$01
+                    fcb       $2C
+                    fcb       $00,$00,$01
+                    fcb       $28
+                    fcb       $00,$02,$17,$BD,$00,$00,$00,$02
+                    fcb       $00,$D5,$00,$F4,$00,$00,$01,$05
+                    fcb       $00,$02,$17,$C1,$00,$00,$00,$02
+                    fcb       $00,$DA,$01,$0A,$00,$00,$01,$1B
+                    fcb       $00,$02,$17,$C6,$00,$00,$00,$02
+                    fcb       $00,$DF,$01
+                    fcb       $20
+                    fcb       $00,$00,$01
+                    fcb       $31
+                    fcb       $00,$02,$17,$CB,$00,$00,$00,$02
+                    fcb       $00,$D5,$01,$05,$00,$00,$00,$FC
+                    fcb       $00,$02,$17,$D0,$00,$00,$00,$02
+                    fcb       $00,$DA,$01,$1B,$00,$00,$01,$12
+                    fcb       $00,$02,$17,$D5,$00,$00,$00,$02
+                    fcb       $00,$DF,$01
+                    fcb       $31
+                    fcb       $00,$00,$01
+                    fcb       $28
+                    fcb       $00,$02,$17,$DA,$00,$00,$00,$02
+                    fcb       $00,$E9,$00,$00,$00,$8F,$01
+                    fcb       $43
+                    fcb       $00,$8A,$00,$02,$00,$00,$00,$02
+                    fcb       $00,$85,$00,$00,$00,$8F,$01
+                    fcb       $43
+                    fcb       $00,$8A,$00,$02,$00,$00,$00,$02
+                    fcb       $00,$E4,$01
+                    fcb       $36
+                    fcb       $00,$BB,$01
                     fcb       $3E
-                    neg       $0001
-                    neg       L005B
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       $00E4
-                    lbsr      $0F55
-                    fcb       $01
-                    neg       $005F
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       $00E4
-                    lbsr      L1465
-                    fcb       $01
-                    neg       $0065
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0002
-                    neg       $0038
-                    fcb       $38
-                    bvc       $2BD8
-                    bvc       $2BDA
-                    bvc       L2BDC
-                    bvc       L2BDE
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    bhi       $2BE1
-                    bhi       $2BE3
-                    bhi       $2BE5
-                    fcb       $02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-L2BDC               neg       $0004
-L2BDE               lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0000
-                    neg       $0000
-                    neg       $0000
-                    beq       L2C0E
-                    com       $00E8
-                    neg       L0064
-                    neg       $000A
-                    lsr       $0040
-                    inc       -$08,s
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-L2C0E               neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$02,$17,$DF,$00,$00,$00
+L2B2B               fcb       $02,$00,$E4,$01
+                    fcb       $36
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$BB,$01
+                    fcb       $3A
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$E4,$01
+                    fcb       $3E
+                    fcb       $00,$01,$00
+                    fcb       $5B
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$E4,$17,$E4,$00,$01,$00
+                    fcb       $5F
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$E4,$17,$E9,$00,$01,$00
+                    fcb       $65
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$02,$00
+                    fcc       /88((((((((/
+                    fcb       $00,$00,$00,$00,$00,$00,$02
+                    fcc       /""""""/
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$00,$00,$00,$00
+                    fcb       $02,$00,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$00,$00,$00,$00
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$04
+                    fcb       $40,$6C,$78
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       L0021
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00
+                    fcb       $21
+                    fcb       $02,$C2,$02,$B2,$02,$A2,$02,$92
+                    fcb       $02,$82,$03
+                    fcb       $32
+                    fcb       $03
+                    fcb       $22
+                    fcb       $03,$12,$03,$02,$02,$F2,$02,$E2
+                    fcb       $02,$D2,$00
+                    fcb       $2D
+                    fcb       $00
+                    fcb       $2B
+                    fcb       $00
+                    fcb       $29
+                    fcb       $00
+                    fcb       $27
+                    fcb       $03,$9E,$03,$8E,$03
+                    fcb       $62
+                    fcb       $00
+                    fcb       $3B
+                    fcb       $00
+                    fcb       $39
+                    fcb       $00
+                    fcb       $37
+                    fcb       $00
+                    fcb       $35
+                    fcb       $00
+                    fcb       $33
+                    fcb       $00
+                    fcb       $31
+                    fcb       $00
+                    fcb       $2F
+                    fcb       $00
+                    fcb       $49
+                    fcb       $00
+                    fcb       $47
+                    fcb       $00
+                    fcb       $45
+                    fcb       $00
+                    fcb       $43
+                    fcb       $00
+                    fcb       $41
+                    fcb       $00
+                    fcb       $3F
+                    fcb       $00
+                    fcb       $3D
+                    fcb       $00,$82,$01
+                    fcb       $58
+                    fcb       $01
+                    fcb       $4C
+                    fcb       $01
+                    fcb       $48
+                    fcb       $04
+                    fcb       $40
+                    fcb       $01,$8C,$01,$88,$01
+                    fcb       $7C
+                    fcb       $01
+                    fcb       $78
+                    fcb       $01
+                    fcb       $6C
+                    fcb       $01
+                    fcb       $68
+                    fcb       $01
+                    fcb       $5C
+                    fcb       $01,$AA,$01,$A8,$01,$A2,$01,$9E
+                    fcb       $01,$9C,$01,$9A,$01,$98,$01,$BE
+                    fcb       $01,$BC,$01,$BA,$01,$B8,$01,$B2
+                    fcb       $01,$AE,$01,$AC,$01,$D8,$01,$D2
+                    fcb       $01,$CE,$01,$CC,$01,$CA,$01,$C8
+                    fcb       $01,$C2,$01,$EC,$01,$EA,$01,$E8
+                    fcb       $01,$E2,$01,$DE,$01,$DC,$01,$DA
+                    fcb       $02,$0C,$02,$08,$01,$FE,$01,$FC
+                    fcb       $01,$F8,$01,$F2,$01,$EE,$02
+                    fcb       $2E
                     fcb       $02
-                    sbcb      #$02
-                    sbca      $02A2
+                    fcb       $2C
                     fcb       $02
-                    sbca      $0002
-                    sbca      #$03
-                    leas      $03,x
-                    bhi       L2CED
-                    nop
-                    com       $0002
-L2CED               fcb       $02
-                    sbcb      L02E2
+                    fcb       $28
+                    fcb       $02,$1E,$02,$1C,$02,$18,$02,$0E
                     fcb       $02
-                    sbcb      $0000
-                    blt       L2CF6
-L2CF6               bmi       L2CF8
-L2CF8               bvs       L2CFA
-L2CFA               beq       $2CFF
-                    ldx       $0003
-                    ldx       #$0362
-                    neg       L003B
-                    neg       L0039
-                    neg       L0037
-                    neg       L0035
-                    neg       $0033
-                    neg       L0031
-                    neg       L002F
-                    neg       $0049
-                    neg       L0047
-                    neg       L0045
-                    neg       L0043
-                    neg       L0041
-                    neg       $003F
-                    neg       L003D
-                    neg       $0082
-                    fcb       $01
-                    aslb
-                    fcb       $01
-                    inca
-                    fcb       $01
-                    asla
-                    lsr       $0040
-                    fcb       $01
-                    cmpx      #$0188
-                    fcb       $01
-                    inc       L0178
-                    fcb       $01
-                    inc       $01,x
-                    asl       $01,x
-                    incb
-                    fcb       $01
-                    ora       $01,x
-                    eora      $01,x
-                    sbca      $01,x
-                    ldx       $0001
-                    cmpx      $0001
-                    ora       $0001
-                    eora      $0001
-                    ldx       $01BC
-                    fcb       $01
-                    ora       L01B8
-                    fcb       $01
-                    sbca      $01AE
-                    fcb       $01
-                    cmpx      $01,x
-                    eorb      $0001
-                    sbcb      $0001
-                    ldu       #$01CC
-                    fcb       $01
-                    orb       #$01
-                    eorb      #$01
-                    sbcb      #$01
-                    ldd       $01,x
-                    orb       $01,x
-                    eorb      $01,x
-                    sbcb      $01,x
-                    ldu       $0001
-                    ldd       $0001
-                    orb       $0002
-                    inc       $0002
-                    asl       $0001
-                    ldu       L01FC
-                    fcb       $01
-                    eorb      $01F2
-                    fcb       $01
-                    ldu       $02,x
-                    bgt       L2D80
-                    bge       L2D82
-L2D80               bvc       L2D84
-L2D82               exg       d,y
-L2D84               andcc     #$02
-                    fcb       $18,$02
-                    jmp       $0002
-                    aslb
+                    fcb       $58
                     fcb       $02
                     fcb       $4E
                     fcb       $02
-                    inca
+                    fcb       $4C
                     fcb       $02
-                    asla
+                    fcb       $48
                     fcb       $02
                     fcb       $3E
                     fcb       $02
-                    cwai      #$02
+                    fcb       $3C
+                    fcb       $02
                     fcb       $38
+                    fcb       $02,$88,$02
+                    fcb       $7E
                     fcb       $02
-                    eora      #$02
-                    jmp       $027A
+                    fcb       $7A
                     fcb       $02
-                    asl       L026C
+                    fcb       $78
                     fcb       $02
-                    asl       $02,x
-                    incb
+                    fcb       $6C
                     fcb       $02
-                    ora       $02,x
-                    eora      $02,x
-                    ldx       $0002
-                    ora       $0002
-                    eora      $0002
-                    ldx       #$028A
+                    fcb       $68
                     fcb       $02
-                    ldu       #$02CA
-                    fcb       $02
-                    eorb      #$02
-                    ldx       $02BA
-                    fcb       $02
-                    eora      $02AE
-                    fcb       $02
-                    eorb      $02EE
-                    fcb       $02
-                    orb       $02,x
-                    eorb      $02,x
-                    ldu       $0002
-                    orb       $0002
-                    eorb      $0003
-                    orcc      #$03
-                    fcb       $18
-                    com       $000E
-                    com       $000A
-                    com       $0008
-                    fcb       $02
-                    ldu       L02FA
-                    com       $003E
-                    com       $003C
-                    com       $0038
-                    com       $002E
-                    com       $002A
-                    com       $0028
-                    com       L001E
-                    com       $005A
-                    com       $0058
-                    com       $0050
-                    com       $004E
-                    com       $004C
-                    com       L0048
-                    com       $0040
-                    com       $0070
-                    com       $006E
-                    com       $006C
-                    com       $006A
-                    com       $0068
-                    com       L005E
-                    com       $005C
-                    com       $0088
-                    com       $0082
-                    com       $007E
-                    com       $007C
-                    com       $007A
-                    com       $0078
-                    com       $0072
-                    com       $00A2
-                    com       $009C
-                    com       $009A
-                    com       $0098
-                    com       $0092
-                    com       $008C
-                    com       $008A
+                    fcb       $5C
+                    fcb       $02,$AA,$02,$A8,$02,$9E,$02,$9A
+                    fcb       $02,$98,$02,$8E,$02,$8A,$02,$CE
+                    fcb       $02,$CA,$02,$C8,$02,$BE,$02,$BA
+                    fcb       $02,$B8,$02,$AE,$02,$F8,$02,$EE
+                    fcb       $02,$EA,$02,$E8,$02,$DE,$02,$DA
+                    fcb       $02,$D8,$03,$1A,$03,$18,$03,$0E
+                    fcb       $03,$0A,$03,$08,$02,$FE,$02,$FA
+                    fcb       $03
+                    fcb       $3E
+                    fcb       $03
+                    fcb       $3C
+                    fcb       $03
+                    fcb       $38
+                    fcb       $03
+                    fcb       $2E
+                    fcb       $03
+                    fcb       $2A
+                    fcb       $03
+                    fcb       $28
+                    fcb       $03,$1E,$03
+                    fcb       $5A
+                    fcb       $03
+                    fcb       $58
+                    fcb       $03
+                    fcb       $50
+                    fcb       $03
+                    fcb       $4E
+                    fcb       $03
+                    fcb       $4C
+                    fcb       $03
+                    fcb       $48
+                    fcb       $03
+                    fcb       $40
+                    fcb       $03
+                    fcb       $70
+                    fcb       $03
+                    fcb       $6E
+                    fcb       $03
+                    fcb       $6C
+                    fcb       $03
+                    fcb       $6A
+                    fcb       $03
+                    fcb       $68
+                    fcb       $03
+                    fcb       $5E
+                    fcb       $03
+                    fcb       $5C
+                    fcb       $03,$88,$03,$82,$03
+                    fcb       $7E
+                    fcb       $03
+                    fcb       $7C
+                    fcb       $03
+                    fcb       $7A
+                    fcb       $03
+                    fcb       $78
+                    fcb       $03
+                    fcb       $72
+                    fcb       $03,$A2,$03,$9C,$03,$9A,$03,$98
+                    fcb       $03,$92,$03,$8C,$03,$8A
                     fcc       /c.opt/
                     fcb       $00
-
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -29,7 +29,7 @@ L0020               clra
 L0021               clrb
 L0022               sta       ,u+
 L0024               decb
-L0025               bne       L0022
+                    bne       L0022
                     ldx       ,s
                     leau      ,x
 L002B               leax      $0887,x
@@ -321,7 +321,7 @@ L02AB               ldd       $0567,y
                     std       $0569,y
                     lbsr      L091F
                     lbsr      L0A7C
-                    lbsr      $10E2
+                    lbsr      L10E2
                     lbsr      L03C0
                     ldd       $0007
                     lbeq      L037E
@@ -739,7 +739,7 @@ L0671               pshs      u
 L0681               lbsr      L0D20
 L0684               ldd       copybytes
                     bne       L0681
-L0688               leax      $07A3,pcr
+L0688               leax      L07A3,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -793,8 +793,8 @@ L079A               fcb       $25,$73
                     fcb       $0D,$00
 L079E               fcb       $6E,$6F,$70
                     fcb       $00
-L07A2               neg       L0020
-                    fcc       /endsect/
+L07A2               fcb       $00
+L07A3               fcc       / endsect/
                     fcb       $0D,$00
 L07AD               pshs      u
                     ldu       $06,s
@@ -1547,7 +1547,7 @@ L0E0D               pshs      u
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    leax      $10DB,pcr
+                    leax      L10DB,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -1557,7 +1557,7 @@ L0E0D               pshs      u
                     beq       L0E42
                     ldd       $13,u
                     pshs      d
-                    leax      $10DE,pcr
+                    leax      L10DE,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -1873,11 +1873,12 @@ L10CF               fcc       /%sb%s %s/
                     fcb       $00
 L10D8               fcb       $6C
                     fcb       $00
-L10DA               neg       L0025
-                    com       >L0020
-                    bcs       $1154
-                    neg       $0034
-                    rora
+L10DA               fcb       $00
+L10DB               fcb       $25,$73
+                    fcb       $00
+L10DE               fcb       $20,$25,$73
+                    fcb       $00
+L10E2               pshs      u,d
                     leau      $0146,y
                     bra       L1106
 

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -4165,11 +4165,22 @@ L23D4               cmpx      #$0064
                     lbeq      L23B7
                     bra       L23C6
                     puls      pc,u
+* ------------------------------------------------------------------
+* L23EB/L23F6 - reached ONLY via leax,pcr data pointers (never
+* branched or called), so the linear sweep decoded them as code.  They
+* read as a pair of function-pointer thunks: L23EB returns &L23F6
+* in D; L23F6 is strlen(4,s) - scan ldb,u+/bne for the NUL, length =
+* (end - start - 1).  But the leading "neg $34 / nega" ($00 $34 $40)
+* prologue would clobber DP $34 and A, which makes no sense as code, so
+* these may instead be data the sweep mis-framed.  Left as code: byte-
+* exact either way and the body reads as a genuine strlen.
+* ------------------------------------------------------------------
 L23EB               neg       $0034
                     nega
                     leax      >L23F6,pcr
                     tfr       x,d
                     puls      pc,u
+* L23F6 - strlen routine (entered via the &L23F6 pointer returned above):
 L23F6               neg       $0034
                     nega
                     ldu       $04,s

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $04
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       5127
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.opt/
                     fcb       edition
 
-L0013               lda       ,y+
+copybytes           lda       ,y+
 L0015               sta       ,u+
 L0017               leax      -$01,x
-L0019               bne       L0013
+L0019               bne       copybytes
 L001B               rts
 
-start               pshs      y
+_start              pshs      y
 L001E               pshs      u
 L0020               clra
 L0021               clrb
@@ -37,12 +37,12 @@ L002F               pshs      x
 L0031               leay      L27DC,pcr
 L0035               ldx       ,y++
 L0037               beq       L003D
-L0039               bsr       L0013
+L0039               bsr       copybytes
 L003B               ldu       $02,s
 L003D               leau      >$0023,u
 L0041               ldx       ,y++
 L0043               beq       L0048
-L0045               bsr       L0013
+L0045               bsr       copybytes
 L0047               clra
 L0048               cmpu      ,s
 L004B               beq       L0051
@@ -119,12 +119,12 @@ L00DF               leax      $0515,u
                     ldd       $0551,u
 L00E9               pshs      d
                     leay      ,u
-L00ED               bsr       L00F9
-                    lbsr      L017B
+L00ED               bsr       stkinit
+                    lbsr      main
                     clr       ,-s
 L00F4               clr       ,-s
-                    lbsr      L27D0
-L00F9               leax      $0887,y
+                    lbsr      exit
+stkinit             leax      $0887,y
                     stx       $055f,y
                     sts       $0553,y
                     sts       $0561,y
@@ -136,10 +136,8 @@ L00F9               leax      $0887,y
                     bcs       L013A
                     stx       $0561,y
 L0120               fcb       $39
-L0121               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+L0121               fcc       /**** STACK OVERFLOW ****/
+                    fcb       $0D
 L013A               leax      L0121,pcr
                     ldb       #$CF
                     pshs      b
@@ -169,7 +167,7 @@ L0169               ldd       ,y++
 L0178               leas      $04,s
                     rts
 
-L017B               pshs      u
+main                pshs      u
                     leas      -$08,s
                     leax      $0445,y
                     stx       $0565,y
@@ -273,7 +271,7 @@ L0243               ldd       $0e,s
                     beq       L0283
                     leax      $0445,y
                     pshs      x
-                    leax      $06C3,pcr
+                    leax      L06C3,pcr
                     pshs      x
                     ldd       $06,s
                     pshs      d
@@ -289,7 +287,7 @@ L026C               leas      $06,s
                     leas      $04,s
 L0283               ldd       ,s
                     beq       L02AB
-                    leax      $06D3,pcr
+                    leax      L06D3,pcr
                     pshs      x
                     ldd       $02,s
                     pshs      d
@@ -312,7 +310,7 @@ L02AB               ldd       $0567,y
                     ldd       $0007
                     lbeq      L037E
                     leas      -$04,s
-                    leax      $06E3,pcr
+                    leax      L06E3,pcr
                     pshs      x
                     leax      $045f,y
                     pshs      x
@@ -503,7 +501,7 @@ L0452               leax      L0775,pcr
 L046E               std       $000F
                     lbra      L0625
 
-L0473               leax      $077D,pcr
+L0473               leax      L077D,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
@@ -545,7 +543,7 @@ L04C2               leax      L078A,pcr
                     lbsr      L0671
                     lbra      L053B
 
-L04DE               leax      $0790,pcr
+L04DE               leax      L0790,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
@@ -555,7 +553,7 @@ L04DE               leax      $0790,pcr
                     beq       L053B
                     lbra      L056C
 
-L04F5               leax      L0794,pcr
+L04F5               leax      $0794,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
@@ -607,7 +605,7 @@ L056C               lbsr      L0671
                     beq       L0586
                     leax      $0080,s
                     pshs      x
-                    leax      $079A,pcr
+                    leax      L079A,pcr
                     pshs      x
                     ldd       $0569,y
                     lbra      L04B8
@@ -678,7 +676,7 @@ L05CB               ldb       $69,s
 L0612               ldd       $0009
                     addd      #$0001
                     std       $0009
-                    ldd       L0013
+                    ldd       copybytes
                     cmpd      >$0025,y
                     blt       L0625
                     lbsr      L0D20
@@ -708,7 +706,7 @@ L0660               bsr       L0671
                     bra       L0667
 
 L0664               lbsr      L0D20
-L0667               ldd       L0013
+L0667               ldd       copybytes
                     bne       L0664
                     leas      $00E4,s
                     puls      pc,u
@@ -723,7 +721,7 @@ L0671               pshs      u
                     bra       L0688
 
 L0681               lbsr      L0D20
-L0684               ldd       L0013
+L0684               ldd       copybytes
                     bne       L0681
 L0688               leax      L07A3,pcr
                     pshs      x
@@ -735,76 +733,49 @@ L0688               leax      L07A3,pcr
                     clrb
                     std       $000F
 L069D               puls      pc,u
-L069F               fcb       $75,$6e,$6b,$6e,$6f,$77,$6e,$20
-                    fcb       $6f,$70,$74,$69,$6f,$6e,$20,$27
-                    fcb       $25,$73,$27,$0d,$00
-L06B4               lsr       $6F6F
-                    bra       L0726
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       L0724
-                    rol       $0C,s
-                    fcb       $65
-                    com       >$0072
+L069F               fcc       /unknown option '%s'/
+                    fcb       $0D,$00
+L06B4               fcc       /too many files/
+                    fcb       $00
+L06C3               fcb       $72
                     neg       $0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       L206F
-                    neg       $656E
-                    bra       L06F6
-                    com       >L0077
-                    neg       $0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       L206F
-                    neg       $656E
-                    bra       L0706
-                    com       >$0073
-                    lsr       $6174
-                    rol       -$0d,s
+                    fcc       /an't open %s/
+                    fcb       $00
+L06D3               asr       >$0063
+                    fcc       /an't open %s/
+                    fcb       $00
+L06E3               com       $7461
+                    lsr       $6973
                     lsr       $6963
                     com       $3A0D
                     neg       $0009
-                    fcb       $74,$6f,$74,$61,$6C
-L06F6               fcb       $20,$69,$6e,$73,$74,$72,$75,$63
-                    fcb       $74,$69,$6f,$6e,$73,$20,$3a,$20
-L0706               fcb       $25,$64,$0d,$00
+                    fcc       /total instructions : %d/
+                    fcb       $0D,$00
 L070A               rol       $006C
-                    fcb       $6f,$6e,$67,$20,$62,$72,$61,$6e
-                    fcb       $63,$68,$65,$73,$20,$3a,$20,$20
-                    fcb       $25,$35,$64,$2C,$20,$25,$35,$64
-L0724               fcb       $2C,$20
-L0726               fcb       $25,$33,$64,$25,$25,$0d,$00
+                    fcc       /ong branches :  %5d, %5d, %3d%%/
+                    fcb       $0D,$00
 L072D               rol       $0072
-                    fcb       $65,$6d,$6f,$76,$65,$64,$20,$20
-                    fcb       $20,$20,$20,$20,$20,$3a,$20,$20
-                    fcb       $20,$20,$20,$20,$20,$20,$20,$25
-                    fcb       $35,$64,$2C,$20,$25,$33,$64,$25
-                    fcb       $25,$0d,$00
+                    fcc       /emoved       :         %5d, %3d%%/
+                    fcb       $0D,$00
 L0752               rol       L0074
-                    fcb       $6f,$74,$61,$6C,$20,$62,$79,$74
-                    fcb       $65,$73,$20,$20,$20,$3a,$20,$20
-                    fcb       $25,$35,$64,$2C,$20,$25,$35,$64
-                    fcb       $2C,$20,$25,$33,$64,$25,$25
-                    fcb       $0d,$00
-L0775               fcb       $65
-                    jmp       $04,s
-                    com       $6563
-                    lsr       >L0069
-                    jmp       $06,s
-                    clr       0,x
+                    fcc       /otal bytes   :  %5d, %5d, %3d%%/
+                    fcb       $0D,$00
+L0775               fcc       /endsect/
+                    fcb       $00
+L077D               fcc       /info/
+                    fcb       $00
 L0782               jmp       $01,s
                     tst       0,x
 L0786               bcs       $07FB
                     tst       $0000
-L078A               neg       $7365
-                    com       -$0C,s
-                    neg       L0074
-                    lsr       $6C00
-L0794               ror       $7365
-                    com       -$0C,s
-                    neg       L0025
-                    com       $0D00
+L078A               fcc       /psect/
+                    fcb       $00
+L0790               lsr       $746C
+                    neg       $0076
+                    fcc       /sect/
+                    fcb       $00
+L079A               bcs       $080F
+                    tst       $0000
 L079E               jmp       $0f,s
                     neg       >$0000
 L07A3               bra       $080A
@@ -969,22 +940,8 @@ L08F5               clra
                     ldd       $0a,s
                     leas      $02,s
                     puls      pc,u
-L08FF               neg       $6172
-                    com       $6520
-                    com       $01,s
-                    inc       $0C,s
-                    fcb       $65
-                    lsr       0,y
-                    asr       $6974
-                    asl       0,y
-                    fcb       $62
-                    fcb       $61
-                    lsr       0,y
-                    lsr       $7970
-                    fcb       $65
-                    bra       $0955
-                    bra       $0942
-                    lsr       0,x
+L08FF               fcc       /parse called with bad type : %d/
+                    fcb       $00
 L091F               pshs      u,d
                     leax      $056b,y
                     stx       ,s
@@ -1106,7 +1063,7 @@ L09EE               pshs      u
 
 L0A04               ldd       #$0018
                     pshs      d
-                    lbsr      $17F3
+                    lbsr      L17F3
                     leas      $02,s
                     tfr       d,u
 L0A10               tfr       u,d
@@ -1168,7 +1125,7 @@ L0A7C               pshs      u
                     clrb
                     std       $001D
                     std       $001F
-                    std       L0013
+                    std       copybytes
                     puls      pc,u
 L0A92               pshs      u
                     leas      -$0a,s
@@ -1226,9 +1183,9 @@ L0AEB               ldd       $04,s
                     stu       [$02,x]
                     ldx       $0e,s
                     stu       $02,x
-                    ldd       L0013
+                    ldd       copybytes
                     addd      #$0001
-                    std       L0013
+                    std       copybytes
                     leax      $08,u
                     stx       $06,s
                     ldb       ,x
@@ -1356,7 +1313,7 @@ L0C15               leax      L1088,pcr
                     leas      $04,s
                     std       -$02,s
                     bne       L0C6B
-                    leax      $108D,pcr
+                    leax      L108D,pcr
                     pshs      x
                     ldd       $14,s
                     addd      $02,s
@@ -1418,7 +1375,7 @@ L0C90               pshs      u
                     leas      $02,s
 L0CB6               ldd       #$0015
                     pshs      d
-                    lbsr      $17F3
+                    lbsr      L17F3
                     leas      $02,s
                     tfr       d,u
                     bra       L0CCF
@@ -1474,7 +1431,7 @@ L0D20               pshs      u,d
                     leax      >$0015,y
                     cmpx      ,s++
                     bne       L0D39
-                    leax      $10AD,pcr
+                    leax      L10AD,pcr
                     pshs      x
                     lbsr      L1814
                     leas      $02,s
@@ -1500,7 +1457,7 @@ L0D50               ldd       $04,u
 L0D62               ldd       ,s
                     addd      #$000C
                     pshs      d
-                    leax      $10CC,pcr
+                    leax      L10CC,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -1558,10 +1515,10 @@ L0DDA               pshs      d
                     clra
                     andb      #$40
                     beq       L0DF2
-                    leax      $10D8,pcr
+                    leax      L10D8,pcr
                     bra       L0DF6
 
-L0DF2               leax      $10DA,pcr
+L0DF2               leax      L10DA,pcr
 L0DF6               tfr       x,d
                     pshs      d
                     leax      $10CF,pcr
@@ -1576,7 +1533,7 @@ L0E0D               pshs      u
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    leax      L10DB,pcr
+                    leax      $10DB,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -1740,9 +1697,9 @@ L0F65               std       ,s
                     ldd       $001D
                     std       ,u
                     stu       $001D
-                    ldd       L0013
+                    ldd       copybytes
                     addd      #$FFFF
-                    std       L0013
+                    std       copybytes
 L0F83               leas      $02,s
                     puls      pc,u
 L0F87               pshs      u,x,d
@@ -1784,7 +1741,7 @@ L0FC3               pshs      u
 
 L0FCF               ldd       #$0004
                     pshs      d
-                    lbsr      $17F3
+                    lbsr      L17F3
                     leas      $02,s
                     tfr       d,u
 L0FDB               clra
@@ -1819,7 +1776,7 @@ L1006               ldu       $0005
 
 L1010               ldd       #$005B
 L1013               pshs      d
-                    lbsr      $17F3
+                    lbsr      L17F3
                     leas      $02,s
                     tfr       d,u
 L101C               clra
@@ -1850,8 +1807,7 @@ L1047               ldd       $0005
                     ldd       $04,s
                     std       $0005
 L1050               puls      pc,u
-                    fcb       $72
-                    fcb       $61
+                    fcb       $72,$61
                     neg       $0073
                     fcb       $72
                     neg       $0065
@@ -1878,46 +1834,23 @@ L107F               com       -$0d,s
                     neg       $0076
                     com       0,x
                     ror       $7300
-L1088               neg       $756C
-                    com       >$002C
-                    neg       $6300
+L1088               fcc       /puls/
+                    fcb       $00
+L108D               bge       L10FF
+                    com       0,x
 L1091               fcb       $72
                     lsr       $7300
-L1095               fcb       $72
-                    fcb       $75
-                    jmp       0,y
-                    clr       -$0b,s
-                    lsr       L206F
-                    ror       0,y
-                    rol       $0e,s
-                    com       $7472
-                    fcb       $75
-                    com       -$0C,s
-                    rol       $0f,s
-                    jmp       -$0d,s
-                    neg       $0072
-                    fcb       $65
-                    tst       $0f,s
-                    ror       $696E
-                    asr       0,y
-                    lsr       $6F6F
-                    bra       $1128
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       L1129
-                    jmp       -$0d,s
-                    lsr       $7275
-                    com       -$0C,s
-                    rol       $0f,s
-                    jmp       -$0d,s
+L1095               fcc       /run out of instructions/
+                    fcb       $00
+L10AD               fcc       /removing too many instructions/
+                    fcb       $00
+L10CC               bcs       L1141
                     neg       L0025
-                    com       >L0025
-                    com       $6225
-                    com       L2025
-                    com       >$006C
-                    neg       $0000
-L10DB               bcs       $1150
-                    neg       L0020
+                    fcc       /sb%s %s/
+                    fcb       $00
+L10D8               inc       0,x
+L10DA               neg       L0025
+                    com       >L0020
                     bcs       $1154
                     neg       $0034
                     rora
@@ -1934,7 +1867,7 @@ L10EA               ldd       $02,u
                     leax      d,x
                     stx       ,s
                     ldd       [,s]
-                    std       $0e,u
+L10FF               std       $0e,u
                     stu       [,s]
                     leau      $10,u
 L1106               ldd       ,u
@@ -1953,7 +1886,7 @@ L111A               leax      >$0015,y
                     cmpu      ,s++
                     lbeq      L12F1
                     ldd       ,u
-L1129               std       $0a,s
+                    std       $0a,s
                     pshs      d
                     leax      >$0015,y
                     cmpx      ,s++
@@ -1962,7 +1895,7 @@ L1129               std       $0a,s
                     ldd       $04,x
                     lbeq      L11C3
                     ldd       $06,u
-                    clra
+L1141               clra
                     andb      #$20
                     lbeq      L12F1
                     ldd       $06,u
@@ -2764,11 +2697,9 @@ L17B5               bge       $17E4
                     com       >$002D
                     pshu      y,dp,b
                     com       >$006C
-                    fcb       $62
-                    fcb       $72
-                    fcb       $61
-                    neg       $0034
-                    rora
+                    fcb       $62,$72,$61
+                    fcb       $00
+L17F3               pshs      u,d
                     ldd       $06,s
                     pshs      d
                     lbsr      $273E
@@ -2784,7 +2715,7 @@ L1810               ldd       ,s
                     bra       L185A
 
 L1814               pshs      u
-                    leax      >$186E,pcr
+                    leax      >L186E,pcr
                     pshs      x
                     leax      $045f,y
                     pshs      x
@@ -2810,28 +2741,13 @@ L1835               pshs      d
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      L27D0
+                    lbsr      exit
 L185A               leas      $02,s
                     puls      pc,u
-L185E               tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       L206F
-                    ror       $6572
-                    ror       $0C,s
-                    clr       -$09,s
-                    neg       L0043
-                    bra       $18E0
-                    neg       $7469
-                    tst       $09,s
-                    com       $6572
-                    bra       $18E0
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    abx
-                    bra       L1882
-
+L185E               fcc       /memory overflow/
+                    fcb       $00
+L186E               fcc       /C optimiser error: /
+                    fcb       $00
 L1882               pshs      u
                     leau      $0445,y
 L1888               ldd       $06,u
@@ -3131,7 +3047,7 @@ L1AA9               leas      $04,s
 L1ACD               pshs      d
                     leax      L1F87,pcr
                     pshs      x
-                    bsr       L1AFF
+                    bsr       doprnt
                     leas      $06,s
                     puls      pc,u
                     pshs      u
@@ -3143,14 +3059,14 @@ L1ACD               pshs      d
                     pshs      d
                     leax      L1F9A,pcr
                     pshs      x
-                    bsr       L1AFF
+                    bsr       doprnt
                     leas      $06,s
                     clra
                     clrb
                     stb       [$086b,y]
                     ldd       $04,s
                     puls      pc,u
-L1AFF               pshs      u
+doprnt              pshs      u
                     ldu       $06,s
                     leas      -$0b,s
 L1B05               ldb       ,u+
@@ -3767,7 +3683,7 @@ L2013               ldd       $06,u
                     lbsr      L2108
                     leas      $02,s
 L2023               ldd       ,u
-L2025               addd      #$0001
+                    addd      #$0001
                     std       ,u
                     subd      #$0001
                     tfr       d,x
@@ -3799,7 +3715,7 @@ L2054               ldd       $04,s
                     pshs      d
                     lbsr      $1FB3
                     leas      $04,s
-L206F               ldd       $06,s
+                    ldd       $06,s
                     pshs      d
                     pshs      u
                     lbsr      $1FB3
@@ -4717,868 +4633,511 @@ L27C3               clra
 L27CC               bcs       L27C3
                     clra
                     clrb
-L27D0               rts
+exit                rts
                     lbsr      L27DC
                     lbsr      L207B
                     ldd       $02,s
                     os9       F$Exit
-L27DC               rts
-                    neg       $0007
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0004
-                    sbcb      >$0000
-                    fcb       $01
-                    bge       L27FD
+* ------------------------------------------------------------------
+* L27DC - cc1-style init image for the work block (see _start);
+* pure data: rts stub + count/block table + reloc dirs + module name.
+* ------------------------------------------------------------------
+L27DC               fcb       $39       init table / work-block image
+                    fcb       $00,$07,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$04,$F2,$00,$00,$01
+                    fcb       $2C
+                    fcb       $10
                     fcb       $52
                     fcb       $10
                     fcb       $55
                     fcb       $10
-                    aslb
+                    fcb       $58
                     fcb       $10
-                    fcb       $5b
+                    fcb       $5B
                     fcb       $10
-                    fcb       $5e
+                    fcb       $5E
                     fcb       $10
                     fcb       $61
                     fcb       $10
-                    lsr       -$10,x
-                    asr       -$10,x
-L27FD               dec       -$10,x
-                    tst       -$10,x
-                    neg       $1073
+                    fcb       $64
                     fcb       $10
-                    ror       L1079
+                    fcb       $67
                     fcb       $10
-                    inc       L107F
+                    fcb       $6A
                     fcb       $10
-                    sbca      #$10
-                    bita      #$64
-                    neg       $0078
-                    neg       $0079
-                    neg       $0075
-                    neg       L0064
-                    bge       L2893
-                    neg       L0064
-                    bge       $2898
-                    neg       L0064
-                    bge       $2898
-                    neg       L0064
-                    bge       $289F
-                    bge       $289E
-                    neg       L0064
-                    bge       L28A5
-                    bge       L28A8
-                    bge       L28A6
-                    neg       $0078
-                    bge       L28AA
-                    bge       L28A7
-                    com       0,x
-                    rol       L2C64
-                    neg       $0079
-                    bge       L28B5
-                    neg       $0075
-                    bge       L28A8
-                    neg       $0075
-                    bge       $28B8
-                    com       0,x
-                    com       $0C,s
-                    fcb       $72
-                    fcb       $61
-                    neg       $0063
-                    tst       -$10,s
-                    fcb       $62
-                    neg       $0063
-                    tst       -$10,s
-                    lsr       0,x
-                    com       $0d,s
-                    neg       $7800
-                    com       $0d,s
-                    neg       $7900
-                    com       $0d,s
-                    neg       $7500
-                    inc       $04,s
-                    fcb       $62
-                    neg       $006C
-                    lsr       $04,s
-                    neg       $006C
-                    lsr       -$08,s
-                    neg       $006C
-                    lsr       -$07,s
-                    neg       $006C
-                    lsr       -$0b,s
-                    neg       $0073
-                    lsr       $6200
-                    com       $7464
-                    neg       $0073
-                    lsr       $7800
-                    com       $7479
-                    neg       $0073
-                    lsr       $7500
-                    neg       $7368
-L2893               com       >$0070
+                    fcb       $6D
+                    fcb       $10
+                    fcb       $70
+                    fcb       $10
+                    fcb       $73
+                    fcb       $10
+                    fcb       $76
+                    fcb       $10
+                    fcb       $79
+                    fcb       $10
+                    fcb       $7C
+                    fcb       $10,$7F,$10,$82,$10,$85
+                    fcb       $64
+                    fcb       $00
+                    fcb       $78
+                    fcb       $00
+                    fcb       $79
+                    fcb       $00
                     fcb       $75
-                    inc       -$0d,s
-                    neg       $006C
-                    fcb       $65
-                    fcb       $61
-                    asl       >$006C
-                    fcb       $65
-                    fcb       $61
-                    rol       >$006C
-L28A5               fcb       $65
-L28A6               fcb       $61
-L28A7               fcb       $75
-L28A8               neg       $006C
-L28AA               fcb       $65
-                    fcb       $61
-                    com       >$0073
-                    fcb       $65
-                    asl       >L0074
-                    ror       -$0e,s
-L28B5               neg       $0023
-                    leax      0,x
-                    leas      $0C,y
-                    asl       >L0031
-                    bge       $2938
-                    neg       $0030
-                    bge       $293C
-                    neg       $002D
-                    leay      $0C,y
-                    asl       >$002D
-                    leas      $0C,y
-                    asl       >$0032
-                    bge       L294B
-                    neg       L0031
-                    bge       L294F
-                    neg       $0030
-                    bge       L2953
-                    neg       $002D
-                    leay      $0C,y
-                    rol       >$002D
-                    leas      $0C,y
-                    rol       >$0032
-                    bge       L295D
-                    neg       L0031
-                    bge       L2961
-                    neg       $0030
-                    bge       L2965
-                    neg       $002D
-                    leay      $0C,y
-                    fcb       $75
-                    neg       $002D
-                    leas      $0C,y
-                    fcb       $75
-                    neg       $0032
-                    bge       L2971
-                    neg       $0030
-                    bge       L2975
-                    neg       $002D
-                    leas      $0C,y
-                    com       >$0023
-                    cwai      #$00
-                    neg       $0002
-                    neg       L00BB
-                    neg       $0000
-                    neg       $00A7
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00BF
-                    neg       $0000
-                    neg       L00AB
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00B7
-                    neg       $0000
-                    neg       L00A3
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       $00A7
-                    neg       $0000
-                    neg       L00BB
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-L294B               neg       $0002
-                    neg       L00AB
-L294F               neg       $0000
-                    neg       L00BF
-L2953               neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0001
-L295D               neg       L00ED
-                    neg       L0074
-L2961               neg       L00CB
-                    neg       L004B
-L2965               neg       $0002
-                    neg       L004F
-                    neg       $0000
-                    neg       $0001
-                    neg       L00ED
-                    neg       $007C
-L2971               neg       L00CB
-                    neg       L004B
-L2975               neg       $0002
-                    neg       L0051
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L004D
-                    neg       L00CB
-                    neg       L004B
-                    neg       $0001
-                    neg       L0053
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       L00CB
-                    neg       L004B
-                    neg       $0001
-                    neg       L005B
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L004F
-                    neg       L00CB
-                    neg       L004B
-                    neg       $0001
-                    neg       L0057
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       L00CB
-                    neg       L004F
-                    neg       $0001
-                    neg       $0078
-                    neg       $0000
-                    neg       $0002
-                    neg       $00A7
-                    neg       $0000
-                    neg       L008F
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00AB
-                    neg       $0000
-                    neg       $0094
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00AF
-                    neg       $0000
-                    neg       L0099
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00B3
-                    neg       $0000
-                    neg       $009E
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00C3
-                    neg       $0000
-                    neg       L0099
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00C7
-                    neg       $0000
-                    neg       $009E
-                    neg       $00F1
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0002
-                    neg       L00A3
-                    neg       $0000
-                    neg       L00B7
-                    neg       $0001
-                    neg       $0001
-                    neg       $0001
-                    neg       $0000
-                    neg       $0001
-                    neg       L00E9
-                    neg       $0000
-                    neg       $0085
-                    neg       $0000
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0002
-                    neg       L00D5
-                    neg       $00F8
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    fcb       $02
-                    lbsr      $D34A
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    jmp       $0000
-                    neg       $0001
-                    lbra      $2A59
-                    lbsr      $D75A
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    bcc       L2A62
-L2A62               neg       $0001
-                    bge       L2A66
-L2A66               fcb       $02
-                    lbsr      $DB6A
-                    neg       $0000
-                    fcb       $02
-                    neg       L00D5
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    ldd       >$0002
-                    lbsr      $DF7A
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    lbra      L2A83
-L2A83               fcb       $01
-                    nop
-                    neg       $0002
-                    lbsr      $E38A
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    bge       L2A92
-L2A92               neg       $0001
-                    bvc       L2A96
-L2A96               fcb       $02
-                    lbsr      $E79A
-                    neg       $0000
-                    fcb       $02
-                    neg       L00D5
-                    neg       L00F4
-                    neg       $0000
-                    fcb       $01
-                    fcb       $05
-                    neg       $0002
-                    lbsr      $EBAA
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    dec       $0000
-                    neg       $0001
-                    fcb       $1b
-                    neg       $0002
-                    lbsr      $F0BA
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    bra       L2AC2
-
-L2AC2               neg       $0001
-                    leay      0,x
-                    fcb       $02
-                    lbsr      $F5CA
-                    neg       $0000
-                    fcb       $02
-                    neg       L00D5
-                    fcb       $01
-                    fcb       $05
-                    neg       $0000
-                    neg       $00FC
-                    neg       $0002
-                    lbsr      $FADA
-                    neg       $0000
-                    fcb       $02
-                    neg       $00DA
-                    fcb       $01
-                    fcb       $1b
-                    neg       $0000
-                    fcb       $01
-                    nop
-                    neg       $0002
-                    lbsr      $FFEA
-                    neg       $0000
-                    fcb       $02
-                    neg       L00DF
-                    fcb       $01
-                    leay      0,x
-                    neg       $0001
-                    bvc       L2AF6
-L2AF6               fcb       $02
-                    lbsr      $04FA
-                    neg       $0000
-                    fcb       $02
-                    neg       L00E9
-                    neg       $0000
-                    neg       L008F
-                    fcb       $01
-                    coma
-                    neg       $008A
-                    neg       $0002
-                    neg       $0000
-                    neg       $0002
-                    neg       $0085
-                    neg       $0000
-                    neg       L008F
-                    fcb       $01
-                    coma
-                    neg       $008A
-                    neg       $0002
-                    neg       $0000
-                    neg       $0002
-                    neg       $00E4
-                    fcb       $01
-                    fcb       $36,$00
-                    adda      $013E
-                    neg       $0002
-                    lbsr      $0A2A
-                    neg       $0000
-                    fcb       $02
-                    neg       $00E4
-                    fcb       $01
-                    fcb       $36,$00
-                    addb      #$00
-                    fcb       $4b
-                    neg       L00BB
-                    fcb       $01
-                    abx
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       $00E4
-                    fcb       $01
-                    fcb       $3E
-                    neg       $0001
-                    neg       L005B
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       $00E4
-                    lbsr      L0F56
-                    fcb       $01
-                    neg       $005F
-                    neg       $0000
-                    neg       $0002
-                    neg       L00CB
-                    neg       L0051
-                    neg       $00E4
-                    lbsr      $1466
-                    fcb       $01
-                    neg       $0065
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0002
-                    neg       $0038
-                    fcb       $38
-                    bvc       $2BD9
-                    bvc       $2BDB
-                    bvc       L2BDD
-                    bvc       L2BDF
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    bhi       $2BE2
-                    bhi       $2BE4
-                    bhi       $2BE6
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-L2BDD               neg       $0004
-L2BDF               lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0000
-                    neg       $0000
-                    neg       $0000
-                    beq       L2C0F
-                    com       $00E8
-                    neg       L0064
-                    neg       $000A
-                    lsr       $0040
-                    inc       -$08,s
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-L2C0F               neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-L2C64               neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       L0021
-                    fcb       $02
-                    sbcb      #$02
-                    sbca      $02A2
-                    fcb       $02
-                    sbca      $0002
-                    sbca      #$03
-                    leas      $03,x
-                    bhi       L2CEE
-                    nop
-                    com       $0002
-L2CEE               fcb       $02
-                    sbcb      L02E2
-                    fcb       $02
-                    sbcb      $0000
-                    blt       L2CF7
-L2CF7               bmi       L2CF9
-L2CF9               bvs       L2CFB
-L2CFB               beq       $2D00
-                    ldx       $0003
-                    ldx       #$0362
-                    neg       L003B
-                    neg       L0039
-                    neg       L0037
-                    neg       L0035
-                    neg       $0033
-                    neg       L0031
-                    neg       L002F
-                    neg       $0049
-                    neg       L0047
-                    neg       L0045
-                    neg       L0043
-                    neg       L0041
-                    neg       $003F
-                    neg       L003D
-                    neg       $0082
-                    fcb       $01
-                    aslb
-                    fcb       $01
-                    inca
-                    fcb       $01
-                    asla
-                    lsr       $0040
-                    fcb       $01
-                    cmpx      #$0188
-                    fcb       $01
-                    inc       L0178
-                    fcb       $01
-                    inc       $01,x
-                    asl       $01,x
-                    incb
-                    fcb       $01
-                    ora       $01,x
-                    eora      $01,x
-                    sbca      $01,x
-                    ldx       $0001
-                    cmpx      $0001
-                    ora       $0001
-                    eora      $0001
-                    ldx       $01BC
-                    fcb       $01
-                    ora       L01B8
-                    fcb       $01
-                    sbca      $01AE
-                    fcb       $01
-                    cmpx      $01,x
-                    eorb      $0001
-                    sbcb      $0001
-                    ldu       #$01CC
-                    fcb       $01
-                    orb       #$01
-                    eorb      #$01
-                    sbcb      #$01
-                    ldd       $01,x
-                    orb       $01,x
-                    eorb      $01,x
-                    sbcb      $01,x
-                    ldu       $0001
-                    ldd       $0001
-                    orb       $0002
-                    inc       $0002
-                    asl       $0001
-                    ldu       L01FC
-                    fcb       $01
-                    eorb      $01F2
-                    fcb       $01
-                    ldu       $02,x
-                    bgt       L2D81
-                    bge       L2D83
-L2D81               bvc       L2D85
-L2D83               exg       d,y
-L2D85               andcc     #$02
-                    fcb       $18
-                    fcb       $02
-                    jmp       $0002
-                    aslb
-                    fcb       $02
-                    fcb       $4e
-                    fcb       $02
-                    inca
-                    fcb       $02
-                    asla
-                    fcb       $02
-                    fcb       $3E
-                    fcb       $02
-                    cwai      #$02
-                    fcb       $38
-                    fcb       $02
-                    eora      #$02
-                    jmp       $027A
-                    fcb       $02
-                    asl       L026C
-                    fcb       $02
-                    asl       $02,x
-                    incb
-                    fcb       $02
-                    ora       $02,x
-                    eora      $02,x
-                    ldx       $0002
-                    ora       $0002
-                    eora      $0002
-                    ldx       #$028A
-                    fcb       $02
-                    ldu       #$02CA
-                    fcb       $02
-                    eorb      #$02
-                    ldx       $02BA
-                    fcb       $02
-                    eora      $02AE
-                    fcb       $02
-                    eorb      $02EE
-                    fcb       $02
-                    orb       $02,x
-                    eorb      $02,x
-                    ldu       $0002
-                    orb       $0002
-                    eorb      $0003
-                    orcc      #$03
-                    fcb       $18
-                    com       $000E
-                    com       $000A
-                    com       $0008
-                    fcb       $02
-                    ldu       L02FA
-                    com       $003E
-                    com       $003C
-                    com       $0038
-                    com       $002E
-                    com       $002A
-                    com       $0028
-                    com       L001E
-                    com       $005A
-                    com       $0058
-                    com       $0050
-                    com       $004E
-                    com       $004C
-                    com       L0048
-                    com       $0040
-                    com       $0070
-                    com       $006E
-                    com       $006C
-                    com       $006A
-                    com       $0068
-                    com       L005E
-                    com       $005C
-                    com       $0088
-                    com       $0082
-                    com       $007E
-                    com       $007C
-                    com       $007A
-                    com       $0078
-                    com       $0072
-                    com       $00A2
-                    com       $009C
-                    com       $009A
-                    com       $0098
-                    com       $0092
-                    com       $008C
-                    com       $008A
-                    com       $0e,y
-                    clr       -$10,s
+                    fcb       $00
+                    fcb       $64,$2C,$78
+                    fcb       $00
+                    fcb       $64,$2C,$79
+                    fcb       $00
+                    fcb       $64,$2C,$75
+                    fcb       $00
+                    fcc       /d,x,u/
+                    fcb       $00
+                    fcc       /d,x,y,u/
+                    fcb       $00
+                    fcc       /x,u,pc/
+                    fcb       $00
+                    fcb       $79,$2C,$64
+                    fcb       $00
+                    fcb       $79,$2C,$75
+                    fcb       $00
+                    fcb       $75,$2C,$64
+                    fcb       $00
+                    fcc       /u,pc/
+                    fcb       $00
+                    fcc       /clra/
+                    fcb       $00
+                    fcc       /cmpb/
+                    fcb       $00
+                    fcc       /cmpd/
+                    fcb       $00
+                    fcc       /cmpx/
+                    fcb       $00
+                    fcc       /cmpy/
+                    fcb       $00
+                    fcc       /cmpu/
+                    fcb       $00
+                    fcb       $6C,$64,$62
+                    fcb       $00
+                    fcb       $6C,$64,$64
+                    fcb       $00
+                    fcb       $6C,$64,$78
+                    fcb       $00
+                    fcb       $6C,$64,$79
+                    fcb       $00
+                    fcb       $6C,$64,$75
+                    fcb       $00
+                    fcb       $73,$74,$62
+                    fcb       $00
+                    fcb       $73,$74,$64
+                    fcb       $00
+                    fcb       $73,$74,$78
+                    fcb       $00
+                    fcb       $73,$74,$79
+                    fcb       $00
+                    fcb       $73,$74,$75
+                    fcb       $00
+                    fcc       /pshs/
+                    fcb       $00
+                    fcc       /puls/
+                    fcb       $00
+                    fcc       /leax/
+                    fcb       $00
+                    fcc       /leay/
+                    fcb       $00
+                    fcc       /leau/
+                    fcb       $00
+                    fcc       /leas/
+                    fcb       $00
+                    fcb       $73,$65,$78
+                    fcb       $00
+                    fcb       $74,$66,$72
+                    fcb       $00
+                    fcb       $23,$30
+                    fcb       $00
+                    fcb       $32,$2C,$78
+                    fcb       $00
+                    fcb       $31,$2C,$78
+                    fcb       $00
+                    fcb       $30,$2C,$78
+                    fcb       $00
+                    fcc       /-1,x/
+                    fcb       $00
+                    fcc       /-2,x/
+                    fcb       $00
+                    fcb       $32,$2C,$79
+                    fcb       $00
+                    fcb       $31,$2C,$79
+                    fcb       $00
+                    fcb       $30,$2C,$79
+                    fcb       $00
+                    fcc       /-1,y/
+                    fcb       $00
+                    fcc       /-2,y/
+                    fcb       $00
+                    fcb       $32,$2C,$75
+                    fcb       $00
+                    fcb       $31,$2C,$75
+                    fcb       $00
+                    fcb       $30,$2C,$75
+                    fcb       $00
+                    fcc       /-1,u/
+                    fcb       $00
+                    fcc       /-2,u/
+                    fcb       $00
+                    fcb       $32,$2C,$73
+                    fcb       $00
+                    fcb       $30,$2C,$73
+                    fcb       $00
+                    fcc       /-2,s/
+                    fcb       $00
+                    fcb       $23,$3C
+                    fcb       $00,$00,$02,$00,$BB,$00,$00,$00
+                    fcb       $A7,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$BF,$00,$00,$00
+                    fcb       $AB,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$B7,$00,$00,$00
+                    fcb       $A3,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$A7,$00,$00,$00
+                    fcb       $BB,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$02,$00,$AB,$00,$00,$00
+                    fcb       $BF,$00,$01,$00,$01,$00,$01,$00
+                    fcb       $00,$00,$01,$00,$ED,$00
                     fcb       $74
-
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$02,$00
+                    fcb       $4F
+                    fcb       $00,$00,$00,$01,$00,$ED,$00
+                    fcb       $7C
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$02,$00
+                    fcb       $51
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $4D
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$01,$00
+                    fcb       $53
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$01,$00
+                    fcb       $5B
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $4F
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$01,$00
+                    fcb       $57
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$CB,$00
+                    fcb       $4F
+                    fcb       $00,$01,$00
+                    fcb       $78
+                    fcb       $00,$00,$00,$02,$00,$A7,$00,$00
+                    fcb       $00,$8F,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$AB,$00,$00
+                    fcb       $00,$94,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$AF,$00,$00
+                    fcb       $00,$99,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$B3,$00,$00
+                    fcb       $00,$9E,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$C3,$00,$00
+                    fcb       $00,$99,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$C7,$00,$00
+                    fcb       $00,$9E,$00,$F1,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$02,$00,$A3,$00,$00
+                    fcb       $00,$B7,$00,$01,$00,$01,$00,$01
+                    fcb       $00,$00,$00,$01,$00,$E9,$00,$00
+                    fcb       $00,$85,$00,$00,$00,$02,$00,$00
+                    fcb       $00,$00,$00,$02,$00,$D5,$00,$F8
+                    fcb       $00,$00,$01,$00,$00,$02,$17,$A9
+                    fcb       $00,$00,$00,$02,$00,$DA,$01,$0E
+                    fcb       $00,$00,$01,$16,$00,$02,$17,$AD
+                    fcb       $00,$00,$00,$02,$00,$DF,$01
+                    fcb       $24
+                    fcb       $00,$00,$01
+                    fcb       $2C
+                    fcb       $00,$02,$17,$B1,$00,$00,$00,$02
+                    fcb       $00,$D5,$01,$00,$00,$00,$00,$FC
+                    fcb       $00,$02,$17,$B5,$00,$00,$00,$02
+                    fcb       $00,$DA,$01,$16,$00,$00,$01,$12
+                    fcb       $00,$02,$17,$B9,$00,$00,$00,$02
+                    fcb       $00,$DF,$01
+                    fcb       $2C
+                    fcb       $00,$00,$01
+                    fcb       $28
+                    fcb       $00,$02,$17,$BD,$00,$00,$00,$02
+                    fcb       $00,$D5,$00,$F4,$00,$00,$01,$05
+                    fcb       $00,$02,$17,$C1,$00,$00,$00,$02
+                    fcb       $00,$DA,$01,$0A,$00,$00,$01,$1B
+                    fcb       $00,$02,$17,$C6,$00,$00,$00,$02
+                    fcb       $00,$DF,$01
+                    fcb       $20
+                    fcb       $00,$00,$01
+                    fcb       $31
+                    fcb       $00,$02,$17,$CB,$00,$00,$00,$02
+                    fcb       $00,$D5,$01,$05,$00,$00,$00,$FC
+                    fcb       $00,$02,$17,$D0,$00,$00,$00,$02
+                    fcb       $00,$DA,$01,$1B,$00,$00,$01,$12
+                    fcb       $00,$02,$17,$D5,$00,$00,$00,$02
+                    fcb       $00,$DF,$01
+                    fcb       $31
+                    fcb       $00,$00,$01
+                    fcb       $28
+                    fcb       $00,$02,$17,$DA,$00,$00,$00,$02
+                    fcb       $00,$E9,$00,$00,$00,$8F,$01
+                    fcb       $43
+                    fcb       $00,$8A,$00,$02,$00,$00,$00,$02
+                    fcb       $00,$85,$00,$00,$00,$8F,$01
+                    fcb       $43
+                    fcb       $00,$8A,$00,$02,$00,$00,$00,$02
+                    fcb       $00,$E4,$01
+                    fcb       $36
+                    fcb       $00,$BB,$01
+                    fcb       $3E
+                    fcb       $00,$02,$17,$DF,$00,$00,$00,$02
+                    fcb       $00,$E4,$01
+                    fcb       $36
+                    fcb       $00,$CB,$00
+                    fcb       $4B
+                    fcb       $00,$BB,$01
+                    fcb       $3A
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$E4,$01
+                    fcb       $3E
+                    fcb       $00,$01,$00
+                    fcb       $5B
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$E4,$17,$E4,$00,$01,$00
+                    fcb       $5F
+                    fcb       $00,$00,$00,$02,$00,$CB,$00
+                    fcb       $51
+                    fcb       $00,$E4,$17,$E9,$00,$01,$00
+                    fcb       $65
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$02,$00
+                    fcc       /88((((((((/
+                    fcb       $00,$00,$00,$00,$00,$00,$02
+                    fcc       /""""""/
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$00,$00,$00,$00
+                    fcb       $02,$00,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$00,$00,$00,$00
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$04
+                    fcb       $40,$6C,$78
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
+                    fcb       $42
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00
+                    fcb       $21
+                    fcb       $02,$C2,$02,$B2,$02,$A2,$02,$92
+                    fcb       $02,$82,$03
+                    fcb       $32
+                    fcb       $03
+                    fcb       $22
+                    fcb       $03,$12,$03,$02,$02,$F2,$02,$E2
+                    fcb       $02,$D2,$00
+                    fcb       $2D
+                    fcb       $00
+                    fcb       $2B
+                    fcb       $00
+                    fcb       $29
+                    fcb       $00
+                    fcb       $27
+                    fcb       $03,$9E,$03,$8E,$03
+                    fcb       $62
+                    fcb       $00
+                    fcb       $3B
+                    fcb       $00
+                    fcb       $39
+                    fcb       $00
+                    fcb       $37
+                    fcb       $00
+                    fcb       $35
+                    fcb       $00
+                    fcb       $33
+                    fcb       $00
+                    fcb       $31
+                    fcb       $00
+                    fcb       $2F
+                    fcb       $00
+                    fcb       $49
+                    fcb       $00
+                    fcb       $47
+                    fcb       $00
+                    fcb       $45
+                    fcb       $00
+                    fcb       $43
+                    fcb       $00
+                    fcb       $41
+                    fcb       $00
+                    fcb       $3F
+                    fcb       $00
+                    fcb       $3D
+                    fcb       $00,$82,$01
+                    fcb       $58
+                    fcb       $01
+                    fcb       $4C
+                    fcb       $01
+                    fcb       $48
+                    fcb       $04
+                    fcb       $40
+                    fcb       $01,$8C,$01,$88,$01
+                    fcb       $7C
+                    fcb       $01
+                    fcb       $78
+                    fcb       $01
+                    fcb       $6C
+                    fcb       $01
+                    fcb       $68
+                    fcb       $01
+                    fcb       $5C
+                    fcb       $01,$AA,$01,$A8,$01,$A2,$01,$9E
+                    fcb       $01,$9C,$01,$9A,$01,$98,$01,$BE
+                    fcb       $01,$BC,$01,$BA,$01,$B8,$01,$B2
+                    fcb       $01,$AE,$01,$AC,$01,$D8,$01,$D2
+                    fcb       $01,$CE,$01,$CC,$01,$CA,$01,$C8
+                    fcb       $01,$C2,$01,$EC,$01,$EA,$01,$E8
+                    fcb       $01,$E2,$01,$DE,$01,$DC,$01,$DA
+                    fcb       $02,$0C,$02,$08,$01,$FE,$01,$FC
+                    fcb       $01,$F8,$01,$F2,$01,$EE,$02
+                    fcb       $2E
+                    fcb       $02
+                    fcb       $2C
+                    fcb       $02
+                    fcb       $28
+                    fcb       $02,$1E,$02,$1C,$02,$18,$02,$0E
+                    fcb       $02
+                    fcb       $58
+                    fcb       $02
+                    fcb       $4E
+                    fcb       $02
+                    fcb       $4C
+                    fcb       $02
+                    fcb       $48
+                    fcb       $02
+                    fcb       $3E
+                    fcb       $02
+                    fcb       $3C
+                    fcb       $02
+                    fcb       $38
+                    fcb       $02,$88,$02
+                    fcb       $7E
+                    fcb       $02
+                    fcb       $7A
+                    fcb       $02
+                    fcb       $78
+                    fcb       $02
+                    fcb       $6C
+                    fcb       $02
+                    fcb       $68
+                    fcb       $02
+                    fcb       $5C
+                    fcb       $02,$AA,$02,$A8,$02,$9E,$02,$9A
+                    fcb       $02,$98,$02,$8E,$02,$8A,$02,$CE
+                    fcb       $02,$CA,$02,$C8,$02,$BE,$02,$BA
+                    fcb       $02,$B8,$02,$AE,$02,$F8,$02,$EE
+                    fcb       $02,$EA,$02,$E8,$02,$DE,$02,$DA
+                    fcb       $02,$D8,$03,$1A,$03,$18,$03,$0E
+                    fcb       $03,$0A,$03,$08,$02,$FE,$02,$FA
+                    fcb       $03
+                    fcb       $3E
+                    fcb       $03
+                    fcb       $3C
+                    fcb       $03
+                    fcb       $38
+                    fcb       $03
+                    fcb       $2E
+                    fcb       $03
+                    fcb       $2A
+                    fcb       $03
+                    fcb       $28
+                    fcb       $03,$1E,$03
+                    fcb       $5A
+                    fcb       $03
+                    fcb       $58
+                    fcb       $03
+                    fcb       $50
+                    fcb       $03
+                    fcb       $4E
+                    fcb       $03
+                    fcb       $4C
+                    fcb       $03
+                    fcb       $48
+                    fcb       $03
+                    fcb       $40
+                    fcb       $03
+                    fcb       $70
+                    fcb       $03
+                    fcb       $6E
+                    fcb       $03
+                    fcb       $6C
+                    fcb       $03
+                    fcb       $6A
+                    fcb       $03
+                    fcb       $68
+                    fcb       $03
+                    fcb       $5E
+                    fcb       $03
+                    fcb       $5C
+                    fcb       $03,$88,$03,$82,$03
+                    fcb       $7E
+                    fcb       $03
+                    fcb       $7C
+                    fcb       $03
+                    fcb       $7A
+                    fcb       $03
+                    fcb       $78
+                    fcb       $03
+                    fcb       $72
+                    fcb       $03,$A2,$03,$9C,$03,$9A,$03,$98
+                    fcb       $03,$92,$03,$8C,$03,$8A
+                    fcc       /c.opt/
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -135,23 +135,39 @@ stkinit             leax      $0887,y
                     cmpx      $055f,y
                     bcs       L013A
                     stx       $0561,y
-L0120               fcb       $39
-L0121               fcc       /**** STACK OVERFLOW ****/
-                    fcb       $0D
+L0120               rts
+
+L0121               bpl       $014D
+                    bpl       L014F
+                    bra       L017A
+                    lsrb
+                    fcb       $41
+                    coma
+                    fcb       $4B
+                    bra       $017C
+                    rorb
+                    fcb       $45,$52
+                    rora
+                    inca
+                    clra
+                    asrb
+                    bra       L0160
+                    bpl       $0162
+                    bpl       L0147
 L013A               leax      L0121,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
-                    os9       I$WritLn
+L0147               os9       I$WritLn
                     clr       ,-s
                     lbsr      L27D6
-                    ldd       $0553,y
+L014F               ldd       $0553,y
                     subd      $0561,y
                     rts
                     ldd       $0561,y
                     subd      $055f,y
-                    rts
+L0160               rts
 
 L0161               pshs      x
                     leax      d,y
@@ -165,7 +181,7 @@ L0169               ldd       ,y++
                     cmpy      ,s
                     bne       L0169
 L0178               leas      $04,s
-                    rts
+L017A               rts
 
 main                pshs      u
                     leas      -$08,s
@@ -281,7 +297,7 @@ L026C               leas      $06,s
                     bne       L0283
                     ldd       $02,s
                     pshs      d
-                    leax      $06C5,pcr
+                    leax      L06C5,pcr
                     pshs      x
                     lbsr      L1814
                     leas      $04,s
@@ -297,7 +313,7 @@ L0283               ldd       ,s
                     bne       L02AB
                     ldd       ,s
                     pshs      d
-                    leax      $06D5,pcr
+                    leax      L06D5,pcr
                     pshs      x
                     lbsr      L1814
                     leas      $04,s
@@ -318,7 +334,7 @@ L02AB               ldd       $0567,y
                     leas      $04,s
                     ldd       $0009
                     pshs      d
-                    leax      $06F0,pcr
+                    leax      L06F0,pcr
                     pshs      x
 L02E2               leax      $045f,y
                     pshs      x
@@ -553,7 +569,7 @@ L04DE               leax      L0790,pcr
                     beq       L053B
                     lbra      L056C
 
-L04F5               leax      $0794,pcr
+L04F5               leax      L0794,pcr
 L04F9               pshs      x
                     leax      $6b,s
                     pshs      x
@@ -694,7 +710,7 @@ L0625               ldd       $0565,y
                     beq       L0660
                     leax      $0C,s
                     pshs      x
-                    leax      $07A2,pcr
+                    leax      L07A2,pcr
                     pshs      x
                     leax      L079E,pcr
                     pshs      x
@@ -723,7 +739,7 @@ L0671               pshs      u
 L0681               lbsr      L0D20
 L0684               ldd       copybytes
                     bne       L0681
-L0688               leax      L07A3,pcr
+L0688               leax      $07A3,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -738,18 +754,17 @@ L069F               fcc       /unknown option '%s'/
 L06B4               fcc       /too many files/
                     fcb       $00
 L06C3               fcb       $72
-                    neg       $0063
-                    fcc       /an't open %s/
                     fcb       $00
-L06D3               asr       >$0063
-                    fcc       /an't open %s/
+L06C5               fcc       /can't open %s/
                     fcb       $00
-L06E3               com       $7461
-                    lsr       $6973
-                    lsr       $6963
-                    com       $3A0D
-                    neg       $0009
-                    fcc       /total instructions : %d/
+L06D3               fcb       $77
+                    fcb       $00
+L06D5               fcc       /can't open %s/
+                    fcb       $00
+L06E3               fcc       /statistics:/
+                    fcb       $0D,$00
+L06F0               rol       L0074
+                    fcc       /otal instructions : %d/
                     fcb       $0D,$00
 L070A               rol       $006C
                     fcc       /ong branches :  %5d, %5d, %3d%%/
@@ -764,24 +779,23 @@ L0775               fcc       /endsect/
                     fcb       $00
 L077D               fcc       /info/
                     fcb       $00
-L0782               jmp       $01,s
-                    tst       0,x
-L0786               bcs       $07FB
-                    tst       $0000
+L0782               fcb       $6E,$61,$6D
+                    fcb       $00
+L0786               fcb       $25,$73
+                    fcb       $0D,$00
 L078A               fcc       /psect/
                     fcb       $00
-L0790               lsr       $746C
-                    neg       $0076
-                    fcc       /sect/
+L0790               fcb       $74,$74,$6C
                     fcb       $00
-L079A               bcs       $080F
-                    tst       $0000
-L079E               jmp       $0f,s
-                    neg       >$0000
-L07A3               bra       $080A
-                    jmp       $04,s
-                    com       $6563
-                    lsr       $0D00
+L0794               fcc       /vsect/
+                    fcb       $00
+L079A               fcb       $25,$73
+                    fcb       $0D,$00
+L079E               fcb       $6E,$6F,$70
+                    fcb       $00
+L07A2               neg       L0020
+                    fcc       /endsect/
+                    fcb       $0D,$00
 L07AD               pshs      u
                     ldu       $06,s
                     leas      -$02,s
@@ -1521,7 +1535,7 @@ L0DDA               pshs      d
 L0DF2               leax      L10DA,pcr
 L0DF6               tfr       x,d
                     pshs      d
-                    leax      $10CF,pcr
+                    leax      L10CF,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
@@ -1808,47 +1822,57 @@ L1047               ldd       $0005
                     std       $0005
 L1050               puls      pc,u
                     fcb       $72,$61
-                    neg       $0073
-                    fcb       $72
-                    neg       $0065
-                    fcb       $71
-                    neg       $006E
-                    fcb       $65
-                    neg       $006C
-                    lsr       >L0067
-                    fcb       $65
-                    neg       $006C
-                    fcb       $65
-                    neg       L0067
-                    lsr       >$006C
-                    clr       0,x
-                    asl       -$0d,s
-                    neg       $006C
-                    com       >$0068
-                    rol       0,x
-                    neg       $6C00
-L1079               tst       $09,s
-                    neg       $0063
-                    com       0,x
-L107F               com       -$0d,s
-                    neg       $0076
-                    com       0,x
-                    ror       $7300
+                    fcb       $00
+                    fcb       $73,$72
+                    fcb       $00
+                    fcb       $65,$71
+                    fcb       $00
+                    fcb       $6E,$65
+                    fcb       $00
+                    fcb       $6C,$74
+                    fcb       $00
+                    fcb       $67,$65
+                    fcb       $00
+                    fcb       $6C,$65
+                    fcb       $00
+                    fcb       $67,$74
+                    fcb       $00
+                    fcb       $6C,$6F
+                    fcb       $00
+                    fcb       $68,$73
+                    fcb       $00
+                    fcb       $6C,$73
+                    fcb       $00
+L1073               fcb       $68,$69
+                    fcb       $00
+                    fcb       $70,$6C
+                    fcb       $00
+L1079               fcb       $6D,$69
+                    fcb       $00
+                    fcb       $63,$63
+                    fcb       $00
+L107F               fcb       $63,$73
+                    fcb       $00
+                    fcb       $76,$63
+                    fcb       $00
+                    fcb       $76,$73
+                    fcb       $00
 L1088               fcc       /puls/
                     fcb       $00
-L108D               bge       L10FF
-                    com       0,x
-L1091               fcb       $72
-                    lsr       $7300
+L108D               fcb       $2C,$70,$63
+                    fcb       $00
+L1091               fcb       $72,$74,$73
+                    fcb       $00
 L1095               fcc       /run out of instructions/
                     fcb       $00
 L10AD               fcc       /removing too many instructions/
                     fcb       $00
-L10CC               bcs       L1141
-                    neg       L0025
-                    fcc       /sb%s %s/
+L10CC               fcb       $25,$73
                     fcb       $00
-L10D8               inc       0,x
+L10CF               fcc       /%sb%s %s/
+                    fcb       $00
+L10D8               fcb       $6C
+                    fcb       $00
 L10DA               neg       L0025
                     com       >L0020
                     bcs       $1154
@@ -1867,7 +1891,7 @@ L10EA               ldd       $02,u
                     leax      d,x
                     stx       ,s
                     ldd       [,s]
-L10FF               std       $0e,u
+                    std       $0e,u
                     stu       [,s]
                     leau      $10,u
 L1106               ldd       ,u
@@ -1895,7 +1919,7 @@ L111A               leax      >$0015,y
                     ldd       $04,x
                     lbeq      L11C3
                     ldd       $06,u
-L1141               clra
+                    clra
                     andb      #$20
                     lbeq      L12F1
                     ldd       $06,u
@@ -2605,7 +2629,7 @@ L171D               ldd       ,s
                     ldd       $04,s
                     addd      #$000C
                     pshs      d
-                    leax      $17EE,pcr
+                    leax      L17EE,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0A92
@@ -2665,39 +2689,37 @@ L17A1               ldd       $06,s
                     bne       L1766
                     leas      $02,s
                     puls      pc,u
-                    bge       $1823
-                    bmi       L17AD
-L17AD               bge       $1828
-                    bmi       L17B1
-L17B1               bge       $1828
-                    bmi       L17B5
-L17B5               bge       $17E4
-                    asl       >$002C
-                    blt       L1835
-                    neg       $002C
-                    blt       L1835
-                    neg       $002C
-                    asl       L2B2B
-                    neg       $002C
-                    rol       L2B2B
-                    neg       $002C
-                    fcb       $75
-                    bmi       $17FA
-                    neg       $002C
-                    blt       L1800
-                    asl       >$002C
-                    blt       $1805
-                    rol       >$002C
-                    blt       L180A
-                    fcb       $75
-                    neg       $002C
-                    com       L2B2B
-                    neg       $002D
-                    pshs      y,dp,b
-                    com       >$002D
-                    pshu      y,dp,b
-                    com       >$006C
-                    fcb       $62,$72,$61
+                    fcb       $2C,$78,$2B
+                    fcb       $00
+                    fcb       $2C,$79,$2B
+                    fcb       $00
+                    fcb       $2C,$75,$2B
+                    fcb       $00
+                    fcb       $2C,$2D,$78
+                    fcb       $00
+                    fcb       $2C,$2D,$79
+                    fcb       $00
+                    fcb       $2C,$2D,$75
+                    fcb       $00
+                    fcc       /,x++/
+                    fcb       $00
+                    fcc       /,y++/
+                    fcb       $00
+                    fcc       /,u++/
+                    fcb       $00
+                    fcc       /,--x/
+                    fcb       $00
+                    fcc       /,--y/
+                    fcb       $00
+                    fcc       /,--u/
+                    fcb       $00
+                    fcc       /,s++/
+                    fcb       $00
+                    fcc       /-4,s/
+                    fcb       $00
+                    fcc       /-6,s/
+                    fcb       $00
+L17EE               fcc       /lbra/
                     fcb       $00
 L17F3               pshs      u,d
                     ldd       $06,s
@@ -2705,10 +2727,10 @@ L17F3               pshs      u,d
                     lbsr      L273E
                     leas      $02,s
                     std       ,s
-L1800               cmpd      #$FFFF
+                    cmpd      #$FFFF
                     bne       L1810
                     leax      >L185E,pcr
-L180A               pshs      x
+                    pshs      x
                     bsr       L1814
                     leas      $02,s
 L1810               ldd       ,s
@@ -2728,7 +2750,7 @@ L1814               pshs      u
                     ldd       $0a,s
                     pshs      d
                     ldd       $0a,s
-L1835               pshs      d
+                    pshs      d
                     leax      $045f,y
                     pshs      x
                     lbsr      fprintf
@@ -4906,8 +4928,8 @@ L27DC               fcb       $00,$07,$00,$00,$00,$00,$00,$00 init table / work-
                     fcb       $36
                     fcb       $00,$BB,$01
                     fcb       $3E
-                    fcb       $00,$02,$17,$DF,$00,$00,$00
-L2B2B               fcb       $02,$00,$E4,$01
+                    fcb       $00,$02,$17,$DF,$00,$00,$00,$02
+                    fcb       $00,$E4,$01
                     fcb       $36
                     fcb       $00,$CB,$00
                     fcb       $4B

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -1,0 +1,5584 @@
+                    nam       c.opt
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $04
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       5127
+size                equ       .
+
+name                equ       *
+                    fcs       /c.opt/
+                    fcb       edition
+
+L0013               lda       ,y+
+L0015               sta       ,u+
+L0017               leax      -$01,x
+L0019               bne       L0013
+L001B               rts
+
+start               pshs      y
+L001E               pshs      u
+L0020               clra
+L0021               clrb
+L0022               sta       ,u+
+L0024               decb
+L0025               bne       L0022
+                    ldx       ,s
+                    leau      ,x
+L002B               leax      $0887,x
+L002F               pshs      x
+L0031               leay      L27DC,pcr
+L0035               ldx       ,y++
+L0037               beq       L003D
+L0039               bsr       L0013
+L003B               ldu       $02,s
+L003D               leau      >$0023,u
+L0041               ldx       ,y++
+L0043               beq       L0048
+L0045               bsr       L0013
+L0047               clra
+L0048               cmpu      ,s
+L004B               beq       L0051
+L004D               sta       ,u+
+L004F               bra       L0048
+
+L0051               ldu       $02,s
+L0053               ldd       ,y++
+                    beq       L005E
+L0057               leax      >$0000,pcr
+L005B               lbsr      L0161
+L005E               ldd       ,y++
+L0060               beq       L0067
+L0062               leax      ,u
+L0064               lbsr      L0161
+L0067               leas      $04,s
+L0069               puls      x
+                    stx       $0555,u
+L006F               sty       $0515,u
+L0074               ldd       #$0001
+L0077               std       $0551,u
+                    leay      $0517,u
+                    leax      ,s
+                    lda       ,x+
+L0083               ldb       $0552,u
+                    cmpb      #$1d
+                    beq       L00DF
+L008B               cmpa      #$0d
+                    beq       L00DF
+L008F               cmpa      #$20
+                    beq       L0097
+                    cmpa      #$2C
+                    bne       L009B
+L0097               lda       ,x+
+L0099               bra       L008B
+
+L009B               cmpa      #$22
+                    beq       L00A3
+                    cmpa      #$27
+                    bne       L00C1
+L00A3               stx       ,y++
+                    inc       $0552,u
+                    pshs      a
+L00AB               lda       ,x+
+                    cmpa      #$0d
+L00AF               beq       L00B5
+                    cmpa      ,s
+L00B3               bne       L00AB
+L00B5               puls      b
+L00B7               clr       -$01,x
+                    cmpa      #$0d
+L00BB               beq       L00DF
+                    lda       ,x+
+L00BF               bra       L0083
+
+L00C1               leax      -$01,x
+L00C3               stx       ,y++
+                    leax      $01,x
+L00C7               inc       $0552,u
+L00CB               cmpa      #$0d
+                    beq       L00DB
+                    cmpa      #$20
+                    beq       L00DB
+                    cmpa      #$2C
+L00D5               beq       L00DB
+                    lda       ,x+
+                    bra       L00CB
+
+L00DB               clr       -$01,x
+                    bra       L0083
+
+L00DF               leax      $0515,u
+                    pshs      x
+                    ldd       $0551,u
+L00E9               pshs      d
+                    leay      ,u
+L00ED               bsr       L00F9
+                    lbsr      L017B
+                    clr       ,-s
+L00F4               clr       ,-s
+                    lbsr      L27D0
+L00F9               leax      $0887,y
+                    stx       $055f,y
+                    sts       $0553,y
+                    sts       $0561,y
+                    ldd       #$FF82
+                    leax      d,s
+                    cmpx      $0561,y
+                    bcc       L0120
+                    cmpx      $055f,y
+                    bcs       L013A
+                    stx       $0561,y
+L0120               fcb       $39
+L0121               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L013A               leax      L0121,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clr       ,-s
+                    lbsr      $27D6
+                    ldd       $0553,y
+                    subd      $0561,y
+                    rts
+                    ldd       $0561,y
+                    subd      $055f,y
+                    rts
+
+L0161               pshs      x
+                    leax      d,y
+                    leax      d,x
+                    pshs      x
+L0169               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+                    std       ,x
+                    cmpy      ,s
+                    bne       L0169
+L0178               leas      $04,s
+                    rts
+
+L017B               pshs      u
+                    leas      -$08,s
+                    leax      $0445,y
+                    stx       $0565,y
+                    leax      $0452,y
+                    stx       $0567,y
+                    clra
+                    clrb
+                    std       ,s
+L0193               std       $02,s
+                    lbra      L0243
+
+L0198               ldd       [$0e,s]
+                    std       $04,s
+                    tfr       d,x
+                    ldb       ,x
+                    cmpb      #$2d
+                    lbne      L0225
+                    ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       ,x
+                    sex
+                    tfr       d,x
+                    lbra      L0216
+
+L01B5               ldd       #$0001
+L01B8               std       $0007
+                    lbra      L0243
+
+L01BD               clra
+                    clrb
+                    std       >$0025,y
+                    ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       ,x
+                    cmpb      #$3d
+                    beq       L01F1
+                    ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    bra       L01F1
+
+L01D8               ldd       >$0025,y
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $247E
+                    pshs      d
+                    ldd       $08,s
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       >$0025,y
+L01F1               ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       ,x
+                    sex
+                    std       $06,s
+L01FC               bne       L01D8
+                    bra       L0243
+
+L0200               ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    pshs      d
+                    leax      L069F,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $04,s
+                    bra       L0243
+
+L0216               stx       -$02,s
+                    lbeq      L01B5
+                    cmpx      #$0069
+                    lbeq      L01BD
+                    bra       L0200
+
+L0225               ldd       $02,s
+                    bne       L022E
+                    ldd       $04,s
+                    lbra      L0193
+
+L022E               ldd       ,s
+                    bne       L0238
+                    ldd       $04,s
+                    std       ,s
+                    bra       L0243
+
+L0238               leax      L06B4,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $02,s
+L0243               ldd       $0e,s
+                    addd      #$0002
+                    std       $0e,s
+                    ldd       $0C,s
+                    addd      #$FFFF
+                    std       $0C,s
+                    lbne      L0198
+                    ldd       $02,s
+                    beq       L0283
+                    leax      $0445,y
+                    pshs      x
+                    leax      $06C3,pcr
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L19F9
+L026C               leas      $06,s
+                    std       $0565,y
+                    bne       L0283
+                    ldd       $02,s
+                    pshs      d
+                    leax      $06C5,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $04,s
+L0283               ldd       ,s
+                    beq       L02AB
+                    leax      $06D3,pcr
+                    pshs      x
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L19DA
+                    leas      $04,s
+                    std       $0567,y
+                    bne       L02AB
+                    ldd       ,s
+                    pshs      d
+                    leax      $06D5,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $04,s
+L02AB               ldd       $0567,y
+                    std       $0569,y
+                    lbsr      L091F
+                    lbsr      L0A7C
+                    lbsr      $10E2
+                    lbsr      L03C0
+                    ldd       $0007
+                    lbeq      L037E
+                    leas      -$04,s
+                    leax      $06E3,pcr
+                    pshs      x
+                    leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $04,s
+                    ldd       $0009
+                    pshs      d
+                    leax      $06F0,pcr
+                    pshs      x
+L02E2               leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $06,s
+                    ldd       L0019
+                    pshs      d
+                    ldd       L001B
+                    pshs      d
+                    lbsr      L03A0
+                    leas      $04,s
+L02FA               pshs      d
+                    ldd       L001B
+                    pshs      d
+                    ldd       L0019
+                    pshs      d
+                    leax      L070A,pcr
+                    pshs      x
+                    leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $0a,s
+                    ldd       $0009
+                    pshs      d
+                    ldd       L0021
+                    pshs      d
+                    lbsr      L03A0
+                    leas      $04,s
+                    pshs      d
+                    ldd       L0021
+                    pshs      d
+                    leax      L072D,pcr
+                    pshs      x
+                    leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $08,s
+                    ldd       L001B
+                    aslb
+                    rola
+                    std       ,s
+                    pshs      d
+                    ldd       L0021
+                    pshs      d
+                    bsr       L0382
+                    leas      $02,s
+                    addd      ,s++
+                    std       ,s
+                    ldd       $0009
+                    pshs      d
+                    bsr       L0382
+                    leas      $02,s
+                    std       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L03A0
+                    leas      $04,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      L0752,pcr
+                    pshs      x
+                    leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $0a,s
+                    leas      $04,s
+L037E               leas      $08,s
+                    puls      pc,u
+L0382               pshs      u
+                    ldd       $04,s
+                    addd      $04,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0003
+                    lbsr      $247E
+                    pshs      d
+                    ldd       #$0005
+                    lbsr      $24EA
+                    addd      ,s++
+                    puls      pc,u
+L03A0               pshs      u
+                    ldd       $06,s
+                    beq       L03BC
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    addd      #$0032
+                    pshs      d
+                    ldd       #$0064
+                    lbsr      L24D1
+                    lbsr      L24D1
+                    bra       L03BE
+
+L03BC               clra
+                    clrb
+L03BE               puls      pc,u
+L03C0               pshs      u
+                    leas      $FF1C,s
+                    clra
+                    clrb
+                    std       $0C,s
+                    clra
+                    clrb
+                    std       $000F
+                    std       $000D
+                    clra
+                    clrb
+                    std       $000B
+                    lbra      L0625
+
+L03D7               leau      $0080,s
+                    bra       L03DF
+
+L03DD               leau      $01,u
+L03DF               ldb       ,u
+                    cmpb      #$0d
+                    bne       L03DD
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    leax      $0080,s
+                    stx       $06,s
+                    ldb       [$06,s]
+                    lbeq      L0625
+                    ldb       [$06,s]
+                    cmpb      #$2a
+                    lbeq      L0625
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    leax      $78,s
+                    pshs      x
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L07AD
+                    leas      $08,s
+                    std       $06,s
+                    pshs      d
+                    leax      $6b,s
+                    pshs      x
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      L07AD
+                    leas      $06,s
+                    bra       L0437
+
+L0432               ldd       $06,s
+                    addd      #$0001
+L0437               std       $06,s
+                    ldb       [$06,s]
+                    cmpb      #$20
+                    beq       L0432
+                    ldb       [$06,s]
+                    cmpb      #$09
+                    lbeq      L0432
+                    ldb       $69,s
+                    sex
+                    tfr       d,x
+                    lbra      L0542
+
+L0452               leax      L0775,pcr
+                    pshs      x
+                    leax      $6b,s
+                    pshs      x
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    lbne      L056C
+                    lbsr      L0671
+                    ldd       #$0001
+L046E               std       $000F
+                    lbra      L0625
+
+L0473               leax      $077D,pcr
+                    pshs      x
+                    leax      $6b,s
+                    pshs      x
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    lbeq      L053B
+                    lbra      L056C
+
+L048C               leax      L0782,pcr
+                    pshs      x
+                    leax      $6b,s
+                    pshs      x
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    lbne      L056C
+                    bra       L04A8
+
+L04A4               leas      $FF1C,x
+L04A8               leax      $0080,s
+                    pshs      x
+                    leax      L0786,pcr
+                    pshs      x
+                    ldd       $0567,y
+L04B8               pshs      d
+                    lbsr      $1ABE
+                    leas      $06,s
+                    lbra      L0625
+
+L04C2               leax      L078A,pcr
+                    pshs      x
+                    leax      $6b,s
+                    pshs      x
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    lbne      L056C
+                    lbsr      L0671
+                    lbra      L053B
+
+L04DE               leax      $0790,pcr
+                    pshs      x
+                    leax      $6b,s
+                    pshs      x
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L053B
+                    lbra      L056C
+
+L04F5               leax      L0794,pcr
+                    pshs      x
+                    leax      $6b,s
+                    pshs      x
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    lbne      L056C
+                    ldb       [$06,s]
+                    cmpb      #$64
+                    bne       L051F
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$70
+                    bne       L051F
+                    ldd       #$0002
+                    bra       L0522
+
+L051F               ldd       #$0001
+L0522               std       $02,s
+                    ldd       $000D
+                    cmpd      $02,s
+                    bne       L0534
+                    ldd       $000F
+                    beq       L0534
+                    clra
+                    clrb
+                    lbra      L046E
+
+L0534               lbsr      L0671
+                    ldd       $02,s
+                    std       $000D
+L053B               leax      $00E4,s
+                    lbra      L04A4
+
+L0542               cmpx      #$0065
+                    lbeq      L0452
+                    cmpx      #$0069
+                    lbeq      L0473
+                    cmpx      #$006E
+                    lbeq      L048C
+                    cmpx      #$0070
+                    lbeq      L04C2
+                    cmpx      #$0074
+                    lbeq      L04DE
+                    cmpx      #$0076
+                    lbeq      L04F5
+L056C               lbsr      L0671
+                    ldd       $000D
+                    beq       L0586
+                    leax      $0080,s
+                    pshs      x
+                    leax      $079A,pcr
+                    pshs      x
+                    ldd       $0569,y
+                    lbra      L04B8
+
+L0586               ldb       $74,s
+                    beq       L05CB
+                    leax      $74,s
+                    pshs      x
+                    lbsr      L0988
+                    leas      $02,s
+                    std       $0a,s
+                    bne       L05A5
+                    leax      $74,s
+                    pshs      x
+                    lbsr      L0946
+                    leas      $02,s
+                    std       $0a,s
+L05A5               ldd       ,s
+                    beq       L05B1
+                    ldx       $0a,s
+                    ldd       $0a,x
+                    orb       #$01
+                    std       $0a,x
+L05B1               ldd       $0a,s
+                    bra       L05B9
+
+L05B5               ldx       $08,s
+                    ldd       $08,x
+L05B9               std       $08,s
+                    ldx       $08,s
+                    ldd       $08,x
+                    bne       L05B5
+                    ldd       $0C,s
+                    ldx       $08,s
+                    std       $08,x
+                    ldd       $0a,s
+                    std       $0C,s
+L05CB               ldb       $69,s
+                    beq       L0625
+                    ldd       $06,s
+                    pshs      d
+                    leax      $10,s
+                    pshs      x
+                    ldd       #$0003
+                    pshs      d
+                    lbsr      L07AD
+                    leas      $06,s
+                    leax      $0C,s
+                    pshs      x
+                    leax      $10,s
+                    pshs      x
+                    leax      $6d,s
+                    pshs      x
+                    leax      >$0015,y
+                    pshs      x
+                    lbsr      L0A92
+                    leas      $08,s
+                    std       -$02,s
+                    beq       L0612
+                    ldd       L0017
+                    pshs      d
+                    lbsr      L110E
+                    leas      $02,s
+                    ldd       L0017
+                    pshs      d
+                    lbsr      L13F5
+                    leas      $02,s
+L0612               ldd       $0009
+                    addd      #$0001
+                    std       $0009
+                    ldd       L0013
+                    cmpd      >$0025,y
+                    blt       L0625
+                    lbsr      L0D20
+L0625               ldd       $0565,y
+                    pshs      d
+                    ldd       #$0064
+                    pshs      d
+                    leax      $0084,s
+                    pshs      x
+                    lbsr      $1A65
+                    leas      $06,s
+                    std       -$02,s
+                    lbne      L03D7
+                    ldd       $0C,s
+                    beq       L0660
+                    leax      $0C,s
+                    pshs      x
+                    leax      $07A2,pcr
+                    pshs      x
+                    leax      L079E,pcr
+                    pshs      x
+                    leax      >$0015,y
+                    pshs      x
+                    lbsr      L0A92
+                    leas      $08,s
+L0660               bsr       L0671
+                    bra       L0667
+
+L0664               lbsr      L0D20
+L0667               ldd       L0013
+                    bne       L0664
+                    leas      $00E4,s
+                    puls      pc,u
+L0671               pshs      u
+                    ldd       $000F
+                    beq       L069D
+                    ldd       $000D
+                    beq       L0684
+                    clra
+                    clrb
+                    std       $000D
+                    bra       L0688
+
+L0681               lbsr      L0D20
+L0684               ldd       L0013
+                    bne       L0681
+L0688               leax      L07A3,pcr
+                    pshs      x
+                    ldd       $0567,y
+                    pshs      d
+                    lbsr      $1ABE
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $000F
+L069D               puls      pc,u
+L069F               fcb       $75,$6e,$6b,$6e,$6f,$77,$6e,$20
+                    fcb       $6f,$70,$74,$69,$6f,$6e,$20,$27
+                    fcb       $25,$73,$27,$0d,$00
+L06B4               lsr       $6F6F
+                    bra       L0726
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       L0724
+                    rol       $0C,s
+                    fcb       $65
+                    com       >$0072
+                    neg       $0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       L206F
+                    neg       $656E
+                    bra       L06F6
+                    com       >L0077
+                    neg       $0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       L206F
+                    neg       $656E
+                    bra       L0706
+                    com       >$0073
+                    lsr       $6174
+                    rol       -$0d,s
+                    lsr       $6963
+                    com       $3A0D
+                    neg       $0009
+                    fcb       $74,$6f,$74,$61,$6C
+L06F6               fcb       $20,$69,$6e,$73,$74,$72,$75,$63
+                    fcb       $74,$69,$6f,$6e,$73,$20,$3a,$20
+L0706               fcb       $25,$64,$0d,$00
+L070A               rol       $006C
+                    fcb       $6f,$6e,$67,$20,$62,$72,$61,$6e
+                    fcb       $63,$68,$65,$73,$20,$3a,$20,$20
+                    fcb       $25,$35,$64,$2C,$20,$25,$35,$64
+L0724               fcb       $2C,$20
+L0726               fcb       $25,$33,$64,$25,$25,$0d,$00
+L072D               rol       $0072
+                    fcb       $65,$6d,$6f,$76,$65,$64,$20,$20
+                    fcb       $20,$20,$20,$20,$20,$3a,$20,$20
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$25
+                    fcb       $35,$64,$2C,$20,$25,$33,$64,$25
+                    fcb       $25,$0d,$00
+L0752               rol       L0074
+                    fcb       $6f,$74,$61,$6C,$20,$62,$79,$74
+                    fcb       $65,$73,$20,$20,$20,$3a,$20,$20
+                    fcb       $25,$35,$64,$2C,$20,$25,$35,$64
+                    fcb       $2C,$20,$25,$33,$64,$25,$25
+                    fcb       $0d,$00
+L0775               fcb       $65
+                    jmp       $04,s
+                    com       $6563
+                    lsr       >L0069
+                    jmp       $06,s
+                    clr       0,x
+L0782               jmp       $01,s
+                    tst       0,x
+L0786               bcs       $07FB
+                    tst       $0000
+L078A               neg       $7365
+                    com       -$0C,s
+                    neg       L0074
+                    lsr       $6C00
+L0794               ror       $7365
+                    com       -$0C,s
+                    neg       L0025
+                    com       $0D00
+L079E               jmp       $0f,s
+                    neg       >$0000
+L07A3               bra       $080A
+                    jmp       $04,s
+                    com       $6563
+                    lsr       $0D00
+L07AD               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldx       $06,s
+                    lbra      L08DE
+
+L07B8               ldd       #$000B
+                    std       ,s
+                    ldb       [$0a,s]
+                    cmpb      #$20
+                    lbeq      L08F5
+                    ldb       [$0a,s]
+                    cmpb      #$09
+                    lbeq      L08F5
+L07CF               ldx       $0a,s
+                    leax      $01,x
+                    stx       $0a,s
+                    ldb       -$01,x
+                    stb       ,u+
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    beq       L07FC
+                    ldb       [$0a,s]
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$0f
+                    bne       L07CF
+                    bra       L07FC
+
+L07F5               ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+L07FC               ldb       [$0a,s]
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$0f
+                    bne       L07F5
+                    ldb       [$0a,s]
+                    cmpb      #$3a
+                    bne       L0819
+                    ldd       #$0001
+                    bra       L081B
+
+L0819               clra
+                    clrb
+L081B               std       [$0C,s]
+                    lbeq      L08F5
+                    ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+                    lbra      L08F5
+
+L082C               ldd       #$000A
+                    std       ,s
+                    bra       L083A
+
+L0833               ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+L083A               ldb       [$0a,s]
+                    cmpb      #$20
+                    beq       L0833
+                    ldb       [$0a,s]
+                    cmpb      #$09
+                    lbeq      L0833
+                    bra       L0856
+
+L084C               ldx       $0a,s
+                    leax      $01,x
+                    stx       $0a,s
+                    ldb       -$01,x
+                    stb       ,u+
+L0856               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    beq       L087C
+                    ldb       [$0a,s]
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$0f
+                    bne       L084C
+                    bra       L087C
+
+L0875               ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+L087C               ldb       [$0a,s]
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$0f
+                    bne       L0875
+                    lbra      L08F5
+
+L0890               ldd       #$005A
+                    std       ,s
+                    bra       L089E
+
+L0897               ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+L089E               ldb       [$0a,s]
+                    cmpb      #$20
+                    beq       L0897
+                    ldb       [$0a,s]
+                    cmpb      #$09
+                    lbeq      L0897
+                    bra       L08BA
+
+L08B0               ldx       $0a,s
+                    leax      $01,x
+                    stx       $0a,s
+                    ldb       -$01,x
+                    stb       ,u+
+L08BA               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    beq       L08F5
+                    ldb       [$0a,s]
+                    bne       L08B0
+                    bra       L08F5
+
+L08CD               ldd       $06,s
+                    pshs      d
+                    leax      >L08FF,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $04,s
+                    bra       L08F5
+
+L08DE               cmpx      #$0001
+                    lbeq      L07B8
+                    cmpx      #$0002
+                    lbeq      L082C
+                    cmpx      #$0003
+                    lbeq      L0890
+                    bra       L08CD
+
+L08F5               clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $02,s
+                    puls      pc,u
+L08FF               neg       $6172
+                    com       $6520
+                    com       $01,s
+                    inc       $0C,s
+                    fcb       $65
+                    lsr       0,y
+                    asr       $6974
+                    asl       0,y
+                    fcb       $62
+                    fcb       $61
+                    lsr       0,y
+                    lsr       $7970
+                    fcb       $65
+                    bra       $0955
+                    bra       $0942
+                    lsr       0,x
+L091F               pshs      u,d
+                    leax      $056b,y
+                    stx       ,s
+                    ldu       #$0000
+                    bra       L093D
+
+L092C               ldd       ,s
+                    ldx       ,s
+                    std       $02,x
+                    std       [,s]
+                    ldd       ,s
+                    addd      #$0004
+                    std       ,s
+                    leau      $01,u
+L093D               cmpu      #$0080
+                    blt       L092C
+                    lbra      L09EA
+
+L0946               pshs      u,d
+                    lbsr      L09EE
+                    std       ,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L09CC
+                    leas      $02,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    leax      $056b,y
+                    leax      d,x
+                    leau      ,x
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    addd      #$000C
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+                    stu       [,s]
+                    ldd       $02,u
+                    ldx       ,s
+                    std       $02,x
+                    ldd       ,s
+                    std       [$02,u]
+                    ldd       ,s
+                    std       $02,u
+                    ldd       ,s
+                    lbra      L09EA
+
+L0988               pshs      u,x,d
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L09CC
+                    leas      $02,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    leax      $056b,y
+                    leax      d,x
+                    stx       ,s
+                    ldd       [,s]
+                    bra       L09BD
+
+L09A2               ldd       $02,s
+                    addd      #$000C
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L09BA
+                    ldd       $02,s
+                    bra       L09C8
+
+L09BA               ldd       [$02,s]
+L09BD               std       $02,s
+                    ldd       $02,s
+                    cmpd      ,s
+                    bne       L09A2
+                    clra
+                    clrb
+L09C8               leas      $04,s
+                    puls      pc,u
+L09CC               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    clra
+                    clrb
+                    bra       L09DF
+
+L09D6               ldd       ,s
+                    pshs      d
+                    ldb       ,u+
+                    sex
+                    addd      ,s++
+L09DF               std       ,s
+                    ldb       ,u
+                    bne       L09D6
+                    ldd       ,s
+                    clra
+                    andb      #$7f
+L09EA               leas      $02,s
+                    puls      pc,u
+L09EE               pshs      u
+                    ldu       $0011
+                    beq       L0A04
+                    ldd       ,u
+                    std       $0011
+                    clra
+                    clrb
+                    std       $0a,u
+                    std       $08,u
+                    std       $06,u
+                    std       $04,u
+                    bra       L0A10
+
+L0A04               ldd       #$0018
+                    pshs      d
+                    lbsr      $17F3
+                    leas      $02,s
+                    tfr       d,u
+L0A10               tfr       u,d
+                    puls      pc,u
+L0A14               pshs      u
+                    ldu       $04,s
+                    ldd       $04,u
+                    bne       L0A31
+                    ldd       $06,u
+                    bne       L0A31
+                    ldd       ,u
+                    std       [$02,u]
+                    ldd       $02,u
+                    ldx       ,u
+                    std       $02,x
+                    ldd       $0011
+                    std       ,u
+                    stu       $0011
+L0A31               puls      pc,u
+L0A33               pshs      u
+                    ldd       >$0023,y
+                    addd      #$0001
+                    std       >$0023,y
+                    pshs      d
+                    leax      >L0A53,pcr
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $1ADA
+                    leas      $06,s
+                    puls      pc,u
+L0A53               clrb
+                    bcc       $0A7B
+                    lsr       0,x
+L0A58               pshs      u
+                    ldu       $06,s
+                    bra       L0A73
+
+L0A5E               ldd       ,u
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    lbeq      L0CCF
+                    leau      $02,u
+L0A73               cmpu      $08,s
+                    bcs       L0A5E
+                    clra
+                    clrb
+                    puls      pc,u
+L0A7C               pshs      u
+                    leax      >$0015,y
+                    stx       L0017
+                    tfr       x,d
+                    std       L0015
+                    clra
+                    clrb
+                    std       $001D
+                    std       $001F
+                    std       L0013
+                    puls      pc,u
+L0A92               pshs      u
+                    leas      -$0a,s
+                    lbsr      L0C90
+                    tfr       d,u
+                    ldd       $14,s
+                    beq       L0AA5
+                    ldd       [$14,s]
+                    bra       L0AA7
+
+L0AA5               clra
+                    clrb
+L0AA7               std       $04,u
+                    beq       L0AC3
+                    ldd       [$14,s]
+                    bra       L0AB8
+
+L0AB0               ldx       $08,s
+                    stu       $04,x
+                    ldx       $08,s
+                    ldd       $08,x
+L0AB8               std       $08,s
+                    ldd       $08,s
+                    bne       L0AB0
+                    clra
+                    clrb
+                    std       [$14,s]
+L0AC3               ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+                    ldd       $12,s
+                    std       $04,s
+                    tfr       d,x
+                    ldb       ,x
+                    beq       L0AEB
+L0AE1               ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       ,x
+                    bne       L0AE1
+L0AEB               ldd       $04,s
+                    subd      $12,s
+                    std       ,s
+                    ldd       $0e,s
+                    std       ,u
+                    ldx       $0e,s
+                    ldd       $02,x
+                    std       $02,u
+                    ldx       $0e,s
+                    stu       [$02,x]
+                    ldx       $0e,s
+                    stu       $02,x
+                    ldd       L0013
+                    addd      #$0001
+                    std       L0013
+                    leax      $08,u
+                    stx       $06,s
+                    ldb       ,x
+                    sex
+                    tfr       d,x
+                    lbra      L0C53
+
+L0B18               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       ,x
+                    cmpb      #$62
+                    lbne      L0C6B
+L0B26               leax      >$004b,y
+                    pshs      x
+                    leax      >$0027,y
+                    pshs      x
+                    ldd       $0a,s
+                    addd      #$0001
+                    pshs      d
+                    lbsr      L0A58
+                    leas      $06,s
+                    std       $02,s
+                    lbeq      L0C6B
+                    ldd       $06,u
+                    pshs      d
+                    leax      >$0027,y
+                    pshs      x
+                    ldd       $06,s
+                    subd      ,s++
+                    pshs      d
+                    ldd       #$0002
+                    lbsr      $24EA
+                    orb       #$60
+                    ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    ldd       [$02,s]
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L07AD
+                    leas      $08,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L0988
+                    leas      $02,s
+                    std       $08,s
+                    leax      >$0027,y
+                    cmpx      $02,s
+                    bne       L0BE8
+                    ldd       $08,s
+                    beq       L0BB8
+                    ldx       $08,s
+                    ldd       $04,x
+                    beq       L0BB8
+                    ldx       $08,s
+                    ldd       $04,x
+                    pshs      d
+                    pshs      u
+                    lbsr      L0CEA
+                    leas      $04,s
+L0BB8               ldd       $04,u
+                    bne       L0BE2
+                    leax      >$0015,y
+                    cmpx      $02,u
+                    beq       L0BE2
+                    ldx       $02,u
+                    ldd       $06,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L0BE2
+                    pshs      u
+                    lbsr      L0F2A
+                    leas      $02,s
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    clra
+                    clrb
+                    lbra      L0C8C
+
+L0BE2               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+L0BE8               ldd       L0019
+                    addd      #$0001
+                    std       L0019
+                    ldd       $08,s
+                    bne       L0BFF
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L0946
+                    leas      $02,s
+                    std       $08,s
+L0BFF               ldd       $06,u
+                    ora       #$02
+                    std       $06,u
+                    ldd       $08,s
+                    std       $13,u
+                    pshs      d
+                    pshs      u
+                    lbsr      L0CD3
+                    leas      $04,s
+                    bra       L0C6B
+
+L0C15               leax      L1088,pcr
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L0C6B
+                    leax      $108D,pcr
+                    pshs      x
+                    ldd       $14,s
+                    addd      $02,s
+                    addd      #$FFFD
+                    bra       L0C40
+
+L0C38               leax      L1091,pcr
+                    pshs      x
+                    ldd       $08,s
+L0C40               pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L0C6B
+                    ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    bra       L0C6B
+
+L0C53               cmpx      #$006C
+                    lbeq      L0B18
+                    cmpx      #$0062
+                    lbeq      L0B26
+                    cmpx      #$0070
+                    beq       L0C15
+                    cmpx      #$0072
+                    beq       L0C38
+L0C6B               ldd       $06,u
+                    clra
+                    andb      #$20
+                    bne       L0C8A
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L0FED
+                    leas      $02,s
+                    std       $13,u
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+L0C8A               tfr       u,d
+L0C8C               leas      $0a,s
+                    puls      pc,u
+L0C90               pshs      u
+                    ldu       $001D
+                    bne       L0CC4
+                    ldd       $001F
+                    addd      #$0001
+                    std       $001F
+                    pshs      d
+                    ldd       >$0025,y
+                    addd      #$0003
+                    cmpd      ,s++
+                    bge       L0CB6
+                    leax      L1095,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $02,s
+L0CB6               ldd       #$0015
+                    pshs      d
+                    lbsr      $17F3
+                    leas      $02,s
+                    tfr       d,u
+                    bra       L0CCF
+
+L0CC4               ldd       ,u
+                    std       $001D
+                    clra
+                    clrb
+                    std       $13,u
+                    std       $06,u
+L0CCF               tfr       u,d
+                    puls      pc,u
+L0CD3               pshs      u
+                    lbsr      L0FC3
+                    tfr       d,u
+                    ldd       $04,s
+                    std       $02,u
+                    ldx       $06,s
+                    ldd       $06,x
+                    std       ,u
+                    ldx       $06,s
+                    stu       $06,x
+                    puls      pc,u
+L0CEA               pshs      u,d
+                    ldd       $06,s
+                    cmpd      $08,s
+                    lbeq      L0F83
+                    ldx       $06,s
+                    ldu       $04,x
+                    lbeq      L0F83
+L0CFD               stu       ,s
+                    ldd       $08,s
+                    std       $04,u
+                    ldu       $08,u
+                    bne       L0CFD
+                    ldx       $08,s
+                    ldd       $04,x
+                    ldx       ,s
+                    std       $08,x
+                    ldx       $06,s
+                    ldd       $04,x
+                    ldx       $08,s
+                    std       $04,x
+                    clra
+                    clrb
+                    ldx       $06,s
+                    std       $04,x
+                    lbra      L0F83
+
+L0D20               pshs      u,d
+                    ldu       L0015
+                    pshs      u
+                    leax      >$0015,y
+                    cmpx      ,s++
+                    bne       L0D39
+                    leax      $10AD,pcr
+                    pshs      x
+                    lbsr      L1814
+                    leas      $02,s
+L0D39               ldd       $06,u
+                    clra
+                    andb      #$60
+                    cmpd      #$0060
+                    bne       L0D50
+                    ldd       #$0004
+                    pshs      d
+                    pshs      u
+                    lbsr      L0E5C
+                    leas      $04,s
+L0D50               ldd       $04,u
+                    std       ,s
+                    beq       L0DAB
+                    ldd       #$0005
+                    pshs      d
+                    pshs      u
+                    lbsr      L0E5C
+                    bra       L0DA9
+
+L0D62               ldd       ,s
+                    addd      #$000C
+                    pshs      d
+                    leax      $10CC,pcr
+                    pshs      x
+                    ldd       $0567,y
+                    pshs      d
+                    lbsr      $1ABE
+                    leas      $06,s
+                    ldx       ,s
+                    ldd       $0a,x
+                    clra
+                    andb      #$01
+                    beq       L0D93
+                    ldd       $0567,y
+                    pshs      d
+                    ldd       #$003A
+                    pshs      d
+                    lbsr      L1FB2
+                    leas      $04,s
+L0D93               ldx       ,s
+                    ldd       $08,x
+                    std       ,s
+                    beq       L0DAB
+                    ldd       $0567,y
+                    pshs      d
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L1FB2
+L0DA9               leas      $04,s
+L0DAB               ldd       ,s
+                    bne       L0D62
+                    ldd       $0567,y
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      L1FB2
+                    leas      $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$20
+                    beq       L0E0D
+                    ldd       $06,u
+                    anda      #$02
+                    clrb
+                    std       -$02,s
+                    beq       L0DD7
+                    ldd       $13,u
+                    addd      #$000C
+                    bra       L0DDA
+
+L0DD7               ldd       $13,u
+L0DDA               pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L0DF2
+                    leax      $10D8,pcr
+                    bra       L0DF6
+
+L0DF2               leax      $10DA,pcr
+L0DF6               tfr       x,d
+                    pshs      d
+                    leax      $10CF,pcr
+                    pshs      x
+                    ldd       $0567,y
+                    pshs      d
+                    lbsr      $1ABE
+                    leas      $0a,s
+                    bra       L0E42
+
+L0E0D               pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    leax      L10DB,pcr
+                    pshs      x
+                    ldd       $0567,y
+                    pshs      d
+                    lbsr      $1ABE
+                    leas      $06,s
+                    ldb       [$13,u]
+                    beq       L0E42
+                    ldd       $13,u
+                    pshs      d
+                    leax      $10DE,pcr
+                    pshs      x
+                    ldd       $0567,y
+                    pshs      d
+                    lbsr      $1ABE
+                    leas      $06,s
+L0E42               ldd       $0567,y
+                    pshs      d
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L1FB2
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L0F2A
+                    leas      $02,s
+                    lbra      L0F83
+
+L0E5C               pshs      u,y,x,d
+                    ldu       $0a,s
+                    ldd       $0C,s
+                    cmpd      #$0004
+                    lbne      L0EC9
+                    ldd       $06,u
+                    anda      #$02
+                    clrb
+                    std       -$02,s
+                    beq       L0E78
+                    ldd       $13,u
+                    bra       L0E82
+
+L0E78               ldd       $13,u
+                    pshs      d
+                    lbsr      L0988
+                    leas      $02,s
+L0E82               std       $02,s
+                    lbeq      L0F26
+                    ldx       $02,s
+                    ldd       $04,x
+                    std       $04,s
+                    lbeq      L0F26
+                    ldd       #$0024
+                    bra       L0EB2
+
+L0E97               cmpu      $04,s
+                    bne       L0EAD
+                    ldd       $06,u
+                    orb       #$80
+                    std       $06,u
+                    ldx       $0a,s
+                    ldd       $06,x
+                    andb      #$BF
+                    std       $06,x
+                    lbra      L0F04
+
+L0EAD               ldd       ,s
+                    addd      #$FFFF
+L0EB2               std       ,s
+                    ldd       ,s
+                    lbeq      L0F26
+                    ldu       ,u
+                    pshs      u
+                    leax      >$0015,y
+                    cmpx      ,s++
+                    bne       L0E97
+                    lbra      L0F26
+
+L0EC9               ldd       #$0024
+                    bra       L0F12
+
+L0ECE               ldd       $06,u
+                    clra
+                    andb      #$60
+                    cmpd      #$0060
+                    bne       L0F0D
+                    ldd       $06,u
+                    anda      #$02
+                    clrb
+                    std       -$02,s
+                    beq       L0EE7
+                    ldd       $13,u
+                    bra       L0EF1
+
+L0EE7               ldd       $13,u
+                    pshs      d
+                    lbsr      L0988
+                    leas      $02,s
+L0EF1               std       $02,s
+                    beq       L0F0D
+                    ldd       $0a,s
+                    ldx       $02,s
+                    cmpd      $04,x
+                    bne       L0F0D
+                    ldd       $06,u
+                    andb      #$BF
+                    std       $06,u
+L0F04               ldd       L001B
+                    addd      #$0001
+                    std       L001B
+                    bra       L0F26
+
+L0F0D               ldd       ,s
+                    addd      #$FFFF
+L0F12               std       ,s
+                    ldd       ,s
+                    beq       L0F26
+                    ldu       ,u
+                    pshs      u
+                    leax      >$0015,y
+                    cmpx      ,s++
+                    lbne      L0ECE
+L0F26               leas      $06,s
+                    puls      pc,u
+L0F2A               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    clra
+                    andb      #$20
+                    beq       L0F44
+                    ldd       $13,u
+                    pshs      d
+                    pshs      u
+                    bsr       L0F87
+                    leas      $04,s
+                    bra       L0F4E
+
+L0F44               ldd       $13,u
+                    pshs      d
+                    lbsr      L1024
+                    leas      $02,s
+L0F4E               ldd       $04,u
+                    bra       L0F65
+
+L0F52               clra
+                    clrb
+                    ldx       ,s
+L0F56               std       $04,x
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L0A14
+                    leas      $02,s
+                    ldx       ,s
+                    ldd       $08,x
+L0F65               std       ,s
+                    ldd       ,s
+                    bne       L0F52
+                    ldd       ,u
+                    std       [$02,u]
+                    ldd       $02,u
+                    ldx       ,u
+                    std       $02,x
+                    ldd       $001D
+                    std       ,u
+                    stu       $001D
+                    ldd       L0013
+                    addd      #$FFFF
+                    std       L0013
+L0F83               leas      $02,s
+                    puls      pc,u
+L0F87               pshs      u,x,d
+                    ldd       $0a,s
+                    beq       L0FBF
+                    ldd       $0a,s
+                    addd      #$0006
+                    bra       L0FB7
+
+L0F94               ldx       $02,s
+                    ldd       $02,x
+                    cmpd      $08,s
+                    bne       L0FB5
+                    ldd       [$02,s]
+                    std       [,s]
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L0A14
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L0FE1
+                    leas      $02,s
+                    bra       L0FBF
+
+L0FB5               ldd       $02,s
+L0FB7               std       ,s
+                    ldd       [,s]
+                    std       $02,s
+                    bne       L0F94
+L0FBF               leas      $04,s
+                    puls      pc,u
+L0FC3               pshs      u
+                    ldu       $0001
+                    beq       L0FCF
+                    ldd       ,u
+                    std       $0001
+                    bra       L0FDB
+
+L0FCF               ldd       #$0004
+                    pshs      d
+                    lbsr      $17F3
+                    leas      $02,s
+                    tfr       d,u
+L0FDB               clra
+                    clrb
+                    std       $02,u
+                    bra       L101E
+
+L0FE1               pshs      u
+                    ldu       $04,s
+                    ldd       $0001
+                    std       ,u
+                    stu       $0001
+                    puls      pc,u
+L0FED               pshs      u
+                    ldd       $04,s
+                    cmpd      #$0010
+                    bge       L1006
+                    ldu       $0003
+                    beq       L1001
+                    ldd       ,u
+                    std       $0003
+                    bra       L101C
+
+L1001               ldd       #$0010
+                    bra       L1013
+
+L1006               ldu       $0005
+                    beq       L1010
+                    ldd       ,u
+                    std       $0005
+                    bra       L101C
+
+L1010               ldd       #$005B
+L1013               pshs      d
+                    lbsr      $17F3
+                    leas      $02,s
+                    tfr       d,u
+L101C               clra
+                    clrb
+L101E               std       ,u
+                    tfr       u,d
+                    puls      pc,u
+L1024               pshs      u
+                    ldu       $04,s
+                    beq       L1050
+                    bra       L102E
+
+L102C               leau      $01,u
+L102E               ldb       ,u
+                    bne       L102C
+                    tfr       u,d
+                    subd      $04,s
+                    cmpd      #$0010
+                    bge       L1047
+                    ldd       $0003
+                    std       [$04,s]
+                    ldd       $04,s
+                    std       $0003
+                    bra       L1050
+
+L1047               ldd       $0005
+                    std       [$04,s]
+                    ldd       $04,s
+                    std       $0005
+L1050               puls      pc,u
+                    fcb       $72
+                    fcb       $61
+                    neg       $0073
+                    fcb       $72
+                    neg       $0065
+                    fcb       $71
+                    neg       $006E
+                    fcb       $65
+                    neg       $006C
+                    lsr       >L0067
+                    fcb       $65
+                    neg       $006C
+                    fcb       $65
+                    neg       L0067
+                    lsr       >$006C
+                    clr       0,x
+                    asl       -$0d,s
+                    neg       $006C
+                    com       >$0068
+                    rol       0,x
+                    neg       $6C00
+L1079               tst       $09,s
+                    neg       $0063
+                    com       0,x
+L107F               com       -$0d,s
+                    neg       $0076
+                    com       0,x
+                    ror       $7300
+L1088               neg       $756C
+                    com       >$002C
+                    neg       $6300
+L1091               fcb       $72
+                    lsr       $7300
+L1095               fcb       $72
+                    fcb       $75
+                    jmp       0,y
+                    clr       -$0b,s
+                    lsr       L206F
+                    ror       0,y
+                    rol       $0e,s
+                    com       $7472
+                    fcb       $75
+                    com       -$0C,s
+                    rol       $0f,s
+                    jmp       -$0d,s
+                    neg       $0072
+                    fcb       $65
+                    tst       $0f,s
+                    ror       $696E
+                    asr       0,y
+                    lsr       $6F6F
+                    bra       $1128
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       L1129
+                    jmp       -$0d,s
+                    lsr       $7275
+                    com       -$0C,s
+                    rol       $0f,s
+                    jmp       -$0d,s
+                    neg       L0025
+                    com       >L0025
+                    com       $6225
+                    com       L2025
+                    com       >$006C
+                    neg       $0000
+L10DB               bcs       $1150
+                    neg       L0020
+                    bcs       $1154
+                    neg       $0034
+                    rora
+                    leau      $0146,y
+                    bra       L1106
+
+L10EA               ldd       $02,u
+                    pshs      d
+                    lbsr      L09CC
+                    leas      $02,s
+                    aslb
+                    rola
+                    leax      $076b,y
+                    leax      d,x
+                    stx       ,s
+                    ldd       [,s]
+                    std       $0e,u
+                    stu       [,s]
+                    leau      $10,u
+L1106               ldd       ,u
+                    bne       L10EA
+                    leas      $02,s
+                    puls      pc,u
+L110E               pshs      u
+                    ldu       $04,s
+                    leas      -$0C,s
+                    ldu       $02,u
+                    bra       L111A
+
+L1118               leas      -$0C,x
+L111A               leax      >$0015,y
+                    pshs      x
+                    cmpu      ,s++
+                    lbeq      L12F1
+                    ldd       ,u
+L1129               std       $0a,s
+                    pshs      d
+                    leax      >$0015,y
+                    cmpx      ,s++
+                    lbeq      L12F1
+                    ldx       $0a,s
+                    ldd       $04,x
+                    lbeq      L11C3
+                    ldd       $06,u
+                    clra
+                    andb      #$20
+                    lbeq      L12F1
+                    ldd       $06,u
+                    clra
+                    andb      #$3f
+                    cmpd      #$0021
+                    lbeq      L12F1
+                    ldx       $13,u
+                    ldd       $04,x
+                    cmpd      $0a,s
+                    bne       L1181
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L0CEA
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L0F2A
+                    leas      $02,s
+                    ldx       $0a,s
+                    ldu       $02,x
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    leax      $0C,s
+                    lbra      L1118
+
+L1181               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L12F1
+                    ldd       $04,u
+                    lbne      L12F1
+                    ldu       $02,u
+                    pshs      u
+                    leax      >$0015,y
+                    cmpx      ,s++
+                    lbeq      L12F1
+                    ldd       $06,u
+                    clra
+                    andb      #$3f
+                    cmpd      #$0021
+                    lble      L12F1
+                    ldx       $13,u
+                    ldd       $04,x
+                    cmpd      $0a,s
+                    lbne      L12F1
+                    pshs      u
+                    lbsr      L12F5
+                    leas      $02,s
+                    lbra      L12F1
+
+L11C3               pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      L09CC
+                    leas      $02,s
+                    aslb
+                    rola
+                    leax      $076b,y
+                    leax      d,x
+                    ldd       ,x
+                    std       $08,s
+                    clra
+                    clrb
+                    std       $04,s
+                    lbra      L125A
+
+L11E4               ldx       $08,s
+                    ldd       $02,x
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      L135C
+                    leas      $04,s
+                    std       -$02,s
+                    lbeq      L1254
+                    ldx       $08,s
+                    ldd       $04,x
+                    pshs      d
+                    ldd       $13,u
+                    pshs      d
+                    lbsr      L135C
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L1254
+                    ldx       $08,s
+                    ldd       $06,x
+                    pshs      d
+                    ldd       $0C,s
+                    addd      #$0008
+                    pshs      d
+                    lbsr      L135C
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L1254
+                    ldx       $08,s
+                    ldd       $08,x
+                    cmpd      #$0001
+                    bne       L1237
+                    ldd       $13,u
+                    bra       L123B
+
+L1237               ldx       $08,s
+                    ldd       $08,x
+L123B               pshs      d
+                    ldx       $0C,s
+                    ldd       $13,x
+                    pshs      d
+                    lbsr      L135C
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L1254
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L1260
+
+L1254               ldx       $08,s
+                    ldd       $0e,x
+                    std       $08,s
+L125A               ldd       $08,s
+                    lbne      L11E4
+L1260               ldd       $04,s
+                    lbeq      L12F1
+                    ldx       $08,s
+                    ldx       $0a,x
+                    bra       L1289
+
+L126C               ldd       $0a,s
+                    addd      #$0008
+                    bra       L1277
+
+L1273               ldx       $08,s
+                    ldd       $0a,x
+L1277               pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+                    bra       L1295
+
+L1289               cmpx      #$0001
+                    beq       L1295
+                    cmpx      #$0002
+                    beq       L126C
+                    bra       L1273
+
+L1295               ldx       $08,s
+                    ldx       $0C,x
+                    bra       L12BB
+
+L129B               clra
+                    clrb
+                    stb       [$13,u]
+                    bra       L12CB
+
+L12A2               ldx       $0a,s
+                    ldd       $13,x
+                    bra       L12AD
+
+L12A9               ldx       $08,s
+                    ldd       $0C,x
+L12AD               pshs      d
+                    ldd       $13,u
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+                    bra       L12CB
+
+L12BB               stx       -$02,s
+                    beq       L129B
+                    cmpx      #$0001
+                    beq       L12CB
+                    cmpx      #$0002
+                    beq       L12A2
+                    bra       L12A9
+
+L12CB               ldd       $0a,s
+                    pshs      d
+                    lbsr      L0F2A
+                    leas      $02,s
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    ldx       [$08,s]
+                    bra       L12E4
+
+L12E0               ldu       $02,u
+                    bra       L12EE
+
+L12E4               cmpx      #$0001
+                    beq       L12E0
+                    cmpx      #$0002
+                    beq       L12F1
+L12EE               lbra      L111A
+
+L12F1               leas      $0C,s
+                    puls      pc,u
+L12F5               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$3f
+                    eorb      #$01
+                    pshs      d
+                    ldx       ,u
+                    ldd       $06,x
+                    anda      #$FE
+                    andb      #$C0
+                    ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    clra
+                    andb      #$1f
+                    aslb
+                    rola
+                    leax      >$0027,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $2408
+                    leas      $04,s
+                    ldd       $13,u
+                    pshs      d
+                    pshs      u
+                    lbsr      L0F87
+                    leas      $04,s
+                    ldx       ,u
+                    ldd       $13,x
+                    std       $13,u
+                    pshs      d
+                    pshs      u
+                    lbsr      L0CD3
+                    leas      $04,s
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L0F2A
+                    leas      $02,s
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    puls      pc,u
+L135C               pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    lbne      L13E1
+                    ldd       #$0001
+                    puls      pc,u
+                    lbra      L13E1
+
+L136E               ldb       [$06,s]
+                    cmpb      #$3C
+                    lbne      L13CE
+                    ldb       ,u
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    lbeq      L13F1
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       ,s
+L138F               ldd       ,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $247E
+                    pshs      d
+                    ldb       ,u+
+                    sex
+                    addd      ,s++
+                    addd      #$FFD0
+                    std       ,s
+                    ldb       ,u
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L138F
+                    ldd       ,s
+                    cmpd      #$00FF
+                    bls       L13C3
+                    clra
+                    clrb
+                    leas      $02,s
+                    puls      pc,u
+L13C3               leas      $02,s
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    bra       L13E1
+
+L13CE               ldb       ,u+
+                    sex
+                    pshs      d
+                    ldx       $08,s
+                    leax      $01,x
+                    stx       $08,s
+                    ldb       -$01,x
+                    sex
+                    cmpd      ,s++
+                    bne       L13F1
+L13E1               ldb       [$06,s]
+                    lbne      L136E
+                    ldb       ,u
+                    bne       L13F1
+                    ldd       #$0001
+                    bra       L13F3
+
+L13F1               clra
+                    clrb
+L13F3               puls      pc,u
+L13F5               pshs      u
+                    ldu       $04,s
+                    leas      -$0a,s
+                    leax      >$0015,y
+                    cmpx      $02,u
+                    lbeq      L15DA
+                    clra
+                    clrb
+                    std       ,s
+                    ldd       $04,u
+                    bra       L1454
+
+L140D               ldx       $06,s
+                    ldd       $06,x
+                    bra       L144A
+
+L1413               ldx       $04,s
+                    ldd       $02,x
+                    std       $08,s
+                    ldx       $08,s
+                    ldd       $04,x
+                    beq       L1447
+                    ldx       $08,s
+                    ldd       $06,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L1447
+                    ldx       $08,s
+                    ldd       $06,x
+                    clra
+                    andb      #$80
+                    bne       L1447
+                    lbsr      L0FC3
+                    std       $02,s
+                    ldd       ,s
+                    std       [$02,s]
+                    ldd       $02,s
+                    std       ,s
+                    ldd       $08,s
+                    ldx       ,s
+                    std       $02,x
+L1447               ldd       [$04,s]
+L144A               std       $04,s
+                    ldd       $04,s
+                    bne       L1413
+                    ldx       $06,s
+                    ldd       $08,x
+L1454               std       $06,s
+                    ldd       $06,s
+                    lbne      L140D
+                    lbra      L14D1
+
+L145F               pshs      u
+                    ldx       $02,s
+                    ldd       $02,x
+                    std       $0a,s
+                    pshs      d
+                    lbsr      L0CEA
+                    leas      $04,s
+                    ldx       $08,s
+                    ldd       $02,x
+                    std       $08,s
+                    pshs      d
+                    leax      >$0015,y
+                    cmpx      ,s++
+                    beq       L14C0
+                    ldx       $08,s
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L14C0
+                    ldx       $08,s
+                    ldd       $06,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L149C
+                    ldd       [$08,s]
+                    pshs      d
+                    lbsr      L0F2A
+                    bra       L14BE
+
+L149C               ldx       $08,s
+                    ldd       $06,x
+                    clra
+                    andb      #$3f
+                    cmpd      #$0021
+                    ble       L14C0
+                    ldx       $08,s
+                    ldx       $13,x
+                    ldd       $04,x
+                    ldx       $08,s
+                    cmpd      [,x]
+                    bne       L14C0
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L12F5
+L14BE               leas      $02,s
+L14C0               ldd       [,s]
+                    std       $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L0FE1
+                    leas      $02,s
+                    ldd       $02,s
+                    std       ,s
+L14D1               ldd       ,s
+                    lbne      L145F
+                    ldx       $02,u
+                    ldd       $06,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L152A
+                    ldd       $04,u
+                    bra       L1519
+
+L14E6               ldx       $06,s
+                    ldd       $06,x
+                    bra       L150F
+
+L14EC               ldx       $04,s
+                    ldd       $02,x
+                    std       $08,s
+                    tfr       d,x
+                    ldd       $06,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L150C
+                    ldd       $08,s
+                    pshs      d
+                    ldx       $08,s
+                    ldd       $08,x
+                    pshs      d
+                    lbsr      L1762
+                    leas      $04,s
+L150C               ldd       [$04,s]
+L150F               std       $04,s
+                    ldd       $04,s
+                    bne       L14EC
+                    ldx       $06,s
+                    ldd       $08,x
+L1519               std       $06,s
+                    ldd       $06,s
+                    bne       L14E6
+                    pshs      u
+                    ldd       $04,u
+                    pshs      d
+                    lbsr      L1762
+                    leas      $04,s
+L152A               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L15DA
+                    ldd       $06,u
+                    clra
+                    andb      #$20
+                    beq       L1571
+                    ldx       $13,u
+                    ldd       $04,x
+                    std       $08,s
+                    beq       L1562
+                    ldx       $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    lbsr      L15DE
+                    leas      $04,s
+                    std       -$02,s
+                    lbne      L15DA
+                    pshs      u
+                    ldx       $0a,s
+                    ldd       $04,x
+                    bra       L1567
+
+L1562               pshs      u
+                    ldd       $13,u
+L1567               pshs      d
+                    lbsr      L1762
+                    leas      $04,s
+                    lbra      L15DA
+
+L1571               ldd       $02,u
+                    lbra      L15CE
+
+L1576               ldx       $08,s
+                    ldd       $06,x
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L15CA
+                    ldx       $08,s
+                    ldd       $06,x
+                    clra
+                    andb      #$A0
+                    bne       L15CA
+                    ldd       $08,s
+                    addd      #$0008
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L15CA
+                    ldx       $08,s
+                    ldd       $13,x
+                    pshs      d
+                    ldd       $13,u
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L15CA
+                    ldd       $02,u
+                    pshs      d
+                    ldx       $0a,s
+                    ldd       $02,x
+                    pshs      d
+                    bsr       L15DE
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L15DA
+L15CA               ldx       $08,s
+                    ldd       $02,x
+L15CE               std       $08,s
+                    leax      >$0015,y
+                    cmpx      $08,s
+                    lbne      L1576
+L15DA               leas      $0a,s
+                    puls      pc,u
+L15DE               pshs      u
+                    ldu       $04,s
+                    leas      -$14,s
+                    clra
+                    clrb
+                    std       ,s
+                    stu       $06,s
+                    pshs      u
+                    ldd       $1C,s
+                    std       $06,s
+                    cmpd      ,s++
+                    bne       L160D
+                    lbra      L175B
+                    bra       L160D
+
+L15FC               ldu       $02,u
+                    ldx       $1a,s
+                    ldd       $02,x
+                    std       $1a,s
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L160D               leax      >$0015,y
+                    pshs      x
+                    cmpu      ,s++
+                    lbeq      L16BA
+                    leax      >$0015,y
+                    cmpx      $1a,s
+                    lbeq      L16BA
+                    cmpu      $04,s
+                    lbeq      L16BA
+                    ldd       $1a,s
+                    cmpd      $06,s
+                    lbeq      L16BA
+                    ldd       $06,u
+                    clra
+                    andb      #$3f
+                    pshs      d
+                    ldx       $1C,s
+                    ldd       $06,x
+                    clra
+                    andb      #$3f
+                    cmpd      ,s++
+                    lbne      L16BA
+                    ldd       $06,u
+                    clra
+                    andb      #$80
+                    lbne      L16BA
+                    ldd       $06,u
+                    clra
+                    andb      #$20
+                    beq       L1684
+                    ldx       $13,u
+                    ldd       $04,x
+                    beq       L1678
+                    ldx       $13,u
+                    ldd       $04,x
+                    ldx       $1a,s
+                    ldx       $13,x
+                    cmpd      $04,x
+                    bne       L16B4
+L1673               ldd       #$0001
+                    bra       L16B6
+
+L1678               ldd       $13,u
+                    ldx       $1a,s
+                    cmpd      $13,x
+                    bra       L16B2
+
+L1684               ldd       $1a,s
+                    addd      #$0008
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L16B4
+                    ldx       $1a,s
+                    ldd       $13,x
+                    pshs      d
+                    ldd       $13,u
+                    pshs      d
+                    lbsr      $244D
+                    leas      $04,s
+                    std       -$02,s
+L16B2               beq       L1673
+L16B4               clra
+                    clrb
+L16B6               lbne      L15FC
+L16BA               ldu       ,u
+                    ldd       ,s
+                    lbeq      L175B
+                    ldd       [$1a,s]
+                    std       $1a,s
+                    std       $04,s
+                    ldd       $04,u
+                    std       $02,s
+                    bne       L171D
+                    ldx       $1a,s
+                    ldd       $04,x
+                    std       $02,s
+                    bne       L171D
+                    leax      $08,s
+                    pshs      x
+                    lbsr      L0A33
+                    std       ,s
+                    lbsr      L0946
+                    leas      $02,s
+                    std       $02,s
+                    ldd       $1a,s
+                    ldx       $02,s
+                    std       $04,x
+                    ldd       $02,s
+                    ldx       $1a,s
+                    std       $04,x
+                    bra       L171D
+
+L16F9               ldd       $1a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L0CEA
+                    leas      $04,s
+                    ldu       ,u
+                    ldd       $02,u
+                    pshs      d
+                    lbsr      L0F2A
+                    leas      $02,s
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    ldd       [$1a,s]
+                    std       $1a,s
+L171D               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bge       L16F9
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $04,s
+                    addd      #$000C
+                    pshs      d
+                    leax      $17EE,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0A92
+                    leas      $08,s
+                    pshs      u
+                    lbsr      L110E
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    ldx       $06,s
+                    ldd       $04,x
+                    pshs      d
+                    bsr       L1762
+                    leas      $04,s
+                    ldd       #$0001
+                    bra       L175D
+
+L175B               clra
+                    clrb
+L175D               leas      $14,s
+                    puls      pc,u
+L1762               pshs      u,d
+                    bra       L17A1
+
+L1766               ldx       $06,s
+                    ldd       $06,x
+                    bra       L1795
+
+L176C               ldx       ,s
+                    ldu       $02,x
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L1793
+                    ldd       $06,u
+                    clra
+                    andb      #$80
+                    bne       L1793
+                    ldx       $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    lbsr      L15DE
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L179B
+L1793               ldd       [,s]
+L1795               std       ,s
+                    ldd       ,s
+                    bne       L176C
+L179B               ldx       $06,s
+                    ldd       $08,x
+                    std       $06,s
+L17A1               ldd       $06,s
+                    bne       L1766
+                    leas      $02,s
+                    puls      pc,u
+                    bge       $1823
+                    bmi       L17AD
+L17AD               bge       $1828
+                    bmi       L17B1
+L17B1               bge       $1828
+                    bmi       L17B5
+L17B5               bge       $17E4
+                    asl       >$002C
+                    blt       L1835
+                    neg       $002C
+                    blt       L1835
+                    neg       $002C
+                    asl       $2B2B
+                    neg       $002C
+                    rol       $2B2B
+                    neg       $002C
+                    fcb       $75
+                    bmi       $17FA
+                    neg       $002C
+                    blt       L1800
+                    asl       >$002C
+                    blt       $1805
+                    rol       >$002C
+                    blt       L180A
+                    fcb       $75
+                    neg       $002C
+                    com       $2B2B
+                    neg       $002D
+                    pshs      y,dp,b
+                    com       >$002D
+                    pshu      y,dp,b
+                    com       >$006C
+                    fcb       $62
+                    fcb       $72
+                    fcb       $61
+                    neg       $0034
+                    rora
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $273E
+                    leas      $02,s
+                    std       ,s
+L1800               cmpd      #$FFFF
+                    bne       L1810
+                    leax      >L185E,pcr
+L180A               pshs      x
+                    bsr       L1814
+                    leas      $02,s
+L1810               ldd       ,s
+                    bra       L185A
+
+L1814               pshs      u
+                    leax      >$186E,pcr
+                    pshs      x
+                    leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+L1835               pshs      d
+                    leax      $045f,y
+                    pshs      x
+                    lbsr      $1ABE
+                    leas      $0a,s
+                    leax      $045f,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L1FB2
+                    leas      $04,s
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L27D0
+L185A               leas      $02,s
+                    puls      pc,u
+L185E               tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       L206F
+                    ror       $6572
+                    ror       $0C,s
+                    clr       -$09,s
+                    neg       L0043
+                    bra       $18E0
+                    neg       $7469
+                    tst       $09,s
+                    com       $6572
+                    bra       $18E0
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    abx
+                    bra       L1882
+
+L1882               pshs      u
+                    leau      $0445,y
+L1888               ldd       $06,u
+                    clra
+                    andb      #$03
+                    lbeq      L18F9
+                    leau      $0d,u
+                    pshs      u
+                    leax      $0515,y
+                    cmpx      ,s++
+                    bhi       L1888
+                    ldd       #$00C8
+                    std       $0563,y
+                    lbra      L18FD
+                    puls      pc,u
+                    pshs      u
+                    ldu       $08,s
+                    bne       L18B3
+                    bsr       L1882
+                    tfr       d,u
+L18B3               stu       -$02,s
+                    beq       L18FD
+                    ldd       $04,s
+                    std       $08,u
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$2b
+                    beq       L18CB
+                    ldx       $06,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L18D1
+L18CB               ldd       $06,u
+                    orb       #$03
+                    bra       L18EF
+
+L18D1               ldd       $06,u
+                    pshs      d
+                    ldb       [$08,s]
+                    cmpb      #$72
+                    beq       L18E3
+                    ldb       [$08,s]
+                    cmpb      #$64
+                    bne       L18E8
+L18E3               ldd       #$0001
+                    bra       L18EB
+
+L18E8               ldd       #$0002
+L18EB               ora       ,s+
+                    orb       ,s+
+L18EF               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+L18F9               tfr       u,d
+                    puls      pc,u
+L18FD               clra
+                    clrb
+                    puls      pc,u
+L1901               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $0a,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L1932
+
+L1914               ldx       $0a,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L1921
+                    ldd       #$0007
+                    bra       L1929
+
+L1921               ldd       #$0004
+                    bra       L1929
+
+L1926               ldd       #$0003
+L1929               std       ,s
+                    bra       L1942
+
+L192D               leax      $04,s
+                    lbra      L199C
+
+L1932               stx       -$02,s
+                    beq       L1942
+                    cmpx      #$0078
+                    beq       L1914
+                    cmpx      #$002B
+                    beq       L1926
+                    bra       L192D
+
+L1942               ldb       [$0a,s]
+                    sex
+                    tfr       d,x
+                    lbra      L19A9
+
+L194B               ldd       ,s
+                    orb       #$01
+                    bra       L198F
+
+L1951               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      $2601
+                    leas      $04,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L197E
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $26D7
+                    leas      $08,s
+                    bra       L19C3
+
+L197E               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      $2622
+                    bra       L1996
+
+L198B               ldd       ,s
+                    orb       #$81
+L198F               pshs      d
+                    pshs      u
+                    lbsr      $2601
+L1996               leas      $04,s
+                    std       $02,s
+                    bra       L19C3
+
+L199C               leas      -$04,x
+L199E               ldd       #$00CB
+                    std       $0563,y
+                    clra
+                    clrb
+                    bra       L19C5
+
+L19A9               cmpx      #$0072
+                    lbeq      L194B
+                    cmpx      #$0061
+                    lbeq      L1951
+                    cmpx      #$0077
+                    beq       L197E
+                    cmpx      #$0064
+                    beq       L198B
+                    bra       L199E
+
+L19C3               ldd       $02,s
+L19C5               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      $1A25
+
+L19DA               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L1901
+                    leas      $04,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L19F5
+                    clra
+                    clrb
+                    bra       $1A2A
+
+L19F5               clra
+                    clrb
+                    bra       $1A1D
+
+L19F9               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $1E08
+                    suba      -$0e,y
+                    fcb       $62
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $1902
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L1A1C
+                    clra
+                    clrb
+                    bra       L1A2B
+
+L1A1C               ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $18AA
+                    leas      $06,s
+L1A2B               puls      pc,u
+                    pshs      u,d
+                    ldu       $06,s
+L1A31               leax      $0445,y
+                    pshs      x
+                    lbsr      L21CA
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$000D
+                    beq       L1A52
+                    ldd       ,s
+                    cmpd      #$FFFF
+                    beq       L1A52
+                    ldd       ,s
+                    stb       ,u+
+                    bra       L1A31
+
+L1A52               ldd       ,s
+                    cmpd      #$FFFF
+                    bne       L1A5E
+                    clra
+                    clrb
+                    puls      pc,u,x
+L1A5E               clra
+                    clrb
+                    stb       ,u
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$04,s
+                    ldd       $08,s
+                    std       ,s
+L1A70               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    ble       L1A97
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L21CA
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L1A97
+                    ldd       $02,s
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    cmpb      #$0d
+                    bne       L1A70
+L1A97               clra
+                    clrb
+                    stb       [,s]
+                    ldd       $02,s
+                    cmpd      #$FFFF
+                    bne       L1AA7
+                    clra
+                    clrb
+                    bra       L1AA9
+
+L1AA7               ldd       $08,s
+L1AA9               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    leax      $0452,y
+                    stx       $086b,y
+                    leax      $06,s
+                    pshs      x
+                    ldd       $06,s
+                    bra       L1ACD
+                    pshs      u
+                    ldd       $04,s
+                    std       $086b,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L1ACD               pshs      d
+                    leax      L1F87,pcr
+                    pshs      x
+                    bsr       L1AFF
+                    leas      $06,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $04,s
+                    std       $086b,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    leax      L1F9A,pcr
+                    pshs      x
+                    bsr       L1AFF
+                    leas      $06,s
+                    clra
+                    clrb
+                    stb       [$086b,y]
+                    ldd       $04,s
+                    puls      pc,u
+L1AFF               pshs      u
+                    ldu       $06,s
+                    leas      -$0b,s
+L1B05               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    beq       L1B1F
+                    ldb       $08,s
+                    lbeq      L1D46
+                    ldb       $08,s
+                    sex
+                    pshs      d
+                    jsr       [$11,s]
+                    leas      $02,s
+                    bra       L1B05
+
+L1B1F               ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L1B3C
+                    ldd       #$0001
+                    std       $0881,y
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L1B42
+
+L1B3C               clra
+                    clrb
+                    std       $0881,y
+L1B42               ldb       $08,s
+                    cmpb      #$30
+                    bne       L1B4D
+                    ldd       #$0030
+                    bra       L1B50
+
+L1B4D               ldd       #$0020
+L1B50               std       $0883,y
+L1B54               ldb       $08,s
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    beq       L1B80
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L247F
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L1B54
+
+L1B80               ldb       $08,s
+                    cmpb      #$2e
+                    bne       L1BB7
+                    ldd       #$0001
+                    std       $04,s
+L1B8B               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    beq       L1BBB
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L247F
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+                    bra       L1B8B
+
+L1BB7               clra
+                    clrb
+                    std       $04,s
+L1BBB               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L1CE9
+
+L1BC3               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L1D4A
+                    bra       L1BEB
+
+L1BD8               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L1E0D
+L1BEB               std       ,s
+                    lbra      L1CCF
+
+L1BF0               ldd       $06,s
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    leax      $03B8,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$02
+                    pshs      d
+                    ldx       $17,s
+                    leax      $02,x
+                    stx       $17,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L1E53
+                    lbra      L1CCB
+
+L1C16               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    leax      $086d,y
+                    pshs      x
+                    lbsr      L1D92
+                    lbra      L1CCB
+
+L1C32               ldd       $04,s
+                    bne       L1C3B
+                    ldd       #$0006
+                    std       $02,s
+L1C3B               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    ldb       $0e,s
+                    sex
+                    pshs      d
+                    lbsr      $23ED
+                    leas      $06,s
+                    lbra      L1CCD
+
+L1C55               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    lbra      L1CDF
+
+L1C62               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L1CAA
+                    ldd       $09,s
+                    std       $04,s
+L1C76               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    beq       L1C90
+                    ldb       [$09,s]
+                    beq       L1C90
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+                    bra       L1C76
+
+L1C90               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $15,s
+                    pshs      d
+                    lbsr      L1EBE
+                    leas      $08,s
+                    bra       L1CD9
+
+L1CAA               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    bra       L1CCD
+
+L1CB2               ldb       ,u+
+                    stb       $08,s
+                    bra       L1CBA
+                    leas      -$0b,x
+L1CBA               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldb       $0C,s
+                    sex
+                    pshs      d
+                    lbsr      L23AF
+L1CCB               leas      $04,s
+L1CCD               pshs      d
+L1CCF               ldd       $13,s
+                    pshs      d
+                    lbsr      L1F20
+                    leas      $06,s
+L1CD9               lbra      L1B05
+
+L1CDC               ldb       $08,s
+                    sex
+L1CDF               pshs      d
+                    jsr       [$11,s]
+                    leas      $02,s
+                    lbra      L1B05
+
+L1CE9               cmpx      #$0064
+                    lbeq      L1BC3
+                    cmpx      #$006F
+                    lbeq      L1BD8
+                    cmpx      #$0078
+                    lbeq      L1BF0
+                    cmpx      #$0058
+                    lbeq      L1BF0
+                    cmpx      #$0075
+                    lbeq      L1C16
+                    cmpx      #$0066
+                    lbeq      L1C32
+                    cmpx      #$0065
+                    lbeq      L1C32
+                    cmpx      #$0067
+                    lbeq      L1C32
+                    cmpx      #$0045
+                    lbeq      L1C32
+                    cmpx      #$0047
+                    lbeq      L1C32
+                    cmpx      #$0063
+                    lbeq      L1C55
+                    cmpx      #$0073
+                    lbeq      L1C62
+                    cmpx      #$006C
+                    lbeq      L1CB2
+                    bra       L1CDC
+
+L1D46               leas      $0b,s
+                    puls      pc,u
+L1D4A               pshs      u,d
+                    leax      $086d,y
+                    stx       ,s
+                    ldd       $06,s
+                    bge       L1D7E
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+                    bge       L1D73
+                    leax      L1FAC,pcr
+                    pshs      x
+                    leax      $086d,y
+                    pshs      x
+                    lbsr      L2409
+                    leas      $04,s
+                    puls      pc,u,x
+L1D73               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L1D7E               ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L1D92
+                    leas      $04,s
+                    leax      $086d,y
+                    tfr       x,d
+                    puls      pc,u,x
+L1D92               pshs      u,y,x,d
+                    ldu       $0a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+L1D9E               ldd       $0C,s
+                    bge       L1DB3
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      $0438,y
+                    std       $0C,s
+                    bra       L1D9E
+
+L1DB3               leax      $0438,y
+                    stx       $04,s
+L1DB9               ldd       $04,s
+                    cmpd      $0440,y
+                    beq       L1DFC
+L1DC2               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    blt       L1DD4
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    bra       L1DC2
+
+L1DD4               ldd       $0C,s
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L1DE4
+                    ldd       #$0001
+                    std       $02,s
+L1DE4               ldd       $02,s
+                    beq       L1DEF
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L1DEF               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+                    bra       L1DB9
+
+L1DFC               ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $06,s
+                    puls      pc,u
+L1E0D               pshs      u,d
+                    leax      $086d,y
+                    stx       ,s
+                    leau      $0877,y
+L1E19               ldd       $06,s
+                    clra
+                    andb      #$07
+                    addd      #$0030
+                    stb       ,u+
+                    ldd       $06,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    std       $06,s
+                    bne       L1E19
+L1E2F               leau      -$01,u
+                    pshs      u
+                    leax      $0877,y
+                    cmpx      ,s++
+                    bhi       L1E47
+                    ldb       ,u
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bra       L1E2F
+
+L1E47               clra
+                    clrb
+                    stb       [,s]
+                    leax      $086d,y
+                    tfr       x,d
+                    puls      pc,u,x
+L1E53               pshs      u,x,d
+                    leax      $086d,y
+                    stx       $02,s
+                    leau      $0877,y
+L1E5F               ldd       $08,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L1E81
+                    ldd       $0C,s
+                    beq       L1E79
+                    ldd       #$0041
+                    bra       L1E7C
+
+L1E79               ldd       #$0061
+L1E7C               addd      #$FFF6
+                    bra       L1E84
+
+L1E81               ldd       #$0030
+L1E84               addd      ,s++
+                    stb       ,u+
+                    ldd       $08,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $08,s
+                    bne       L1E5F
+L1E98               leau      -$01,u
+                    pshs      u
+                    leax      $0877,y
+                    cmpx      ,s++
+                    bhi       L1EB0
+                    ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+                    bra       L1E98
+
+L1EB0               clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $086d,y
+                    tfr       x,d
+                    lbra      L1F96
+
+L1EBE               pshs      u
+                    ldu       $06,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       $0a,s
+                    ldd       $0881,y
+                    bne       L1EE7
+L1ECE               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L1EE7
+                    ldd       $0883,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+                    bra       L1ECE
+
+L1EE7               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    beq       L1EFF
+                    ldb       ,u+
+                    sex
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+                    bra       L1EE7
+
+L1EFF               ldd       $0881,y
+                    beq       L1F1E
+L1F05               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L1F1E
+                    ldd       $0883,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+                    bra       L1F05
+
+L1F1E               puls      pc,u
+L1F20               pshs      u
+                    ldu       $06,s
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $23F8
+                    leas      $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    addd      ,s++
+                    std       $08,s
+                    ldd       $0881,y
+                    bne       L1F56
+L1F3D               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    ble       L1F56
+                    ldd       $0883,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+                    bra       L1F3D
+
+L1F56               ldb       ,u
+                    beq       L1F66
+                    ldb       ,u+
+                    sex
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+                    bra       L1F56
+
+L1F66               ldd       $0881,y
+                    beq       L1F85
+L1F6C               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    ble       L1F85
+                    ldd       $0883,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+                    bra       L1F6C
+
+L1F85               puls      pc,u
+L1F87               pshs      u
+                    ldd       $086b,y
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $1FB3
+L1F96               leas      $04,s
+                    puls      pc,u
+L1F9A               pshs      u
+                    ldd       $04,s
+                    ldx       $086b,y
+                    leax      $01,x
+                    stx       $086b,y
+                    stb       -$01,x
+                    puls      pc,u
+L1FAC               blt       L1FE1
+                    leas      -$09,y
+                    pshu      y,x,dp
+L1FB2               neg       $0034
+                    nega
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       L1FD7
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    lbne      L20ED
+                    pshs      u
+                    lbsr      L231F
+                    leas      $02,s
+L1FD7               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       L2013
+                    ldd       #$0001
+L1FE1               pshs      d
+                    leax      $07,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L1FF8
+                    leax      L26C8,pcr
+                    bra       L1FFC
+
+L1FF8               leax      L26AF,pcr
+L1FFC               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       L2054
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      L20ED
+
+L2013               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L2023
+                    pshs      u
+                    lbsr      L2108
+                    leas      $02,s
+L2023               ldd       ,u
+L2025               addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L2049
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2054
+                    ldd       $04,s
+                    cmpd      #$000D
+                    bne       L2054
+L2049               pshs      u
+                    lbsr      L2108
+                    std       ,s++
+                    lbne      L20ED
+L2054               ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      L2561
+                    pshs      d
+                    lbsr      $1FB3
+                    leas      $04,s
+L206F               ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $1FB3
+                    lbra      L21C2
+
+L207B               pshs      u,d
+                    leau      $0445,y
+                    clra
+                    clrb
+                    std       ,s
+L2085               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    bge       L20A1
+                    tfr       u,d
+                    leau      $0d,u
+                    pshs      d
+                    bsr       L20A3
+                    leas      $02,s
+                    bra       L2085
+
+L20A1               puls      pc,u,x
+L20A3               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       L20B3
+                    ldd       $06,u
+                    bne       L20B8
+L20B3               ldd       #$FFFF
+                    puls      pc,u,x
+L20B8               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       L20C7
+                    pshs      u
+                    bsr       L20DC
+                    leas      $02,s
+                    bra       L20C9
+
+L20C7               clra
+                    clrb
+L20C9               std       ,s
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L2611
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $06,u
+                    ldd       ,s
+                    puls      pc,u,x
+L20DC               pshs      u
+                    ldu       $04,s
+                    beq       L20ED
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       L20F2
+L20ED               ldd       #$FFFF
+                    puls      pc,u
+L20F2               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L2102
+                    pshs      u
+                    lbsr      L231F
+                    leas      $02,s
+L2102               pshs      u
+                    bsr       L2108
+                    puls      pc,u,x
+L2108               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L213A
+                    ldd       ,u
+                    cmpd      $04,u
+                    beq       L213A
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L21C6
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L26D8
+                    leas      $08,s
+L213A               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      L21B2
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L21B2
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2189
+                    ldd       $02,u
+L2158               std       ,u
+                    ldd       $02,s
+                    lbeq      L21B2
+                    ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L26C8
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L217D
+                    leax      $04,s
+                    bra       L21A1
+
+L217D               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+                    bra       L2158
+
+L2189               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L26AF
+                    leas      $06,s
+                    cmpd      $02,s
+                    beq       L21B2
+                    bra       L21A3
+
+L21A1               leas      -$04,x
+L21A3               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       L21C2
+
+L21B2               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+L21C2               leas      $04,s
+                    puls      pc,u
+L21C6               pshs      u
+                    puls      pc,u
+L21CA               pshs      u
+                    ldu       $04,s
+                    beq       L2216
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L2216
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L21F1
+                    ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldb       ,x
+                    clra
+                    bra       L21F8
+
+L21F1               pshs      u
+                    lbsr      L2265
+                    leas      $02,s
+L21F8               puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    beq       L2216
+                    ldd       $06,u
+                    clra
+                    andb      #$01
+                    beq       L2216
+                    ldd       $04,s
+                    cmpd      #$FFFF
+                    beq       L2216
+                    ldd       ,u
+                    cmpd      $02,u
+                    bhi       L221B
+L2216               ldd       #$FFFF
+                    puls      pc,u
+L221B               ldd       ,u
+                    addd      #$FFFF
+                    std       ,u
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      L21CA
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L2250
+                    pshs      u
+                    lbsr      L21CA
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L2255
+L2250               ldd       #$FFFF
+                    bra       L2261
+
+L2255               ldd       $02,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      L2578
+                    addd      ,s
+L2261               leas      $04,s
+                    puls      pc,u
+L2265               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$31
+                    cmpd      #$8001
+                    beq       L228E
+                    ldd       $06,u
+                    clra
+                    andb      #$31
+                    cmpd      #$0001
+                    beq       L2287
+                    ldd       #$FFFF
+                    puls      pc,u,x
+L2287               pshs      u
+                    lbsr      L231F
+                    leas      $02,s
+L228E               leax      $0445,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L22AB
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L22AB
+                    leax      $0452,y
+                    pshs      x
+                    lbsr      L20DC
+                    leas      $02,s
+L22AB               ldd       $06,u
+                    clra
+                    andb      #$08
+                    beq       L22D7
+                    ldd       $0b,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L22CB
+                    leax      L269F,pcr
+                    bra       L22CF
+
+L22CB               leax      L267E,pcr
+L22CF               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    bra       L22E9
+
+L22D7               ldd       #$0001
+                    pshs      d
+                    leax      $0a,u
+                    stx       $02,u
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L267E
+L22E9               leas      $06,s
+                    std       ,s
+                    ldd       ,s
+                    bgt       L230C
+                    ldd       $06,u
+                    pshs      d
+                    ldd       $02,s
+                    beq       L22FE
+                    ldd       #$0020
+                    bra       L2301
+
+L22FE               ldd       #$0010
+L2301               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    ldd       #$FFFF
+                    puls      pc,u,x
+L230C               ldd       $02,u
+                    addd      #$0001
+                    std       ,u
+                    ldd       $02,u
+                    addd      ,s
+                    std       $04,u
+                    ldb       [$02,u]
+                    clra
+                    puls      pc,u,x
+L231F               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       L2357
+                    leas      -$20,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L2593
+                    leas      $06,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       L234B
+                    ldd       #$0040
+                    bra       L234E
+
+L234B               ldd       #$0080
+L234E               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $20,s
+L2357               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       L2364
+                    puls      pc,u
+L2364               ldd       $0b,u
+L2366               bne       L2379
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2374
+                    ldd       #$0080
+                    bra       L2377
+
+L2374               ldd       #$0100
+L2377               std       $0b,u
+L2379               ldd       $02,u
+                    bne       L238E
+                    ldd       $0b,u
+                    pshs      d
+                    lbsr      L2796
+                    leas      $02,s
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       L2396
+L238E               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       L23A5
+
+L2396               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+L23A5               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    puls      pc,u
+L23AF               pshs      u
+                    ldb       $05,s
+                    sex
+                    tfr       d,x
+                    bra       L23D5
+
+L23B8               ldd       [$06,s]
+                    addd      #$0004
+                    std       [$06,s]
+                    leax      >L23EC,pcr
+                    bra       L23D1
+
+L23C7               ldb       $05,s
+                    stb       $0443,y
+                    leax      $0442,y
+L23D1               tfr       x,d
+                    puls      pc,u
+L23D5               cmpx      #$0064
+                    beq       L23B8
+                    cmpx      #$006F
+                    lbeq      L23B8
+                    cmpx      #$0078
+                    lbeq      L23B8
+                    bra       L23C7
+                    puls      pc,u
+L23EC               neg       $0034
+                    nega
+                    leax      >L23F7,pcr
+                    tfr       x,d
+                    puls      pc,u
+L23F7               neg       $0034
+                    nega
+                    ldu       $04,s
+L23FC               ldb       ,u+
+                    bne       L23FC
+                    tfr       u,d
+                    subd      $04,s
+                    addd      #$FFFF
+                    puls      pc,u
+L2409               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L2413               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L2413
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L242D               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L242D
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L243E               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L243E
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+L2452               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    bne       L2472
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L246E
+                    clra
+                    clrb
+                    puls      pc,u
+L246E               leau      $01,u
+                    bra       L2452
+
+L2472               ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+                    puls      pc,u
+L247F               tsta
+                    bne       L2494
+                    tst       $02,s
+                    bne       L2494
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+L2494               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L24B1
+                    inc       ,s
+L24B1               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L24BE
+                    inc       ,s
+L24BE               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+L24D1               rts
+                    subd      #$0000
+                    beq       L24E1
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    bra       L250F
+
+L24E1               puls      d
+                    std       ,s
+                    ldd       #$002D
+                    lbra      L2584
+                    subd      #$0000
+                    beq       L24E1
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    tsta
+                    bpl       L2503
+                    nega
+                    negb
+                    sbca      #$00
+                    inc       $01,s
+                    std       $02,s
+L2503               ldd       $06,s
+                    bpl       L250F
+                    nega
+                    negb
+                    sbca      #$00
+                    com       $01,s
+                    std       $06,s
+L250F               lda       #$01
+L2511               inca
+                    asl       $03,s
+                    rol       $02,s
+                    bpl       L2511
+                    sta       ,s
+                    ldd       $06,s
+                    clr       $06,s
+                    clr       $07,s
+L2520               subd      $02,s
+                    bcc       L252A
+                    addd      $02,s
+                    andcc     #$FE
+                    bra       L252C
+
+L252A               orcc      #$01
+L252C               rol       $07,s
+                    rol       $06,s
+                    lsr       $02,s
+                    ror       $03,s
+                    dec       ,s
+                    bne       L2520
+                    std       $02,s
+                    tst       $01,s
+                    beq       L2546
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+L2546               ldx       $04,s
+                    ldd       $06,s
+                    std       $04,s
+                    stx       $06,s
+                    ldx       $02,s
+                    ldd       $04,s
+                    leas      $06,s
+                    rts
+                    tstb
+                    beq       L256B
+L2558               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L2558
+                    bra       L256B
+
+L2561               tstb
+                    beq       L256B
+L2564               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L2564
+L256B               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+                    leas      $04,s
+                    rts
+
+L2578               tstb
+                    beq       L256B
+L257B               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       L257B
+                    bra       L256B
+
+L2584               std       $0563,y
+                    pshs      y,b
+                    os9       F$ID
+                    puls      y,b
+                    os9       F$Send
+                    rts
+
+L2593               lda       $05,s
+                    ldb       $03,s
+                    beq       L25C6
+                    cmpb      #$01
+                    beq       L25C8
+                    cmpb      #$06
+                    beq       L25C8
+                    cmpb      #$02
+                    beq       L25AE
+                    cmpb      #$05
+                    beq       L25AE
+                    ldb       #$D0
+                    lbra      L27C3
+
+L25AE               pshs      u
+                    os9       I$GetStt
+                    bcc       L25BA
+                    puls      u
+                    lbra      L27C3
+
+L25BA               stx       [$08,s]
+                    ldx       $08,s
+                    stu       $02,x
+                    puls      u
+                    clra
+                    clrb
+                    rts
+
+L25C6               ldx       $06,s
+L25C8               os9       I$GetStt
+                    lbra      L27CC
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       L25DD
+                    cmpb      #$02
+                    beq       L25E5
+                    ldb       #$D0
+                    lbra      L27C3
+
+L25DD               ldx       $06,s
+                    os9       I$SetStt
+                    lbra      L27CC
+
+L25E5               pshs      u
+                    ldx       $08,s
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u
+                    lbra      L27CC
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    bcs       L25FF
+                    os9       I$Close
+L25FF               lbra      L27CC
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    lbcs      L27C3
+                    tfr       a,b
+                    clra
+                    rts
+
+L2611               lda       $03,s
+                    os9       I$Close
+                    lbra      L27CC
+                    ldx       $02,s
+                    ldb       $05,s
+                    os9       I$MakDir
+                    lbra      L27CC
+                    ldx       $02,s
+                    lda       $05,s
+                    tfr       a,b
+                    andb      #$24
+                    orb       #$0b
+                    os9       I$Create
+                    bcs       L2636
+L2632               tfr       a,b
+                    clra
+                    rts
+
+L2636               cmpb      #$DA
+                    lbne      L27C3
+                    lda       $05,s
+                    bita      #$80
+                    lbne      L27C3
+                    anda      #$07
+                    ldx       $02,s
+                    os9       I$Open
+                    lbcs      L27C3
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+                    bcc       L2632
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+                    lbra      L27C3
+                    ldx       $02,s
+                    os9       I$Delete
+                    lbra      L27CC
+                    lda       $03,s
+                    os9       I$Dup
+                    lbcs      L27C3
+                    tfr       a,b
+                    clra
+                    rts
+
+L267E               pshs      y
+                    ldx       $06,s
+                    lda       $05,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$Read
+L268C               bcc       L269B
+                    cmpb      #$D3
+                    bne       L2696
+                    clra
+                    clrb
+                    puls      pc,y,x
+L2696               puls      y,x
+                    lbra      L27C3
+
+L269B               tfr       y,d
+                    puls      pc,y,x
+L269F               pshs      y
+                    lda       $05,s
+                    ldx       $06,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$ReadLn
+                    bra       L268C
+
+L26AF               pshs      y
+                    ldy       $08,s
+                    beq       L26C4
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$Write
+L26BD               bcc       L26C4
+                    puls      y
+                    lbra      L27C3
+
+L26C4               tfr       y,d
+                    puls      pc,y
+L26C8               pshs      y
+                    ldy       $08,s
+                    beq       L26C4
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$WritLn
+                    bra       L26BD
+
+L26D8               pshs      u
+                    ldd       $0a,s
+                    bne       L26E6
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       L271A
+
+L26E6               cmpd      #$0001
+                    beq       L2711
+                    cmpd      #$0002
+                    beq       L2706
+                    ldb       #$F7
+L26F4               clra
+                    std       $0563,y
+                    ldd       #$FFFF
+                    leax      $0557,y
+                    std       ,x
+                    std       $02,x
+                    puls      pc,u
+L2706               lda       $05,s
+                    ldb       #$02
+                    os9       I$GetStt
+                    bcs       L26F4
+                    bra       L271A
+
+L2711               lda       $05,s
+                    ldb       #$05
+                    os9       I$GetStt
+                    bcs       L26F4
+L271A               tfr       u,d
+                    addd      $08,s
+                    std       $0559,y
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       L26F4
+                    tfr       d,x
+                    std       $0557,y
+                    lda       $05,s
+                    os9       I$Seek
+                    bcs       L26F4
+                    leax      $0557,y
+                    puls      pc,u
+                    ldd       $0555,y
+                    pshs      d
+                    ldd       $04,s
+                    cmpd      $0885,y
+                    bcs       L2773
+                    addd      $0555,y
+                    pshs      y
+                    subd      ,s
+                    os9       F$Mem
+                    tfr       y,d
+                    puls      y
+                    bcc       L2765
+                    ldd       #$FFFF
+                    leas      $02,s
+                    rts
+
+L2765               std       $0555,y
+                    addd      $0885,y
+                    subd      ,s
+                    std       $0885,y
+L2773               leas      $02,s
+                    ldd       $0885,y
+                    pshs      d
+                    subd      $04,s
+                    std       $0885,y
+                    ldd       $0555,y
+                    subd      ,s++
+                    pshs      d
+                    clra
+                    ldx       ,s
+L278C               sta       ,x+
+                    cmpx      $0555,y
+                    bcs       L278C
+                    puls      pc,d
+L2796               ldd       $02,s
+                    addd      $055f,y
+                    bcs       L27BF
+                    cmpd      $0561,y
+                    bcc       L27BF
+                    pshs      d
+                    ldx       $055f,y
+                    clra
+L27AC               cmpx      ,s
+                    bcc       L27B4
+                    sta       ,x+
+                    bra       L27AC
+
+L27B4               ldd       $055f,y
+                    puls      x
+                    stx       $055f,y
+                    rts
+
+L27BF               ldd       #$FFFF
+                    rts
+
+L27C3               clra
+                    std       $0563,y
+                    ldd       #$FFFF
+                    rts
+
+L27CC               bcs       L27C3
+                    clra
+                    clrb
+L27D0               rts
+                    lbsr      L27DC
+                    lbsr      L207B
+                    ldd       $02,s
+                    os9       F$Exit
+L27DC               rts
+                    neg       $0007
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0004
+                    sbcb      >$0000
+                    fcb       $01
+                    bge       L27FD
+                    fcb       $52
+                    fcb       $10
+                    fcb       $55
+                    fcb       $10
+                    aslb
+                    fcb       $10
+                    fcb       $5b
+                    fcb       $10
+                    fcb       $5e
+                    fcb       $10
+                    fcb       $61
+                    fcb       $10
+                    lsr       -$10,x
+                    asr       -$10,x
+L27FD               dec       -$10,x
+                    tst       -$10,x
+                    neg       $1073
+                    fcb       $10
+                    ror       L1079
+                    fcb       $10
+                    inc       L107F
+                    fcb       $10
+                    sbca      #$10
+                    bita      #$64
+                    neg       $0078
+                    neg       $0079
+                    neg       $0075
+                    neg       L0064
+                    bge       L2893
+                    neg       L0064
+                    bge       $2898
+                    neg       L0064
+                    bge       $2898
+                    neg       L0064
+                    bge       $289F
+                    bge       $289E
+                    neg       L0064
+                    bge       L28A5
+                    bge       L28A8
+                    bge       L28A6
+                    neg       $0078
+                    bge       L28AA
+                    bge       L28A7
+                    com       0,x
+                    rol       L2C64
+                    neg       $0079
+                    bge       L28B5
+                    neg       $0075
+                    bge       L28A8
+                    neg       $0075
+                    bge       $28B8
+                    com       0,x
+                    com       $0C,s
+                    fcb       $72
+                    fcb       $61
+                    neg       $0063
+                    tst       -$10,s
+                    fcb       $62
+                    neg       $0063
+                    tst       -$10,s
+                    lsr       0,x
+                    com       $0d,s
+                    neg       $7800
+                    com       $0d,s
+                    neg       $7900
+                    com       $0d,s
+                    neg       $7500
+                    inc       $04,s
+                    fcb       $62
+                    neg       $006C
+                    lsr       $04,s
+                    neg       $006C
+                    lsr       -$08,s
+                    neg       $006C
+                    lsr       -$07,s
+                    neg       $006C
+                    lsr       -$0b,s
+                    neg       $0073
+                    lsr       $6200
+                    com       $7464
+                    neg       $0073
+                    lsr       $7800
+                    com       $7479
+                    neg       $0073
+                    lsr       $7500
+                    neg       $7368
+L2893               com       >$0070
+                    fcb       $75
+                    inc       -$0d,s
+                    neg       $006C
+                    fcb       $65
+                    fcb       $61
+                    asl       >$006C
+                    fcb       $65
+                    fcb       $61
+                    rol       >$006C
+L28A5               fcb       $65
+L28A6               fcb       $61
+L28A7               fcb       $75
+L28A8               neg       $006C
+L28AA               fcb       $65
+                    fcb       $61
+                    com       >$0073
+                    fcb       $65
+                    asl       >L0074
+                    ror       -$0e,s
+L28B5               neg       $0023
+                    leax      0,x
+                    leas      $0C,y
+                    asl       >L0031
+                    bge       $2938
+                    neg       $0030
+                    bge       $293C
+                    neg       $002D
+                    leay      $0C,y
+                    asl       >$002D
+                    leas      $0C,y
+                    asl       >$0032
+                    bge       L294B
+                    neg       L0031
+                    bge       L294F
+                    neg       $0030
+                    bge       L2953
+                    neg       $002D
+                    leay      $0C,y
+                    rol       >$002D
+                    leas      $0C,y
+                    rol       >$0032
+                    bge       L295D
+                    neg       L0031
+                    bge       L2961
+                    neg       $0030
+                    bge       L2965
+                    neg       $002D
+                    leay      $0C,y
+                    fcb       $75
+                    neg       $002D
+                    leas      $0C,y
+                    fcb       $75
+                    neg       $0032
+                    bge       L2971
+                    neg       $0030
+                    bge       L2975
+                    neg       $002D
+                    leas      $0C,y
+                    com       >$0023
+                    cwai      #$00
+                    neg       $0002
+                    neg       L00BB
+                    neg       $0000
+                    neg       $00A7
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00BF
+                    neg       $0000
+                    neg       L00AB
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00B7
+                    neg       $0000
+                    neg       L00A3
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       $00A7
+                    neg       $0000
+                    neg       L00BB
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+L294B               neg       $0002
+                    neg       L00AB
+L294F               neg       $0000
+                    neg       L00BF
+L2953               neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0001
+L295D               neg       L00ED
+                    neg       L0074
+L2961               neg       L00CB
+                    neg       L004B
+L2965               neg       $0002
+                    neg       L004F
+                    neg       $0000
+                    neg       $0001
+                    neg       L00ED
+                    neg       $007C
+L2971               neg       L00CB
+                    neg       L004B
+L2975               neg       $0002
+                    neg       L0051
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L004D
+                    neg       L00CB
+                    neg       L004B
+                    neg       $0001
+                    neg       L0053
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       L00CB
+                    neg       L004B
+                    neg       $0001
+                    neg       L005B
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L004F
+                    neg       L00CB
+                    neg       L004B
+                    neg       $0001
+                    neg       L0057
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       L00CB
+                    neg       L004F
+                    neg       $0001
+                    neg       $0078
+                    neg       $0000
+                    neg       $0002
+                    neg       $00A7
+                    neg       $0000
+                    neg       L008F
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00AB
+                    neg       $0000
+                    neg       $0094
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00AF
+                    neg       $0000
+                    neg       L0099
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00B3
+                    neg       $0000
+                    neg       $009E
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00C3
+                    neg       $0000
+                    neg       L0099
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00C7
+                    neg       $0000
+                    neg       $009E
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00A3
+                    neg       $0000
+                    neg       L00B7
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0001
+                    neg       L00E9
+                    neg       $0000
+                    neg       $0085
+                    neg       $0000
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0002
+                    neg       L00D5
+                    neg       $00F8
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    fcb       $02
+                    lbsr      $D34A
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    jmp       $0000
+                    neg       $0001
+                    lbra      $2A59
+                    lbsr      $D75A
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    bcc       L2A62
+L2A62               neg       $0001
+                    bge       L2A66
+L2A66               fcb       $02
+                    lbsr      $DB6A
+                    neg       $0000
+                    fcb       $02
+                    neg       L00D5
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    ldd       >$0002
+                    lbsr      $DF7A
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    lbra      L2A83
+L2A83               fcb       $01
+                    nop
+                    neg       $0002
+                    lbsr      $E38A
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    bge       L2A92
+L2A92               neg       $0001
+                    bvc       L2A96
+L2A96               fcb       $02
+                    lbsr      $E79A
+                    neg       $0000
+                    fcb       $02
+                    neg       L00D5
+                    neg       L00F4
+                    neg       $0000
+                    fcb       $01
+                    fcb       $05
+                    neg       $0002
+                    lbsr      $EBAA
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    dec       $0000
+                    neg       $0001
+                    fcb       $1b
+                    neg       $0002
+                    lbsr      $F0BA
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    bra       L2AC2
+
+L2AC2               neg       $0001
+                    leay      0,x
+                    fcb       $02
+                    lbsr      $F5CA
+                    neg       $0000
+                    fcb       $02
+                    neg       L00D5
+                    fcb       $01
+                    fcb       $05
+                    neg       $0000
+                    neg       $00FC
+                    neg       $0002
+                    lbsr      $FADA
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    fcb       $1b
+                    neg       $0000
+                    fcb       $01
+                    nop
+                    neg       $0002
+                    lbsr      $FFEA
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    leay      0,x
+                    neg       $0001
+                    bvc       L2AF6
+L2AF6               fcb       $02
+                    lbsr      $04FA
+                    neg       $0000
+                    fcb       $02
+                    neg       L00E9
+                    neg       $0000
+                    neg       L008F
+                    fcb       $01
+                    coma
+                    neg       $008A
+                    neg       $0002
+                    neg       $0000
+                    neg       $0002
+                    neg       $0085
+                    neg       $0000
+                    neg       L008F
+                    fcb       $01
+                    coma
+                    neg       $008A
+                    neg       $0002
+                    neg       $0000
+                    neg       $0002
+                    neg       $00E4
+                    fcb       $01
+                    fcb       $36,$00
+                    adda      $013E
+                    neg       $0002
+                    lbsr      $0A2A
+                    neg       $0000
+                    fcb       $02
+                    neg       $00E4
+                    fcb       $01
+                    fcb       $36,$00
+                    addb      #$00
+                    fcb       $4b
+                    neg       L00BB
+                    fcb       $01
+                    abx
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       $00E4
+                    fcb       $01
+                    fcb       $3E
+                    neg       $0001
+                    neg       L005B
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       $00E4
+                    lbsr      L0F56
+                    fcb       $01
+                    neg       $005F
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       $00E4
+                    lbsr      $1466
+                    fcb       $01
+                    neg       $0065
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0002
+                    neg       $0038
+                    fcb       $38
+                    bvc       $2BD9
+                    bvc       $2BDB
+                    bvc       L2BDD
+                    bvc       L2BDF
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    bhi       $2BE2
+                    bhi       $2BE4
+                    bhi       $2BE6
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+L2BDD               neg       $0004
+L2BDF               lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0000
+                    neg       $0000
+                    neg       $0000
+                    beq       L2C0F
+                    com       $00E8
+                    neg       L0064
+                    neg       $000A
+                    lsr       $0040
+                    inc       -$08,s
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L2C0F               neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L2C64               neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       L0021
+                    fcb       $02
+                    sbcb      #$02
+                    sbca      $02A2
+                    fcb       $02
+                    sbca      $0002
+                    sbca      #$03
+                    leas      $03,x
+                    bhi       L2CEE
+                    nop
+                    com       $0002
+L2CEE               fcb       $02
+                    sbcb      L02E2
+                    fcb       $02
+                    sbcb      $0000
+                    blt       L2CF7
+L2CF7               bmi       L2CF9
+L2CF9               bvs       L2CFB
+L2CFB               beq       $2D00
+                    ldx       $0003
+                    ldx       #$0362
+                    neg       L003B
+                    neg       L0039
+                    neg       L0037
+                    neg       L0035
+                    neg       $0033
+                    neg       L0031
+                    neg       L002F
+                    neg       $0049
+                    neg       L0047
+                    neg       L0045
+                    neg       L0043
+                    neg       L0041
+                    neg       $003F
+                    neg       L003D
+                    neg       $0082
+                    fcb       $01
+                    aslb
+                    fcb       $01
+                    inca
+                    fcb       $01
+                    asla
+                    lsr       $0040
+                    fcb       $01
+                    cmpx      #$0188
+                    fcb       $01
+                    inc       L0178
+                    fcb       $01
+                    inc       $01,x
+                    asl       $01,x
+                    incb
+                    fcb       $01
+                    ora       $01,x
+                    eora      $01,x
+                    sbca      $01,x
+                    ldx       $0001
+                    cmpx      $0001
+                    ora       $0001
+                    eora      $0001
+                    ldx       $01BC
+                    fcb       $01
+                    ora       L01B8
+                    fcb       $01
+                    sbca      $01AE
+                    fcb       $01
+                    cmpx      $01,x
+                    eorb      $0001
+                    sbcb      $0001
+                    ldu       #$01CC
+                    fcb       $01
+                    orb       #$01
+                    eorb      #$01
+                    sbcb      #$01
+                    ldd       $01,x
+                    orb       $01,x
+                    eorb      $01,x
+                    sbcb      $01,x
+                    ldu       $0001
+                    ldd       $0001
+                    orb       $0002
+                    inc       $0002
+                    asl       $0001
+                    ldu       L01FC
+                    fcb       $01
+                    eorb      $01F2
+                    fcb       $01
+                    ldu       $02,x
+                    bgt       L2D81
+                    bge       L2D83
+L2D81               bvc       L2D85
+L2D83               exg       d,y
+L2D85               andcc     #$02
+                    fcb       $18
+                    fcb       $02
+                    jmp       $0002
+                    aslb
+                    fcb       $02
+                    fcb       $4e
+                    fcb       $02
+                    inca
+                    fcb       $02
+                    asla
+                    fcb       $02
+                    fcb       $3E
+                    fcb       $02
+                    cwai      #$02
+                    fcb       $38
+                    fcb       $02
+                    eora      #$02
+                    jmp       $027A
+                    fcb       $02
+                    asl       L026C
+                    fcb       $02
+                    asl       $02,x
+                    incb
+                    fcb       $02
+                    ora       $02,x
+                    eora      $02,x
+                    ldx       $0002
+                    ora       $0002
+                    eora      $0002
+                    ldx       #$028A
+                    fcb       $02
+                    ldu       #$02CA
+                    fcb       $02
+                    eorb      #$02
+                    ldx       $02BA
+                    fcb       $02
+                    eora      $02AE
+                    fcb       $02
+                    eorb      $02EE
+                    fcb       $02
+                    orb       $02,x
+                    eorb      $02,x
+                    ldu       $0002
+                    orb       $0002
+                    eorb      $0003
+                    orcc      #$03
+                    fcb       $18
+                    com       $000E
+                    com       $000A
+                    com       $0008
+                    fcb       $02
+                    ldu       L02FA
+                    com       $003E
+                    com       $003C
+                    com       $0038
+                    com       $002E
+                    com       $002A
+                    com       $0028
+                    com       L001E
+                    com       $005A
+                    com       $0058
+                    com       $0050
+                    com       $004E
+                    com       $004C
+                    com       L0048
+                    com       $0040
+                    com       $0070
+                    com       $006E
+                    com       $006C
+                    com       $006A
+                    com       $0068
+                    com       L005E
+                    com       $005C
+                    com       $0088
+                    com       $0082
+                    com       $007E
+                    com       $007C
+                    com       $007A
+                    com       $0078
+                    com       $0072
+                    com       $00A2
+                    com       $009C
+                    com       $009A
+                    com       $0098
+                    com       $0092
+                    com       $008C
+                    com       $008A
+                    com       $0e,y
+                    clr       -$10,s
+                    fcb       $74
+
+                    emod
+eom                 equ       *
+                    end

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $04
 
-                    mod       eom,name,tylg,atrv,_start,size
+                    mod       eom,name,tylg,atrv,start,size
 
 u0000               rmb       5127
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.opt/
                     fcb       edition
 
-copybytes           lda       ,y+
+L0013               lda       ,y+
 L0015               sta       ,u+
 L0017               leax      -$01,x
-L0019               bne       copybytes
+L0019               bne       L0013
 L001B               rts
 
-_start              pshs      y
+start               pshs      y
 L001E               pshs      u
 L0020               clra
 L0021               clrb
@@ -37,12 +37,12 @@ L002F               pshs      x
 L0031               leay      L27DC,pcr
 L0035               ldx       ,y++
 L0037               beq       L003D
-L0039               bsr       copybytes
+L0039               bsr       L0013
 L003B               ldu       $02,s
 L003D               leau      >$0023,u
 L0041               ldx       ,y++
 L0043               beq       L0048
-L0045               bsr       copybytes
+L0045               bsr       L0013
 L0047               clra
 L0048               cmpu      ,s
 L004B               beq       L0051
@@ -119,12 +119,12 @@ L00DF               leax      $0515,u
                     ldd       $0551,u
 L00E9               pshs      d
                     leay      ,u
-L00ED               bsr       stkinit
-                    lbsr      main
+L00ED               bsr       L00F9
+                    lbsr      L017B
                     clr       ,-s
 L00F4               clr       ,-s
-                    lbsr      exit
-stkinit             leax      $0887,y
+                    lbsr      L27D0
+L00F9               leax      $0887,y
                     stx       $055f,y
                     sts       $0553,y
                     sts       $0561,y
@@ -145,7 +145,7 @@ L013A               leax      L0121,pcr
                     ldy       #$0064
                     os9       I$WritLn
                     clr       ,-s
-                    lbsr      $27D6
+                    lbsr      L27D6
                     ldd       $0553,y
                     subd      $0561,y
                     rts
@@ -167,7 +167,7 @@ L0169               ldd       ,y++
 L0178               leas      $04,s
                     rts
 
-main                pshs      u
+L017B               pshs      u
                     leas      -$08,s
                     leax      $0445,y
                     stx       $0565,y
@@ -214,7 +214,7 @@ L01BD               clra
 L01D8               ldd       >$0025,y
                     pshs      d
                     ldd       #$000A
-                    lbsr      $247E
+                    lbsr      L247E
                     pshs      d
                     ldd       $08,s
                     addd      #$FFD0
@@ -314,7 +314,7 @@ L02AB               ldd       $0567,y
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $04,s
                     ldd       $0009
                     pshs      d
@@ -322,7 +322,7 @@ L02AB               ldd       $0567,y
                     pshs      x
 L02E2               leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $06,s
                     ldd       L0019
                     pshs      d
@@ -339,7 +339,7 @@ L02FA               pshs      d
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $0a,s
                     ldd       $0009
                     pshs      d
@@ -354,7 +354,7 @@ L02FA               pshs      d
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $08,s
                     ldd       L001B
                     aslb
@@ -386,7 +386,7 @@ L02FA               pshs      d
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $0a,s
                     leas      $04,s
 L037E               leas      $08,s
@@ -398,10 +398,10 @@ L0382               pshs      u
                     ldd       $06,s
                     pshs      d
                     ldd       #$0003
-                    lbsr      $247E
+                    lbsr      L247E
                     pshs      d
                     ldd       #$0005
-                    lbsr      $24EA
+                    lbsr      L24EA
                     addd      ,s++
                     puls      pc,u
 L03A0               pshs      u
@@ -492,7 +492,7 @@ L0452               leax      L0775,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     lbne      L056C
@@ -505,7 +505,7 @@ L0473               leax      L077D,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     lbeq      L053B
@@ -515,7 +515,7 @@ L048C               leax      L0782,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     lbne      L056C
@@ -528,7 +528,7 @@ L04A8               leax      $0080,s
                     pshs      x
                     ldd       $0567,y
 L04B8               pshs      d
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $06,s
                     lbra      L0625
 
@@ -536,7 +536,7 @@ L04C2               leax      L078A,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     lbne      L056C
@@ -547,17 +547,17 @@ L04DE               leax      L0790,pcr
                     pshs      x
                     leax      $6b,s
                     pshs      x
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     beq       L053B
                     lbra      L056C
 
 L04F5               leax      $0794,pcr
-                    pshs      x
+L04F9               pshs      x
                     leax      $6b,s
                     pshs      x
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     lbne      L056C
@@ -676,7 +676,7 @@ L05CB               ldb       $69,s
 L0612               ldd       $0009
                     addd      #$0001
                     std       $0009
-                    ldd       copybytes
+                    ldd       L0013
                     cmpd      >$0025,y
                     blt       L0625
                     lbsr      L0D20
@@ -686,7 +686,7 @@ L0625               ldd       $0565,y
                     pshs      d
                     leax      $0084,s
                     pshs      x
-                    lbsr      $1A65
+                    lbsr      L1A65
                     leas      $06,s
                     std       -$02,s
                     lbne      L03D7
@@ -706,7 +706,7 @@ L0660               bsr       L0671
                     bra       L0667
 
 L0664               lbsr      L0D20
-L0667               ldd       copybytes
+L0667               ldd       L0013
                     bne       L0664
                     leas      $00E4,s
                     puls      pc,u
@@ -721,13 +721,13 @@ L0671               pshs      u
                     bra       L0688
 
 L0681               lbsr      L0D20
-L0684               ldd       copybytes
+L0684               ldd       L0013
                     bne       L0681
 L0688               leax      L07A3,pcr
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $04,s
                     clra
                     clrb
@@ -979,7 +979,7 @@ L0946               pshs      u,d
                     ldd       $02,s
                     addd      #$000C
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
                     stu       [,s]
                     ldd       $02,u
@@ -1012,7 +1012,7 @@ L09A2               ldd       $02,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     bne       L09BA
@@ -1078,7 +1078,7 @@ L0A14               pshs      u
                     std       [$02,u]
                     ldd       $02,u
                     ldx       ,u
-                    std       $02,x
+L0A29               std       $02,x
                     ldd       $0011
                     std       ,u
                     stu       $0011
@@ -1092,7 +1092,7 @@ L0A33               pshs      u
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    lbsr      $1ADA
+                    lbsr      L1ADA
                     leas      $06,s
                     puls      pc,u
 L0A53               clrb
@@ -1106,7 +1106,7 @@ L0A5E               ldd       ,u
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     lbeq      L0CCF
@@ -1125,7 +1125,7 @@ L0A7C               pshs      u
                     clrb
                     std       $001D
                     std       $001F
-                    std       copybytes
+                    std       L0013
                     puls      pc,u
 L0A92               pshs      u
                     leas      -$0a,s
@@ -1159,7 +1159,7 @@ L0AC3               ldd       $10,s
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
                     ldd       $12,s
                     std       $04,s
@@ -1183,9 +1183,9 @@ L0AEB               ldd       $04,s
                     stu       [$02,x]
                     ldx       $0e,s
                     stu       $02,x
-                    ldd       copybytes
+                    ldd       L0013
                     addd      #$0001
-                    std       copybytes
+                    std       L0013
                     leax      $08,u
                     stx       $06,s
                     ldb       ,x
@@ -1218,7 +1218,7 @@ L0B26               leax      >$004b,y
                     subd      ,s++
                     pshs      d
                     ldd       #$0002
-                    lbsr      $24EA
+                    lbsr      L24EA
                     orb       #$60
                     ora       ,s+
                     orb       ,s+
@@ -1229,7 +1229,7 @@ L0B26               leax      >$004b,y
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
                     leax      ,s
                     pshs      x
@@ -1309,7 +1309,7 @@ L0C15               leax      L1088,pcr
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     bne       L0C6B
@@ -1324,7 +1324,7 @@ L0C38               leax      L1091,pcr
                     pshs      x
                     ldd       $08,s
 L0C40               pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     bne       L0C6B
@@ -1353,7 +1353,7 @@ L0C6B               ldd       $06,u
                     leas      $02,s
                     std       $13,u
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
 L0C8A               tfr       u,d
 L0C8C               leas      $0a,s
@@ -1461,7 +1461,7 @@ L0D62               ldd       ,s
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $06,s
                     ldx       ,s
                     ldd       $0a,x
@@ -1472,7 +1472,7 @@ L0D62               ldd       ,s
                     pshs      d
                     ldd       #$003A
                     pshs      d
-                    lbsr      L1FB2
+                    lbsr      $1FB2
                     leas      $04,s
 L0D93               ldx       ,s
                     ldd       $08,x
@@ -1482,7 +1482,7 @@ L0D93               ldx       ,s
                     pshs      d
                     ldd       #$000D
                     pshs      d
-                    lbsr      L1FB2
+                    lbsr      $1FB2
 L0DA9               leas      $04,s
 L0DAB               ldd       ,s
                     bne       L0D62
@@ -1490,7 +1490,7 @@ L0DAB               ldd       ,s
                     pshs      d
                     ldd       #$0020
                     pshs      d
-                    lbsr      L1FB2
+                    lbsr      $1FB2
                     leas      $04,s
                     ldd       $06,u
                     clra
@@ -1525,7 +1525,7 @@ L0DF6               tfr       x,d
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $0a,s
                     bra       L0E42
 
@@ -1537,7 +1537,7 @@ L0E0D               pshs      u
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $06,s
                     ldb       [$13,u]
                     beq       L0E42
@@ -1547,13 +1547,13 @@ L0E0D               pshs      u
                     pshs      x
                     ldd       $0567,y
                     pshs      d
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $06,s
 L0E42               ldd       $0567,y
                     pshs      d
                     ldd       #$000D
                     pshs      d
-                    lbsr      L1FB2
+                    lbsr      $1FB2
                     leas      $04,s
                     pshs      u
                     lbsr      L0F2A
@@ -1679,7 +1679,7 @@ L0F4E               ldd       $04,u
 L0F52               clra
                     clrb
                     ldx       ,s
-L0F56               std       $04,x
+                    std       $04,x
                     ldd       ,s
                     pshs      d
                     lbsr      L0A14
@@ -1697,9 +1697,9 @@ L0F65               std       ,s
                     ldd       $001D
                     std       ,u
                     stu       $001D
-                    ldd       copybytes
+                    ldd       L0013
                     addd      #$FFFF
-                    std       copybytes
+                    std       L0013
 L0F83               leas      $02,s
                     puls      pc,u
 L0F87               pshs      u,x,d
@@ -2039,7 +2039,7 @@ L1277               pshs      d
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
                     bra       L1295
 
@@ -2067,7 +2067,7 @@ L12A9               ldx       $08,s
 L12AD               pshs      d
                     ldd       $13,u
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
                     bra       L12CB
 
@@ -2126,7 +2126,7 @@ L12F5               pshs      u
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    lbsr      $2408
+                    lbsr      L2408
                     leas      $04,s
                     ldd       $13,u
                     pshs      d
@@ -2174,7 +2174,7 @@ L136E               ldb       [$06,s]
 L138F               ldd       ,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      $247E
+                    lbsr      L247E
                     pshs      d
                     ldb       ,u+
                     sex
@@ -2278,7 +2278,7 @@ L1454               std       $06,s
 L145F               pshs      u
                     ldx       $02,s
                     ldd       $02,x
-                    std       $0a,s
+L1465               std       $0a,s
                     pshs      d
                     lbsr      L0CEA
                     leas      $04,s
@@ -2429,7 +2429,7 @@ L1576               ldx       $08,s
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     bne       L15CA
@@ -2438,7 +2438,7 @@ L1576               ldx       $08,s
                     pshs      d
                     ldd       $13,u
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     bne       L15CA
@@ -2535,7 +2535,7 @@ L1684               ldd       $1a,s
                     ldd       #$0008
                     addd      ,s++
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
                     bne       L16B4
@@ -2544,7 +2544,7 @@ L1684               ldd       $1a,s
                     pshs      d
                     ldd       $13,u
                     pshs      d
-                    lbsr      $244D
+                    lbsr      L244D
                     leas      $04,s
                     std       -$02,s
 L16B2               beq       L1673
@@ -2677,9 +2677,9 @@ L17B5               bge       $17E4
                     neg       $002C
                     blt       L1835
                     neg       $002C
-                    asl       $2B2B
+                    asl       L2B2B
                     neg       $002C
-                    rol       $2B2B
+                    rol       L2B2B
                     neg       $002C
                     fcb       $75
                     bmi       $17FA
@@ -2691,7 +2691,7 @@ L17B5               bge       $17E4
                     blt       L180A
                     fcb       $75
                     neg       $002C
-                    com       $2B2B
+                    com       L2B2B
                     neg       $002D
                     pshs      y,dp,b
                     com       >$002D
@@ -2702,7 +2702,7 @@ L17B5               bge       $17E4
 L17F3               pshs      u,d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $273E
+                    lbsr      L273E
                     leas      $02,s
                     std       ,s
 L1800               cmpd      #$FFFF
@@ -2719,7 +2719,7 @@ L1814               pshs      u
                     pshs      x
                     leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $04,s
                     ldd       $0a,s
                     pshs      d
@@ -2731,17 +2731,17 @@ L1814               pshs      u
 L1835               pshs      d
                     leax      $045f,y
                     pshs      x
-                    lbsr      $1ABE
+                    lbsr      L1ABE
                     leas      $0a,s
                     leax      $045f,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      L1FB2
+                    lbsr      $1FB2
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      exit
+                    lbsr      L27D0
 L185A               leas      $02,s
                     puls      pc,u
 L185E               fcc       /memory overflow/
@@ -2763,7 +2763,7 @@ L1888               ldd       $06,u
                     std       $0563,y
                     lbra      L18FD
                     puls      pc,u
-                    pshs      u
+L18A9               pshs      u
                     ldu       $08,s
                     bne       L18B3
                     bsr       L1882
@@ -2858,7 +2858,7 @@ L1951               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      $2601
+                    lbsr      L2601
                     leas      $04,s
                     std       $02,s
                     cmpd      #$FFFF
@@ -2873,7 +2873,7 @@ L1951               ldd       ,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      $26D7
+                    lbsr      L26D7
                     leas      $08,s
                     bra       L19C3
 
@@ -2881,14 +2881,14 @@ L197E               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      $2622
+                    lbsr      L2622
                     bra       L1996
 
 L198B               ldd       ,s
                     orb       #$81
 L198F               pshs      d
                     pshs      u
-                    lbsr      $2601
+                    lbsr      L2601
 L1996               leas      $04,s
                     std       $02,s
                     bra       L19C3
@@ -2921,7 +2921,7 @@ L19C5               leas      $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbra      $1A25
+                    lbra      L1A25
 
 L19DA               pshs      u
                     ldd       $06,s
@@ -2935,101 +2935,100 @@ L19DA               pshs      u
                     bne       L19F5
                     clra
                     clrb
-                    bra       $1A2A
+                    bra       L1A2A
 
 L19F5               clra
                     clrb
-                    bra       $1A1D
+                    bra       L1A1D
 
 L19F9               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      $1E08
-                    suba      -$0e,y
-                    fcb       $62
+                    lbsr      L20A2
+                    leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $1902
+                    lbsr      L1901
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    bge       L1A1C
+                    bge       L1A1B
                     clra
                     clrb
-                    bra       L1A2B
+                    bra       L1A2A
 
-L1A1C               ldd       $08,s
-                    pshs      d
+L1A1B               ldd       $08,s
+L1A1D               pshs      d
                     ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      $18AA
+L1A25               lbsr      L18A9
                     leas      $06,s
-L1A2B               puls      pc,u
+L1A2A               puls      pc,u
                     pshs      u,d
                     ldu       $06,s
-L1A31               leax      $0445,y
+L1A30               leax      $0445,y
                     pshs      x
-                    lbsr      L21CA
+                    lbsr      L21C9
                     leas      $02,s
                     std       ,s
                     cmpd      #$000D
-                    beq       L1A52
+                    beq       L1A51
                     ldd       ,s
                     cmpd      #$FFFF
-                    beq       L1A52
+                    beq       L1A51
                     ldd       ,s
                     stb       ,u+
-                    bra       L1A31
+                    bra       L1A30
 
-L1A52               ldd       ,s
+L1A51               ldd       ,s
                     cmpd      #$FFFF
-                    bne       L1A5E
+                    bne       L1A5D
                     clra
                     clrb
                     puls      pc,u,x
-L1A5E               clra
+L1A5D               clra
                     clrb
                     stb       ,u
                     ldd       $06,s
                     puls      pc,u,x
-                    pshs      u
+L1A65               pshs      u
                     ldu       $06,s
                     leas      -$04,s
                     ldd       $08,s
                     std       ,s
-L1A70               tfr       u,d
+L1A6F               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    ble       L1A97
+                    ble       L1A96
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L21CA
+                    lbsr      L21C9
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L1A97
+                    beq       L1A96
                     ldd       $02,s
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
                     cmpb      #$0d
-                    bne       L1A70
-L1A97               clra
+                    bne       L1A6F
+L1A96               clra
                     clrb
                     stb       [,s]
                     ldd       $02,s
                     cmpd      #$FFFF
-                    bne       L1AA7
+                    bne       L1AA6
                     clra
                     clrb
-                    bra       L1AA9
+                    bra       L1AA8
 
-L1AA7               ldd       $08,s
-L1AA9               leas      $04,s
+L1AA6               ldd       $08,s
+L1AA8               leas      $04,s
                     puls      pc,u
                     pshs      u
                     leax      $0452,y
@@ -3037,52 +3036,53 @@ L1AA9               leas      $04,s
                     leax      $06,s
                     pshs      x
                     ldd       $06,s
-                    bra       L1ACD
-                    pshs      u
+                    bra       L1ACC
+
+L1ABE               pshs      u
                     ldd       $04,s
                     std       $086b,y
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
-L1ACD               pshs      d
-                    leax      L1F87,pcr
+L1ACC               pshs      d
+                    leax      L1F86,pcr
                     pshs      x
-                    bsr       doprnt
+                    bsr       L1AFE
                     leas      $06,s
                     puls      pc,u
-                    pshs      u
+L1ADA               pshs      u
                     ldd       $04,s
                     std       $086b,y
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    leax      L1F9A,pcr
+                    leax      L1F99,pcr
                     pshs      x
-                    bsr       doprnt
+                    bsr       L1AFE
                     leas      $06,s
                     clra
                     clrb
                     stb       [$086b,y]
                     ldd       $04,s
                     puls      pc,u
-doprnt              pshs      u
+L1AFE               pshs      u
                     ldu       $06,s
                     leas      -$0b,s
-L1B05               ldb       ,u+
+L1B04               ldb       ,u+
                     stb       $08,s
                     cmpb      #$25
-                    beq       L1B1F
+                    beq       L1B1E
                     ldb       $08,s
-                    lbeq      L1D46
+                    lbeq      L1D45
                     ldb       $08,s
                     sex
                     pshs      d
                     jsr       [$11,s]
                     leas      $02,s
-                    bra       L1B05
+                    bra       L1B04
 
-L1B1F               ldb       ,u+
+L1B1E               ldb       ,u+
                     stb       $08,s
                     clra
                     clrb
@@ -3090,36 +3090,36 @@ L1B1F               ldb       ,u+
                     std       $06,s
                     ldb       $08,s
                     cmpb      #$2d
-                    bne       L1B3C
+                    bne       L1B3B
                     ldd       #$0001
                     std       $0881,y
                     ldb       ,u+
                     stb       $08,s
-                    bra       L1B42
+                    bra       L1B41
 
-L1B3C               clra
+L1B3B               clra
                     clrb
                     std       $0881,y
-L1B42               ldb       $08,s
+L1B41               ldb       $08,s
                     cmpb      #$30
-                    bne       L1B4D
+                    bne       L1B4C
                     ldd       #$0030
-                    bra       L1B50
+                    bra       L1B4F
 
-L1B4D               ldd       #$0020
-L1B50               std       $0883,y
-L1B54               ldb       $08,s
+L1B4C               ldd       #$0020
+L1B4F               std       $0883,y
+L1B53               ldb       $08,s
                     sex
                     leax      $03B8,y
                     leax      d,x
                     ldb       ,x
                     clra
                     andb      #$08
-                    beq       L1B80
+                    beq       L1B7F
                     ldd       $06,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L247F
+                    lbsr      L247E
                     pshs      d
                     ldb       $0a,s
                     sex
@@ -3128,14 +3128,14 @@ L1B54               ldb       $08,s
                     std       $06,s
                     ldb       ,u+
                     stb       $08,s
-                    bra       L1B54
+                    bra       L1B53
 
-L1B80               ldb       $08,s
+L1B7F               ldb       $08,s
                     cmpb      #$2e
-                    bne       L1BB7
+                    bne       L1BB6
                     ldd       #$0001
                     std       $04,s
-L1B8B               ldb       ,u+
+L1B8A               ldb       ,u+
                     stb       $08,s
                     ldb       $08,s
                     sex
@@ -3144,49 +3144,49 @@ L1B8B               ldb       ,u+
                     ldb       ,x
                     clra
                     andb      #$08
-                    beq       L1BBB
+                    beq       L1BBA
                     ldd       $02,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L247F
+                    lbsr      L247E
                     pshs      d
                     ldb       $0a,s
                     sex
                     addd      #$FFD0
                     addd      ,s++
                     std       $02,s
-                    bra       L1B8B
+                    bra       L1B8A
 
-L1BB7               clra
+L1BB6               clra
                     clrb
                     std       $04,s
-L1BBB               ldb       $08,s
+L1BBA               ldb       $08,s
                     sex
                     tfr       d,x
-                    lbra      L1CE9
+                    lbra      L1CE8
 
-L1BC3               ldd       $06,s
+L1BC2               ldd       $06,s
                     pshs      d
                     ldx       $15,s
                     leax      $02,x
                     stx       $15,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L1D4A
-                    bra       L1BEB
+                    lbsr      L1D49
+                    bra       L1BEA
 
-L1BD8               ldd       $06,s
+L1BD7               ldd       $06,s
                     pshs      d
                     ldx       $15,s
                     leax      $02,x
                     stx       $15,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L1E0D
-L1BEB               std       ,s
-                    lbra      L1CCF
+                    lbsr      L1E0C
+L1BEA               std       ,s
+                    lbra      L1CCE
 
-L1BF0               ldd       $06,s
+L1BEF               ldd       $06,s
                     pshs      d
                     ldb       $0a,s
                     sex
@@ -3201,10 +3201,10 @@ L1BF0               ldd       $06,s
                     stx       $17,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L1E53
-                    lbra      L1CCB
+                    lbsr      L1E52
+                    lbra      L1CCA
 
-L1C16               ldd       $06,s
+L1C15               ldd       $06,s
                     pshs      d
                     ldx       $15,s
                     leax      $02,x
@@ -3213,14 +3213,14 @@ L1C16               ldd       $06,s
                     pshs      d
                     leax      $086d,y
                     pshs      x
-                    lbsr      L1D92
-                    lbra      L1CCB
+                    lbsr      L1D91
+                    lbra      L1CCA
 
-L1C32               ldd       $04,s
-                    bne       L1C3B
+L1C31               ldd       $04,s
+                    bne       L1C3A
                     ldd       #$0006
                     std       $02,s
-L1C3B               ldd       $06,s
+L1C3A               ldd       $06,s
                     pshs      d
                     leax      $15,s
                     pshs      x
@@ -3229,38 +3229,38 @@ L1C3B               ldd       $06,s
                     ldb       $0e,s
                     sex
                     pshs      d
-                    lbsr      $23ED
+                    lbsr      $23EC
                     leas      $06,s
-                    lbra      L1CCD
+                    lbra      L1CCC
 
-L1C55               ldx       $13,s
+L1C54               ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
-                    lbra      L1CDF
+                    lbra      L1CDE
 
-L1C62               ldx       $13,s
+L1C61               ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
                     std       $09,s
                     ldd       $04,s
-                    beq       L1CAA
+                    beq       L1CA9
                     ldd       $09,s
                     std       $04,s
-L1C76               ldd       $02,s
+L1C75               ldd       $02,s
                     addd      #$FFFF
                     std       $02,s
                     subd      #$FFFF
-                    beq       L1C90
+                    beq       L1C8F
                     ldb       [$09,s]
-                    beq       L1C90
+                    beq       L1C8F
                     ldd       $09,s
                     addd      #$0001
                     std       $09,s
-                    bra       L1C76
+                    bra       L1C75
 
-L1C90               ldd       $06,s
+L1C8F               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
                     subd      $06,s
@@ -3269,105 +3269,105 @@ L1C90               ldd       $06,s
                     pshs      d
                     ldd       $15,s
                     pshs      d
-                    lbsr      L1EBE
+                    lbsr      L1EBD
                     leas      $08,s
-                    bra       L1CD9
+                    bra       L1CD8
 
-L1CAA               ldd       $06,s
+L1CA9               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
-                    bra       L1CCD
+                    bra       L1CCC
 
-L1CB2               ldb       ,u+
+L1CB1               ldb       ,u+
                     stb       $08,s
-                    bra       L1CBA
+                    bra       L1CB9
                     leas      -$0b,x
-L1CBA               ldd       $06,s
+L1CB9               ldd       $06,s
                     pshs      d
                     leax      $15,s
                     pshs      x
                     ldb       $0C,s
                     sex
                     pshs      d
-                    lbsr      L23AF
-L1CCB               leas      $04,s
-L1CCD               pshs      d
-L1CCF               ldd       $13,s
+                    lbsr      L23AE
+L1CCA               leas      $04,s
+L1CCC               pshs      d
+L1CCE               ldd       $13,s
                     pshs      d
-                    lbsr      L1F20
+                    lbsr      L1F1F
                     leas      $06,s
-L1CD9               lbra      L1B05
+L1CD8               lbra      L1B04
 
-L1CDC               ldb       $08,s
+L1CDB               ldb       $08,s
                     sex
-L1CDF               pshs      d
+L1CDE               pshs      d
                     jsr       [$11,s]
                     leas      $02,s
-                    lbra      L1B05
+                    lbra      L1B04
 
-L1CE9               cmpx      #$0064
-                    lbeq      L1BC3
+L1CE8               cmpx      #$0064
+                    lbeq      L1BC2
                     cmpx      #$006F
-                    lbeq      L1BD8
+                    lbeq      L1BD7
                     cmpx      #$0078
-                    lbeq      L1BF0
+                    lbeq      L1BEF
                     cmpx      #$0058
-                    lbeq      L1BF0
+                    lbeq      L1BEF
                     cmpx      #$0075
-                    lbeq      L1C16
+                    lbeq      L1C15
                     cmpx      #$0066
-                    lbeq      L1C32
+                    lbeq      L1C31
                     cmpx      #$0065
-                    lbeq      L1C32
+                    lbeq      L1C31
                     cmpx      #$0067
-                    lbeq      L1C32
+                    lbeq      L1C31
                     cmpx      #$0045
-                    lbeq      L1C32
+                    lbeq      L1C31
                     cmpx      #$0047
-                    lbeq      L1C32
+                    lbeq      L1C31
                     cmpx      #$0063
-                    lbeq      L1C55
+                    lbeq      L1C54
                     cmpx      #$0073
-                    lbeq      L1C62
+                    lbeq      L1C61
                     cmpx      #$006C
-                    lbeq      L1CB2
-                    bra       L1CDC
+                    lbeq      L1CB1
+                    bra       L1CDB
 
-L1D46               leas      $0b,s
+L1D45               leas      $0b,s
                     puls      pc,u
-L1D4A               pshs      u,d
+L1D49               pshs      u,d
                     leax      $086d,y
                     stx       ,s
                     ldd       $06,s
-                    bge       L1D7E
+                    bge       L1D7D
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-                    bge       L1D73
-                    leax      L1FAC,pcr
+                    bge       L1D72
+                    leax      L1FAB,pcr
                     pshs      x
                     leax      $086d,y
                     pshs      x
-                    lbsr      L2409
+                    lbsr      L2408
                     leas      $04,s
                     puls      pc,u,x
-L1D73               ldd       #$002D
+L1D72               ldd       #$002D
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L1D7E               ldd       $06,s
+L1D7D               ldd       $06,s
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    bsr       L1D92
+                    bsr       L1D91
                     leas      $04,s
                     leax      $086d,y
                     tfr       x,d
                     puls      pc,u,x
-L1D92               pshs      u,y,x,d
+L1D91               pshs      u,y,x,d
                     ldu       $0a,s
                     clra
                     clrb
@@ -3375,51 +3375,51 @@ L1D92               pshs      u,y,x,d
                     clra
                     clrb
                     std       ,s
-L1D9E               ldd       $0C,s
-                    bge       L1DB3
+L1D9D               ldd       $0C,s
+                    bge       L1DB2
                     ldd       ,s
                     addd      #$0001
                     std       ,s
                     ldd       $0C,s
                     subd      $0438,y
                     std       $0C,s
-                    bra       L1D9E
+                    bra       L1D9D
 
-L1DB3               leax      $0438,y
+L1DB2               leax      $0438,y
                     stx       $04,s
-L1DB9               ldd       $04,s
+L1DB8               ldd       $04,s
                     cmpd      $0440,y
-                    beq       L1DFC
-L1DC2               ldd       $0C,s
+                    beq       L1DFB
+L1DC1               ldd       $0C,s
                     subd      [$04,s]
                     std       $0C,s
-                    blt       L1DD4
+                    blt       L1DD3
                     ldd       ,s
                     addd      #$0001
                     std       ,s
-                    bra       L1DC2
+                    bra       L1DC1
 
-L1DD4               ldd       $0C,s
+L1DD3               ldd       $0C,s
                     addd      [$04,s]
                     std       $0C,s
                     ldd       ,s
-                    beq       L1DE4
+                    beq       L1DE3
                     ldd       #$0001
                     std       $02,s
-L1DE4               ldd       $02,s
-                    beq       L1DEF
+L1DE3               ldd       $02,s
+                    beq       L1DEE
                     ldd       ,s
                     addd      #$0030
                     stb       ,u+
-L1DEF               clra
+L1DEE               clra
                     clrb
                     std       ,s
                     ldd       $04,s
                     addd      #$0002
                     std       $04,s
-                    bra       L1DB9
+                    bra       L1DB8
 
-L1DFC               ldd       $0C,s
+L1DFB               ldd       $0C,s
                     addd      #$0030
                     stb       ,u+
                     clra
@@ -3428,11 +3428,11 @@ L1DFC               ldd       $0C,s
                     ldd       $0a,s
                     leas      $06,s
                     puls      pc,u
-L1E0D               pshs      u,d
+L1E0C               pshs      u,d
                     leax      $086d,y
                     stx       ,s
                     leau      $0877,y
-L1E19               ldd       $06,s
+L1E18               ldd       $06,s
                     clra
                     andb      #$07
                     addd      #$0030
@@ -3445,48 +3445,48 @@ L1E19               ldd       $06,s
                     lsra
                     rorb
                     std       $06,s
-                    bne       L1E19
-L1E2F               leau      -$01,u
+                    bne       L1E18
+L1E2E               leau      -$01,u
                     pshs      u
                     leax      $0877,y
                     cmpx      ,s++
-                    bhi       L1E47
+                    bhi       L1E46
                     ldb       ,u
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bra       L1E2F
+                    bra       L1E2E
 
-L1E47               clra
+L1E46               clra
                     clrb
                     stb       [,s]
                     leax      $086d,y
                     tfr       x,d
                     puls      pc,u,x
-L1E53               pshs      u,x,d
+L1E52               pshs      u,x,d
                     leax      $086d,y
                     stx       $02,s
                     leau      $0877,y
-L1E5F               ldd       $08,s
+L1E5E               ldd       $08,s
                     clra
                     andb      #$0f
                     std       ,s
                     pshs      d
                     ldd       $02,s
                     cmpd      #$0009
-                    ble       L1E81
+                    ble       L1E80
                     ldd       $0C,s
-                    beq       L1E79
+                    beq       L1E78
                     ldd       #$0041
-                    bra       L1E7C
+                    bra       L1E7B
 
-L1E79               ldd       #$0061
-L1E7C               addd      #$FFF6
-                    bra       L1E84
+L1E78               ldd       #$0061
+L1E7B               addd      #$FFF6
+                    bra       L1E83
 
-L1E81               ldd       #$0030
-L1E84               addd      ,s++
+L1E80               ldd       #$0030
+L1E83               addd      ,s++
                     stb       ,u+
                     ldd       $08,s
                     lsra
@@ -3499,76 +3499,76 @@ L1E84               addd      ,s++
                     rorb
                     anda      #$0f
                     std       $08,s
-                    bne       L1E5F
-L1E98               leau      -$01,u
+                    bne       L1E5E
+L1E97               leau      -$01,u
                     pshs      u
                     leax      $0877,y
                     cmpx      ,s++
-                    bhi       L1EB0
+                    bhi       L1EAF
                     ldb       ,u
                     ldx       $02,s
                     leax      $01,x
                     stx       $02,s
                     stb       -$01,x
-                    bra       L1E98
+                    bra       L1E97
 
-L1EB0               clra
+L1EAF               clra
                     clrb
                     stb       [$02,s]
                     leax      $086d,y
                     tfr       x,d
-                    lbra      L1F96
+                    lbra      L1F95
 
-L1EBE               pshs      u
+L1EBD               pshs      u
                     ldu       $06,s
                     ldd       $0a,s
                     subd      $08,s
                     std       $0a,s
                     ldd       $0881,y
-                    bne       L1EE7
-L1ECE               ldd       $0a,s
+                    bne       L1EE6
+L1ECD               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       L1EE7
+                    ble       L1EE6
                     ldd       $0883,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-                    bra       L1ECE
+                    bra       L1ECD
 
-L1EE7               ldd       $08,s
+L1EE6               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    beq       L1EFF
+                    beq       L1EFE
                     ldb       ,u+
                     sex
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-                    bra       L1EE7
+                    bra       L1EE6
 
-L1EFF               ldd       $0881,y
-                    beq       L1F1E
-L1F05               ldd       $0a,s
+L1EFE               ldd       $0881,y
+                    beq       L1F1D
+L1F04               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       L1F1E
+                    ble       L1F1D
                     ldd       $0883,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-                    bra       L1F05
+                    bra       L1F04
 
-L1F1E               puls      pc,u
-L1F20               pshs      u
+L1F1D               puls      pc,u
+L1F1F               pshs      u
                     ldu       $06,s
                     ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      $23F8
+                    lbsr      $23F7
                     leas      $02,s
                     nega
                     negb
@@ -3576,81 +3576,81 @@ L1F20               pshs      u
                     addd      ,s++
                     std       $08,s
                     ldd       $0881,y
-                    bne       L1F56
-L1F3D               ldd       $08,s
+                    bne       L1F55
+L1F3C               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    ble       L1F56
+                    ble       L1F55
                     ldd       $0883,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-                    bra       L1F3D
+                    bra       L1F3C
 
-L1F56               ldb       ,u
-                    beq       L1F66
+L1F55               ldb       ,u
+                    beq       L1F65
                     ldb       ,u+
                     sex
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-                    bra       L1F56
+                    bra       L1F55
 
-L1F66               ldd       $0881,y
-                    beq       L1F85
-L1F6C               ldd       $08,s
+L1F65               ldd       $0881,y
+                    beq       L1F84
+L1F6B               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    ble       L1F85
+                    ble       L1F84
                     ldd       $0883,y
                     pshs      d
                     jsr       [$06,s]
                     leas      $02,s
-                    bra       L1F6C
+                    bra       L1F6B
 
-L1F85               puls      pc,u
-L1F87               pshs      u
+L1F84               puls      pc,u
+L1F86               pshs      u
                     ldd       $086b,y
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $1FB3
-L1F96               leas      $04,s
+                    lbsr      $1FB2
+L1F95               leas      $04,s
                     puls      pc,u
-L1F9A               pshs      u
+L1F99               pshs      u
                     ldd       $04,s
                     ldx       $086b,y
                     leax      $01,x
                     stx       $086b,y
                     stb       -$01,x
                     puls      pc,u
-L1FAC               blt       L1FE1
+L1FAB               blt       L1FE0
                     leas      -$09,y
                     pshu      y,x,dp
-L1FB2               neg       $0034
+                    neg       $0034
                     nega
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$22
                     cmpd      #$8002
-                    beq       L1FD7
+                    beq       L1FD6
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    lbne      L20ED
+                    lbne      L20EC
                     pshs      u
-                    lbsr      L231F
+                    lbsr      L231E
                     leas      $02,s
-L1FD7               ldd       $06,u
+L1FD6               ldd       $06,u
                     clra
                     andb      #$04
-                    beq       L2013
+                    beq       L2012
                     ldd       #$0001
-L1FE1               pshs      d
+L1FE0               pshs      d
                     leax      $07,s
                     pshs      x
                     ldd       $08,u
@@ -3658,31 +3658,31 @@ L1FE1               pshs      d
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L1FF8
-                    leax      L26C8,pcr
-                    bra       L1FFC
+                    beq       L1FF7
+                    leax      L26C7,pcr
+                    bra       L1FFB
 
-L1FF8               leax      L26AF,pcr
-L1FFC               tfr       x,d
+L1FF7               leax      L26AE,pcr
+L1FFB               tfr       x,d
                     tfr       d,x
                     jsr       ,x
                     leas      $06,s
                     cmpd      #$FFFF
-                    bne       L2054
+                    bne       L2053
                     ldd       $06,u
                     orb       #$20
                     std       $06,u
-                    lbra      L20ED
+                    lbra      L20EC
 
-L2013               ldd       $06,u
+L2012               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L2023
+                    bne       L2022
                     pshs      u
-                    lbsr      L2108
+                    lbsr      L2107
                     leas      $02,s
-L2023               ldd       ,u
+L2022               ldd       ,u
                     addd      #$0001
                     std       ,u
                     subd      #$0001
@@ -3691,19 +3691,19 @@ L2023               ldd       ,u
                     stb       ,x
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L2049
+                    bcc       L2048
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2054
+                    beq       L2053
                     ldd       $04,s
                     cmpd      #$000D
-                    bne       L2054
-L2049               pshs      u
-                    lbsr      L2108
+                    bne       L2053
+L2048               pshs      u
+                    lbsr      L2107
                     std       ,s++
-                    lbne      L20ED
-L2054               ldd       $04,s
+                    lbne      L20EC
+L2053               ldd       $04,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
@@ -3711,102 +3711,102 @@ L2054               ldd       $04,s
                     pshs      d
                     pshs      u
                     ldd       #$0008
-                    lbsr      L2561
+                    lbsr      L2560
                     pshs      d
-                    lbsr      $1FB3
+                    lbsr      $1FB2
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      $1FB3
-                    lbra      L21C2
+                    lbsr      $1FB2
+                    lbra      L21C1
 
-L207B               pshs      u,d
+L207A               pshs      u,d
                     leau      $0445,y
                     clra
                     clrb
                     std       ,s
-L2085               ldd       ,s
+L2084               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0010
-                    bge       L20A1
+                    bge       L20A0
                     tfr       u,d
                     leau      $0d,u
                     pshs      d
-                    bsr       L20A3
+                    bsr       L20A2
                     leas      $02,s
-                    bra       L2085
+                    bra       L2084
 
-L20A1               puls      pc,u,x
-L20A3               pshs      u
+L20A0               puls      pc,u,x
+L20A2               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     cmpu      #$0000
-                    beq       L20B3
+                    beq       L20B2
                     ldd       $06,u
-                    bne       L20B8
-L20B3               ldd       #$FFFF
+                    bne       L20B7
+L20B2               ldd       #$FFFF
                     puls      pc,u,x
-L20B8               ldd       $06,u
+L20B7               ldd       $06,u
                     clra
                     andb      #$02
-                    beq       L20C7
+                    beq       L20C6
                     pshs      u
-                    bsr       L20DC
+                    bsr       L20DB
                     leas      $02,s
-                    bra       L20C9
+                    bra       L20C8
 
-L20C7               clra
+L20C6               clra
                     clrb
-L20C9               std       ,s
+L20C8               std       ,s
                     ldd       $08,u
                     pshs      d
-                    lbsr      L2611
+                    lbsr      L2610
                     leas      $02,s
                     clra
                     clrb
                     std       $06,u
                     ldd       ,s
                     puls      pc,u,x
-L20DC               pshs      u
+L20DB               pshs      u
                     ldu       $04,s
-                    beq       L20ED
+                    beq       L20EC
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    beq       L20F2
-L20ED               ldd       #$FFFF
+                    beq       L20F1
+L20EC               ldd       #$FFFF
                     puls      pc,u
-L20F2               ldd       $06,u
+L20F1               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L2102
+                    bne       L2101
                     pshs      u
-                    lbsr      L231F
+                    lbsr      L231E
                     leas      $02,s
-L2102               pshs      u
-                    bsr       L2108
+L2101               pshs      u
+                    bsr       L2107
                     puls      pc,u,x
-L2108               pshs      u
+L2107               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L213A
+                    bne       L2139
                     ldd       ,u
                     cmpd      $04,u
-                    beq       L213A
+                    beq       L2139
                     clra
                     clrb
                     pshs      d
                     pshs      u
-                    lbsr      L21C6
+                    lbsr      L21C5
                     leas      $02,s
                     ldd       $02,x
                     pshs      d
@@ -3814,68 +3814,68 @@ L2108               pshs      u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L26D8
+                    lbsr      L26D7
                     leas      $08,s
-L213A               ldd       ,u
+L2139               ldd       ,u
                     subd      $02,u
                     std       $02,s
-                    lbeq      L21B2
+                    lbeq      L21B1
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      L21B2
+                    lbeq      L21B1
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2189
+                    beq       L2188
                     ldd       $02,u
-L2158               std       ,u
+L2157               std       ,u
                     ldd       $02,s
-                    lbeq      L21B2
+                    lbeq      L21B1
                     ldd       $02,s
                     pshs      d
                     ldd       ,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L26C8
+                    lbsr      L26C7
                     leas      $06,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L217D
+                    bne       L217C
                     leax      $04,s
-                    bra       L21A1
+                    bra       L21A0
 
-L217D               ldd       $02,s
+L217C               ldd       $02,s
                     subd      ,s
                     std       $02,s
                     ldd       ,u
                     addd      ,s
-                    bra       L2158
+                    bra       L2157
 
-L2189               ldd       $02,s
+L2188               ldd       $02,s
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L26AF
+                    lbsr      L26AE
                     leas      $06,s
                     cmpd      $02,s
-                    beq       L21B2
-                    bra       L21A3
+                    beq       L21B1
+                    bra       L21A2
 
-L21A1               leas      -$04,x
-L21A3               ldd       $06,u
+L21A0               leas      -$04,x
+L21A2               ldd       $06,u
                     orb       #$20
                     std       $06,u
                     ldd       $04,u
                     std       ,u
                     ldd       #$FFFF
-                    bra       L21C2
+                    bra       L21C1
 
-L21B2               ldd       $06,u
+L21B1               ldd       $06,u
                     ora       #$01
                     std       $06,u
                     ldd       $02,u
@@ -3884,21 +3884,21 @@ L21B2               ldd       $06,u
                     std       $04,u
                     clra
                     clrb
-L21C2               leas      $04,s
+L21C1               leas      $04,s
                     puls      pc,u
-L21C6               pshs      u
+L21C5               pshs      u
                     puls      pc,u
-L21CA               pshs      u
+L21C9               pshs      u
                     ldu       $04,s
-                    beq       L2216
+                    beq       L2215
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L2216
+                    bne       L2215
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L21F1
+                    bcc       L21F0
                     ldd       ,u
                     addd      #$0001
                     std       ,u
@@ -3906,28 +3906,28 @@ L21CA               pshs      u
                     tfr       d,x
                     ldb       ,x
                     clra
-                    bra       L21F8
+                    bra       L21F7
 
-L21F1               pshs      u
-                    lbsr      L2265
+L21F0               pshs      u
+                    lbsr      L2264
                     leas      $02,s
-L21F8               puls      pc,u
+L21F7               puls      pc,u
                     pshs      u
                     ldu       $06,s
-                    beq       L2216
+                    beq       L2215
                     ldd       $06,u
                     clra
                     andb      #$01
-                    beq       L2216
+                    beq       L2215
                     ldd       $04,s
                     cmpd      #$FFFF
-                    beq       L2216
+                    beq       L2215
                     ldd       ,u
                     cmpd      $02,u
-                    bhi       L221B
-L2216               ldd       #$FFFF
+                    bhi       L221A
+L2215               ldd       #$FFFF
                     puls      pc,u
-L221B               ldd       ,u
+L221A               ldd       ,u
                     addd      #$FFFF
                     std       ,u
                     tfr       d,x
@@ -3939,61 +3939,61 @@ L221B               ldd       ,u
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
-                    lbsr      L21CA
+                    lbsr      L21C9
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L2250
+                    beq       L224F
                     pshs      u
-                    lbsr      L21CA
+                    lbsr      L21C9
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L2255
-L2250               ldd       #$FFFF
-                    bra       L2261
+                    bne       L2254
+L224F               ldd       #$FFFF
+                    bra       L2260
 
-L2255               ldd       $02,s
+L2254               ldd       $02,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      L2578
+                    lbsr      L2577
                     addd      ,s
-L2261               leas      $04,s
+L2260               leas      $04,s
                     puls      pc,u
-L2265               pshs      u
+L2264               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$31
                     cmpd      #$8001
-                    beq       L228E
+                    beq       L228D
                     ldd       $06,u
                     clra
                     andb      #$31
                     cmpd      #$0001
-                    beq       L2287
+                    beq       L2286
                     ldd       #$FFFF
                     puls      pc,u,x
-L2287               pshs      u
-                    lbsr      L231F
+L2286               pshs      u
+                    lbsr      L231E
                     leas      $02,s
-L228E               leax      $0445,y
+L228D               leax      $0445,y
                     pshs      x
                     cmpu      ,s++
-                    bne       L22AB
+                    bne       L22AA
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L22AB
+                    beq       L22AA
                     leax      $0452,y
                     pshs      x
-                    lbsr      L20DC
+                    lbsr      L20DB
                     leas      $02,s
-L22AB               ldd       $06,u
+L22AA               ldd       $06,u
                     clra
                     andb      #$08
-                    beq       L22D7
+                    beq       L22D6
                     ldd       $0b,u
                     pshs      d
                     ldd       $02,u
@@ -4003,42 +4003,42 @@ L22AB               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L22CB
-                    leax      L269F,pcr
-                    bra       L22CF
+                    beq       L22CA
+                    leax      L269E,pcr
+                    bra       L22CE
 
-L22CB               leax      L267E,pcr
-L22CF               tfr       x,d
+L22CA               leax      L267D,pcr
+L22CE               tfr       x,d
                     tfr       d,x
                     jsr       ,x
-                    bra       L22E9
+                    bra       L22E8
 
-L22D7               ldd       #$0001
+L22D6               ldd       #$0001
                     pshs      d
                     leax      $0a,u
                     stx       $02,u
                     pshs      x
                     ldd       $08,u
                     pshs      d
-                    lbsr      L267E
-L22E9               leas      $06,s
+                    lbsr      L267D
+L22E8               leas      $06,s
                     std       ,s
                     ldd       ,s
-                    bgt       L230C
+                    bgt       L230B
                     ldd       $06,u
                     pshs      d
                     ldd       $02,s
-                    beq       L22FE
+                    beq       L22FD
                     ldd       #$0020
-                    bra       L2301
+                    bra       L2300
 
-L22FE               ldd       #$0010
-L2301               ora       ,s+
+L22FD               ldd       #$0010
+L2300               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     ldd       #$FFFF
                     puls      pc,u,x
-L230C               ldd       $02,u
+L230B               ldd       $02,u
                     addd      #$0001
                     std       ,u
                     ldd       $02,u
@@ -4047,12 +4047,12 @@ L230C               ldd       $02,u
                     ldb       [$02,u]
                     clra
                     puls      pc,u,x
-L231F               pshs      u
+L231E               pshs      u
                     ldu       $04,s
                     ldd       $06,u
                     clra
                     andb      #$C0
-                    bne       L2357
+                    bne       L2356
                     leas      -$20,s
                     leax      ,s
                     pshs      x
@@ -4061,114 +4061,114 @@ L231F               pshs      u
                     clra
                     clrb
                     pshs      d
-                    lbsr      L2593
+                    lbsr      L2592
                     leas      $06,s
                     ldd       $06,u
                     pshs      d
                     ldb       $02,s
-                    bne       L234B
+                    bne       L234A
                     ldd       #$0040
-                    bra       L234E
+                    bra       L234D
 
-L234B               ldd       #$0080
-L234E               ora       ,s+
+L234A               ldd       #$0080
+L234D               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     leas      $20,s
-L2357               ldd       $06,u
+L2356               ldd       $06,u
                     ora       #$80
                     std       $06,u
                     clra
                     andb      #$0C
-                    beq       L2364
+                    beq       L2363
                     puls      pc,u
-L2364               ldd       $0b,u
-L2366               bne       L2379
+L2363               ldd       $0b,u
+L2365               bne       L2378
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L2374
+                    beq       L2373
                     ldd       #$0080
-                    bra       L2377
+                    bra       L2376
 
-L2374               ldd       #$0100
-L2377               std       $0b,u
-L2379               ldd       $02,u
-                    bne       L238E
+L2373               ldd       #$0100
+L2376               std       $0b,u
+L2378               ldd       $02,u
+                    bne       L238D
                     ldd       $0b,u
                     pshs      d
-                    lbsr      L2796
+                    lbsr      L2795
                     leas      $02,s
                     std       $02,u
                     cmpd      #$FFFF
-                    beq       L2396
-L238E               ldd       $06,u
+                    beq       L2395
+L238D               ldd       $06,u
                     orb       #$08
                     std       $06,u
-                    bra       L23A5
+                    bra       L23A4
 
-L2396               ldd       $06,u
+L2395               ldd       $06,u
                     orb       #$04
                     std       $06,u
                     leax      $0a,u
                     stx       $02,u
                     ldd       #$0001
                     std       $0b,u
-L23A5               ldd       $02,u
+L23A4               ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
                     puls      pc,u
-L23AF               pshs      u
+L23AE               pshs      u
                     ldb       $05,s
                     sex
                     tfr       d,x
-                    bra       L23D5
+                    bra       L23D4
 
-L23B8               ldd       [$06,s]
+L23B7               ldd       [$06,s]
                     addd      #$0004
                     std       [$06,s]
-                    leax      >L23EC,pcr
-                    bra       L23D1
+                    leax      >L23EB,pcr
+                    bra       L23D0
 
-L23C7               ldb       $05,s
+L23C6               ldb       $05,s
                     stb       $0443,y
                     leax      $0442,y
-L23D1               tfr       x,d
+L23D0               tfr       x,d
                     puls      pc,u
-L23D5               cmpx      #$0064
-                    beq       L23B8
+L23D4               cmpx      #$0064
+                    beq       L23B7
                     cmpx      #$006F
-                    lbeq      L23B8
+                    lbeq      L23B7
                     cmpx      #$0078
-                    lbeq      L23B8
-                    bra       L23C7
+                    lbeq      L23B7
+                    bra       L23C6
                     puls      pc,u
-L23EC               neg       $0034
+L23EB               neg       $0034
                     nega
-                    leax      >L23F7,pcr
+                    leax      >L23F6,pcr
                     tfr       x,d
                     puls      pc,u
-L23F7               neg       $0034
+L23F6               neg       $0034
                     nega
                     ldu       $04,s
-L23FC               ldb       ,u+
-                    bne       L23FC
+L23FB               ldb       ,u+
+                    bne       L23FB
                     tfr       u,d
                     subd      $04,s
                     addd      #$FFFF
                     puls      pc,u
-L2409               pshs      u
+L2408               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L2413               ldb       ,u+
+L2412               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L2413
+                    bne       L2412
                     ldd       $06,s
                     puls      pc,u,x
                     pshs      u
@@ -4176,53 +4176,53 @@ L2413               ldb       ,u+
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L242D               ldx       ,s
+L242C               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L242D
+                    bne       L242C
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-L243E               ldb       ,u+
+L243D               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L243E
+                    bne       L243D
                     ldd       $06,s
                     puls      pc,u,x
-                    pshs      u
+L244D               pshs      u
                     ldu       $04,s
-L2452               ldb       ,u
+L2451               ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    bne       L2472
+                    bne       L2471
                     ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       L246E
+                    bne       L246D
                     clra
                     clrb
                     puls      pc,u
-L246E               leau      $01,u
-                    bra       L2452
+L246D               leau      $01,u
+                    bra       L2451
 
-L2472               ldb       [$06,s]
+L2471               ldb       [$06,s]
                     sex
                     pshs      d
                     ldb       ,u
                     sex
                     subd      ,s++
                     puls      pc,u
-L247F               tsta
-                    bne       L2494
+L247E               tsta
+                    bne       L2493
                     tst       $02,s
-                    bne       L2494
+                    bne       L2493
                     lda       $03,s
                     mul
                     ldx       ,s
@@ -4230,7 +4230,7 @@ L247F               tsta
                     ldx       #$0000
                     std       ,s
                     puls      pc,d
-L2494               pshs      d
+L2493               pshs      d
                     ldd       #$0000
                     pshs      d
                     pshs      d
@@ -4243,16 +4243,16 @@ L2494               pshs      d
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L24B1
+                    bcc       L24B0
                     inc       ,s
-L24B1               lda       $04,s
+L24B0               lda       $04,s
                     ldb       $09,s
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L24BE
+                    bcc       L24BD
                     inc       ,s
-L24BE               lda       $04,s
+L24BD               lda       $04,s
                     ldb       $08,s
                     mul
                     addd      ,s
@@ -4262,70 +4262,72 @@ L24BE               lda       $04,s
                     ldx       ,s
                     ldd       $02,s
                     leas      $08,s
-L24D1               rts
-                    subd      #$0000
-                    beq       L24E1
+                    rts
+
+L24D1               subd      #$0000
+                    beq       L24E0
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
-                    bra       L250F
+                    bra       L250E
 
-L24E1               puls      d
+L24E0               puls      d
                     std       ,s
                     ldd       #$002D
-                    lbra      L2584
-                    subd      #$0000
-                    beq       L24E1
+                    lbra      L2583
+
+L24EA               subd      #$0000
+                    beq       L24E0
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
                     tsta
-                    bpl       L2503
+                    bpl       L2502
                     nega
                     negb
                     sbca      #$00
                     inc       $01,s
                     std       $02,s
-L2503               ldd       $06,s
-                    bpl       L250F
+L2502               ldd       $06,s
+                    bpl       L250E
                     nega
                     negb
                     sbca      #$00
                     com       $01,s
                     std       $06,s
-L250F               lda       #$01
-L2511               inca
+L250E               lda       #$01
+L2510               inca
                     asl       $03,s
                     rol       $02,s
-                    bpl       L2511
+                    bpl       L2510
                     sta       ,s
                     ldd       $06,s
                     clr       $06,s
                     clr       $07,s
-L2520               subd      $02,s
-                    bcc       L252A
+L251F               subd      $02,s
+                    bcc       L2529
                     addd      $02,s
                     andcc     #$FE
-                    bra       L252C
+                    bra       L252B
 
-L252A               orcc      #$01
-L252C               rol       $07,s
+L2529               orcc      #$01
+L252B               rol       $07,s
                     rol       $06,s
                     lsr       $02,s
                     ror       $03,s
                     dec       ,s
-                    bne       L2520
+                    bne       L251F
                     std       $02,s
                     tst       $01,s
-                    beq       L2546
+                    beq       L2545
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-L2546               ldx       $04,s
+L2545               ldx       $04,s
                     ldd       $06,s
                     std       $04,s
                     stx       $06,s
@@ -4334,20 +4336,20 @@ L2546               ldx       $04,s
                     leas      $06,s
                     rts
                     tstb
-                    beq       L256B
-L2558               asr       $02,s
+                    beq       L256A
+L2557               asr       $02,s
                     ror       $03,s
                     decb
-                    bne       L2558
-                    bra       L256B
+                    bne       L2557
+                    bra       L256A
 
-L2561               tstb
-                    beq       L256B
-L2564               lsr       $02,s
+L2560               tstb
+                    beq       L256A
+L2563               lsr       $02,s
                     ror       $03,s
                     decb
-                    bne       L2564
-L256B               ldd       $02,s
+                    bne       L2563
+L256A               ldd       $02,s
                     pshs      d
                     ldd       $02,s
                     std       $04,s
@@ -4355,42 +4357,42 @@ L256B               ldd       $02,s
                     leas      $04,s
                     rts
 
-L2578               tstb
-                    beq       L256B
-L257B               asl       $03,s
+L2577               tstb
+                    beq       L256A
+L257A               asl       $03,s
                     rol       $02,s
                     decb
-                    bne       L257B
-                    bra       L256B
+                    bne       L257A
+                    bra       L256A
 
-L2584               std       $0563,y
+L2583               std       $0563,y
                     pshs      y,b
                     os9       F$ID
                     puls      y,b
                     os9       F$Send
                     rts
 
-L2593               lda       $05,s
+L2592               lda       $05,s
                     ldb       $03,s
-                    beq       L25C6
+                    beq       L25C5
                     cmpb      #$01
-                    beq       L25C8
+                    beq       L25C7
                     cmpb      #$06
-                    beq       L25C8
+                    beq       L25C7
                     cmpb      #$02
-                    beq       L25AE
+                    beq       L25AD
                     cmpb      #$05
-                    beq       L25AE
+                    beq       L25AD
                     ldb       #$D0
-                    lbra      L27C3
+                    lbra      L27C2
 
-L25AE               pshs      u
+L25AD               pshs      u
                     os9       I$GetStt
-                    bcc       L25BA
+                    bcc       L25B9
                     puls      u
-                    lbra      L27C3
+                    lbra      L27C2
 
-L25BA               stx       [$08,s]
+L25B9               stx       [$08,s]
                     ldx       $08,s
                     stu       $02,x
                     puls      u
@@ -4398,199 +4400,201 @@ L25BA               stx       [$08,s]
                     clrb
                     rts
 
-L25C6               ldx       $06,s
-L25C8               os9       I$GetStt
-                    lbra      L27CC
+L25C5               ldx       $06,s
+L25C7               os9       I$GetStt
+                    lbra      L27CB
                     lda       $05,s
                     ldb       $03,s
-                    beq       L25DD
+                    beq       L25DC
                     cmpb      #$02
-                    beq       L25E5
+                    beq       L25E4
                     ldb       #$D0
-                    lbra      L27C3
+                    lbra      L27C2
 
-L25DD               ldx       $06,s
+L25DC               ldx       $06,s
                     os9       I$SetStt
-                    lbra      L27CC
+                    lbra      L27CB
 
-L25E5               pshs      u
+L25E4               pshs      u
                     ldx       $08,s
                     ldu       $0a,s
                     os9       I$SetStt
                     puls      u
-                    lbra      L27CC
+                    lbra      L27CB
                     ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    bcs       L25FF
+                    bcs       L25FE
                     os9       I$Close
-L25FF               lbra      L27CC
-                    ldx       $02,s
+L25FE               lbra      L27CB
+
+L2601               ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    lbcs      L27C3
+                    lbcs      L27C2
                     tfr       a,b
                     clra
                     rts
 
-L2611               lda       $03,s
+L2610               lda       $03,s
                     os9       I$Close
-                    lbra      L27CC
+                    lbra      L27CB
                     ldx       $02,s
                     ldb       $05,s
                     os9       I$MakDir
-                    lbra      L27CC
-                    ldx       $02,s
+                    lbra      L27CB
+
+L2622               ldx       $02,s
                     lda       $05,s
                     tfr       a,b
                     andb      #$24
                     orb       #$0b
                     os9       I$Create
-                    bcs       L2636
-L2632               tfr       a,b
+                    bcs       L2635
+L2631               tfr       a,b
                     clra
                     rts
 
-L2636               cmpb      #$DA
-                    lbne      L27C3
+L2635               cmpb      #$DA
+                    lbne      L27C2
                     lda       $05,s
                     bita      #$80
-                    lbne      L27C3
+                    lbne      L27C2
                     anda      #$07
                     ldx       $02,s
                     os9       I$Open
-                    lbcs      L27C3
+                    lbcs      L27C2
                     pshs      u,a
                     ldx       #$0000
                     leau      ,x
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-                    bcc       L2632
+                    bcc       L2631
                     pshs      b
                     os9       I$Close
                     puls      b
-                    lbra      L27C3
+                    lbra      L27C2
                     ldx       $02,s
                     os9       I$Delete
-                    lbra      L27CC
+                    lbra      L27CB
                     lda       $03,s
                     os9       I$Dup
-                    lbcs      L27C3
+                    lbcs      L27C2
                     tfr       a,b
                     clra
                     rts
 
-L267E               pshs      y
+L267D               pshs      y
                     ldx       $06,s
                     lda       $05,s
                     ldy       $08,s
                     pshs      y
                     os9       I$Read
-L268C               bcc       L269B
+L268B               bcc       L269A
                     cmpb      #$D3
-                    bne       L2696
+                    bne       L2695
                     clra
                     clrb
                     puls      pc,y,x
-L2696               puls      y,x
-                    lbra      L27C3
+L2695               puls      y,x
+                    lbra      L27C2
 
-L269B               tfr       y,d
+L269A               tfr       y,d
                     puls      pc,y,x
-L269F               pshs      y
+L269E               pshs      y
                     lda       $05,s
                     ldx       $06,s
                     ldy       $08,s
                     pshs      y
                     os9       I$ReadLn
-                    bra       L268C
+                    bra       L268B
 
-L26AF               pshs      y
+L26AE               pshs      y
                     ldy       $08,s
-                    beq       L26C4
+                    beq       L26C3
                     lda       $05,s
                     ldx       $06,s
                     os9       I$Write
-L26BD               bcc       L26C4
+L26BC               bcc       L26C3
                     puls      y
-                    lbra      L27C3
+                    lbra      L27C2
 
-L26C4               tfr       y,d
+L26C3               tfr       y,d
                     puls      pc,y
-L26C8               pshs      y
+L26C7               pshs      y
                     ldy       $08,s
-                    beq       L26C4
+                    beq       L26C3
                     lda       $05,s
                     ldx       $06,s
                     os9       I$WritLn
-                    bra       L26BD
+                    bra       L26BC
 
-L26D8               pshs      u
+L26D7               pshs      u
                     ldd       $0a,s
-                    bne       L26E6
+                    bne       L26E5
                     ldu       #$0000
                     ldx       #$0000
-                    bra       L271A
+                    bra       L2719
 
-L26E6               cmpd      #$0001
-                    beq       L2711
+L26E5               cmpd      #$0001
+                    beq       L2710
                     cmpd      #$0002
-                    beq       L2706
+                    beq       L2705
                     ldb       #$F7
-L26F4               clra
+L26F3               clra
                     std       $0563,y
                     ldd       #$FFFF
                     leax      $0557,y
                     std       ,x
                     std       $02,x
                     puls      pc,u
-L2706               lda       $05,s
+L2705               lda       $05,s
                     ldb       #$02
                     os9       I$GetStt
-                    bcs       L26F4
-                    bra       L271A
+                    bcs       L26F3
+                    bra       L2719
 
-L2711               lda       $05,s
+L2710               lda       $05,s
                     ldb       #$05
                     os9       I$GetStt
-                    bcs       L26F4
-L271A               tfr       u,d
+                    bcs       L26F3
+L2719               tfr       u,d
                     addd      $08,s
                     std       $0559,y
                     tfr       d,u
                     tfr       x,d
                     adcb      $07,s
                     adca      $06,s
-                    bmi       L26F4
+                    bmi       L26F3
                     tfr       d,x
                     std       $0557,y
                     lda       $05,s
                     os9       I$Seek
-                    bcs       L26F4
+                    bcs       L26F3
                     leax      $0557,y
                     puls      pc,u
-                    ldd       $0555,y
+L273E               ldd       $0555,y
                     pshs      d
                     ldd       $04,s
                     cmpd      $0885,y
-                    bcs       L2773
+                    bcs       L2772
                     addd      $0555,y
                     pshs      y
                     subd      ,s
                     os9       F$Mem
                     tfr       y,d
                     puls      y
-                    bcc       L2765
+                    bcc       L2764
                     ldd       #$FFFF
                     leas      $02,s
                     rts
 
-L2765               std       $0555,y
+L2764               std       $0555,y
                     addd      $0885,y
                     subd      ,s
                     std       $0885,y
-L2773               leas      $02,s
+L2772               leas      $02,s
                     ldd       $0885,y
                     pshs      d
                     subd      $04,s
@@ -4600,58 +4604,60 @@ L2773               leas      $02,s
                     pshs      d
                     clra
                     ldx       ,s
-L278C               sta       ,x+
+L278B               sta       ,x+
                     cmpx      $0555,y
-                    bcs       L278C
+                    bcs       L278B
                     puls      pc,d
-L2796               ldd       $02,s
+L2795               ldd       $02,s
                     addd      $055f,y
-                    bcs       L27BF
+                    bcs       L27BE
                     cmpd      $0561,y
-                    bcc       L27BF
+                    bcc       L27BE
                     pshs      d
                     ldx       $055f,y
                     clra
-L27AC               cmpx      ,s
-                    bcc       L27B4
+L27AB               cmpx      ,s
+                    bcc       L27B3
                     sta       ,x+
-                    bra       L27AC
+                    bra       L27AB
 
-L27B4               ldd       $055f,y
+L27B3               ldd       $055f,y
                     puls      x
                     stx       $055f,y
                     rts
 
-L27BF               ldd       #$FFFF
+L27BE               ldd       #$FFFF
                     rts
 
-L27C3               clra
+L27C2               clra
                     std       $0563,y
                     ldd       #$FFFF
                     rts
 
-L27CC               bcs       L27C3
+L27CB               bcs       L27C2
                     clra
                     clrb
-exit                rts
-                    lbsr      L27DC
-                    lbsr      L207B
-                    ldd       $02,s
+                    rts
+
+L27D0               lbsr      L27DB
+                    lbsr      L207A
+L27D6               ldd       $02,s
                     os9       F$Exit
-* ------------------------------------------------------------------
-* L27DC - cc1-style init image for the work block (see _start);
-* pure data: rts stub + count/block table + reloc dirs + module name.
-* ------------------------------------------------------------------
-L27DC               fcb       $39       init table / work-block image
-                    fcb       $00,$07,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$04,$F2,$00,$00,$01
-                    fcb       $2C
-                    fcb       $10
+L27DB               rts
+
+L27DC               neg       $0007
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0004
+                    sbcb      >$0000
+                    fcb       $01
+                    bge       L27FC
                     fcb       $52
                     fcb       $10
                     fcb       $55
                     fcb       $10
-                    fcb       $58
+                    aslb
                     fcb       $10
                     fcb       $5B
                     fcb       $10
@@ -4659,51 +4665,41 @@ L27DC               fcb       $39       init table / work-block image
                     fcb       $10
                     fcb       $61
                     fcb       $10
-                    fcb       $64
+                    lsr       -$10,x
+                    asr       -$10,x
+L27FC               dec       -$10,x
+                    tst       -$10,x
+                    neg       $1073
                     fcb       $10
-                    fcb       $67
+                    ror       L1079
                     fcb       $10
-                    fcb       $6A
+                    inc       L107F
                     fcb       $10
-                    fcb       $6D
-                    fcb       $10
-                    fcb       $70
-                    fcb       $10
-                    fcb       $73
-                    fcb       $10
-                    fcb       $76
-                    fcb       $10
-                    fcb       $79
-                    fcb       $10
-                    fcb       $7C
-                    fcb       $10,$7F,$10,$82,$10,$85
-                    fcb       $64
-                    fcb       $00
-                    fcb       $78
-                    fcb       $00
-                    fcb       $79
-                    fcb       $00
-                    fcb       $75
-                    fcb       $00
-                    fcb       $64,$2C,$78
-                    fcb       $00
-                    fcb       $64,$2C,$79
-                    fcb       $00
-                    fcb       $64,$2C,$75
-                    fcb       $00
-                    fcc       /d,x,u/
+                    sbca      #$10
+                    bita      #$64
+                    neg       $0078
+                    neg       $0079
+                    neg       $0075
+                    neg       L0064
+                    bge       L2892
+                    neg       L0064
+                    bge       L2897
+                    neg       L0064
+                    bge       L2897
+                    neg       L0064
+                    fcc       /,x,u/
                     fcb       $00
                     fcc       /d,x,y,u/
                     fcb       $00
                     fcc       /x,u,pc/
                     fcb       $00
-                    fcb       $79,$2C,$64
-                    fcb       $00
-                    fcb       $79,$2C,$75
-                    fcb       $00
-                    fcb       $75,$2C,$64
-                    fcb       $00
-                    fcc       /u,pc/
+                    rol       $2C64
+                    neg       $0079
+                    bge       L28B4
+                    neg       $0075
+                    bge       L28A7
+                    neg       $0075
+                    fcb       $2C,$70,$63
                     fcb       $00
                     fcc       /clra/
                     fcb       $00
@@ -4717,427 +4713,761 @@ L27DC               fcb       $39       init table / work-block image
                     fcb       $00
                     fcc       /cmpu/
                     fcb       $00
-                    fcb       $6C,$64,$62
+                    inc       $04,s
+                    fcb       $62
+                    neg       $006C
+                    lsr       $04,s
+                    neg       $006C
+                    lsr       -$08,s
+                    neg       $006C
+                    lsr       -$07,s
+                    neg       $006C
+                    lsr       -$0b,s
+                    neg       $0073
+                    lsr       $6200
+                    com       $7464
+                    neg       $0073
+                    lsr       $7800
+                    com       $7479
+                    neg       $0073
+                    lsr       $7500
+                    fcb       $70,$73,$68
+L2892               fcb       $73
                     fcb       $00
-                    fcb       $6C,$64,$64
-                    fcb       $00
-                    fcb       $6C,$64,$78
-                    fcb       $00
-                    fcb       $6C,$64,$79
-                    fcb       $00
-                    fcb       $6C,$64,$75
-                    fcb       $00
-                    fcb       $73,$74,$62
-                    fcb       $00
-                    fcb       $73,$74,$64
-                    fcb       $00
-                    fcb       $73,$74,$78
-                    fcb       $00
-                    fcb       $73,$74,$79
-                    fcb       $00
-                    fcb       $73,$74,$75
-                    fcb       $00
-                    fcc       /pshs/
-                    fcb       $00
-                    fcc       /puls/
+                    fcb       $70,$75,$6C
+L2897               fcb       $73
                     fcb       $00
                     fcc       /leax/
                     fcb       $00
                     fcc       /leay/
                     fcb       $00
                     fcc       /leau/
-                    fcb       $00
+L28A7               fcb       $00
                     fcc       /leas/
                     fcb       $00
-                    fcb       $73,$65,$78
-                    fcb       $00
-                    fcb       $74,$66,$72
-                    fcb       $00
-                    fcb       $23,$30
-                    fcb       $00
-                    fcb       $32,$2C,$78
-                    fcb       $00
-                    fcb       $31,$2C,$78
-                    fcb       $00
-                    fcb       $30,$2C,$78
-                    fcb       $00
-                    fcc       /-1,x/
-                    fcb       $00
-                    fcc       /-2,x/
-                    fcb       $00
-                    fcb       $32,$2C,$79
-                    fcb       $00
-                    fcb       $31,$2C,$79
-                    fcb       $00
-                    fcb       $30,$2C,$79
-                    fcb       $00
-                    fcc       /-1,y/
-                    fcb       $00
-                    fcc       /-2,y/
-                    fcb       $00
-                    fcb       $32,$2C,$75
-                    fcb       $00
-                    fcb       $31,$2C,$75
-                    fcb       $00
-                    fcb       $30,$2C,$75
-                    fcb       $00
-                    fcc       /-1,u/
-                    fcb       $00
-                    fcc       /-2,u/
-                    fcb       $00
-                    fcb       $32,$2C,$73
-                    fcb       $00
-                    fcb       $30,$2C,$73
-                    fcb       $00
-                    fcc       /-2,s/
-                    fcb       $00
-                    fcb       $23,$3C
-                    fcb       $00,$00,$02,$00,$BB,$00,$00,$00
-                    fcb       $A7,$00,$01,$00,$01,$00,$01,$00
-                    fcb       $00,$00,$02,$00,$BF,$00,$00,$00
-                    fcb       $AB,$00,$01,$00,$01,$00,$01,$00
-                    fcb       $00,$00,$02,$00,$B7,$00,$00,$00
-                    fcb       $A3,$00,$01,$00,$01,$00,$01,$00
-                    fcb       $00,$00,$02,$00,$A7,$00,$00,$00
-                    fcb       $BB,$00,$01,$00,$01,$00,$01,$00
-                    fcb       $00,$00,$02,$00,$AB,$00,$00,$00
-                    fcb       $BF,$00,$01,$00,$01,$00,$01,$00
-                    fcb       $00,$00,$01,$00,$ED,$00
-                    fcb       $74
-                    fcb       $00,$CB,$00
-                    fcb       $4B
-                    fcb       $00,$02,$00
-                    fcb       $4F
-                    fcb       $00,$00,$00,$01,$00,$ED,$00
-                    fcb       $7C
-                    fcb       $00,$CB,$00
-                    fcb       $4B
-                    fcb       $00,$02,$00
-                    fcb       $51
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $4D
-                    fcb       $00,$CB,$00
-                    fcb       $4B
-                    fcb       $00,$01,$00
-                    fcb       $53
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $51
-                    fcb       $00,$CB,$00
-                    fcb       $4B
-                    fcb       $00,$01,$00
-                    fcb       $5B
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $4F
-                    fcb       $00,$CB,$00
-                    fcb       $4B
-                    fcb       $00,$01,$00
-                    fcb       $57
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $51
-                    fcb       $00,$CB,$00
-                    fcb       $4F
-                    fcb       $00,$01,$00
-                    fcb       $78
-                    fcb       $00,$00,$00,$02,$00,$A7,$00,$00
-                    fcb       $00,$8F,$00,$F1,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$02,$00,$AB,$00,$00
-                    fcb       $00,$94,$00,$F1,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$02,$00,$AF,$00,$00
-                    fcb       $00,$99,$00,$F1,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$02,$00,$B3,$00,$00
-                    fcb       $00,$9E,$00,$F1,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$02,$00,$C3,$00,$00
-                    fcb       $00,$99,$00,$F1,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$02,$00,$C7,$00,$00
-                    fcb       $00,$9E,$00,$F1,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$02,$00,$A3,$00,$00
-                    fcb       $00,$B7,$00,$01,$00,$01,$00,$01
-                    fcb       $00,$00,$00,$01,$00,$E9,$00,$00
-                    fcb       $00,$85,$00,$00,$00,$02,$00,$00
-                    fcb       $00,$00,$00,$02,$00,$D5,$00,$F8
-                    fcb       $00,$00,$01,$00,$00,$02,$17,$A9
-                    fcb       $00,$00,$00,$02,$00,$DA,$01,$0E
-                    fcb       $00,$00,$01,$16,$00,$02,$17,$AD
-                    fcb       $00,$00,$00,$02,$00,$DF,$01
-                    fcb       $24
-                    fcb       $00,$00,$01
-                    fcb       $2C
-                    fcb       $00,$02,$17,$B1,$00,$00,$00,$02
-                    fcb       $00,$D5,$01,$00,$00,$00,$00,$FC
-                    fcb       $00,$02,$17,$B5,$00,$00,$00,$02
-                    fcb       $00,$DA,$01,$16,$00,$00,$01,$12
-                    fcb       $00,$02,$17,$B9,$00,$00,$00,$02
-                    fcb       $00,$DF,$01
-                    fcb       $2C
-                    fcb       $00,$00,$01
-                    fcb       $28
-                    fcb       $00,$02,$17,$BD,$00,$00,$00,$02
-                    fcb       $00,$D5,$00,$F4,$00,$00,$01,$05
-                    fcb       $00,$02,$17,$C1,$00,$00,$00,$02
-                    fcb       $00,$DA,$01,$0A,$00,$00,$01,$1B
-                    fcb       $00,$02,$17,$C6,$00,$00,$00,$02
-                    fcb       $00,$DF,$01
-                    fcb       $20
-                    fcb       $00,$00,$01
-                    fcb       $31
-                    fcb       $00,$02,$17,$CB,$00,$00,$00,$02
-                    fcb       $00,$D5,$01,$05,$00,$00,$00,$FC
-                    fcb       $00,$02,$17,$D0,$00,$00,$00,$02
-                    fcb       $00,$DA,$01,$1B,$00,$00,$01,$12
-                    fcb       $00,$02,$17,$D5,$00,$00,$00,$02
-                    fcb       $00,$DF,$01
-                    fcb       $31
-                    fcb       $00,$00,$01
-                    fcb       $28
-                    fcb       $00,$02,$17,$DA,$00,$00,$00,$02
-                    fcb       $00,$E9,$00,$00,$00,$8F,$01
-                    fcb       $43
-                    fcb       $00,$8A,$00,$02,$00,$00,$00,$02
-                    fcb       $00,$85,$00,$00,$00,$8F,$01
-                    fcb       $43
-                    fcb       $00,$8A,$00,$02,$00,$00,$00,$02
-                    fcb       $00,$E4,$01
+                    com       $6578
+                    neg       L0074
+                    ror       -$0e,s
+L28B4               neg       $0023
+                    leax      0,x
+                    leas      $0C,y
+                    asl       >L0031
+                    bge       $2937
+                    neg       $0030
+                    bge       $293B
+                    neg       $002D
+                    leay      $0C,y
+                    asl       >$002D
+                    leas      $0C,y
+                    asl       >$0032
+                    bge       L294A
+                    neg       L0031
+                    bge       L294E
+                    neg       $0030
+                    bge       L2952
+                    neg       $002D
+                    leay      $0C,y
+                    rol       >$002D
+                    leas      $0C,y
+                    rol       >$0032
+                    bge       L295C
+                    neg       L0031
+                    bge       L2960
+                    neg       $0030
+                    bge       L2964
+                    neg       $002D
+                    leay      $0C,y
+                    fcb       $75
+                    neg       $002D
+                    leas      $0C,y
+                    fcb       $75
+                    neg       $0032
+                    bge       L2970
+                    neg       $0030
+                    bge       L2974
+                    neg       $002D
+                    leas      $0C,y
+                    com       >$0023
+                    cwai      #$00
+                    neg       $0002
+                    neg       L00BB
+                    neg       $0000
+                    neg       $00A7
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00BF
+                    neg       $0000
+                    neg       L00AB
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00B7
+                    neg       $0000
+                    neg       L00A3
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       $00A7
+                    neg       $0000
+                    neg       L00BB
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+L294A               neg       $0002
+                    neg       L00AB
+L294E               neg       $0000
+                    neg       L00BF
+L2952               neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0001
+L295C               neg       L00ED
+                    neg       L0074
+L2960               neg       L00CB
+                    neg       L004B
+L2964               neg       $0002
+                    neg       L004F
+                    neg       $0000
+                    neg       $0001
+                    neg       L00ED
+                    neg       $007C
+L2970               neg       L00CB
+                    neg       L004B
+L2974               neg       $0002
+                    neg       L0051
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L004D
+                    neg       L00CB
+                    neg       L004B
+                    neg       $0001
+                    neg       L0053
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       L00CB
+                    neg       L004B
+                    neg       $0001
+                    neg       L005B
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L004F
+                    neg       L00CB
+                    neg       L004B
+                    neg       $0001
+                    neg       L0057
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       L00CB
+                    neg       L004F
+                    neg       $0001
+                    neg       $0078
+                    neg       $0000
+                    neg       $0002
+                    neg       $00A7
+                    neg       $0000
+                    neg       L008F
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00AB
+                    neg       $0000
+                    neg       $0094
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00AF
+                    neg       $0000
+                    neg       L0099
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00B3
+                    neg       $0000
+                    neg       $009E
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00C3
+                    neg       $0000
+                    neg       L0099
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00C7
+                    neg       $0000
+                    neg       $009E
+                    neg       $00F1
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0002
+                    neg       L00A3
+                    neg       $0000
+                    neg       L00B7
+                    neg       $0001
+                    neg       $0001
+                    neg       $0001
+                    neg       $0000
+                    neg       $0001
+                    neg       L00E9
+                    neg       $0000
+                    neg       $0085
+                    neg       $0000
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0002
+                    neg       L00D5
+                    neg       $00F8
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    fcb       $02
+                    lbsr      $D349
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    jmp       $0000
+                    neg       $0001
+                    lbra      $2A58
+                    lbsr      $D759
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    bcc       L2A61
+L2A61               neg       $0001
+                    bge       L2A65
+L2A65               fcb       $02
+                    lbsr      $DB69
+                    neg       $0000
+                    fcb       $02
+                    neg       L00D5
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    ldd       >$0002
+                    lbsr      $DF79
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    lbra      L2A82
+L2A82               fcb       $01
+                    nop
+                    neg       $0002
+                    lbsr      $E389
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    bge       L2A91
+L2A91               neg       $0001
+                    bvc       L2A95
+L2A95               fcb       $02
+                    lbsr      $E799
+                    neg       $0000
+                    fcb       $02
+                    neg       L00D5
+                    neg       L00F4
+                    neg       $0000
+                    fcb       $01,$05
+                    neg       $0002
+                    lbsr      $EBA9
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01
+                    dec       $0000
+                    neg       $0001
+                    fcb       $1B
+                    neg       $0002
+                    lbsr      $F0B9
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    bra       L2AC1
+
+L2AC1               neg       $0001
+                    leay      0,x
+                    fcb       $02
+                    lbsr      $F5C9
+                    neg       $0000
+                    fcb       $02
+                    neg       L00D5
+                    fcb       $01,$05
+                    neg       $0000
+                    neg       $00FC
+                    neg       $0002
+                    lbsr      $FAD9
+                    neg       $0000
+                    fcb       $02
+                    neg       $00DA
+                    fcb       $01,$1B
+                    neg       $0000
+                    fcb       $01
+                    nop
+                    neg       $0002
+                    lbsr      $FFE9
+                    neg       $0000
+                    fcb       $02
+                    neg       L00DF
+                    fcb       $01
+                    leay      0,x
+                    neg       $0001
+                    bvc       L2AF5
+L2AF5               fcb       $02
+                    lbsr      L04F9
+                    neg       $0000
+                    fcb       $02
+                    neg       L00E9
+                    neg       $0000
+                    neg       L008F
+                    fcb       $01
+                    coma
+                    neg       $008A
+                    neg       $0002
+                    neg       $0000
+                    neg       $0002
+                    neg       $0085
+                    neg       $0000
+                    neg       L008F
+                    fcb       $01
+                    coma
+                    neg       $008A
+                    neg       $0002
+                    neg       $0000
+                    neg       $0002
+                    neg       $00E4
+                    fcb       $01
                     fcb       $36
-                    fcb       $00,$BB,$01
-                    fcb       $3E
-                    fcb       $00,$02,$17,$DF,$00,$00,$00,$02
-                    fcb       $00,$E4,$01
-                    fcb       $36
-                    fcb       $00,$CB,$00
-                    fcb       $4B
-                    fcb       $00,$BB,$01
-                    fcb       $3A
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $51
-                    fcb       $00,$E4,$01
-                    fcb       $3E
-                    fcb       $00,$01,$00
-                    fcb       $5B
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $51
-                    fcb       $00,$E4,$17,$E4,$00,$01,$00
-                    fcb       $5F
-                    fcb       $00,$00,$00,$02,$00,$CB,$00
-                    fcb       $51
-                    fcb       $00,$E4,$17,$E9,$00,$01,$00
-                    fcb       $65
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$02,$00
-                    fcc       /88((((((((/
-                    fcb       $00,$00,$00,$00,$00,$00,$02
-                    fcc       /""""""/
-                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
-                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
-                    fcb       $02,$02,$02,$02,$00,$00,$00,$00
-                    fcb       $02,$00,$04,$04,$04,$04,$04,$04
-                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
-                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
-                    fcb       $04,$04,$04,$04,$00,$00,$00,$00
                     fcb       $00
-                    fcb       $27
-                    fcb       $10,$03,$E8,$00
-                    fcb       $64
-                    fcb       $00,$0A,$04
-                    fcb       $40,$6C,$78
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00
+                    adda      $013E
+                    neg       $0002
+                    lbsr      L0A29
+                    neg       $0000
+L2B2B               fcb       $02
+                    neg       $00E4
+                    fcb       $01
+                    fcb       $36
+                    fcb       $00
+                    addb      #$00
+                    fcb       $4B
+                    neg       L00BB
+                    fcb       $01
+                    abx
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       $00E4
+                    fcb       $01
+                    fcb       $3E
+                    neg       $0001
+                    neg       L005B
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       $00E4
+                    lbsr      $0F55
+                    fcb       $01
+                    neg       $005F
+                    neg       $0000
+                    neg       $0002
+                    neg       L00CB
+                    neg       L0051
+                    neg       $00E4
+                    lbsr      L1465
+                    fcb       $01
+                    neg       $0065
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0002
+                    neg       $0038
+                    fcb       $38
+                    bvc       $2BD8
+                    bvc       $2BDA
+                    bvc       L2BDC
+                    bvc       L2BDE
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    bhi       $2BE1
+                    bhi       $2BE3
+                    bhi       $2BE5
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+L2BDC               neg       $0004
+L2BDE               lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0000
+                    neg       $0000
+                    neg       $0000
+                    beq       L2C0E
+                    com       $00E8
+                    neg       L0064
+                    neg       $000A
+                    lsr       $0040
+                    inc       -$08,s
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L2C0E               neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
                     fcb       $42
-                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00
-                    fcb       $21
-                    fcb       $02,$C2,$02,$B2,$02,$A2,$02,$92
-                    fcb       $02,$82,$03
-                    fcb       $32
-                    fcb       $03
-                    fcb       $22
-                    fcb       $03,$12,$03,$02,$02,$F2,$02,$E2
-                    fcb       $02,$D2,$00
-                    fcb       $2D
-                    fcb       $00
-                    fcb       $2B
-                    fcb       $00
-                    fcb       $29
-                    fcb       $00
-                    fcb       $27
-                    fcb       $03,$9E,$03,$8E,$03
-                    fcb       $62
-                    fcb       $00
-                    fcb       $3B
-                    fcb       $00
-                    fcb       $39
-                    fcb       $00
-                    fcb       $37
-                    fcb       $00
-                    fcb       $35
-                    fcb       $00
-                    fcb       $33
-                    fcb       $00
-                    fcb       $31
-                    fcb       $00
-                    fcb       $2F
-                    fcb       $00
-                    fcb       $49
-                    fcb       $00
-                    fcb       $47
-                    fcb       $00
-                    fcb       $45
-                    fcb       $00
-                    fcb       $43
-                    fcb       $00
-                    fcb       $41
-                    fcb       $00
-                    fcb       $3F
-                    fcb       $00
-                    fcb       $3D
-                    fcb       $00,$82,$01
-                    fcb       $58
-                    fcb       $01
-                    fcb       $4C
-                    fcb       $01
-                    fcb       $48
-                    fcb       $04
-                    fcb       $40
-                    fcb       $01,$8C,$01,$88,$01
-                    fcb       $7C
-                    fcb       $01
-                    fcb       $78
-                    fcb       $01
-                    fcb       $6C
-                    fcb       $01
-                    fcb       $68
-                    fcb       $01
-                    fcb       $5C
-                    fcb       $01,$AA,$01,$A8,$01,$A2,$01,$9E
-                    fcb       $01,$9C,$01,$9A,$01,$98,$01,$BE
-                    fcb       $01,$BC,$01,$BA,$01,$B8,$01,$B2
-                    fcb       $01,$AE,$01,$AC,$01,$D8,$01,$D2
-                    fcb       $01,$CE,$01,$CC,$01,$CA,$01,$C8
-                    fcb       $01,$C2,$01,$EC,$01,$EA,$01,$E8
-                    fcb       $01,$E2,$01,$DE,$01,$DC,$01,$DA
-                    fcb       $02,$0C,$02,$08,$01,$FE,$01,$FC
-                    fcb       $01,$F8,$01,$F2,$01,$EE,$02
-                    fcb       $2E
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       L0021
                     fcb       $02
-                    fcb       $2C
+                    sbcb      #$02
+                    sbca      $02A2
                     fcb       $02
-                    fcb       $28
-                    fcb       $02,$1E,$02,$1C,$02,$18,$02,$0E
+                    sbca      $0002
+                    sbca      #$03
+                    leas      $03,x
+                    bhi       L2CED
+                    nop
+                    com       $0002
+L2CED               fcb       $02
+                    sbcb      L02E2
                     fcb       $02
-                    fcb       $58
+                    sbcb      $0000
+                    blt       L2CF6
+L2CF6               bmi       L2CF8
+L2CF8               bvs       L2CFA
+L2CFA               beq       $2CFF
+                    ldx       $0003
+                    ldx       #$0362
+                    neg       L003B
+                    neg       L0039
+                    neg       L0037
+                    neg       L0035
+                    neg       $0033
+                    neg       L0031
+                    neg       L002F
+                    neg       $0049
+                    neg       L0047
+                    neg       L0045
+                    neg       L0043
+                    neg       L0041
+                    neg       $003F
+                    neg       L003D
+                    neg       $0082
+                    fcb       $01
+                    aslb
+                    fcb       $01
+                    inca
+                    fcb       $01
+                    asla
+                    lsr       $0040
+                    fcb       $01
+                    cmpx      #$0188
+                    fcb       $01
+                    inc       L0178
+                    fcb       $01
+                    inc       $01,x
+                    asl       $01,x
+                    incb
+                    fcb       $01
+                    ora       $01,x
+                    eora      $01,x
+                    sbca      $01,x
+                    ldx       $0001
+                    cmpx      $0001
+                    ora       $0001
+                    eora      $0001
+                    ldx       $01BC
+                    fcb       $01
+                    ora       L01B8
+                    fcb       $01
+                    sbca      $01AE
+                    fcb       $01
+                    cmpx      $01,x
+                    eorb      $0001
+                    sbcb      $0001
+                    ldu       #$01CC
+                    fcb       $01
+                    orb       #$01
+                    eorb      #$01
+                    sbcb      #$01
+                    ldd       $01,x
+                    orb       $01,x
+                    eorb      $01,x
+                    sbcb      $01,x
+                    ldu       $0001
+                    ldd       $0001
+                    orb       $0002
+                    inc       $0002
+                    asl       $0001
+                    ldu       L01FC
+                    fcb       $01
+                    eorb      $01F2
+                    fcb       $01
+                    ldu       $02,x
+                    bgt       L2D80
+                    bge       L2D82
+L2D80               bvc       L2D84
+L2D82               exg       d,y
+L2D84               andcc     #$02
+                    fcb       $18,$02
+                    jmp       $0002
+                    aslb
                     fcb       $02
                     fcb       $4E
                     fcb       $02
-                    fcb       $4C
+                    inca
                     fcb       $02
-                    fcb       $48
+                    asla
                     fcb       $02
                     fcb       $3E
                     fcb       $02
-                    fcb       $3C
-                    fcb       $02
+                    cwai      #$02
                     fcb       $38
-                    fcb       $02,$88,$02
-                    fcb       $7E
                     fcb       $02
-                    fcb       $7A
+                    eora      #$02
+                    jmp       $027A
                     fcb       $02
-                    fcb       $78
+                    asl       L026C
                     fcb       $02
-                    fcb       $6C
+                    asl       $02,x
+                    incb
                     fcb       $02
-                    fcb       $68
+                    ora       $02,x
+                    eora      $02,x
+                    ldx       $0002
+                    ora       $0002
+                    eora      $0002
+                    ldx       #$028A
                     fcb       $02
-                    fcb       $5C
-                    fcb       $02,$AA,$02,$A8,$02,$9E,$02,$9A
-                    fcb       $02,$98,$02,$8E,$02,$8A,$02,$CE
-                    fcb       $02,$CA,$02,$C8,$02,$BE,$02,$BA
-                    fcb       $02,$B8,$02,$AE,$02,$F8,$02,$EE
-                    fcb       $02,$EA,$02,$E8,$02,$DE,$02,$DA
-                    fcb       $02,$D8,$03,$1A,$03,$18,$03,$0E
-                    fcb       $03,$0A,$03,$08,$02,$FE,$02,$FA
-                    fcb       $03
-                    fcb       $3E
-                    fcb       $03
-                    fcb       $3C
-                    fcb       $03
-                    fcb       $38
-                    fcb       $03
-                    fcb       $2E
-                    fcb       $03
-                    fcb       $2A
-                    fcb       $03
-                    fcb       $28
-                    fcb       $03,$1E,$03
-                    fcb       $5A
-                    fcb       $03
-                    fcb       $58
-                    fcb       $03
-                    fcb       $50
-                    fcb       $03
-                    fcb       $4E
-                    fcb       $03
-                    fcb       $4C
-                    fcb       $03
-                    fcb       $48
-                    fcb       $03
-                    fcb       $40
-                    fcb       $03
-                    fcb       $70
-                    fcb       $03
-                    fcb       $6E
-                    fcb       $03
-                    fcb       $6C
-                    fcb       $03
-                    fcb       $6A
-                    fcb       $03
-                    fcb       $68
-                    fcb       $03
-                    fcb       $5E
-                    fcb       $03
-                    fcb       $5C
-                    fcb       $03,$88,$03,$82,$03
-                    fcb       $7E
-                    fcb       $03
-                    fcb       $7C
-                    fcb       $03
-                    fcb       $7A
-                    fcb       $03
-                    fcb       $78
-                    fcb       $03
-                    fcb       $72
-                    fcb       $03,$A2,$03,$9C,$03,$9A,$03,$98
-                    fcb       $03,$92,$03,$8C,$03,$8A
+                    ldu       #$02CA
+                    fcb       $02
+                    eorb      #$02
+                    ldx       $02BA
+                    fcb       $02
+                    eora      $02AE
+                    fcb       $02
+                    eorb      $02EE
+                    fcb       $02
+                    orb       $02,x
+                    eorb      $02,x
+                    ldu       $0002
+                    orb       $0002
+                    eorb      $0003
+                    orcc      #$03
+                    fcb       $18
+                    com       $000E
+                    com       $000A
+                    com       $0008
+                    fcb       $02
+                    ldu       L02FA
+                    com       $003E
+                    com       $003C
+                    com       $0038
+                    com       $002E
+                    com       $002A
+                    com       $0028
+                    com       L001E
+                    com       $005A
+                    com       $0058
+                    com       $0050
+                    com       $004E
+                    com       $004C
+                    com       L0048
+                    com       $0040
+                    com       $0070
+                    com       $006E
+                    com       $006C
+                    com       $006A
+                    com       $0068
+                    com       L005E
+                    com       $005C
+                    com       $0088
+                    com       $0082
+                    com       $007E
+                    com       $007C
+                    com       $007A
+                    com       $0078
+                    com       $0072
+                    com       $00A2
+                    com       $009C
+                    com       $009A
+                    com       $0098
+                    com       $0092
+                    com       $008C
+                    com       $008A
                     fcc       /c.opt/
+                    fcb       $00
+
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.opt_dis.asm
+++ b/3rdparty/packages/ccompiler/c.opt_dis.asm
@@ -3649,11 +3649,9 @@ L1F99               pshs      u
                     stx       $086b,y
                     stb       -$01,x
                     puls      pc,u
-L1FAB               blt       L1FE0
-                    leas      -$09,y
-                    pshu      y,x,dp
-                    neg       $0034
-                    nega
+L1FAB               fcc       /-32768/
+                    fcb       $00
+L1FB2               pshs      u
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -9324,11 +9324,9 @@ L5486               ldd       $000F
                     lbsr      L6F01
 L5491               leas      $04,s
 L5493               puls      pc,u
-L5495               blt       $54CA
-                    leas      -$09,y
-                    pshu      y,x,dp
-                    neg       $00AE
-                    fcb       $62
+L5495               fcc       /-32768/
+                    fcb       $00
+L549C               ldx       $02,s
                     leas      -$08,s
                     ldd       $05,x
                     aslb
@@ -12218,9 +12216,9 @@ L6E98               ldd       ,s
 L6EAE               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
-L6EB4               bcs       L6F1A
-                    neg       $0034
-                    nega
+L6EB4               fcc       /%d/
+                    fcb       $00
+L6EB7               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -1,0 +1,14491 @@
+                    nam       c.pass1
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $05
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       3987
+size                equ       .
+
+name                equ       *
+                    fcs       /c.pass1/
+                    fcb       edition
+
+L0015               lda       ,y+
+L0017               sta       ,u+
+L0019               leax      -$01,x
+L001B               bne       L0015
+L001D               rts
+
+start               pshs      y
+L0020               pshs      u
+L0022               clra
+L0023               clrb
+L0024               sta       ,u+
+L0026               decb
+L0027               bne       L0024
+L0029               ldx       ,s
+L002B               leau      ,x
+L002D               leax      $0813,x
+L0031               pshs      x
+L0033               leay      L794C,pcr
+L0037               ldx       ,y++
+L0039               beq       L003F
+L003B               bsr       L0015
+L003D               ldu       $02,s
+L003F               leau      >$0076,u
+L0043               ldx       ,y++
+L0045               beq       L004A
+L0047               bsr       L0015
+L0049               clra
+L004A               cmpu      ,s
+L004D               beq       L0053
+L004F               sta       ,u+
+L0051               bra       L004A
+
+L0053               ldu       $02,s
+L0055               ldd       ,y++
+L0057               beq       L0060
+L0059               leax      >$0000,pcr
+L005D               lbsr      L0163
+L0060               ldd       ,y++
+L0062               beq       L0069
+L0064               leax      ,u
+L0066               lbsr      L0163
+L0069               leas      $04,s
+L006B               puls      x
+L006D               stx       $02C4,u
+                    sty       $0284,u
+L0076               ldd       #$0001
+                    std       $02C0,u
+L007D               leay      $0286,u
+                    leax      ,s
+L0083               lda       ,x+
+L0085               ldb       $02C1,u
+                    cmpb      #$1d
+                    beq       L00E1
+L008D               cmpa      #$0d
+L008F               beq       L00E1
+L0091               cmpa      #$20
+                    beq       L0099
+                    cmpa      #$2C
+                    bne       L009D
+L0099               lda       ,x+
+                    bra       L008D
+
+L009D               cmpa      #$22
+                    beq       L00A5
+L00A1               cmpa      #$27
+                    bne       L00C3
+L00A5               stx       ,y++
+L00A7               inc       $02C1,u
+                    pshs      a
+L00AD               lda       ,x+
+                    cmpa      #$0d
+                    beq       L00B7
+                    cmpa      ,s
+                    bne       L00AD
+L00B7               puls      b
+                    clr       -$01,x
+                    cmpa      #$0d
+                    beq       L00E1
+                    lda       ,x+
+                    bra       L0085
+
+L00C3               leax      -$01,x
+                    stx       ,y++
+                    leax      $01,x
+                    inc       $02C1,u
+L00CD               cmpa      #$0d
+                    beq       L00DD
+                    cmpa      #$20
+                    beq       L00DD
+                    cmpa      #$2C
+                    beq       L00DD
+                    lda       ,x+
+                    bra       L00CD
+
+L00DD               clr       -$01,x
+                    bra       L0085
+
+L00E1               leax      $0284,u
+                    pshs      x
+                    ldd       0,x
+                    adcb      #$02
+                    subb      #$34
+                    ror       L0031
+                    andb      #$8d
+                    dec       L0017
+                    rol       -$04,s
+                    clr       ,-s
+                    clr       ,-s
+                    lbsr      L7941
+                    leax      $0813,y
+L0100               stx       $02CE,y
+                    sts       $02C2,y
+                    sts       $02D0,y
+                    ldd       #$FF82
+L0111               leax      d,s
+L0113               cmpx      $02D0,y
+                    bcc       L0123
+                    cmpx      $02CE,y
+                    bcs       L013D
+                    stx       $02D0,y
+L0123               rts
+L0124               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L013D               leax      L0124,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clr       ,-s
+                    lbsr      L7947
+                    ldd       $02C2,y
+                    subd      $02D0,y
+                    rts
+                    ldd       $02D0,y
+                    subd      $02CE,y
+L0163               rts
+                    pshs      x
+                    leax      d,y
+                    leax      d,x
+                    pshs      x
+L016C               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+                    std       ,x
+                    cmpy      ,s
+                    bne       L016C
+                    leas      $04,s
+                    rts
+                    pshs      u
+L0180               ldu       $04,s
+                    leas      -$06,s
+                    ldd       L0043
+                    std       $02,s
+                    beq       L0193
+                    ldx       $02,s
+                    ldd       $10,x
+                    std       L0043
+                    bra       L019F
+
+L0193               ldd       #$0012
+                    pshs      d
+                    lbsr      L5C28
+                    leas      $02,s
+                    std       $02,s
+L019F               ldd       #$0012
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    stu       $08,s
+                    pshs      u
+                    bsr       L01F7
+                    leas      $06,s
+                    ldd       #$0009
+                    std       ,s
+                    bra       L01BB
+
+L01B7               clra
+                    clrb
+                    std       ,u++
+L01BB               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bne       L01B7
+                    ldd       $02,s
+                    ldx       $04,s
+                    std       $0e,x
+                    lbra      L03D7
+                    pshs      u
+L01D2               ldu       $04,s
+                    leas      -$02,s
+                    ldd       $0e,u
+                    std       ,s
+                    ldd       #$0012
+                    pshs      d
+                    pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L01F7
+                    leas      $06,s
+                    ldd       L0043
+                    ldx       ,s
+                    std       $10,x
+                    ldd       ,s
+                    std       L0043
+                    lbra      L03B1
+
+L01F7               pshs      u
+L01F9               ldu       $04,s
+                    bra       L0207
+
+L01FD               ldb       ,u+
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    stb       -$01,x
+L0207               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L01FD
+                    puls      pc,u
+L0215               pshs      u
+                    leax      $03EE,y
+                    pshs      x
+                    leax      L0521,pcr
+                    pshs      x
+                    lbsr      L034B
+                    lbra      L0390
+                    pshs      u
+L022B               ldd       $04,s
+                    pshs      d
+                    bsr       L024C
+                    leas      $02,s
+                    leax      $01CE,y
+                    pshs      x
+                    lbsr      $702D
+                    lbra      L0344
+                    pshs      u
+L0241               leax      L0527,pcr
+                    pshs      x
+                    bsr       L024C
+                    lbra      L03B1
+
+L024C               pshs      u
+L024E               ldd       L003F
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $060C,y
+                    pshs      x
+                    ldd       $0063
+                    bra       L02A9
+                    pshs      u
+L0262               leas      -$32,s
+                    leax      L053B,pcr
+                    pshs      x
+                    leax      $02,s
+                    pshs      x
+                    lbsr      $7312
+                    leas      $04,s
+                    ldd       $38,s
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    lbsr      $732A
+                    leas      $04,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $38,s
+                    pshs      d
+                    bsr       L0294
+                    leas      $04,s
+                    leas      $32,s
+                    puls      pc,u
+L0294               pshs      u
+L0296               ldu       $04,s
+                    ldd       $0e,u
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    leax      $060C,y
+                    pshs      x
+                    ldd       $10,u
+L02A9               subd      ,s++
+                    pshs      d
+                    bsr       L02B2
+                    lbra      L03D7
+
+L02B2               pshs      u
+                    ldu       $04,s
+                    lbsr      L0215
+                    ldd       $08,s
+                    pshs      d
+                    leax      L054D,pcr
+                    pshs      x
+                    lbsr      L034B
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    leax      L0557,pcr
+                    pshs      x
+                    lbsr      L034B
+                    leas      $04,s
+                    ldd       $08,s
+                    cmpd      L0027
+                    bne       L02ED
+                    leax      $060C,y
+                    pshs      x
+                    lbsr      L0366
+                    leas      $02,s
+                    leax      ,s
+                    bra       L0304
+
+L02ED               ldd       L0027
+                    addd      #$FFFF
+                    cmpd      $08,s
+                    bne       L0324
+                    leax      $070C,y
+                    pshs      x
+                    lbsr      L0366
+                    leas      $02,s
+                    bra       L0314
+
+L0304               leas      ,x
+                    bra       L0314
+
+L0308               ldd       #$0020
+                    pshs      d
+                    lbsr      L0380
+                    leas      $02,s
+                    leau      -$01,u
+L0314               cmpu      #$0000
+                    bgt       L0308
+                    leax      L0567,pcr
+                    pshs      x
+                    bsr       L0366
+                    leas      $02,s
+L0324               ldd       L0029
+                    addd      #$0001
+                    std       L0029
+                    cmpd      #start
+                    ble       L0349
+                    leax      $01CE,y
+                    pshs      x
+                    lbsr      $702D
+                    leas      $02,s
+                    leax      $0569,pcr
+                    pshs      x
+                    bsr       L0366
+L0344               leas      $02,s
+                    lbsr      $68C2
+L0349               puls      pc,u
+L034B               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    leax      $01CE,y
+                    pshs      x
+                    lbsr      L50E4
+                    leas      $08,s
+                    puls      pc,u
+L0366               pshs      u
+                    leax      $01CE,y
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $6E62
+                    leas      $04,s
+                    ldd       #$000D
+                    pshs      d
+                    bsr       L0380
+                    bra       L03B1
+
+L0380               pshs      u
+                    leax      $01CE,y
+                    pshs      x
+                    ldb       $07,s
+                    sex
+                    pshs      d
+                    lbsr      $6F02
+L0390               leas      $04,s
+                    puls      pc,u
+L0394               pshs      u
+L0396               ldu       $04,s
+                    stu       -$02,s
+                    beq       L03B3
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L0394
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L0394
+                    leas      $02,s
+                    pshs      u
+                    bsr       L03B5
+L03B1               leas      $02,s
+L03B3               puls      pc,u
+L03B5               pshs      u
+L03B7               ldu       $04,s
+                    stu       -$02,s
+                    beq       L03C3
+                    ldd       L002D
+                    std       $0a,u
+                    stu       L002D
+L03C3               puls      pc,u
+                    pshs      u
+L03C7               ldd       #$0016
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L01F7
+L03D7               leas      $06,s
+                    puls      pc,u
+L03DB               pshs      u
+L03DD               ldd       $005F
+                    cmpd      #$0033
+                    bne       L0429
+                    ldx       $0061
+                    cmpx      #$0001
+                    lbeq      L04FB
+                    cmpx      #$0002
+                    lbeq      L04FB
+                    cmpx      #$0007
+                    lbeq      L04FB
+                    cmpx      #$000A
+                    lbeq      L04FB
+                    cmpx      #$0008
+                    lbeq      L04FB
+                    cmpx      #$0004
+                    lbeq      L04FB
+                    cmpx      #$0003
+                    lbeq      L04FB
+                    cmpx      #$0006
+                    lbeq      L04FB
+                    cmpx      #$0005
+                    lbeq      L04FB
+                    lbra      L04C9
+
+L0429               ldd       $005F
+                    cmpd      #$0034
+                    lbne      L04C9
+                    ldx       $0061
+                    ldd       $08,x
+                    cmpd      #start
+                    bra       L0471
+                    pshs      u
+L043F               ldd       $005F
+                    cmpd      #$0033
+                    lbne      L04C9
+                    ldx       $0061
+                    cmpx      #$000E
+                    lbeq      L04FB
+                    cmpx      #$000D
+                    lbeq      L04FB
+                    cmpx      #start
+                    lbeq      L04FB
+                    cmpx      #$0010
+                    lbeq      L04FB
+                    cmpx      #$000F
+                    lbeq      L04FB
+                    cmpx      #$0021
+L0471               lbeq      L04FB
+                    lbra      L04C9
+
+L0478               pshs      u
+L047A               ldd       $04,s
+                    asra
+                    rorb
+                    asra
+                    rorb
+                    andb      #$F0
+                    bra       L0491
+
+L0484               pshs      u
+L0486               ldd       $04,s
+                    andb      #$F0
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      #$0010
+L0491               pshs      d
+                    ldd       $06,s
+                    clra
+                    andb      #$0f
+                    addd      ,s++
+                    puls      pc,u
+L049C               pshs      u
+                    ldu       $04,s
+                    cmpu      #$004C
+                    blt       L04C9
+                    cmpu      #$0063
+                    bgt       L04C9
+                    ldd       #$0001
+                    bra       L04CB
+
+L04B1               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L04C9
+                    ldd       $02,u
+                    bra       L04CB
+
+L04BD               pshs      u
+L04BF               ldd       $005F
+                    cmpd      $04,s
+                    bne       L04CD
+                    lbsr      $552C
+L04C9               clra
+                    clrb
+L04CB               puls      pc,u
+L04CD               ldu       #$0000
+                    bra       L04E4
+
+L04D2               tfr       u,d
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    cmpd      $04,s
+                    beq       L04EA
+                    leau      $01,u
+L04E4               cmpu      #$0080
+                    blt       L04D2
+L04EA               tfr       u,d
+                    stb       >$0076,y
+                    leax      >$0076,y
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+L04FB               ldd       #$0001
+                    puls      pc,u
+                    pshs      u
+L0502               bra       L0507
+
+L0504               lbsr      $552C
+L0507               ldd       $005F
+                    cmpd      #$0028
+                    beq       L051F
+                    ldd       $005F
+                    cmpd      #$002A
+                    beq       L051F
+                    ldd       $005F
+                    cmpd      #$FFFF
+                    bne       L0504
+L051F               puls      pc,u
+L0521               bcs       L0596
+                    bra       L055F
+                    bra       L0527
+
+L0527               tst       -$0b,s
+                    inc       -$0C,s
+                    rol       -$10,s
+                    inc       $05,s
+                    bra       L0595
+                    fcb       $65
+                    ror       $09,s
+                    jmp       $09,s
+                    lsr       L696F
+                    jmp       0,x
+
+L053B               com       $0f,s
+                    tst       -$10,s
+                    rol       $0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L05AA
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       $0578
+                    bra       L054D
+
+L054D               inc       $09,s
+                    jmp       $05,s
+                    bra       $0578
+                    lsr       0,y
+                    bra       L0557
+
+L0557               bpl       L0583
+                    bpl       $0585
+                    bra       L057D
+                    bcs       $05D2
+L055F               bra       $0581
+                    bpl       $058D
+                    bpl       $058F
+                    tst       $0000
+L0567               fcb       $5e
+                    neg       $0074
+                    clr       $0f,s
+                    bra       $05DB
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       L05D8
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    com       $202D
+                    bra       L05BD
+                    fcb       $42
+L057D               clra
+                    fcb       $52
+                    lsrb
+                    neg       $0034
+                    nega
+L0583               ldd       #$FFA2
+                    lbsr      L0111
+                    leas      -$0e,s
+                    lbsr      L0695
+                    std       $0C,s
+                    lbne      L067A
+                    clra
+L0595               clrb
+L0596               lbra      L0691
+                    lbra      L067A
+
+L059C               ldd       $005F
+                    std       $0a,s
+                    ldd       $0061
+                    std       $08,s
+                    std       ,s
+                    ldd       L003F
+                    std       $04,s
+L05AA               ldd       $0063
+                    std       $02,s
+                    lbsr      $552C
+                    ldx       $0a,s
+                    bra       L05CE
+
+L05B5               ldd       $0a,s
+                    cmpd      #$00A0
+                    blt       L05C5
+L05BD               ldd       $0a,s
+                    cmpd      #$00A9
+                    ble       L05DA
+L05C5               ldd       $08,s
+                    addd      #$0001
+                    std       ,s
+                    bra       L05DA
+
+L05CE               cmpx      #$0064
+                    beq       L05DA
+                    cmpx      #$0078
+                    beq       L05DA
+L05D8               bra       L05B5
+
+L05DA               ldd       ,s
+                    pshs      d
+                    lbsr      $0581
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    lbeq      L066F
+                    ldd       $0a,s
+                    cmpd      #$0064
+                    lbne      L064E
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L04BD
+                    std       ,s++
+                    bne       L0643
+                    ldd       $0063
+                    std       $02,s
+                    ldd       L003F
+                    std       $04,s
+                    ldd       #$0003
+                    pshs      d
+                    lbsr      $0581
+                    leas      $02,s
+                    std       $06,s
+                    beq       L0638
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0003
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    bra       L064E
+
+L0638               leax      L0E98,pcr
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+L0643               pshs      u
+                    lbsr      L0394
+                    leas      $02,s
+                    leax      $0e,s
+                    bra       L068D
+
+L064E               ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $0C,s
+                    bra       L067A
+
+L066F               leax      L0EB1,pcr
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+L067A               lbsr      L0A9C
+                    std       -$02,s
+                    beq       L068F
+                    ldd       $12,s
+                    cmpd      $0061
+                    lble      L059C
+                    bra       L068F
+
+L068D               leas      -$0e,x
+L068F               ldd       $0C,s
+L0691               leas      $0e,s
+                    puls      pc,u
+L0695               pshs      u
+                    ldd       #$FFA4
+                    lbsr      L0111
+                    leas      -$0C,s
+                    ldu       #$0000
+                    ldx       $005F
+                    lbra      L07FD
+
+L06A7               ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    ldd       $0061
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $005F
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    lbsr      $552C
+                    lbra      L085F
+
+L06CC               lbsr      $552C
+                    lbsr      L03DB
+                    std       -$02,s
+                    beq       L06FA
+                    lbsr      L0D48
+                    tfr       d,u
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L04BD
+                    leas      $02,s
+                    bsr       L0695
+                    std       $0a,u
+                    lbne      L085F
+                    pshs      u
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldu       #$0000
+                    lbra      L085F
+
+L06FA               clra
+                    clrb
+                    pshs      d
+                    lbsr      $0581
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L0730
+                    bra       L070D
+
+L070B               leas      -$0C,x
+L070D               lbsr      L0E16
+                    ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+L0730               ldd       #$002E
+                    pshs      d
+                    lbsr      L04BD
+                    lbra      L07F9
+
+L073B               ldd       $005F
+                    std       $08,s
+                    ldd       L003F
+                    std       $06,s
+                    ldd       $0063
+                    std       $04,s
+                    lbsr      $552C
+                    lbsr      L0695
+                    std       $0a,s
+                    beq       L0776
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000E
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    lbra      L085F
+
+L0776               leax      L0EC2,pcr
+                    pshs      x
+                    lbsr      L024C
+                    lbra      L07F9
+
+L0782               ldd       L003F
+                    std       $06,s
+                    ldd       $0063
+                    std       $04,s
+                    lbsr      $552C
+                    ldd       $005F
+                    cmpd      #$002D
+                    bne       L07C4
+                    lbsr      $552C
+                    lbsr      L03DB
+                    std       -$02,s
+                    beq       L07A6
+                    lbsr      L0D48
+                    std       $0a,s
+                    bra       L07B8
+
+L07A6               clra
+                    clrb
+                    pshs      d
+                    lbsr      $0581
+                    leas      $02,s
+                    std       $0a,s
+                    bne       L07B8
+                    leax      $0C,s
+                    lbra      L070B
+
+L07B8               ldd       #$002E
+                    pshs      d
+                    lbsr      L04BD
+                    leas      $02,s
+                    bra       L07C9
+
+L07C4               lbsr      L0695
+                    std       $0a,s
+L07C9               ldd       $0a,s
+                    std       ,s
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L0E2A
+                    std       ,s
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L0394
+L07F9               leas      $02,s
+                    bra       L085F
+
+L07FD               cmpx      #$0037
+                    lbeq      L06A7
+                    cmpx      #$0034
+                    lbeq      L06A7
+                    cmpx      #$004A
+                    lbeq      L06A7
+                    cmpx      #$004B
+                    lbeq      L06A7
+                    cmpx      #$0036
+                    lbeq      L06A7
+                    cmpx      #$002D
+                    lbeq      L06CC
+                    cmpx      #$0040
+                    lbeq      L073B
+                    cmpx      #$0043
+                    lbeq      L073B
+                    cmpx      #$0044
+                    lbeq      L073B
+                    cmpx      #$0042
+                    lbeq      L073B
+                    cmpx      #$003D
+                    lbeq      L073B
+                    cmpx      #$003C
+                    lbeq      L073B
+                    cmpx      #$0041
+                    lbeq      L073B
+                    cmpx      #$003B
+                    lbeq      L0782
+L085F               cmpu      #$0000
+                    bne       L086A
+                    clra
+                    clrb
+                    lbra      L09F1
+
+L086A               ldx       $005F
+                    lbra      L0990
+
+L086F               ldd       $0063
+                    std       $04,s
+                    ldd       L003F
+                    std       $06,s
+                    lbsr      $552C
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000F
+                    pshs      d
+                    lbsr      L09F5
+                    pshs      d
+                    pshs      u
+                    ldd       #$0065
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       #$002E
+                    lbra      L0916
+
+L08A0               lbsr      $552C
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      $0581
+                    leas      $02,s
+                    std       $0a,s
+                    bne       L08D4
+                    lbsr      L0E16
+                    ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $0a,s
+L08D4               ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    ldd       #$000C
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0050
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    ldd       #$000F
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       #$0042
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       #$002C
+L0916               pshs      d
+                    lbsr      L04BD
+                    leas      $02,s
+                    lbra      L086A
+
+L0920               ldd       $005F
+                    std       $08,s
+                    ldd       L003F
+                    std       $06,s
+                    ldd       $0063
+                    std       $04,s
+                    ldd       $0041
+                    addd      #$0001
+                    std       $0041
+                    lbsr      $552C
+                    ldd       $0041
+                    addd      #$FFFF
+                    std       $0041
+                    ldd       $005F
+                    cmpd      #$0034
+                    beq       L094B
+                    lbsr      L42E0
+                    lbra      L09AC
+
+L094B               ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    ldd       $0061
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $005F
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $0a,s
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000F
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    lbsr      $552C
+                    lbra      L086A
+
+L0990               cmpx      #$002D
+                    lbeq      L086F
+                    cmpx      #$002B
+                    lbeq      L08A0
+                    cmpx      #$0045
+                    lbeq      L0920
+                    cmpx      #$0046
+                    lbeq      L0920
+L09AC               ldx       $005F
+                    bra       L09E5
+
+L09B0               ldd       #$003E
+                    std       $005F
+                    leax      $0C,s
+                    bra       L09C0
+
+L09B9               ldd       #$003F
+                    std       $005F
+                    bra       L09C2
+
+L09C0               leas      -$0C,x
+L09C2               ldd       $0063
+                    pshs      d
+                    ldd       L003F
+                    pshs      d
+                    ldd       #$000E
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $005F
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    tfr       d,u
+                    lbsr      $552C
+                    bra       L09EF
+
+L09E5               cmpx      #$003C
+                    beq       L09B0
+                    cmpx      #$003D
+                    beq       L09B9
+L09EF               tfr       u,d
+L09F1               leas      $0C,s
+                    puls      pc,u
+L09F5               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    leas      -$02,s
+                    ldu       #$0000
+                    bra       L0A04
+
+L0A04               ldd       $005F
+                    cmpd      #$002E
+                    beq       L0A4C
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      $0581
+                    leas      $02,s
+                    std       ,s
+                    beq       L0A3F
+                    ldx       ,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$000B
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       ,s
+                    ldu       ,s
+L0A3F               ldd       $005F
+                    cmpd      #$0030
+                    bne       L0A4C
+                    lbsr      $552C
+                    bra       L0A04
+
+L0A4C               tfr       u,d
+                    bra       L0A98
+                    pshs      u
+L0A52               ldd       #$FFB8
+                    lbsr      L0111
+                    leas      -$02,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $0581
+                    std       ,s
+                    lbsr      L0F19
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L0A7C
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L0A7C
+                    ldd       $08,u
+                    std       ,s
+                    bra       L0A8B
+
+L0A7C               clra
+                    clrb
+                    std       ,s
+                    leax      L0ED3,pcr
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+L0A8B               stu       -$02,s
+                    beq       L0A96
+                    pshs      u
+                    lbsr      L0394
+                    leas      $02,s
+L0A96               ldd       ,s
+L0A98               leas      $02,s
+                    puls      pc,u
+L0A9C               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldx       $005F
+                    bra       L0AF5
+
+L0AA8               ldd       #$0057
+                    std       $005F
+                    ldd       #$0008
+                    bra       L0AC4
+
+L0AB2               ldd       #$0052
+                    std       $005F
+                    ldd       #$000D
+                    bra       L0AC4
+
+L0ABC               ldd       #$0051
+                    std       $005F
+                    ldd       #$000C
+L0AC4               std       $0061
+L0AC6               ldd       #$0001
+                    puls      pc,u
+L0ACB               ldd       $005F
+                    cmpd      #$0047
+                    blt       L0ADB
+                    ldd       $005F
+                    cmpd      #$005F
+                    ble       L0AEF
+L0ADB               ldd       $005F
+                    cmpd      #$00A0
+                    lblt      L0C90
+                    ldd       $005F
+                    cmpd      #$00A9
+                    lbgt      L0C90
+L0AEF               ldd       #$0001
+                    lbra      L0C92
+
+L0AF5               cmpx      #$0041
+                    beq       L0AA8
+                    cmpx      #$0042
+                    beq       L0AB2
+                    cmpx      #$0043
+                    beq       L0ABC
+                    cmpx      #$0030
+                    beq       L0AC6
+                    cmpx      #$0078
+                    lbeq      L0AC6
+                    cmpx      #$0064
+                    lbeq      L0AC6
+                    cmpx      #$002F
+                    lbeq      L0C90
+                    bra       L0ACB
+                    puls      pc,u
+L0B22               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0111
+                    ldx       $04,s
+                    lbra      L0C94
+
+L0B2F               ldd       $06,s
+                    addd      $08,s
+                    puls      pc,u
+L0B35               ldd       $06,s
+                    subd      $08,s
+                    puls      pc,u
+L0B3B               ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      L7540
+                    puls      pc,u
+L0B46               ldd       $08,s
+                    beq       L0B64
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      L75F4
+                    bra       L0B62
+
+L0B55               ldd       $08,s
+                    beq       L0B64
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      $75A1
+L0B62               puls      pc,u
+L0B64               lbsr      L136E
+                    lbra      L0C90
+
+L0B6A               ldd       $06,s
+                    anda      $08,s
+                    andb      $09,s
+                    puls      pc,u
+L0B72               ldd       $06,s
+                    ora       $08,s
+                    orb       $09,s
+                    puls      pc,u
+L0B7A               ldd       $06,s
+                    eora      $08,s
+                    eorb      $09,s
+                    puls      pc,u
+L0B82               ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      L7681
+                    puls      pc,u
+L0B8D               ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      L765E
+                    puls      pc,u
+L0B98               ldd       $06,s
+                    cmpd      $08,s
+                    lbne      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0BA7               ldd       $06,s
+                    cmpd      $08,s
+                    lbeq      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0BB6               ldd       $06,s
+                    cmpd      $08,s
+                    lble      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0BC5               ldd       $06,s
+                    cmpd      $08,s
+                    lbge      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0BD4               ldd       $06,s
+                    cmpd      $08,s
+                    lblt      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0BE3               ldd       $06,s
+                    cmpd      $08,s
+                    lbgt      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0BF2               ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    puls      pc,u
+L0BFA               ldd       $06,s
+                    lbne      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0C06               ldd       $06,s
+                    coma
+                    comb
+                    puls      pc,u
+L0C0C               ldd       $06,s
+                    lbeq      L0C90
+                    ldd       $08,s
+                    lbeq      L0C90
+                    ldd       #$0001
+                    lbra      L0C92
+
+L0C1E               ldd       $06,s
+                    bne       L0C28
+                    ldd       $08,s
+                    lbeq      L0C90
+L0C28               ldd       #$0001
+                    lbra      L0C92
+
+L0C2E               leas      -$04,s
+                    ldd       $0C,s
+                    std       $02,s
+                    ldd       $0a,s
+                    std       ,s
+                    ldx       $08,s
+                    bra       L0C72
+
+L0C3C               ldd       ,s
+                    cmpd      $02,s
+                    bhi       L0C6C
+                    ldd       #$0001
+                    bra       L0C6E
+
+L0C48               ldd       ,s
+                    cmpd      $02,s
+                    bcc       L0C6C
+                    ldd       #$0001
+                    bra       L0C6E
+
+L0C54               ldd       ,s
+                    cmpd      $02,s
+                    bcs       L0C6C
+                    ldd       #$0001
+                    bra       L0C6E
+
+L0C60               ldd       ,s
+                    cmpd      $02,s
+                    bls       L0C6C
+                    ldd       #$0001
+                    bra       L0C6E
+
+L0C6C               clra
+                    clrb
+L0C6E               leas      $04,s
+                    puls      pc,u
+L0C72               cmpx      #$0060
+                    beq       L0C3C
+                    cmpx      #$0061
+                    beq       L0C48
+                    cmpx      #$0062
+                    beq       L0C54
+                    bra       L0C60
+                    leas      $04,s
+L0C85               leax      L0EE5,pcr
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+L0C90               clra
+                    clrb
+L0C92               puls      pc,u
+L0C94               cmpx      #$0050
+                    lbeq      L0B2F
+                    cmpx      #$0051
+                    lbeq      L0B35
+                    cmpx      #$0052
+                    lbeq      L0B3B
+                    cmpx      #$0053
+                    lbeq      L0B46
+                    cmpx      #$0054
+                    lbeq      L0B55
+                    cmpx      #$0057
+                    lbeq      L0B6A
+                    cmpx      #$0058
+                    lbeq      L0B72
+                    cmpx      #$0059
+                    lbeq      L0B7A
+                    cmpx      #$0056
+                    lbeq      L0B82
+                    cmpx      #$0055
+                    lbeq      L0B8D
+                    cmpx      #$005A
+                    lbeq      L0B98
+                    cmpx      #$005B
+                    lbeq      L0BA7
+                    cmpx      #$005F
+                    lbeq      L0BB6
+                    cmpx      #$005D
+                    lbeq      L0BC5
+                    cmpx      #$005E
+                    lbeq      L0BD4
+                    cmpx      #$005C
+L0D00               lbeq      L0BE3
+                    cmpx      #$0043
+                    lbeq      L0BF2
+                    cmpx      #$0040
+                    lbeq      L0BFA
+                    cmpx      #$0044
+                    lbeq      L0C06
+                    cmpx      #$0047
+                    lbeq      L0C0C
+                    cmpx      #$0048
+                    lbeq      L0C1E
+                    cmpx      #$0060
+                    lbeq      L0C2E
+                    cmpx      #$0061
+                    lbeq      L0C2E
+                    cmpx      #$0062
+                    lbeq      L0C2E
+                    cmpx      #$0063
+                    lbeq      L0C2E
+                    lbra      L0C85
+                    puls      pc,u
+L0D48               pshs      u
+                    ldd       #$FFA2
+                    lbsr      L0111
+                    leas      -$0e,s
+                    ldd       L003F
+                    std       $04,s
+                    ldd       $0063
+                    std       $02,s
+                    leax      ,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    leax      $10,s
+                    pshs      x
+                    lbsr      L3C36
+                    leas      $06,s
+                    std       $08,s
+                    pshs      d
+                    leax      $0C,s
+                    pshs      x
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      L3F8B
+                    leas      $06,s
+                    std       $08,s
+                    leax      >$0047,y
+                    pshs      x
+                    lbsr      $4205
+                    leas      $02,s
+                    ldd       $06,s
+                    beq       L0D99
+                    leax      $0EF7,pcr
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+L0D99               ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    bsr       L0DD4
+                    leas      $0C,s
+                    std       $06,s
+                    ldd       $08,s
+                    std       [$06,s]
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      $4101
+                    leas      $06,s
+                    ldd       $06,s
+                    leas      $0e,s
+                    puls      pc,u
+L0DD4               pshs      u
+L0DD6               ldd       #$FFBA
+                    lbsr      L0111
+                    ldd       L002D
+                    beq       L0DE8
+                    ldu       L002D
+                    ldd       $0a,u
+                    std       L002D
+                    bra       L0DF4
+
+L0DE8               ldd       #$0016
+                    pshs      d
+                    lbsr      L5C28
+                    leas      $02,s
+                    tfr       d,u
+L0DF4               ldd       $04,s
+                    std       $06,u
+                    ldd       $06,s
+                    std       $0a,u
+                    ldd       $08,s
+                    std       $0C,u
+                    ldd       $0a,s
+                    std       $08,u
+                    ldd       $0C,s
+                    std       $0e,u
+                    ldd       $0e,s
+                    std       $10,u
+                    clra
+                    clrb
+                    std       $14,u
+                    tfr       u,d
+                    puls      pc,u
+L0E16               pshs      u
+L0E18               ldd       #$FFBA
+                    lbsr      L0111
+                    leax      L0F06,pcr
+                    pshs      x
+                    lbsr      L024C
+                    lbra      L0E79
+
+L0E2A               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0111
+                    ldu       [$04,s]
+                    ldx       $06,u
+                    bra       L0E7D
+
+L0E39               pshs      u
+                    lbsr      L0F19
+                    leas      $02,s
+                    std       [$04,s]
+                    tfr       d,u
+                    leax      ,s
+                    bra       L0E59
+
+L0E49               ldd       [$08,u]
+                    std       ,u
+                    pshs      u
+                    lbsr      $24D4
+                    leas      $02,s
+                    ldu       $08,u
+                    bra       L0E5B
+
+L0E59               leas      ,x
+L0E5B               ldd       $04,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L418B
+                    leas      $06,s
+                    puls      pc,u
+L0E6E               pshs      u
+                    ldd       #$000C
+                    addd      ,s++
+                    pshs      d
+                    bsr       L0E2A
+L0E79               leas      $02,s
+                    puls      pc,u
+L0E7D               cmpx      #$0034
+                    beq       L0E49
+                    cmpx      #$0020
+                    beq       L0E5B
+                    cmpx      #$0045
+                    beq       L0E6E
+                    cmpx      #$0046
+                    lbeq      L0E6E
+                    lbra      L0E39
+                    puls      pc,u
+L0E98               lsr       L6869
+                    fcb       $72
+                    lsr       0,y
+                    fcb       $65
+                    asl       L7072
+                    fcb       $65
+                    com       $7369
+                    clr       $0e,s
+                    bra       L0F17
+                    rol       -$0d,s
+                    com       $696E
+                    asr       0,x
+L0EB1               clr       -$10,s
+                    fcb       $65
+                    fcb       $72
+                    fcb       $61
+                    jmp       $04,s
+                    bra       $0F1F
+                    asl       $7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+L0EC2               neg       $7269
+                    tst       $01,s
+                    fcb       $72
+                    rol       L2065
+                    asl       $7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+L0ED3               com       $0f,s
+                    jmp       -$0d,s
+                    lsr       $616E
+                    lsr       L2072
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L0EE5               com       $0f,s
+                    jmp       -$0d,s
+                    lsr       $616E
+                    lsr       $206F
+                    neg       $6572
+                    fcb       $61
+                    lsr       $6F72
+                    neg       $006E
+                    fcb       $61
+                    tst       $05,s
+                    bra       L0F66
+                    jmp       0,y
+                    fcb       $61
+                    bra       $0F65
+                    fcb       $61
+                    com       L7400
+L0F06               fcb       $65
+                    asl       L7072
+                    fcb       $65
+                    com       $7369
+                    clr       $0e,s
+                    bra       $0F7F
+                    rol       -$0d,s
+                    com       $696E
+L0F17               asr       0,x
+L0F19               pshs      u
+L0F1B               ldd       #$FFAE
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$0C,s
+                    stu       -$02,s
+                    lbeq      L1000
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L0F19
+                    leas      $02,s
+                    std       $0a,u
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L0F19
+                    leas      $02,s
+                    std       $0C,u
+                    pshs      u
+                    lbsr      L1383
+                    leas      $02,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L1324
+                    std       ,s++
+                    beq       L0F57
+                    leax      $0C,s
+                    lbra      L0FFE
+
+L0F57               pshs      u
+                    lbsr      L1006
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       $0a,u
+                    std       $0a,s
+                    ldd       $0C,u
+L0F66               std       $08,s
+                    ldd       $06,u
+                    std       $04,s
+                    cmpd      #$0064
+                    bne       L0FB5
+                    ldx       $0a,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L0FB5
+                    ldx       $0a,s
+                    ldd       $08,x
+                    beq       L0F8E
+                    ldx       $08,s
+                    ldd       $0a,x
+                    std       $02,s
+                    ldx       $08,s
+                    ldd       $0C,x
+                    bra       L0F98
+
+L0F8E               ldx       $08,s
+                    ldd       $0C,x
+                    std       $02,s
+                    ldx       $08,s
+                    ldd       $0a,x
+L0F98               pshs      d
+                    lbsr      L0394
+                    leas      $02,s
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    pshs      u
+                    bra       L0FF5
+
+L0FB5               ldd       $04,s
+                    cmpd      #$0042
+                    bne       L0FC7
+                    ldx       $0a,s
+                    ldd       $06,x
+                    cmpd      #$0041
+                    beq       L0FD9
+L0FC7               ldd       $04,s
+                    cmpd      #$0041
+                    bne       L1000
+                    ldx       $0a,s
+                    ldd       $06,x
+                    cmpd      #$0042
+                    bne       L1000
+L0FD9               ldx       $0a,s
+                    ldd       $0a,x
+                    std       $02,s
+                    ldd       ,u
+                    std       [$02,s]
+                    ldd       $02,u
+                    ldx       $02,s
+                    std       $02,x
+                    pshs      u
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+L0FF5               lbsr      L03B5
+                    leas      $02,s
+                    ldu       $02,s
+                    bra       L1000
+
+L0FFE               leas      -$0C,x
+L1000               tfr       u,d
+                    leas      $0C,s
+                    puls      pc,u
+L1006               pshs      u
+L1008               ldd       #$FFA8
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$0e,s
+                    stu       -$02,s
+                    bne       L101B
+                    clra
+                    clrb
+                    lbra      L1320
+
+L101B               ldd       $0a,u
+                    std       $0C,s
+                    ldd       $0C,u
+                    std       $0a,s
+                    ldd       $06,u
+                    std       $06,s
+                    pshs      d
+                    lbsr      L049C
+                    std       ,s++
+                    bne       L1042
+                    ldd       $06,s
+                    cmpd      #$0047
+                    beq       L1042
+                    ldd       $06,s
+                    cmpd      #$0048
+                    lbne      L1259
+L1042               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1051
+                    ldd       #$0001
+                    bra       L1053
+
+L1051               clra
+                    clrb
+L1053               std       $02,s
+                    pshs      d
+                    ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1066
+                    ldd       #$0001
+                    bra       L1068
+
+L1066               clra
+                    clrb
+L1068               std       $02,s
+                    anda      ,s+
+                    andb      ,s+
+                    std       -$02,s
+                    beq       L1077
+                    leax      $0e,s
+                    lbra      L126A
+
+L1077               ldd       $02,s
+                    beq       L10B7
+                    ldx       $06,s
+                    bra       L1096
+
+L107F               ldd       $0C,s
+                    std       $08,s
+                    ldd       $0a,s
+                    std       $0C,s
+                    std       $0a,u
+                    ldd       $08,s
+                    std       $0a,s
+                    std       $0C,u
+                    ldd       #$0001
+                    std       ,s
+                    bra       L10B7
+
+L1096               cmpx      #$0050
+                    beq       L107F
+                    cmpx      #$0052
+                    lbeq      L107F
+                    cmpx      #$0057
+                    lbeq      L107F
+                    cmpx      #$0058
+                    lbeq      L107F
+                    cmpx      #$0059
+                    lbeq      L107F
+L10B7               ldx       $06,s
+                    lbra      L1225
+
+L10BC               ldd       ,s
+                    lbeq      L131E
+                    ldx       $0a,s
+                    ldd       $08,x
+                    lbeq      L11EA
+                    lbra      L131E
+
+L10CD               ldd       ,s
+                    lbeq      L131E
+                    ldx       $0a,s
+                    ldd       $08,x
+                    lbeq      L11EA
+                    ldx       $0C,s
+                    ldx       $06,x
+                    lbra      L1134
+
+L10E2               ldx       $0C,s
+                    ldx       $0a,x
+                    ldd       $14,x
+                    leax      $14,x
+                    pshs      x,d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    addd      ,s++
+                    std       [,s++]
+                    bra       L10FA
+
+L10F8               leas      -$0e,x
+L10FA               ldd       $0C,s
+                    std       $08,s
+                    pshs      u
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldu       $08,s
+                    lbra      L131E
+
+L1113               ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L131E
+                    ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $08,x
+                    leax      $08,x
+                    pshs      x,d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    addd      ,s++
+                    lbra      L11CD
+
+L1134               cmpx      #$0041
+                    lbeq      L10E2
+                    cmpx      #$0050
+                    beq       L1113
+                    lbra      L131E
+
+L1143               ldd       ,s
+                    beq       L1162
+                    ldx       $0a,s
+                    ldd       $08,x
+                    nega
+                    negb
+                    sbca      #$00
+                    ldx       $0a,s
+                    std       $08,x
+                    ldd       #$0050
+                    std       $06,u
+                    pshs      u
+                    lbsr      L1006
+                    leas      $02,s
+                    lbra      L1320
+
+L1162               ldd       $02,s
+                    lbeq      L131E
+                    ldx       $0C,s
+                    ldd       $08,x
+                    lbne      L131E
+                    ldd       #$0043
+                    std       $06,u
+                    ldd       $0a,s
+                    std       $0a,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    ldd       $0C,s
+                    lbra      L121B
+
+L1182               ldd       ,s
+                    lbeq      L131E
+                    ldx       $0a,s
+                    ldd       $08,x
+                    beq       L119D
+                    lbra      L131E
+
+L1191               ldd       ,s
+                    lbeq      L131E
+                    ldx       $0a,s
+                    ldx       $08,x
+                    bra       L11D1
+
+L119D               leax      $0e,s
+                    lbra      L11FF
+
+L11A2               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0052
+                    lbne      L131E
+                    ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L131E
+                    ldx       $0C,s
+                    ldx       $0C,x
+                    ldd       $08,x
+                    leax      $08,x
+                    pshs      x,d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    lbsr      L7540
+L11CD               std       [,s++]
+                    bra       L11EA
+
+L11D1               stx       -$02,s
+                    beq       L119D
+                    cmpx      #$0001
+                    beq       L11EA
+                    bra       L11A2
+
+L11DC               ldd       ,s
+                    beq       L11EF
+                    ldx       $0a,s
+                    ldd       $08,x
+                    cmpd      #$0001
+                    bne       L11EF
+L11EA               leax      $0e,s
+                    lbra      L10F8
+
+L11EF               ldd       $02,s
+                    lbeq      L131E
+                    ldx       $0C,s
+                    ldd       $08,x
+                    lbne      L131E
+                    bra       L1201
+
+L11FF               leas      -$0e,x
+L1201               ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+L1208               std       $08,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    std       $0a,u
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldd       $0a,s
+L121B               pshs      d
+                    lbsr      L03B5
+L1220               leas      $02,s
+                    lbra      L131E
+
+L1225               cmpx      #$0058
+                    lbeq      L10BC
+                    cmpx      #$0059
+                    lbeq      L10BC
+                    cmpx      #$0050
+                    lbeq      L10CD
+                    cmpx      #$0051
+                    lbeq      L1143
+                    cmpx      #$0057
+                    lbeq      L1182
+                    cmpx      #$0052
+                    lbeq      L1191
+                    cmpx      #$0053
+                    lbeq      L11DC
+                    lbra      L131E
+
+L1259               ldx       $06,s
+                    lbra      L1309
+
+L125E               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L128E
+                    bra       L126C
+
+L126A               leas      -$0e,x
+L126C               ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $12,u
+                    ldx       $0a,s
+                    ldd       $08,x
+                    pshs      d
+                    ldx       $0e,s
+                    ldd       $08,x
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L0B22
+                    leas      $06,s
+                    lbra      L1208
+
+L128E               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L12DD
+                    leas      -$02,s
+                    ldx       $0e,s
+                    ldd       $08,x
+                    std       ,s
+                    bne       L12AE
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L5C28
+                    leas      $02,s
+                    std       ,s
+L12AE               ldx       $08,s
+                    bra       L12CB
+
+L12B2               ldx       ,s
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      L7494
+                    bra       L12C6
+
+L12BD               ldx       ,s
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      L74A8
+L12C6               lbsr      L74D4
+                    bra       L12D5
+
+L12CB               cmpx      #$0043
+                    beq       L12B2
+                    cmpx      #$0044
+                    beq       L12BD
+L12D5               ldd       ,s
+                    ldx       $0e,s
+                    std       $08,x
+                    bra       L12FD
+
+L12DD               ldx       $0C,s
+                    ldd       $06,x
+                    cmpd      #$004B
+                    bne       L131E
+                    leas      -$02,s
+                    ldx       $0e,s
+                    ldd       $08,x
+                    std       ,s
+                    beq       L12FD
+                    ldx       ,s
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      $6974
+                    lbsr      $6A00
+L12FD               pshs      u
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldu       $0e,s
+                    lbra      L1220
+
+L1309               cmpx      #$0040
+                    lbeq      L125E
+                    cmpx      #$0044
+                    lbeq      L125E
+                    cmpx      #$0043
+                    lbeq      L125E
+L131E               tfr       u,d
+L1320               leas      $0e,s
+                    puls      pc,u
+L1324               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L136A
+                    ldx       $06,u
+                    bra       L133B
+
+L1336               ldd       #$0001
+                    puls      pc,u
+L133B               cmpx      #$0076
+                    beq       L1336
+                    cmpx      #$006F
+                    lbeq      L1336
+                    cmpx      #$0036
+                    lbeq      L1336
+                    cmpx      #$004A
+                    lbeq      L1336
+                    cmpx      #$004B
+                    lbeq      L1336
+                    cmpx      #$0034
+                    lbeq      L1336
+                    cmpx      #$0037
+                    lbeq      L1336
+L136A               clra
+                    clrb
+                    puls      pc,u
+L136E               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    leax      L2676,pcr
+                    pshs      x
+                    lbsr      L024C
+                    leas      $02,s
+                    puls      pc,u
+L1383               pshs      u
+L1385               ldd       #$FF9C
+                    lbsr      L0111
+                    leas      -$14,s
+                    ldx       $18,s
+                    ldu       $0a,x
+                    ldx       $18,s
+                    ldd       $0C,x
+                    std       $12,s
+                    ldd       #$0002
+                    std       $0a,s
+                    std       $08,s
+                    clra
+                    clrb
+                    std       $06,s
+                    ldd       #$0001
+                    std       $0C,s
+                    ldx       $18,s
+                    ldd       $06,x
+                    std       $0e,s
+                    tfr       d,x
+                    lbra      $1E4A
+                    ldx       $18,s
+                    ldd       $08,x
+                    std       $10,s
+                    ldx       $10,s
+                    ldd       $08,x
+                    cmpd      #start
+                    bne       L13E7
+                    leax      L2685,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0294
+                    leas      $04,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L25E7
+                    leas      $02,s
+                    lbra      $1F6C
+
+L13E7               ldd       [$10,s]
+                    std       $0C,s
+                    ldx       $10,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$0f
+                    cmpd      #$000A
+                    bne       L1428
+                    leas      -$02,s
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       ,s
+                    ldd       $0e,s
+                    andb      #$F0
+                    addd      [,s]
+                    std       [$12,s]
+                    std       $0e,s
+                    ldx       ,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    lbsr      $4101
+                    leas      $06,s
+                    leas      $02,s
+L1428               ldx       $10,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L1447
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    lbne      L14AA
+L1447               ldu       $18,s
+                    ldd       $0a,s
+                    std       $02,u
+                    ldx       $18,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $1a,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       #$0041
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $18,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L1495
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L04B1
+                    leas      $02,s
+                    std       $06,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0478
+                    leas      $02,s
+                    bra       L1497
+
+L1495               ldd       $0C,s
+L1497               std       ,u
+                    pshs      d
+                    lbsr      L0484
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       #$0001
+                    std       $12,u
+                    bra       L14D1
+
+L14AA               ldx       $10,s
+                    ldd       $08,x
+                    std       $04,s
+                    tfr       d,x
+                    bra       L14C5
+
+L14B5               ldd       $04,s
+                    ldx       $18,s
+                    std       $06,x
+                    clra
+                    clrb
+                    ldx       $18,s
+                    std       $08,x
+                    bra       L14D1
+
+L14C5               cmpx      #$0076
+                    beq       L14B5
+                    cmpx      #$006F
+                    lbeq      L14B5
+L14D1               ldd       #$0001
+                    bra       L14D8
+                    clra
+                    clrb
+L14D8               std       $08,s
+                    lbra      $1F6C
+                    ldd       #$0008
+                    std       $0C,s
+                    ldd       #$0001
+                    std       $08,s
+                    ldd       #$0004
+                    lbra      L1642
+                    ldd       #$0006
+                    std       $0C,s
+                    ldd       #$0001
+                    std       $08,s
+                    ldd       #$0008
+                    lbra      L1642
+                    ldd       #$0012
+                    std       $0C,s
+                    ldd       #$0001
+                    lbra      L1642
+                    pshs      u
+L150A               lbsr      $24D4
+                    leas      $02,s
+                    ldd       [$18,s]
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L1528
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L1543
+L1528               leax      $269E,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0294
+                    leas      $04,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0484
+                    leas      $02,s
+                    std       $0C,s
+L1543               ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L155C
+                    ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L2028
+                    leas      $04,s
+                    bra       L1569
+
+L155C               ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2028
+                    leas      $04,s
+                    std       $0C,s
+L1569               ldx       $18,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldx       $18,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    stu       $18,s
+                    lbra      $1F6C
+                    ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L2464
+                    leas      $04,s
+                    ldd       $06,u
+                    cmpd      #$0076
+                    beq       L15A3
+                    ldd       $06,u
+                    cmpd      #$006F
+                    bne       L15BA
+L15A3               leax      $26AA,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0294
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L25E7
+                    leas      $02,s
+L15BA               ldd       $12,u
+                    std       $08,s
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L0484
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       $04,u
+                    std       $06,s
+                    lbra      $1F6C
+                    ldd       $04,u
+L15D7               std       $06,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1619
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0478
+                    leas      $02,s
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L163B
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0478
+                    std       ,s
+                    lbsr      L0484
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    stu       $18,s
+                    bra       L163B
+
+L1619               leax      $26BD,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0294
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L25E7
+                    leas      $02,s
+                    ldd       #$0011
+                    std       ,u
+                    ldd       #$0001
+                    std       $0C,s
+                    clra
+                    clrb
+                    std       $06,s
+L163B               ldd       $12,u
+                    std       $08,s
+                    ldd       $02,u
+L1642               std       $0a,s
+                    lbra      $1F6C
+                    leax      ,s
+L1649               pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    ldd       $16,s
+                    pshs      d
+                    lbsr      $2503
+                    leas      $06,s
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L2464
+                    leas      $04,s
+                    ldx       $12,s
+                    ldd       $08,x
+                    bne       L169B
+                    ldd       ,s
+                    bne       L169B
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L03B5
+                    leas      $02,s
+                    stu       $18,s
+                    ldx       $18,s
+                    ldd       $12,x
+                    std       $08,s
+                    lbra      L16FE
+
+L169B               ldd       $12,u
+                    std       $08,s
+                    ldd       $06,u
+                    cmpd      #$0042
+                    bne       L16C0
+                    ldd       $0a,u
+                    std       $10,s
+                    pshs      u
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldu       $10,s
+                    tfr       u,d
+                    ldx       $18,s
+                    std       $0a,x
+                    bra       L16F3
+
+L16C0               ldd       ,u
+                    std       $04,s
+                    ldd       $10,u
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       #$0041
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    ldx       $18,s
+                    std       $0a,x
+                    tfr       d,u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0484
+                    leas      $02,s
+                    std       ,u
+L16F3               ldd       $08,s
+                    std       $12,u
+                    leax      $14,s
+                    lbra      L175C
+
+L16FE               lbra      $1F6C
+                    leax      ,s
+L1703               pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    ldd       $16,s
+                    pshs      d
+                    lbsr      $2503
+                    leas      $06,s
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       ,u
+                    std       $04,s
+                    cmpd      #$0001
+                    beq       L1755
+                    ldd       $04,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1736
+                    ldd       #$0001
+                    bra       L1738
+
+L1736               clra
+                    clrb
+L1738               bne       L1755
+                    leax      L26CE,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0294
+                    leas      $04,s
+                    ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $12,u
+L1755               ldd       $12,u
+                    std       $08,s
+                    bra       L175F
+
+L175C               leas      -$14,x
+L175F               ldd       #$0050
+                    ldx       $18,s
+                    std       $06,x
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L1006
+                    leas      $02,s
+                    std       $18,s
+                    ldd       ,s
+                    bne       L17BC
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0484
+                    leas      $02,s
+                    std       [$18,s]
+                    ldd       $08,s
+                    ldx       $18,s
+                    std       $12,x
+                    ldd       $0a,s
+                    ldx       $18,s
+                    std       $02,x
+                    ldx       $18,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $1a,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $20,s
+                    pshs      d
+                    ldd       #$0042
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $18,s
+L17BC               lbra      $1F6C
+                    ldd       ,u
+L17C1               std       $0C,s
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L17FB
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0478
+                    leas      $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L17FB
+                    ldd       $0a,u
+                    ldx       $18,s
+                    std       $0a,x
+                    std       $10,s
+                    pshs      u
+                    lbsr      L03B5
+                    leas      $02,s
+                    ldd       [$10,s]
+L17F1               pshs      d
+                    lbsr      L0478
+                    leas      $02,s
+                    lbra      L185F
+
+L17FB               ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L180A
+                    ldd       $0C,s
+                    bra       L17F1
+
+L180A               ldd       $0C,s
+                    bne       L184D
+                    ldd       $08,u
+                    std       $10,s
+                    ldd       #$0031
+                    std       [$10,s]
+                    ldd       #$0002
+                    ldx       $10,s
+                    std       $02,x
+                    clra
+                    clrb
+                    ldx       $10,s
+                    std       $04,x
+                    ldd       #$000E
+                    ldx       $10,s
+                    std       $08,x
+                    clra
+                    clrb
+                    ldx       $10,s
+                    std       $0C,x
+                    ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L01F7
+                    leas      $06,s
+                    ldd       #$0001
+                    bra       L185F
+
+L184D               leax      L26EA,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0294
+                    leas      $04,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$0f
+L185F               std       $0C,s
+                    ldd       $04,u
+                    std       $06,s
+                    ldd       $02,u
+                    std       $0a,s
+                    pshs      u
+L186B               lbsr      $24D4
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L25B6
+                    leas      $02,s
+                    ldx       ,u
+                    bra       L188E
+
+L187B               ldd       #$0001
+                    bra       L1883
+
+L1880               ldd       #$0006
+L1883               pshs      d
+                    pshs      u
+                    lbsr      L2028
+                    leas      $04,s
+                    bra       L1898
+
+L188E               cmpx      #$0002
+                    beq       L187B
+                    cmpx      #$0005
+                    beq       L1880
+L1898               lbra      $1F6C
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldd       [$12,s]
+                    std       $0C,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    lbra      $1F6C
+                    ldd       ,u
+L18B3               clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L18C3
+                    pshs      u
+                    lbsr      L1FBD
+                    leas      $02,s
+L18C3               ldd       #$0001
+                    lbra      L1E0E
+                    pshs      u
+L18CB               lbsr      L1FBD
+                    leas      $02,s
+                    lbra      L1E0E
+                    pshs      u
+L18D5               lbsr      L1FBD
+                    leas      $02,s
+                    std       $0C,s
+                    cmpd      #$0006
+                    lbne      L19C4
+                    pshs      u
+                    lbsr      L265D
+                    leas      $02,s
+                    pshs      u
+                    lbra      L19BF
+                    clra
+                    clrb
+L18F2               pshs      d
+                    pshs      u
+                    lbsr      L2464
+                    leas      $04,s
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    beq       L1921
+                    ldd       $04,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L0478
+                    std       ,s
+                    lbsr      L418B
+                    leas      $06,s
+                    bra       L1924
+
+L1921               ldd       #$0001
+L1924               ldx       $18,s
+                    std       $08,x
+                    ldd       $12,u
+                    std       $08,s
+                    ldd       $06,u
+                    cmpd      #$0042
+                    lbne      L1AA8
+                    ldd       $08,s
+                    addd      #$0001
+                    lbra      L1AA6
+                    ldd       ,u
+L1942               clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1952
+                    pshs      u
+                    lbsr      L1FBD
+                    leas      $02,s
+L1952               ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbeq      L19C4
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L1FBD
+                    bra       L19C2
+                    ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $2341
+                    leas      $04,s
+                    std       $0C,s
+                    cmpd      #$0006
+                    bne       L1983
+                    leax      $14,s
+                    bra       L19A7
+
+L1983               lbra      $1F6C
+                    pshs      u
+L1988               lbsr      L1FBD
+                    leas      $02,s
+                    std       $0C,s
+                    cmpd      #$0006
+                    beq       L19AA
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L1FBD
+                    leas      $02,s
+                    cmpd      #$0006
+                    bne       L19C7
+                    bra       L19AA
+
+L19A7               leas      -$14,x
+L19AA               leax      L26F9,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0294
+                    leas      $04,s
+                    ldd       $18,s
+                    pshs      d
+L19BF               lbsr      L25E7
+L19C2               leas      $02,s
+L19C4               lbra      $1F6C
+
+L19C7               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L2028
+                    lbra      L1A50
+                    ldd       ,u
+L19D9               clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L19EE
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1A00
+L19EE               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $2341
+                    leas      $04,s
+                    cmpd      #$0007
+                    bne       L1A0A
+L1A00               ldd       $0e,s
+                    addd      #$0004
+                    ldx       $18,s
+                    std       $06,x
+L1A0A               lbra      $1F6C
+                    ldd       ,u
+L1A0F               clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1A46
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1A29
+                    ldd       #$0001
+                    bra       L1A2B
+
+L1A29               clra
+                    clrb
+L1A2B               bne       L1A52
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L1FBD
+                    leas      $02,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L2028
+                    bra       L1A50
+
+L1A46               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $2341
+L1A50               leas      $04,s
+L1A52               lbra      $1F6C
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1A74
+                    leas      -$02,s
+                    stu       ,s
+                    ldu       $14,s
+                    ldd       ,s
+                    std       $14,s
+                    leas      $02,s
+                    ldx       $18,s
+                    stu       $0a,x
+L1A74               ldd       $02,u
+                    std       $0a,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1A8F
+                    ldd       $04,u
+                    std       $06,s
+                    leax      $14,s
+                    lbra      L1B8E
+
+L1A8F               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $2341
+                    leas      $04,s
+                    std       $0C,s
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+L1AA6               std       $08,s
+L1AA8               lbra      $1F6C
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+                    std       $08,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L1E02
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       $04,u
+                    std       $06,s
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L1B91
+                    ldd       $08,s
+                    ldx       $18,s
+                    std       $12,x
+                    ldd       $0C,s
+                    cmpd      [$12,s]
+                    bne       L1AF5
+                    ldd       $0a,s
+                    ldx       $12,s
+                    cmpd      $02,x
+                    beq       L1B08
+L1AF5               leax      L270F,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0294
+                    leas      $04,s
+                    lbra      L1B7F
+
+L1B08               ldd       $0C,s
+                    pshs      d
+                    lbsr      L0478
+                    leas      $02,s
+                    std       $0C,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L418B
+                    leas      $06,s
+                    std       $0a,s
+                    cmpd      #$0001
+                    lbeq      L1B7F
+                    ldd       #$0002
+                    std       $08,s
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $10,s
+                    ldx       $18,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $1a,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    ldd       $20,s
+                    pshs      d
+                    ldd       #$0053
+                    pshs      d
+                    lbsr      L0DD4
+                    leas      $0C,s
+                    std       $18,s
+L1B7F               ldd       #$0002
+                    std       $0a,s
+                    clra
+                    clrb
+                    std       $06,s
+                    ldd       #$0001
+                    lbra      L1E0E
+
+L1B8E               leas      -$14,x
+L1B91               ldd       $12,s
+                    pshs      d
+                    lbsr      L1FBD
+                    leas      $02,s
+                    ldd       [$12,s]
+                    pshs      d
+                    lbsr      L262E
+                    std       ,s++
+                    bne       L1BBB
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L265D
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L25E7
+                    leas      $02,s
+L1BBB               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L2028
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L23C5
+                    leas      $08,s
+                    ldx       $18,s
+                    std       $0C,x
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+                    std       $08,s
+                    lbra      $1F6C
+                    clra
+                    clrb
+L1BF7               pshs      d
+                    pshs      u
+                    lbsr      L2464
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      $24D4
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L25B6
+                    leas      $02,s
+                    std       $02,s
+                    ldd       ,u
+                    std       $0b,y
+                    inc       $0f,u
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C3C
+                    ldd       $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1C3C
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      $262F
+                    std       ,s++
+                    lbeq      $1CBC
+L1C3C               ldd       $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C5F
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1C5F
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      $262F
+                    std       ,s++
+                    lbeq      $1CBC
+L1C5F               ldd       $0C,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      $2029
+                    leas      $04,s
+                    leax      $14,s
+                    lbra      $1D51
+                    leas      -$14,x
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      $2465
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      $1FBE
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      $25B7
+                    leas      $02,s
+                    std       $02,s
+                    ldd       ,u
+                    std       $0b,y
+                    inc       $0f,u
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1CD1
+                    ldx       $0e,s
+                    bra       L1CC3
+
+L1CA9               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L202A
+                    leas      $04,s
+                    leax      $14,s
+                    bra       L1CF3
+
+L1CBD               leax      $14,s
+                    lbra      L1D69
+
+L1CC3               cmpx      #$00A1
+                    beq       L1CA9
+                    cmpx      #$00A0
+                    lbeq      L1CA9
+                    bra       L1CBD
+
+L1CD1               ldx       $0e,s
+                    lbra      L1D43
+
+L1CD6               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L1CE3
+                    ldd       #$0006
+                    bra       L1CE5
+
+L1CE3               ldd       $0C,s
+L1CE5               pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L202A
+                    leas      $04,s
+                    bra       L1CF6
+
+L1CF3               leas      -$14,x
+L1CF6               ldd       $0e,s
+                    addd      #$FFB0
+                    ldx       $18,s
+                    std       $06,x
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L1385
+                    leas      $02,s
+                    std       $18,s
+                    ldd       $0C,s
+                    cmpd      #$0002
+                    bne       L1D2D
+                    ldd       $0a,u
+                    ldx       $18,s
+                    std       $0a,x
+                    pshs      u
+                    lbsr      L03B7
+                    leas      $02,s
+                    ldx       $18,s
+                    ldu       $0a,x
+                    ldd       #$0001
+                    std       $0C,s
+L1D2D               ldd       $0e,s
+                    addd      #$FFB0
+                    ldx       $18,s
+                    cmpd      $06,x
+                    bne       L1D55
+                    ldd       $0e,s
+                    ldx       $18,s
+                    std       $06,x
+                    bra       L1D55
+
+L1D43               cmpx      #$00A6
+                    beq       L1CF6
+                    cmpx      #$00A5
+                    lbeq      L1CF6
+                    lbra      L1CD6
+                    leas      -$14,x
+L1D55               ldd       $02,u
+                    std       $0a,s
+                    ldd       $12,u
+                    ldx       $12,s
+                    addd      $12,x
+                    std       $08,s
+                    ldd       $04,u
+                    lbra      L1E26
+
+L1D69               leas      -$14,x
+                    leax      $2722,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0296
+                    lbra      L1E47
+
+L1D7D               ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1DDC
+                    ldd       $02,u
+                    std       $0a,s
+                    ldd       $12,u
+                    std       $08,s
+                    ldd       $02,u
+                    std       $06,s
+                    ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1DCF
+                    ldd       $0C,s
+                    cmpd      [$12,s]
+                    bne       L1DB5
+                    ldd       $02,u
+                    ldx       $12,s
+                    cmpd      $02,x
+                    beq       L1DC8
+L1DB5               leax      $2730,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0296
+                    leas      $04,s
+                    lbra      L1F6E
+
+L1DC8               clra
+                    clrb
+                    std       $06,s
+                    lbra      L1F6E
+
+L1DCF               ldd       $12,s
+                    pshs      d
+L1DD4               lbsr      L1F91
+                    leas      $02,s
+                    lbra      L1F6E
+
+L1DDC               ldd       [$12,s]
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1E04
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $12,x
+                    std       $08,s
+                    ldx       $12,s
+                    ldd       $04,x
+                    std       $06,s
+                    pshs      u
+L1E02               bra       L1DD4
+
+L1E04               ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L2343
+L1E0E               leas      $04,s
+                    std       $0C,s
+                    lbra      L1F6E
+
+L1E15               ldd       [$12,s]
+                    std       $0C,s
+                    ldx       $12,s
+                    ldd       $02,x
+                    std       $0a,s
+                    ldx       $12,s
+                    ldd       $04,x
+L1E26               std       $06,s
+                    lbra      L1F6E
+
+L1E2B               ldd       $0e,s
+                    cmpd      #$00A0
+                    blt       L1E39
+                    leax      $14,s
+                    lbra      $1C74
+
+L1E39               leax      $2741,pcr
+                    pshs      x
+                    ldd       $1a,s
+                    pshs      d
+                    lbsr      L0262
+L1E47               leas      $04,s
+                    lbra      L1F6E
+                    cmpx      #$0034
+                    lbeq      $13B9
+                    cmpx      #$0036
+                    lbeq      L14D8
+                    cmpx      #$004A
+                    lbeq      $14DF
+                    cmpx      #$004B
+                    lbeq      $14EF
+                    cmpx      #$0037
+                    lbeq      $14FF
+                    cmpx      #$0020
+                    lbeq      L150A
+                    cmpx      #$0041
+                    lbeq      $1589
+                    cmpx      #$0042
+                    lbeq      L15D7
+                    cmpx      #$0045
+                    lbeq      L1649
+                    cmpx      #$0046
+                    lbeq      L1703
+                    cmpx      #$0065
+                    lbeq      L17C1
+                    cmpx      #$000B
+                    lbeq      L186B
+                    cmpx      #$0030
+                    lbeq      $189D
+                    cmpx      #$0040
+                    lbeq      L18B3
+                    cmpx      #$0043
+                    lbeq      L18CB
+                    cmpx      #$0044
+                    lbeq      L18D5
+                    cmpx      #$003C
+                    lbeq      L18F2
+                    cmpx      #$003E
+                    lbeq      L18F2
+                    cmpx      #$003D
+                    lbeq      L18F2
+                    cmpx      #$003F
+                    lbeq      L18F2
+                    cmpx      #$0047
+                    lbeq      L1942
+                    cmpx      #$0048
+                    lbeq      L1942
+                    cmpx      #$0053
+                    lbeq      L1E04
+                    cmpx      #$0052
+                    lbeq      L1E04
+                    cmpx      #$0057
+                    lbeq      $196C
+                    cmpx      #$0058
+                    lbeq      $196C
+                    cmpx      #$0059
+                    lbeq      $196C
+                    cmpx      #$0054
+                    lbeq      $196C
+                    cmpx      #$0056
+                    lbeq      L1988
+                    cmpx      #$0055
+                    lbeq      L1988
+                    cmpx      #$005D
+                    lbeq      L19D9
+                    cmpx      #$005F
+                    lbeq      L19D9
+                    cmpx      #$005C
+                    lbeq      L19D9
+                    cmpx      #$005E
+                    lbeq      L19D9
+                    cmpx      #$005A
+                    lbeq      L1A0F
+                    cmpx      #$005B
+                    lbeq      L1A0F
+                    cmpx      #$0050
+                    lbeq      $1A57
+                    cmpx      #$0051
+                    lbeq      $1AAD
+                    cmpx      #$0078
+                    lbeq      L1BF7
+                    cmpx      #$002F
+                    lbeq      L1D7D
+                    cmpx      #$0064
+                    lbeq      L1E15
+                    lbra      L1E2B
+
+L1F6E               ldd       $0C,s
+                    std       [$18,s]
+                    ldd       $0a,s
+                    ldx       $18,s
+                    std       $02,x
+                    ldd       $08,s
+                    ldx       $18,s
+                    std       $12,x
+                    ldd       $06,s
+                    ldx       $18,s
+                    std       $04,x
+                    ldd       $18,s
+                    leas      $14,s
+                    puls      pc,u
+L1F91               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L1FA7
+                    ldd       $08,u
+                    beq       L1FBD
+L1FA7               leax      $274C,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0296
+                    leas      $04,s
+                    ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+L1FBD               puls      pc,u
+L1FBF               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$02,s
+                    pshs      u
+                    lbsr      L24D6
+                    leas      $02,s
+                    ldd       ,u
+                    std       ,s
+                    tfr       d,x
+                    bra       L2002
+
+L1FDA               ldd       #$0001
+                    bra       L1FE2
+
+L1FDF               ldd       #$0006
+L1FE2               std       ,s
+                    pshs      d
+                    pshs      u
+                    bsr       L202A
+                    leas      $04,s
+                    bra       L2022
+
+L1FEE               leax      $275B,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0296
+                    leas      $04,s
+                    ldd       #$0001
+                    std       ,s
+                    bra       L2022
+
+L2002               cmpx      #$0002
+                    beq       L1FDA
+                    cmpx      #$0005
+                    beq       L1FDF
+                    cmpx      #$0006
+                    beq       L2022
+                    cmpx      #$0008
+                    beq       L2022
+                    cmpx      #$0001
+                    beq       L2022
+                    cmpx      #$0007
+                    beq       L2022
+                    bra       L1FEE
+
+L2022               ldd       ,s
+                    std       ,u
+                    leas      $02,s
+L2028               puls      pc,u
+L202A               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       ,u
+                    lbra      L22D9
+
+L203F               ldx       $0a,s
+                    bra       L2075
+
+L2043               ldd       #$0085
+                    bra       L2056
+
+L2048               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    bsr       L202A
+                    leas      $04,s
+                    ldd       #$0083
+L2056               std       ,s
+                    lbra      L2306
+
+L205B               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+L2065               leas      $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+L2072               lbra      L2306
+
+L2075               cmpx      #$0001
+                    beq       L2043
+L207A               cmpx      #$0007
+                    lbeq      L2043
+                    cmpx      #$0008
+                    beq       L2048
+                    cmpx      #$0006
+                    beq       L205B
+                    cmpx      #$0005
+                    lbeq      L205B
+                    lbra      L2306
+
+L2095               ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L2306
+L20A2               ldx       $0a,s
+                    lbra      L213A
+
+L20A7               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L20E2
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    std       $02,s
+                    ldd       $08,u
+                    ldx       $02,s
+                    std       $02,x
+                    bge       L20C8
+                    ldd       #$FFFF
+                    bra       L20CA
+
+L20C8               clra
+                    clrb
+L20CA               std       [$02,s]
+                    ldd       $02,s
+                    std       $08,u
+                    bra       L20D5
+
+L20D3               leas      -$04,x
+L20D5               ldd       #$004A
+                    std       $06,u
+                    ldd       #$0004
+L20DD               std       $02,u
+                    lbra      L2306
+
+L20E2               ldd       #$0083
+                    bra       L2135
+
+L20E7               ldd       #$0001
+                    std       $0a,s
+                    lbra      L2306
+
+L20EF               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    ldd       #$008D
+                    bra       L2135
+
+L2100               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L2132
+                    ldd       #$0008
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    std       $02,s
+                    ldx       $02,s
+                    pshs      x
+                    ldd       $08,u
+                    lbsr      L6A1F
+                    lbsr      $6A02
+                    bra       L2124
+
+L2122               leas      -$04,x
+L2124               ldd       $02,s
+                    std       $08,u
+                    ldd       #$004B
+                    std       $06,u
+                    ldd       #$0008
+                    bra       L20DD
+
+L2132               ldd       #$008E
+L2135               std       ,s
+                    lbra      L2306
+
+L213A               cmpx      #$0008
+                    lbeq      L20A7
+                    cmpx      #$0002
+                    lbeq      L20E7
+                    cmpx      #$0005
+                    beq       L20EF
+                    cmpx      #$0006
+                    beq       L2100
+                    lbra      L2306
+
+L2155               ldx       $0a,s
+                    bra       L217F
+
+L2159               ldd       #$0086
+                    bra       L2172
+
+L215E               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    ldd       #$008D
+                    bra       L2172
+
+L216F               ldd       #$0092
+L2172               std       ,s
+                    lbra      L2306
+
+L2177               ldd       #$0001
+                    std       $0a,s
+                    lbra      L2306
+
+L217F               cmpx      #$0008
+                    beq       L2159
+                    cmpx      #$0005
+                    beq       L215E
+                    cmpx      #$0006
+                    beq       L216F
+                    cmpx      #$0002
+                    beq       L2177
+                    lbra      L2306
+
+L2196               ldx       $0a,s
+                    lbra      L220E
+
+L219B               ldd       $0a,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbne      L2306
+L21A8               ldd       $06,u
+                    cmpd      #$004A
+                    bne       L21CB
+                    ldd       $08,u
+                    std       $02,s
+                    ldx       $02,s
+                    ldd       $02,x
+                    std       $08,u
+                    bra       L21BE
+
+L21BC               leas      -$04,x
+L21BE               ldd       #$0036
+                    std       $06,u
+                    ldd       #$0002
+                    std       $02,u
+                    lbra      L2306
+
+L21CB               ldd       #$0084
+                    bra       L2209
+
+L21D0               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    ldd       #$008D
+                    bra       L2209
+
+L21E1               ldd       $06,u
+                    cmpd      #$004A
+                    bne       L2206
+                    ldd       #$0008
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    std       $02,s
+                    ldx       $02,s
+                    pshs      x
+                    ldx       $08,u
+                    lbsr      $6A3F
+                    lbsr      $6A02
+                    leax      $04,s
+                    lbra      L2122
+
+L2206               ldd       #$0090
+L2209               std       ,s
+                    lbra      L2306
+
+L220E               cmpx      #$0001
+                    lbeq      L21A8
+                    cmpx      #$0007
+                    lbeq      L21A8
+                    cmpx      #$0002
+                    lbeq      L21A8
+                    cmpx      #$0005
+                    beq       L21D0
+                    cmpx      #$0006
+                    beq       L21E1
+                    lbra      L219B
+
+L2230               ldx       $0a,s
+                    bra       L2256
+
+L2234               ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    lbra      L2306
+
+L224E               ldd       #$008C
+                    std       ,s
+                    lbra      L2306
+
+L2256               cmpx      #$0008
+                    beq       L2234
+                    cmpx      #$0007
+                    lbeq      L2234
+                    cmpx      #$0002
+                    lbeq      L2234
+                    cmpx      #$0001
+                    lbeq      L2234
+                    cmpx      #$0006
+                    beq       L224E
+                    lbra      L2306
+
+L2278               ldx       $0a,s
+                    bra       L22BA
+
+L227C               ldd       $06,u
+                    cmpd      #$004B
+                    bne       L2290
+                    ldx       $08,u
+                    lbsr      L697F
+                    std       $08,u
+                    leax      $04,s
+                    lbra      L21BC
+
+L2290               ldd       #$008F
+                    bra       L22B6
+
+L2295               ldd       $06,u
+                    cmpd      #$004B
+                    bne       L22AE
+                    ldx       $08,u
+                    pshs      x
+                    ldx       $08,u
+                    lbsr      L6984
+                    lbsr      L74D6
+                    leax      $04,s
+                    lbra      L20D3
+
+L22AE               ldd       #$0091
+                    bra       L22B6
+
+L22B3               ldd       #$008D
+L22B6               std       ,s
+                    bra       L2306
+
+L22BA               cmpx      #$0002
+                    beq       L227C
+                    cmpx      #$0007
+                    lbeq      L227C
+                    cmpx      #$0001
+                    lbeq      L227C
+                    cmpx      #$0008
+                    beq       L2295
+                    cmpx      #$0005
+                    beq       L22B3
+                    bra       L2306
+
+L22D9               cmpx      #$0002
+                    lbeq      L203F
+                    cmpx      #$0001
+                    lbeq      L20A2
+                    cmpx      #$0007
+                    lbeq      L2155
+                    cmpx      #$0008
+                    lbeq      L2196
+                    cmpx      #$0005
+                    lbeq      L2230
+                    cmpx      #$0006
+                    lbeq      L2278
+                    lbra      L2095
+
+L2306               ldd       ,s
+                    beq       L233E
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0DD6
+                    leas      $0C,s
+                    std       $02,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L03C7
+                    leas      $04,s
+                    ldd       ,s
+                    std       $06,u
+                    ldd       $02,s
+                    std       $0a,u
+                    clra
+                    clrb
+                    std       $0C,u
+L233E               ldd       $0a,s
+                    lbra      L23BC
+
+L2343               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      L1FBF
+                    leas      $02,s
+                    std       $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L1FBF
+                    leas      $02,s
+                    std       ,s
+                    ldd       $02,s
+                    cmpd      #$0006
+                    bne       L2370
+                    ldd       #$0006
+                    bra       L2388
+
+L2370               ldd       ,s
+                    cmpd      #$0006
+                    bne       L237D
+                    ldd       #$0006
+                    bra       L239B
+
+L237D               ldd       $02,s
+                    cmpd      #$0008
+                    bne       L2390
+                    ldd       #$0008
+L2388               pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    bra       L239F
+
+L2390               ldd       ,s
+                    cmpd      #$0008
+                    bne       L23A6
+                    ldd       #$0008
+L239B               pshs      d
+                    pshs      u
+L239F               lbsr      L202A
+                    leas      $04,s
+                    bra       L23C3
+
+L23A6               ldd       $02,s
+                    cmpd      #$0007
+                    beq       L23B6
+                    ldd       ,s
+                    cmpd      #$0007
+                    bne       L23C0
+L23B6               ldd       #$0007
+                    std       [$0a,s]
+L23BC               std       ,u
+                    bra       L23C3
+
+L23C0               ldd       #$0001
+L23C3               leas      $04,s
+L23C5               puls      pc,u
+                    pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0113
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L047A
+                    std       ,s
+                    lbsr      L418D
+                    leas      $06,s
+                    std       $04,s
+                    cmpd      #$0001
+                    bne       L23F1
+                    ldd       $0a,s
+                    puls      pc,u
+L23F1               ldx       $0a,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $0C,s
+                    ldd       $0e,x
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    lbsr      L0DD6
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       #$0001
+                    std       ,u
+                    ldx       $0a,s
+                    ldd       $10,x
+                    pshs      d
+                    ldx       $0C,s
+                    ldd       $0e,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0052
+                    pshs      d
+                    lbsr      L0DD6
+                    leas      $0C,s
+                    pshs      d
+                    lbsr      L1008
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L2452
+                    clra
+                    clrb
+                    bra       L2455
+
+L2452               ldd       #$0002
+L2455               std       $12,u
+                    ldd       #$0001
+                    std       ,u
+                    ldd       #$0002
+                    std       $02,u
+                    tfr       u,d
+L2464               puls      pc,u
+                    pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    std       ,s
+                    tfr       d,x
+                    cmpx      #$0076
+                    lbeq      L25B4
+                    cmpx      #$006F
+                    lbeq      L25B4
+                    cmpx      #$0042
+                    lbeq      L25B4
+                    ldd       ,s
+                    cmpd      #$0034
+                    bne       L24BF
+                    pshs      u
+                    bsr       L24D6
+                    leas      $02,s
+                    ldd       $08,s
+                    lbne      L25B4
+                    ldd       ,u
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L24B1
+                    ldd       #$0001
+                    bra       L24B3
+
+L24B1               clra
+                    clrb
+L24B3               bne       L24BF
+                    ldd       ,u
+                    cmpd      #$0004
+                    lbne      L25B4
+L24BF               leax      $2766,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0296
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L25E9
+                    leas      $02,s
+                    lbra      L25B4
+
+L24D6               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       $06,u
+                    cmpd      #$0034
+                    lbne      L25B6
+                    ldd       ,u
+                    lbne      L25B6
+                    leax      L2776,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0296
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L25E9
+                    lbra      L25B4
+                    pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       ,u
+                    std       [$08,s]
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L2544
+                    ldd       #$0001
+                    std       [$0a,s]
+                    ldd       $0a,u
+                    std       ,s
+                    ldd       $04,u
+                    ldx       ,s
+                    std       $04,x
+                    pshs      u
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L03C7
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L03B7
+                    leas      $02,s
+                    bra       L2549
+
+L2544               clra
+                    clrb
+                    std       [$0a,s]
+L2549               pshs      u
+                    lbsr      L24D6
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0034
+                    bne       L2589
+                    ldd       $08,u
+                    std       ,s
+                    ldx       ,s
+                    ldd       $08,x
+                    cmpd      #$0011
+                    beq       L256A
+                    leax      $02,s
+                    bra       L2587
+
+L256A               ldd       #$0036
+                    std       $06,u
+                    ldx       ,s
+                    ldd       $06,x
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $12,u
+                    ldd       #$0001
+                    std       ,u
+                    ldx       ,s
+                    ldd       $02,x
+                    bra       L25B4
+                    bra       L2589
+
+L2587               leas      -$02,x
+L2589               leax      $278A,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0296
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L25E9
+                    leas      $02,s
+                    ldd       #$0036
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $12,u
+                    ldd       #$0001
+                    std       [$08,s]
+                    ldd       #$0002
+L25B4               leas      $02,s
+L25B6               puls      pc,u
+L25B8               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       ,u
+                    cmpd      #$0004
+                    beq       L25D2
+                    ldd       ,u
+                    cmpd      #$0003
+                    bne       L25E5
+L25D2               leax      L27A1,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L0296
+                    leas      $04,s
+                    pshs      u
+                    bsr       L25E9
+                    leas      $02,s
+L25E5               ldd       ,u
+L25E7               puls      pc,u
+L25E9               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       #$0006
+                    pshs      d
+                    pshs      u
+                    leax      $018b,y
+                    pshs      x
+                    lbsr      L01F9
+                    leas      $06,s
+                    ldd       #$0001
+                    std       $12,u
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L0396
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L0396
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $0C,u
+                    std       $0a,u
+                    ldd       #$0034
+                    std       $06,u
+                    leax      $018b,y
+                    stx       $08,u
+L262E               puls      pc,u
+L2630               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0113
+                    ldx       $04,s
+                    bra       L2641
+
+L263C               ldd       #$0001
+                    puls      pc,u
+L2641               cmpx      #$0001
+                    beq       L263C
+                    cmpx      #$0002
+                    lbeq      L263C
+                    cmpx      #$0008
+                    lbeq      L263C
+                    cmpx      #$0007
+                    lbeq      L263C
+                    clra
+                    clrb
+L265D               puls      pc,u
+L265F               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    leax      L27C2,pcr
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L0296
+                    leas      $04,s
+L2676               puls      pc,u
+                    lsr       $09,s
+                    ror       $6964
+                    fcb       $65
+                    bra       L26E2
+                    rol       L207A
+                    fcb       $65
+                    fcb       $72
+L2685               clr       0,x
+                    lsr       L7970
+                    fcb       $65
+                    lsr       $05,s
+                    ror       0,y
+                    blt       $26B1
+                    jmp       $0f,s
+                    lsr       $2061
+                    bra       L270E
+                    fcb       $61
+                    fcb       $72
+                    rol       $01,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       $0063
+                    fcb       $61
+                    jmp       $0e,s
+                    clr       -$0C,s
+                    bra       L270B
+                    fcb       $61
+                    com       L7400
+                    com       $01,s
+                    jmp       $07,y
+                    lsr       $2074
+                    fcb       $61
+                    fcb       $6b
+                    fcb       $65
+                    bra       $2719
+                    lsr       $04,s
+                    fcb       $72
+                    fcb       $65
+                    com       L7300
+                    neg       L6F69
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $273A
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+L26CE               lsr       0,x
+                    neg       L6F69
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $2748
+                    fcb       $72
+                    bra       L2745
+                    jmp       -$0C,s
+                    fcb       $65
+                    asr       $05,s
+                    fcb       $72
+L26E2               bra       $2756
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+L26EA               lsr       0,x
+                    jmp       $0f,s
+                    lsr       $2061
+                    bra       L2759
+                    fcb       $75
+                    jmp       $03,s
+                    lsr       L696F
+L26F9               jmp       0,x
+                    fcb       $62
+                    clr       -$0C,s
+                    asl       0,y
+                    tst       -$0b,s
+                    com       $7420
+                    fcb       $62
+                    fcb       $65
+                    bra       $2772
+                    jmp       -$0C,s
+L270B               fcb       $65
+                    asr       -$0e,s
+L270E               fcb       $61
+L270F               inc       0,x
+                    neg       L6F69
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L2787
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       $6368
+                    neg       $0074
+                    rol       $7065
+                    bra       L2795
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       $6368
+                    neg       $0070
+                    clr       $09,s
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       $27A6
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       $6368
+                    neg       $0074
+                    rol       $7065
+L2745               bra       L27AA
+                    asl       $05,s
+                    com       $0b,s
+                    neg       $0073
+                    asl       $0f,s
+                    fcb       $75
+                    inc       $04,s
+                    bra       $27B6
+                    fcb       $65
+                    bra       L27A5
+                    fcb       $55
+                    inca
+L2759               inca
+                    neg       $0074
+                    rol       $7065
+                    bra       $27C6
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $006C
+                    ror       L616C
+                    fcb       $75
+                    fcb       $65
+                    bra       $27E0
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L2776               fcb       $75
+                    jmp       $04,s
+                    fcb       $65
+                    com       $0C,s
+                    fcb       $61
+                    fcb       $72
+                    fcb       $65
+                    lsr       0,y
+                    ror       $6172
+                    rol       $01,s
+                    fcb       $62
+L2787               inc       $05,s
+                    neg       $0073
+                    lsr       $7275
+                    com       -$0C,s
+                    bra       $27FF
+                    fcb       $65
+                    tst       $02,s
+L2795               fcb       $65
+                    fcb       $72
+                    bra       $280B
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L27A1               com       $7472
+                    fcb       $75
+L27A5               com       -$0C,s
+                    fcb       $75
+                    fcb       $72
+                    fcb       $65
+L27AA               bra       $281B
+                    fcb       $72
+                    bra       L2824
+                    jmp       $09,s
+                    clr       $0e,s
+                    bra       $281E
+                    jmp       $01,s
+                    neg       L7072
+                    clr       -$10,s
+                    fcb       $72
+                    rol       $01,s
+                    lsr       $6500
+L27C2               tst       -$0b,s
+                    com       $7420
+                    fcb       $62
+                    fcb       $65
+                    bra       L2834
+                    jmp       -$0C,s
+                    fcb       $65
+                    asr       -$0e,s
+                    fcb       $61
+                    inc       0,x
+L27D3               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldd       $005F
+                    cmpd      #$0028
+                    beq       L27EB
+                    clra
+                    clrb
+                    std       L004F
+                    bra       L27EB
+
+L27E9               leas      ,x
+L27EB               ldx       $005F
+                    lbra      L28EA
+
+L27F0               ldx       $0061
+                    bra       L2846
+
+L27F4               lbsr      L291A
+                    puls      pc,u
+L27F9               lbsr      L29DD
+                    puls      pc,u
+L27FE               lbsr      L2E96
+                    lbra      L290E
+
+L2804               lbsr      L2BF4
+                    puls      pc,u
+L2809               lbsr      L2A8D
+                    puls      pc,u
+L280E               lbsr      L2F24
+                    lbra      L290E
+
+L2814               lbsr      L2F63
+                    lbra      L290E
+
+L281A               lbsr      L2C5C
+                    puls      pc,u
+L281F               lbsr      L2D5D
+                    puls      pc,u
+L2824               lbsr      L2CAF
+                    lbra      L290E
+
+L282A               lbsr      L2FA1
+                    lbra      L290E
+
+L2830               leax      L316D,pcr
+L2834               pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbsr      L552E
+                    lbra      L289A
+
+L2841               leax      ,s
+                    lbra      L28A3
+
+L2846               cmpx      #$0013
+                    beq       L27F4
+                    cmpx      #$0014
+                    beq       L27F9
+                    cmpx      #$0012
+                    beq       L27FE
+                    cmpx      #$0017
+                    beq       L2804
+                    cmpx      #$0016
+                    beq       L2809
+                    cmpx      #$0018
+                    beq       L280E
+                    cmpx      #$0019
+                    beq       L2814
+                    cmpx      #$001B
+                    beq       L281A
+                    cmpx      #$001C
+                    beq       L281F
+                    cmpx      #$001A
+                    beq       L2824
+                    cmpx      #$001D
+                    beq       L282A
+                    cmpx      #$0015
+                    beq       L2830
+                    bra       L2841
+
+L2884               lbsr      L3A4F
+                    lbsr      L552E
+                    puls      pc,u
+L288C               puls      pc,u
+L288E               lbsr      $6348
+                    ldb       $0065
+                    cmpb      #$3a
+                    bne       L289F
+                    lbsr      L2FEC
+L289A               leax      ,s
+                    lbra      L27E9
+
+L289F               leax      ,s
+                    bra       L28CB
+
+L28A3               leas      ,x
+L28A5               lbsr      L043F
+                    std       -$02,s
+                    bne       L28B3
+                    lbsr      L03DD
+                    std       -$02,s
+                    beq       L28CD
+L28B3               leax      L3180,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L28BE               lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0028
+                    bne       L28BE
+                    bra       L290E
+
+L28CB               leas      ,x
+L28CD               clra
+                    clrb
+                    pshs      d
+                    lbsr      L3085
+                    std       ,s++
+                    bne       L290E
+                    leax      L3194,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbsr      L0502
+                    puls      pc,u
+                    bra       L290E
+
+L28EA               cmpx      #$0028
+                    beq       L290E
+                    cmpx      #$0033
+                    lbeq      L27F0
+                    cmpx      #$0029
+                    lbeq      L2884
+                    cmpx      #$FFFF
+                    lbeq      L288C
+                    cmpx      #$0034
+                    lbeq      L288E
+                    lbra      L28A5
+
+L290E               ldd       #$0028
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    puls      pc,u
+L291A               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0113
+                    leas      -$06,s
+                    lbsr      L552E
+                    lbsr      L30EA
+                    std       ,s
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    tfr       d,u
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $04,s
+                    ldd       $005F
+                    cmpd      #$0028
+                    bne       L2969
+                    lbsr      L552E
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L3143
+                    leas      $08,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    stu       $02,s
+                    bra       L298B
+
+L2969               ldd       #$0001
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L3143
+                    leas      $08,s
+                    pshs      u
+                    lbsr      L4AC7
+                    leas      $02,s
+                    lbsr      L27D3
+                    ldd       $04,s
+                    std       $02,s
+L298B               ldd       $005F
+                    cmpd      #$0033
+                    bne       L29D0
+                    ldd       $0061
+                    cmpd      #$0015
+                    bne       L29D0
+                    lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0028
+                    beq       L29D0
+                    cmpu      $02,s
+                    beq       L29CD
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $04,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+L29CD               lbsr      L27D3
+L29D0               ldd       $02,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    leas      $06,s
+                    puls      pc,u
+L29DD               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L0113
+                    leas      -$0a,s
+                    ldd       L0053
+                    std       $08,s
+                    ldd       L0055
+                    std       $06,s
+                    ldd       $02D6,y
+                    std       $04,s
+                    ldd       $02D8,y
+                    std       $02,s
+                    lbsr      L552E
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       L0053
+                    ldd       $002F
+                    std       $02D8,y
+                    std       $02D6,y
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       L0055
+                    lbsr      L30EA
+                    std       ,s
+                    ldd       $005F
+                    cmpd      #$0028
+                    bne       L2A2B
+                    ldu       L0055
+                    bra       L2A50
+
+L2A2B               clra
+                    clrb
+                    pshs      d
+                    ldd       L0055
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L4AC7
+                    leas      $02,s
+                    lbsr      L27D3
+L2A50               ldd       L0055
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L0053
+                    pshs      d
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L3143
+                    leas      $08,s
+                    ldd       L0053
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    ldd       $08,s
+                    std       L0053
+                    ldd       $06,s
+                    std       L0055
+                    ldd       $04,s
+                    std       $02D6,y
+                    ldd       $02,s
+                    std       $02D8,y
+                    leas      $0a,s
+                    puls      pc,u
+L2A8D               pshs      u
+                    ldd       #$FFA8
+                    lbsr      L0113
+                    leas      -$0e,s
+                    lbsr      L552E
+                    ldd       L0057
+                    addd      #$0001
+                    std       L0057
+                    ldd       $005B
+                    std       ,s
+                    ldd       L0059
+                    std       $0a,s
+                    clra
+                    clrb
+                    std       L0059
+                    ldd       L0053
+                    std       $0C,s
+                    ldd       $02D4,y
+                    std       $08,s
+                    ldd       $02D6,y
+                    std       $02,s
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       L0053
+                    ldd       $002F
+                    std       $02D6,y
+                    clra
+                    clrb
+                    std       $02D4,y
+                    ldd       #$002D
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0583
+                    std       ,s
+                    lbsr      L0F1B
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L2B41
+                    pshs      u
+                    lbsr      L24D6
+                    leas      $02,s
+                    ldx       ,u
+                    bra       L2B19
+
+L2AFB               ldd       #$0001
+                    pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    bra       L2B31
+
+L2B09               pshs      u
+                    lbsr      L265F
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L25E9
+                    leas      $02,s
+                    bra       L2B31
+
+L2B19               cmpx      #$0002
+                    beq       L2AFB
+                    cmpx      #$0008
+                    lbeq      L2AFB
+                    cmpx      #$0001
+                    beq       L2B31
+                    cmpx      #$0007
+                    beq       L2B31
+                    bra       L2B09
+
+L2B31               pshs      u
+                    lbsr      L4C1E
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L0396
+                    leas      $02,s
+                    bra       L2B44
+
+L2B41               lbsr      L0E18
+L2B44               ldd       #$002E
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $08,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    lbsr      L27D3
+                    ldd       L004F
+                    bne       L2B80
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L0053
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L2B80               ldd       $06,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    ldu       L0059
+                    bra       L2BAB
+
+L2B8D               ldd       ,u
+                    std       $04,s
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $04,u
+                    pshs      d
+                    ldd       #$007D
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    ldd       L0045
+                    std       ,u
+                    stu       L0045
+                    ldu       $04,s
+L2BAB               stu       -$02,s
+                    bne       L2B8D
+                    ldd       $02D4,y
+                    beq       L2BC9
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $02D4,y
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L2BC9               ldd       L0053
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    ldd       $0a,s
+                    std       L0059
+                    ldd       $08,s
+                    std       $02D4,y
+                    ldd       L0057
+                    addd      #$FFFF
+                    std       L0057
+                    ldd       ,s
+                    std       $005B
+                    ldd       $0C,s
+                    std       L0053
+                    ldd       $02,s
+                    std       $02D6,y
+                    lbra      L2E92
+
+L2BF4               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    leas      -$02,s
+                    lbsr      L552E
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0A52
+                    leas      $02,s
+                    std       ,s
+                    ldd       #$002F
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    ldd       L0057
+                    beq       L2C58
+                    ldu       L0045
+                    beq       L2C24
+                    ldd       ,u
+                    std       L0045
+                    bra       L2C30
+
+L2C24               ldd       #$0006
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    tfr       d,u
+L2C30               ldd       L0059
+                    beq       L2C3A
+                    stu       [$005B,y]
+                    bra       L2C3C
+
+L2C3A               stu       L0059
+L2C3C               stu       $005B
+                    clra
+                    clrb
+                    std       ,u
+                    ldd       ,s
+                    std       $02,u
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $04,u
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    bra       L2CAB
+
+L2C58               bsr       L2C9A
+                    bra       L2CAB
+
+L2C5C               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    lbsr      L552E
+                    ldd       L0057
+                    bne       L2C6D
+                    bsr       L2C9A
+L2C6D               ldd       $02D4,y
+                    beq       L2C7E
+                    leax      $31A1,pcr
+                    pshs      x
+                    lbsr      L024E
+                    bra       L2C8E
+
+L2C7E               ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $02D4,y
+                    pshs      d
+                    lbsr      L4AC7
+L2C8E               leas      $02,s
+                    ldd       #$002F
+L2C93               pshs      d
+                    lbsr      L04BF
+                    bra       L2CAB
+
+L2C9A               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    leax      $31B3,pcr
+                    pshs      x
+                    lbsr      L024E
+L2CAB               leas      $02,s
+                    puls      pc,u
+L2CAF               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L0113
+                    leas      -$0a,s
+                    ldd       L0053
+                    std       $08,s
+                    ldd       L0055
+                    std       $06,s
+                    ldd       $02D8,y
+                    std       ,s
+                    ldd       $02D6,y
+                    std       $02,s
+                    ldd       $002F
+                    std       $02D8,y
+                    std       $02D6,y
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       L0055
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       L0053
+                    lbsr      L552E
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $04,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    lbsr      L27D3
+                    ldd       $005F
+                    cmpd      #$0033
+                    bne       L2D0F
+                    ldd       $0061
+                    cmpd      #$0014
+                    beq       L2D1A
+L2D0F               leax      $31C7,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L2D1A               lbsr      L552E
+                    ldd       L0055
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L0053
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L30EA
+                    pshs      d
+                    lbsr      L3143
+                    leas      $08,s
+                    ldd       L0053
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    ldd       $08,s
+                    std       L0053
+                    ldd       $06,s
+                    std       L0055
+                    ldd       $02,s
+                    std       $02D6,y
+                    ldd       ,s
+                    std       $02D8,y
+                    leas      $0a,s
+                    puls      pc,u
+L2D5D               pshs      u
+                    ldd       #$FFA6
+                    lbsr      L0113
+                    leas      -$0e,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldu       L0053
+                    ldd       L0055
+                    std       $0C,s
+                    ldd       $02D6,y
+                    std       $06,s
+                    ldd       $02D8,y
+                    std       $04,s
+                    ldd       $002F
+                    std       $02D6,y
+                    std       $02D8,y
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $0a,s
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       L0053
+                    lbsr      L552E
+                    ldd       #$002D
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L3085
+                    leas      $02,s
+                    ldd       #$0028
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    ldd       $005F
+                    cmpd      #$0028
+                    beq       L2DE3
+                    lbsr      L3111
+                    std       $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $0a,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L2DE3               ldd       #$0028
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0583
+                    std       ,s
+                    lbsr      L0F1B
+                    leas      $02,s
+                    std       ,s
+                    beq       L2E11
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L24D6
+                    leas      $02,s
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    bra       L2E13
+
+L2E11               ldd       $0a,s
+L2E13               std       L0055
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    lbsr      L27D3
+                    ldd       ,s
+                    beq       L2E41
+                    ldd       L0055
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L30AE
+                    leas      $02,s
+L2E41               ldd       $02,s
+                    beq       L2E65
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L0053
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L3143
+                    leas      $08,s
+                    bra       L2E77
+
+L2E65               clra
+                    clrb
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L2E77               ldd       L0053
+                    pshs      d
+                    lbsr      L4AC7
+                    leas      $02,s
+                    stu       L0053
+                    ldd       $0C,s
+                    std       L0055
+                    ldd       $06,s
+                    std       $02D6,y
+                    ldd       $04,s
+                    std       $02D8,y
+L2E92               leas      $0e,s
+                    puls      pc,u
+L2E96               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0028
+                    lbeq      L2F03
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0583
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L2F03
+                    pshs      u
+                    lbsr      L0F1B
+                    leas      $02,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L24D6
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L25B8
+                    leas      $02,s
+                    ldd       L004D
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L2EE1
+                    ldd       #$0001
+                    bra       L2EE3
+
+L2EE1               ldd       L004D
+L2EE3               pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+                    ldd       L004D
+                    pshs      d
+                    pshs      u
+                    ldd       #$0012
+                    pshs      d
+                    lbsr      L4C6B
+                    leas      $06,s
+                    pshs      u
+                    lbsr      L0396
+                    leas      $02,s
+L2F03               clra
+                    clrb
+                    pshs      d
+                    lbsr      L4B33
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0012
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    ldd       #$0012
+                    lbra      L2FE8
+
+L2F24               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    lbsr      L552E
+                    ldd       L0053
+                    bne       L2F40
+                    leax      L31D6,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    bra       L2F5D
+
+L2F40               ldd       $02D6,y
+                    pshs      d
+                    lbsr      L4B33
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L0053
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L2F5D               ldd       #$0018
+                    lbra      L2FE8
+
+L2F63               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    lbsr      L552E
+                    ldd       L0055
+                    bne       L2F7F
+                    leax      $31E2,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    bra       L2F9C
+
+L2F7F               ldd       $02D8,y
+                    pshs      d
+                    lbsr      L4B33
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       L0055
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L2F9C               ldd       #$0019
+                    bra       L2FE8
+
+L2FA1               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0034
+                    beq       L2FC1
+                    leax      $31F1,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    bra       L2FE5
+
+L2FC1               lbsr      L302E
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L2FE2
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$001D
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    ldd       $0a,u
+                    orb       #$02
+                    std       $0a,u
+L2FE2               lbsr      L552E
+L2FE5               ldd       #$001D
+L2FE8               std       L004F
+                    puls      pc,u
+L2FEC               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    bsr       L302E
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L3026
+                    ldd       $08,u
+                    cmpd      #$000F
+                    bne       L3009
+                    lbsr      L0241
+                    bra       L3026
+
+L3009               ldd       #$000F
+                    std       $08,u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$0009
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+                    ldd       $0a,u
+                    orb       #$01
+                    std       $0a,u
+L3026               lbsr      L552E
+                    lbsr      L552E
+                    puls      pc,u
+L302E               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldu       $0061
+                    ldd       ,u
+                    cmpd      #$0009
+                    lbeq      L313F
+                    ldd       ,u
+                    beq       L3060
+                    ldd       $0C,u
+                    beq       L3059
+                    leax      L3200,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    clra
+                    clrb
+                    puls      pc,u
+L3059               pshs      u
+                    lbsr      L0180
+                    leas      $02,s
+L3060               ldd       #$0009
+                    std       ,u
+                    ldd       #$000D
+                    std       $08,u
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $0a,u
+                    ldd       L0051
+                    std       $0C,u
+                    ldd       L0049
+                    std       $10,u
+                    stu       L0049
+                    lbra      L313F
+
+L3085               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0583
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    lbeq      L313F
+                    pshs      u
+                    lbsr      L0F1B
+                    std       ,s
+                    bsr       L30AE
+                    leas      $02,s
+                    tfr       d,u
+                    lbra      L313F
+
+L30AE               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldu       $04,s
+                    pshs      u
+                    lbsr      L24D6
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L30CF
+
+L30C3               ldd       #$003C
+                    bra       L30CB
+
+L30C8               ldd       #$003D
+L30CB               std       $06,u
+                    bra       L30D9
+
+L30CF               cmpx      #$003E
+                    beq       L30C3
+                    cmpx      #$003F
+                    beq       L30C8
+L30D9               pshs      u
+                    lbsr      L4C52
+                    leas      $02,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L0396
+                    lbra      L313D
+
+L30EA               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    leas      -$02,s
+                    ldd       #$002D
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    bsr       L3111
+                    std       ,s
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    ldd       ,s
+                    lbra      L3169
+
+L3111               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L0583
+                    std       ,s
+                    lbsr      L0F1B
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L3134
+                    pshs      u
+                    lbsr      L24D6
+                    bra       L313D
+
+L3134               leax      $3219,pcr
+                    pshs      x
+                    lbsr      L024E
+L313D               leas      $02,s
+L313F               tfr       u,d
+                    puls      pc,u
+L3143               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0113
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L316B
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4C2F
+                    leas      $08,s
+                    pshs      u
+                    lbsr      L0396
+L3169               leas      $02,s
+L316B               puls      pc,u
+L316D               jmp       $0f,s
+                    bra       $3198
+                    rol       $06,s
+                    beq       $3195
+                    ror       $0f,s
+                    fcb       $72
+                    bra       $31A1
+                    fcb       $65
+                    inc       -$0d,s
+                    fcb       $65
+                    beq       L3180
+L3180               rol       $0C,s
+                    inc       $05,s
+                    asr       $01,s
+                    inc       0,y
+                    lsr       $05,s
+                    com       $0C,s
+                    fcb       $61
+                    fcb       $72
+                    fcb       $61
+                    lsr       L696F
+                    jmp       0,x
+
+L3194               com       L796E
+                    lsr       L6178
+                    bra       L3201
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L006D
+                    fcb       $75
+                    inc       -$0C,s
+                    rol       -$10,s
+                    inc       $05,s
+                    bra       $320F
+                    fcb       $65
+                    ror       $01,s
+                    fcb       $75
+                    inc       -$0C,s
+                    com       >$006E
+                    clr       0,y
+                    com       L7769
+                    lsr       $6368
+                    bra       $3231
+                    lsr       $6174
+                    fcb       $65
+                    tst       $05,s
+                    jmp       -$0C,s
+                    neg       $0077
+                    asl       $09,s
+                    inc       $05,s
+                    bra       $3233
+                    asl       $7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+L31D6               fcb       $62
+                    fcb       $72
+                    fcb       $65
+                    fcb       $61
+                    fcb       $6b
+                    bra       L3242
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $0063
+                    clr       $0e,s
+                    lsr       $696E
+                    fcb       $75
+                    fcb       $65
+                    bra       $3251
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $006C
+                    fcb       $61
+                    fcb       $62
+                    fcb       $65
+                    inc       0,y
+                    fcb       $72
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L3200               fcb       $61
+L3201               inc       -$0e,s
+                    fcb       $65
+                    fcb       $61
+                    lsr       -$07,s
+                    bra       $326A
+                    bra       L3277
+                    clr       $03,s
+                    fcb       $61
+                    inc       0,y
+                    ror       $6172
+                    rol       $01,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       $0063
+                    clr       $0e,s
+                    lsr       $09,s
+                    lsr       L696F
+                    jmp       0,y
+                    jmp       $05,s
+                    fcb       $65
+                    lsr       $05,s
+                    lsr       0,x
+                    pshs      u
+                    ldd       #$FFA2
+                    lbsr      L0113
+                    leas      -$14,s
+                    bra       L3245
+
+L3237               leax      L42F7,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L3242               lbsr      L552E
+L3245               ldd       $005F
+                    cmpd      #$002A
+                    beq       L3237
+                    ldd       $005F
+                    cmpd      #$0029
+                    bne       L327A
+                    leax      L4309,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L3A4F
+                    leas      $02,s
+                    leax      >$0049,y
+                    pshs      x
+                    lbsr      L4207
+                    leas      $02,s
+                    lbsr      L552E
+L3277               lbra      L34D4
+
+L327A               lbsr      L3BE9
+                    std       $0a,s
+                    tfr       d,x
+                    bra       L3295
+
+L3283               leax      L4321,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L328E               ldd       #$000C
+                    std       $0a,s
+                    bra       L32A5
+
+L3295               cmpx      #$0010
+                    beq       L3283
+                    cmpx      #$000D
+                    lbeq      L3283
+                    stx       -$02,s
+                    beq       L328E
+L32A5               leax      ,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    leax      $16,s
+                    pshs      x
+                    lbsr      L3C38
+                    leas      $06,s
+                    std       $08,s
+                    bne       L32C0
+                    ldd       #$0001
+                    std       $08,s
+L32C0               ldd       $04,s
+                    std       $0C,s
+                    ldd       $08,s
+                    pshs      d
+                    leax      $0e,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    lbsr      L3F8D
+                    leas      $06,s
+                    std       $06,s
+                    ldu       $02,s
+                    bne       L32F4
+                    ldd       $06,s
+                    cmpd      #$0004
+                    beq       L32EE
+                    ldd       $06,s
+                    cmpd      #$0003
+                    beq       L32EE
+                    lbsr      L42E2
+L32EE               leax      $14,s
+                    lbra      L34B4
+
+L32F4               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L3319
+                    ldd       $005F
+                    cmpd      #$0030
+                    beq       L330F
+                    ldd       $005F
+                    cmpd      #$0028
+                    bne       L3314
+L330F               ldd       #$000E
+                    bra       L331B
+
+L3314               ldd       #$000C
+                    bra       L331B
+
+L3319               ldd       $0a,s
+L331B               std       $0e,s
+                    ldd       ,u
+                    beq       L3367
+                    ldd       ,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L387E
+                    leas      $06,s
+                    std       -$02,s
+                    lbne      L343B
+                    ldd       $0e,s
+                    cmpd      #$000E
+                    lbeq      L343B
+                    ldd       $08,u
+                    cmpd      #$000E
+                    beq       L3356
+                    ldd       $08,u
+                    cmpd      #$0022
+                    beq       L3356
+                    lbsr      L0241
+                    lbra      L343B
+
+L3356               ldd       $0e,s
+                    std       $08,u
+                    ldd       $0C,s
+                    std       $04,u
+                    ldd       ,s
+                    std       $0a,u
+                    leax      $14,s
+                    bra       L3379
+
+L3367               ldd       $06,s
+                    std       ,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    ldd       $0e,s
+                    std       $08,u
+                    ldd       ,s
+                    std       $0a,u
+                    bra       L337C
+
+L3379               leas      -$14,x
+L337C               ldd       $12,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4103
+                    leas      $06,s
+                    std       $10,s
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    lbeq      L343B
+                    ldd       $005F
+                    cmpd      #$0078
+                    bne       L33B7
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4435
+L33B2               leas      $06,s
+                    lbra      L3421
+
+L33B7               ldd       $10,s
+                    bne       L33CA
+                    ldd       $0e,s
+                    cmpd      #$000E
+                    beq       L33CA
+                    lbsr      L42D4
+                    lbra      L3421
+
+L33CA               ldx       $0e,s
+                    bra       L3409
+
+L33CE               ldd       $0e,s
+                    cmpd      #$0023
+                    bne       L33DB
+                    ldd       #$0001
+                    bra       L33DD
+
+L33DB               clra
+                    clrb
+L33DD               pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $66FB
+                    bra       L33B2
+
+L33EB               ldd       $0e,s
+                    cmpd      #$0021
+                    bne       L33F8
+                    ldd       #$0001
+                    bra       L33FA
+
+L33F8               clra
+                    clrb
+L33FA               pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $66EB
+                    lbra      L33B2
+
+L3409               cmpx      #$0023
+                    beq       L33CE
+                    cmpx      #$000F
+                    lbeq      L33CE
+                    cmpx      #$0021
+                    beq       L33EB
+                    cmpx      #$000C
+                    lbeq      L33EB
+L3421               ldd       $0e,s
+                    cmpd      #$000F
+                    bne       L342E
+                    ldd       #$000C
+                    bra       L3439
+
+L342E               ldd       $0e,s
+                    cmpd      #$0023
+                    bne       L343B
+                    ldd       #$0021
+L3439               std       $08,u
+L343B               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    lbne      L34B7
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L047A
+                    leas      $02,s
+                    std       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L3477
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L3477
+                    ldd       $06,s
+                    cmpd      #$0004
+                    beq       L3477
+                    ldd       $06,s
+                    cmpd      #$0003
+                    bne       L348C
+L3477               leax      $432F,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    ldd       #$0031
+                    std       ,u
+                    ldd       #$0001
+                    std       $06,s
+L348C               ldd       $0e,s
+                    cmpd      #$000E
+                    bne       L34A1
+                    leax      >$0047,y
+                    pshs      x
+                    lbsr      L4207
+                    leas      $02,s
+                    bra       L34B7
+
+L34A1               ldd       $06,s
+                    std       L004D
+                    ldd       $0a,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L3907
+                    leas      $04,s
+                    bra       L34D4
+                    bra       L34B7
+
+L34B4               leas      -$14,x
+L34B7               ldd       $005F
+                    cmpd      #$0030
+                    bne       L34C5
+                    lbsr      L552E
+                    lbra      L32C0
+
+L34C5               ldd       #$0028
+                    pshs      d
+                    lbsr      L04BF
+                    std       ,s++
+                    beq       L34D4
+                    lbsr      L0502
+L34D4               leas      $14,s
+                    puls      pc,u
+L34D9               pshs      u
+                    ldd       #$FFA4
+                    lbsr      L0113
+                    leas      -$12,s
+                    lbsr      L3BE9
+                    std       $10,s
+                    tfr       d,x
+                    bra       L3501
+
+L34EE               leax      $4343,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L34F9               ldd       #$000D
+                    std       $10,s
+                    bra       L350C
+
+L3501               stx       -$02,s
+                    beq       L34F9
+                    cmpx      #$0010
+                    beq       L350C
+                    bra       L34EE
+
+L350C               leax      ,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    lbsr      L3C38
+                    leas      $06,s
+                    std       $0e,s
+                    bne       L3526
+                    ldd       #$0001
+                    std       $0e,s
+L3526               ldd       $0a,s
+                    std       $0C,s
+                    ldd       $0e,s
+                    pshs      d
+                    leax      $0e,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    lbsr      L3F8D
+                    leas      $06,s
+                    std       $04,s
+                    ldu       $02,s
+                    ldd       $04,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L355A
+                    ldd       $04,s
+                    cmpd      #$0004
+                    beq       L355A
+                    ldd       $04,s
+                    cmpd      #$000A
+                    bne       L3567
+L355A               leax      $4354,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    bra       L3598
+
+L3567               ldd       $04,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L3582
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L047A
+                    std       ,s
+                    lbsr      L0486
+                    leas      $02,s
+                    bra       L358D
+
+L3582               ldd       $04,s
+                    cmpd      #$0005
+                    bne       L358F
+                    ldd       #$0006
+L358D               std       $04,s
+L358F               cmpu      #$0000
+                    bne       L359E
+                    lbsr      L42E2
+L3598               leax      $12,s
+                    lbra      L35FB
+
+L359E               ldd       $04,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L38B2
+                    leas      $04,s
+                    std       $06,s
+                    ldx       $08,u
+                    bra       L35E8
+
+L35B2               ldd       $04,s
+                    std       ,u
+                    ldd       $06,s
+                    std       $08,u
+                    ldd       ,s
+                    std       $0a,u
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4103
+                    leas      $06,s
+                    std       -$02,s
+                    bne       L35FE
+                    lbsr      L42D4
+                    bra       L35FE
+
+L35D6               lbsr      L0241
+                    bra       L35FE
+
+L35DB               leax      $4363,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    bra       L35FE
+
+L35E8               cmpx      #$000B
+                    beq       L35B2
+                    cmpx      #$000D
+                    beq       L35D6
+                    cmpx      #$0010
+                    lbeq      L35D6
+                    bra       L35DB
+
+L35FB               leas      -$12,x
+L35FE               ldd       $005F
+                    cmpd      #$0078
+                    bne       L3609
+                    lbsr      L4980
+L3609               ldd       $005F
+                    cmpd      #$0030
+                    bne       L3617
+                    lbsr      L552E
+                    lbra      L3526
+
+L3617               ldd       #$0028
+                    pshs      d
+                    lbsr      L04BF
+                    std       ,s++
+                    lbeq      L3879
+                    lbsr      L0502
+                    lbra      L3879
+
+L362B               pshs      u
+                    ldd       #$FF9E
+                    lbsr      L0113
+                    leas      -$12,s
+                    lbsr      L3BE9
+                    std       $10,s
+                    tfr       d,x
+                    bra       L3653
+
+L3640               leax      $4373,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L364B               ldd       #$000D
+                    std       $10,s
+                    bra       L365C
+
+L3653               cmpx      #$0021
+                    beq       L3640
+                    stx       -$02,s
+                    beq       L364B
+L365C               leax      $02,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    leax      $0C,s
+                    pshs      x
+                    lbsr      L3C38
+                    leas      $06,s
+                    std       $0e,s
+                    bne       L3676
+                    ldd       #$0001
+                    std       $0e,s
+L3676               leas      -$06,s
+                    ldd       $10,s
+                    std       ,s
+                    ldd       $14,s
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    lbsr      L3F8D
+                    leas      $06,s
+                    std       $12,s
+                    ldu       $0a,s
+                    bne       L36B2
+                    ldd       $12,s
+                    cmpd      #$0004
+                    lbeq      L371D
+                    ldd       $12,s
+                    cmpd      #$0003
+                    lbeq      L371D
+                    lbsr      L42E2
+                    lbra      L371D
+
+L36B2               ldd       $12,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    beq       L36C7
+                    ldd       $16,s
+                    cmpd      #$000E
+                    bne       L36FE
+L36C7               ldd       ,u
+                    bne       L36EC
+                    ldd       $12,s
+                    std       ,u
+                    ldd       #$000E
+                    std       $08,u
+                    clra
+                    clrb
+                    std       $0C,u
+                    ldd       $08,s
+                    std       $0a,u
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4103
+                    bra       L36FA
+
+L36EC               ldd       $08,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L387E
+L36FA               leas      $06,s
+                    bra       L371D
+
+L36FE               ldd       $12,s
+                    pshs      d
+                    ldd       $18,s
+                    pshs      d
+                    lbsr      L38B2
+                    leas      $04,s
+                    std       $04,s
+                    ldd       ,u
+                    beq       L372A
+                    ldd       $0C,u
+                    cmpd      L0051
+                    bne       L3723
+                    lbsr      L0241
+L371D               leax      $18,s
+                    lbra      L3858
+
+L3723               pshs      u
+                    lbsr      L0180
+                    leas      $02,s
+L372A               ldd       $12,s
+                    std       ,u
+                    ldd       $04,s
+                    std       $08,u
+                    ldd       $08,s
+                    std       $0a,u
+                    ldd       L0051
+                    std       $0C,u
+                    ldd       $004B
+                    std       $10,u
+                    stu       $004B
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4103
+                    leas      $06,s
+                    std       $02,s
+                    bne       L3760
+                    ldd       $005F
+                    cmpd      #$0078
+                    beq       L3760
+                    lbsr      L42D4
+L3760               ldx       $04,s
+                    bra       L3779
+
+L3764               ldd       L0031
+                    subd      $02,s
+                    std       L0031
+                    ldd       L0031
+                    bra       L3775
+
+L376E               ldd       L002B
+                    addd      #$0001
+                    std       L002B
+L3775               std       $06,u
+                    bra       L378A
+
+L3779               cmpx      #$000D
+                    beq       L3764
+                    cmpx      #$0023
+                    beq       L376E
+                    cmpx      #$000F
+                    lbeq      L376E
+L378A               ldd       $005F
+                    cmpd      #$0078
+                    lbne      L3827
+                    ldd       $04,s
+                    cmpd      #$000F
+                    beq       L37A4
+                    ldd       $04,s
+                    cmpd      #$0023
+                    bne       L37B7
+L37A4               ldd       $12,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4435
+L37B2               leas      $06,s
+                    lbra      L385B
+
+L37B7               lbsr      L552E
+                    ldd       $12,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    lbeq      L3822
+                    ldd       $12,s
+                    cmpd      #$0004
+                    lbeq      L3822
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      L0583
+                    leas      $02,s
+                    std       $0C,s
+                    beq       L3822
+                    ldd       $0009
+                    beq       L37F6
+                    ldd       $0009
+                    std       $06,s
+                    tfr       d,x
+                    ldd       ,x
+                    std       $0009
+                    clra
+                    clrb
+                    std       [$06,s]
+                    bra       L3802
+
+L37F6               ldd       #$0006
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    std       $06,s
+L3802               ldd       $0C,s
+                    ldx       $06,s
+                    std       $02,x
+                    ldx       $06,s
+                    stu       $04,x
+                    ldd       $0005
+                    beq       L3818
+                    ldd       $06,s
+                    std       [$0007,y]
+                    bra       L381C
+
+L3818               ldd       $06,s
+                    std       $0005
+L381C               ldd       $06,s
+                    std       $0007
+                    bra       L385B
+
+L3822               lbsr      L4980
+                    bra       L385B
+
+L3827               ldx       $04,s
+                    bra       L384A
+
+L382B               ldd       $04,s
+                    cmpd      #$0023
+                    bne       L3838
+                    ldd       #$0001
+                    bra       L383A
+
+L3838               clra
+                    clrb
+L383A               pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    lbsr      $66C1
+                    lbra      L37B2
+
+L384A               cmpx      #$000F
+                    beq       L382B
+                    cmpx      #$0023
+                    lbeq      L382B
+                    bra       L385B
+
+L3858               leas      -$18,x
+L385B               ldd       $005F
+                    cmpd      #$0030
+                    beq       L3867
+                    leas      $06,s
+                    bra       L386F
+
+L3867               lbsr      L552E
+                    leas      $06,s
+                    lbra      L3676
+
+L386F               ldd       #$0028
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+L3879               leas      $12,s
+                    puls      pc,u
+L387E               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       ,u
+                    cmpd      $06,s
+                    bne       L389E
+                    ldd       $06,s
+                    cmpd      #$0004
+                    bne       L38AE
+                    ldd       $0a,u
+                    cmpd      $08,s
+                    beq       L38AE
+L389E               leax      $4381,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    ldd       #$0001
+                    puls      pc,u
+L38AE               clra
+                    clrb
+                    puls      pc,u
+L38B2               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0113
+                    ldd       $04,s
+                    cmpd      #$0010
+                    bne       L3903
+                    ldd       $0003
+                    cmpd      #$0001
+                    bge       L38FE
+                    ldx       $06,s
+                    bra       L38F0
+
+L38CE               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L38FE
+L38D9               ldd       $0003
+                    addd      #$0001
+                    std       $0003
+                    cmpd      #$0001
+                    bne       L38EB
+                    ldd       #$006F
+                    bra       L38EE
+
+L38EB               ldd       #$0076
+L38EE               puls      pc,u
+L38F0               cmpx      #$0001
+                    beq       L38D9
+                    cmpx      #$0007
+                    lbeq      L38D9
+                    bra       L38CE
+
+L38FE               ldd       #$000D
+                    puls      pc,u
+L3903               ldd       $04,s
+                    puls      pc,u
+L3907               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L0113
+                    leas      -$0a,s
+                    ldd       #$0001
+                    std       L0051
+                    clra
+                    clrb
+                    std       $002F
+                    std       L003B
+                    std       L0031
+                    std       $0003
+                    std       L0033
+                    bra       L3927
+
+L3924               lbsr      L34D9
+L3927               ldd       $005F
+                    cmpd      #$0029
+                    bne       L3924
+                    ldd       $0e,s
+                    addd      #$0014
+                    std       $02,s
+                    ldd       L0037
+                    beq       L394E
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       ,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      $679F
+                    leas      $04,s
+L394E               ldd       ,s
+                    pshs      d
+                    ldd       $12,s
+                    cmpd      #$000F
+                    beq       L3960
+                    ldd       #$0001
+                    bra       L3962
+
+L3960               clra
+                    clrb
+L3962               pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $6742
+                    leas      $06,s
+                    ldu       L0047
+                    ldd       #$0004
+                    std       $08,s
+                    lbra      L39EB
+
+L3977               leas      -$02,s
+                    ldd       $0a,s
+                    std       $06,u
+                    ldx       ,u
+                    bra       L3999
+
+L3981               ldd       #$0004
+                    bra       L3995
+
+L3986               ldd       #$0008
+                    bra       L3995
+
+L398B               ldd       $06,u
+                    addd      #$0001
+                    std       $06,u
+L3992               ldd       #$0002
+L3995               std       ,s
+                    bra       L39B1
+
+L3999               cmpx      #$0008
+                    beq       L3981
+                    cmpx      #$0005
+                    lbeq      L3981
+                    cmpx      #$0006
+                    beq       L3986
+                    cmpx      #$0002
+                    beq       L398B
+                    bra       L3992
+
+L39B1               ldd       $08,u
+                    std       $08,s
+                    tfr       d,x
+                    bra       L39CF
+
+L39B9               ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $04,s
+                    bra       L39E0
+
+L39C8               ldd       #$000D
+                    std       $08,u
+                    bra       L39E0
+
+L39CF               cmpx      #$006F
+                    beq       L39B9
+                    cmpx      #$0076
+                    lbeq      L39B9
+                    cmpx      #$000B
+                    beq       L39C8
+L39E0               ldd       $0a,s
+                    addd      ,s
+                    std       $0a,s
+                    ldu       $10,u
+                    leas      $02,s
+L39EB               stu       -$02,s
+                    lbne      L3977
+                    ldd       L0047
+                    std       $04,s
+                    clra
+                    clrb
+                    std       L0047
+                    lbsr      L3A4F
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L4207
+                    leas      $02,s
+                    leax      >$0049,y
+                    pshs      x
+                    lbsr      L4207
+                    leas      $02,s
+                    ldd       L004F
+                    cmpd      #$0012
+                    beq       L3A2A
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0012
+                    pshs      d
+                    lbsr      L4B61
+                    leas      $06,s
+L3A2A               clra
+                    clrb
+                    std       L004F
+                    lbsr      $67D1
+                    clra
+                    clrb
+                    std       L0051
+                    ldd       $005F
+                    cmpd      #$FFFF
+                    bne       L3A48
+                    leax      $4396,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L3A48               lbsr      L552E
+                    leas      $0a,s
+                    puls      pc,u
+L3A4F               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L0113
+                    leas      -$06,s
+                    ldd       $004B
+                    std       $02,s
+                    clra
+                    clrb
+                    std       $004B
+                    lbsr      L552E
+                    ldd       L0051
+                    addd      #$0001
+                    std       L0051
+                    ldd       L0031
+                    std       ,s
+                    bra       L3A74
+
+L3A71               lbsr      L362B
+L3A74               lbsr      L043F
+                    std       -$02,s
+                    bne       L3A71
+                    lbsr      L03DD
+                    std       -$02,s
+                    lbne      L3A71
+                    ldd       L003B
+                    cmpd      L0031
+                    ble       L3A8F
+                    ldd       L0031
+                    std       L003B
+L3A8F               ldd       L0031
+                    pshs      d
+                    lbsr      L4B33
+                    leas      $02,s
+                    std       $002F
+                    lbra      L3B0D
+
+L3A9D               ldd       $0005
+                    std       $04,s
+                    ldx       $04,s
+                    ldu       $02,x
+                    ldd       $10,u
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    ldx       $08,s
+                    ldd       $04,x
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0034
+                    pshs      d
+                    lbsr      L0DD6
+                    leas      $0C,s
+                    tfr       d,u
+                    ldd       $10,u
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldx       $0a,s
+                    ldd       $02,x
+                    pshs      d
+                    pshs      u
+                    ldd       #$0078
+                    pshs      d
+                    lbsr      L0DD6
+                    leas      $0C,s
+                    tfr       d,u
+                    pshs      u
+                    lbsr      L0F1B
+                    std       ,s
+                    lbsr      L4C52
+                    std       ,s
+                    lbsr      L0396
+                    leas      $02,s
+                    ldd       [$04,s]
+                    std       $04,s
+                    ldd       $0009
+                    std       [$0005,y]
+                    ldd       $0005
+                    std       $0009
+                    ldd       $04,s
+                    std       $0005
+L3B0D               ldd       $0005
+                    lbne      L3A9D
+                    bra       L3B18
+
+L3B15               lbsr      L27D3
+L3B18               ldd       $005F
+                    cmpd      #$002A
+                    beq       L3B28
+                    ldd       $005F
+                    cmpd      #$FFFF
+                    bne       L3B15
+L3B28               leax      >$004b,y
+                    pshs      x
+                    lbsr      L4207
+                    leas      $02,s
+                    ldd       $02,s
+                    std       $004B
+                    ldd       L0051
+                    addd      #$FFFF
+                    std       L0051
+                    ldd       ,s
+                    std       L0031
+                    ldd       L004F
+                    cmpd      #$0012
+                    beq       L3B55
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4B33
+                    leas      $02,s
+                    bra       L3B57
+
+L3B55               ldd       ,s
+L3B57               std       $002F
+                    leas      $06,s
+                    puls      pc,u
+L3B5D               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       [$06,s]
+L3B6C               lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$002E
+                    lbeq      L3BDD
+                    ldd       $005F
+                    cmpd      #$0034
+                    bne       L3BD0
+                    ldu       $0061
+                    ldd       $08,u
+                    cmpd      #$000B
+                    bne       L3B96
+                    leax      L43AA,pcr
+                    pshs      x
+                    lbsr      L024E
+                    bra       L3B9F
+
+L3B96               ldd       ,u
+                    beq       L3BA1
+                    pshs      u
+                    lbsr      L0180
+L3B9F               leas      $02,s
+L3BA1               ldd       #$0001
+                    std       ,u
+                    ldd       #$000B
+                    std       $08,u
+                    ldd       #$0001
+                    std       $0C,u
+                    ldd       #$0002
+                    std       $02,u
+                    ldd       [$06,s]
+                    beq       L3BC1
+                    ldx       ,s
+                    stu       $10,x
+                    bra       L3BC4
+
+L3BC1               stu       [$06,s]
+L3BC4               clra
+                    clrb
+                    std       $10,u
+                    stu       ,s
+                    lbsr      L552E
+                    bra       L3BD3
+
+L3BD0               lbsr      L42E2
+L3BD3               ldd       $005F
+                    cmpd      #$0030
+                    lbeq      L3B6C
+L3BDD               ldd       #$002E
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    bra       L3C34
+
+L3BE9               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    leas      -$02,s
+                    lbsr      L043F
+                    std       -$02,s
+                    beq       L3C32
+                    ldd       $0061
+                    std       ,s
+                    lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0033
+                    bne       L3C2E
+                    ldd       $0061
+                    cmpd      #$0021
+                    bne       L3C2E
+                    ldx       ,s
+                    bra       L3C21
+
+L3C15               ldd       #$0023
+                    bra       L3C1D
+
+L3C1A               ldd       #$0022
+L3C1D               std       ,s
+                    bra       L3C2B
+
+L3C21               cmpx      #$000F
+                    beq       L3C15
+                    cmpx      #$000E
+                    beq       L3C1A
+L3C2B               lbsr      L552E
+L3C2E               ldd       ,s
+                    bra       L3C34
+
+L3C32               clra
+                    clrb
+L3C34               leas      $02,s
+L3C36               puls      pc,u
+L3C38               pshs      u
+                    ldd       #$FF98
+                    lbsr      L0113
+                    leas      -$1a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       #$0002
+                    std       ,s
+                    clra
+                    clrb
+                    std       [$22,s]
+                    ldd       $005F
+                    cmpd      #$0033
+                    lbne      L3F54
+                    ldd       $0061
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L3F12
+
+L3C64               ldd       #$0001
+                    std       $02,s
+L3C69               lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0033
+                    lbne      L3F7C
+                    ldd       $0061
+                    cmpd      #$0001
+                    lbne      L3F7C
+                    bra       L3CBA
+
+L3C82               ldd       #$0001
+                    bra       L3CB8
+
+L3C87               lbsr      L552E
+                    ldd       #$0004
+                    std       ,s
+                    ldd       $005F
+                    cmpd      #$0033
+                    lbne      L3F7C
+                    ldd       $0061
+                    cmpd      #$0001
+                    beq       L3CBA
+                    ldd       $0061
+                    cmpd      #$0005
+                    lbne      L3F7C
+L3CAB               ldd       #$0006
+                    std       $02,s
+                    ldd       #$0008
+                    bra       L3CB8
+
+L3CB5               ldd       #$0004
+L3CB8               std       ,s
+L3CBA               lbsr      L552E
+                    lbra      L3F7C
+
+L3CC0               clra
+                    clrb
+                    std       $02,s
+                    lbra      L3F7C
+
+L3CC7               clra
+                    clrb
+                    std       $16,s
+                    std       ,s
+                    ldd       $0041
+                    addd      #$0001
+                    std       $0041
+                    clra
+                    clrb
+                    std       $18,s
+                    lbsr      L552E
+                    ldd       $0041
+                    addd      #$FFFF
+                    std       $0041
+                    ldd       $005F
+                    cmpd      #$0034
+                    lbne      L3D60
+                    ldd       $0061
+                    std       $18,s
+                    ldd       [$18,s]
+                    bne       L3D08
+                    ldd       #$000A
+                    std       [$18,s]
+                    ldd       #$0008
+                    ldx       $18,s
+                    std       $08,x
+                    bra       L3D1E
+
+L3D08               ldx       $18,s
+                    ldd       $08,x
+                    cmpd      #$0008
+                    beq       L3D1E
+                    leax      $43B6,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L3D1E               lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0029
+                    beq       L3D54
+                    ldd       [$18,s]
+                    cmpd      #$0004
+                    bne       L3D48
+                    ldx       $18,s
+                    ldd       $02,x
+                    std       [$1e,s]
+                    ldx       $18,s
+                    ldd       $0a,x
+                    std       [$22,s]
+                    ldd       #$0004
+                    lbra      L3F88
+
+L3D48               ldd       $18,s
+                    std       [$1e,s]
+                    ldd       #$000A
+                    lbra      L3F88
+
+L3D54               ldd       [$18,s]
+                    cmpd      #$0004
+                    bne       L3D60
+                    lbsr      L0241
+L3D60               ldd       $005F
+                    cmpd      #$0029
+                    beq       L3D76
+                    leax      L43C1,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbra      L3F7C
+
+L3D76               ldd       $0041
+                    addd      #$0001
+                    std       $0041
+L3D7D               ldd       $0041
+                    std       $10,s
+                    clra
+                    clrb
+                    std       $0041
+                    lbsr      L552E
+                    ldd       $10,s
+                    std       $0041
+                    ldd       $005F
+                    cmpd      #$002A
+                    lbeq      L3EE5
+                    leax      $04,s
+                    pshs      x
+                    leax      $0e,s
+                    pshs      x
+                    leax      $18,s
+                    pshs      x
+                    lbsr      L3C38
+                    leas      $06,s
+                    std       $12,s
+                    bra       L3DAF
+
+L3DAF               leas      -$04,s
+                    ldd       $10,s
+                    std       $02,s
+                    ldd       $005F
+                    cmpd      #$0028
+                    lbeq      L3ECF
+                    ldd       L0051
+                    addd      #$0001
+                    std       L0051
+                    ldd       $16,s
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L3F8D
+                    leas      $06,s
+                    std       $12,s
+                    ldu       ,s
+                    ldd       L0051
+                    addd      #$FFFF
+                    std       L0051
+                    cmpu      #$0000
+                    bne       L3DF4
+                    lbsr      L42E2
+                    leax      $1e,s
+                    lbra      L3EC4
+
+L3DF4               ldd       ,u
+                    beq       L3E29
+                    ldd       $0C,u
+                    cmpd      L0051
+                    bne       L3E22
+                    ldd       ,u
+                    cmpd      $12,s
+                    bne       L3E17
+                    ldd       $08,u
+                    cmpd      #$0011
+                    bne       L3E17
+                    ldd       $06,u
+                    cmpd      $1a,s
+                    beq       L3E29
+L3E17               leax      $43CF,pcr
+                    pshs      x
+                    lbsr      L024E
+                    bra       L3E27
+
+L3E22               pshs      u
+                    lbsr      L0180
+L3E27               leas      $02,s
+L3E29               ldd       $12,s
+                    cmpd      #$000A
+                    bne       L3E3D
+                    leax      $43E6,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+L3E3D               ldd       $12,s
+                    std       ,u
+                    ldd       #$0011
+                    std       $08,u
+                    ldd       $1a,s
+                    std       $06,u
+                    ldd       $08,s
+                    std       $0a,u
+                    ldd       $18,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4103
+                    leas      $06,s
+                    std       $0e,s
+                    beq       L3E87
+                    ldd       $06,s
+                    cmpd      #$0004
+                    bne       L3E76
+                    ldd       $1a,s
+                    addd      $0e,s
+                    std       $1a,s
+                    bra       L3E83
+
+L3E76               ldd       $0e,s
+                    cmpd      $04,s
+                    ble       L3E81
+                    ldd       $0e,s
+                    bra       L3E83
+
+L3E81               ldd       $04,s
+L3E83               std       $04,s
+                    bra       L3E8A
+
+L3E87               lbsr      L42D4
+L3E8A               ldd       L0051
+                    std       $0C,u
+                    ldd       $004B
+                    std       $10,u
+                    stu       $004B
+                    ldd       $06,s
+                    cmpd      #$0004
+                    bne       L3EC7
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    std       $0C,s
+                    ldx       $0C,s
+                    stu       $02,x
+                    ldd       [$26,s]
+                    beq       L3EB9
+                    ldd       $0C,s
+                    std       [$0a,s]
+                    bra       L3EBE
+
+L3EB9               ldd       $0C,s
+                    std       [$26,s]
+L3EBE               ldd       $0C,s
+                    std       $0a,s
+                    bra       L3EC7
+
+L3EC4               leas      -$1e,x
+L3EC7               ldd       $005F
+                    cmpd      #$0030
+                    beq       L3ED3
+L3ECF               leas      $04,s
+                    bra       L3EDB
+
+L3ED3               lbsr      L552E
+                    leas      $04,s
+                    lbra      L3DAF
+
+L3EDB               ldd       $005F
+                    cmpd      #$0028
+                    lbeq      L3D7D
+L3EE5               ldd       $0041
+                    addd      #$FFFF
+                    std       $0041
+                    ldd       $18,s
+                    beq       L3F06
+                    ldd       ,s
+                    ldx       $18,s
+                    std       $02,x
+                    ldd       #$0004
+                    std       [$18,s]
+                    ldd       [$22,s]
+                    ldx       $18,s
+                    std       $0a,x
+L3F06               ldd       #$002A
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    bra       L3F7C
+
+L3F12               cmpx      #$000A
+                    lbeq      L3C64
+                    cmpx      #$0007
+                    lbeq      L3C69
+                    cmpx      #$0002
+                    lbeq      L3C82
+                    cmpx      #$0001
+                    lbeq      L3CBA
+                    cmpx      #$0008
+                    lbeq      L3C87
+                    cmpx      #$0006
+                    lbeq      L3CAB
+                    cmpx      #$0005
+                    lbeq      L3CB5
+                    cmpx      #$0003
+                    lbeq      L3CC7
+                    cmpx      #$0004
+                    lbeq      L3CC7
+                    lbra      L3CC0
+
+L3F54               ldd       $005F
+                    cmpd      #$0034
+                    bne       L3F7C
+                    ldu       $0061
+                    ldd       $08,u
+                    cmpd      #start
+                    bne       L3F7C
+                    ldd       $02,u
+                    std       [$1e,s]
+                    ldd       $04,u
+                    std       [$20,s]
+                    ldd       $0a,u
+                    std       [$22,s]
+                    lbsr      L552E
+                    ldd       ,u
+                    bra       L3F88
+
+L3F7C               ldd       ,s
+                    std       [$1e,s]
+                    clra
+                    clrb
+                    std       [$20,s]
+                    ldd       $02,s
+L3F88               leas      $1a,s
+L3F8B               puls      pc,u
+L3F8D               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L0113
+                    leas      -$0C,s
+                    clra
+                    clrb
+                    std       [$10,s]
+                    std       $0a,s
+                    bra       L3FAE
+
+L3FA0               ldd       $0a,s
+                    pshs      d
+                    lbsr      L0486
+                    leas      $02,s
+                    std       $0a,s
+                    lbsr      L552E
+L3FAE               ldd       $005F
+                    cmpd      #$0042
+                    beq       L3FA0
+                    ldd       $005F
+                    cmpd      #$0034
+                    bne       L3FC8
+                    ldd       $0061
+                    std       [$10,s]
+                    lbsr      L552E
+                    bra       L4002
+
+L3FC8               ldd       $005F
+                    cmpd      #$002D
+                    bne       L4002
+                    lbsr      L552E
+                    ldd       L0051
+                    addd      #$0001
+                    std       L0051
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L3F8D
+                    leas      $06,s
+                    std       $14,s
+                    ldd       L0051
+                    addd      #$FFFF
+                    std       L0051
+                    ldd       #$002E
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+L4002               ldd       $005F
+                    cmpd      #$002D
+                    bne       L4039
+                    ldd       $0a,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      #$0030
+                    std       $0a,s
+                    ldd       L0051
+                    bne       L4024
+                    leax      >$0047,y
+                    pshs      x
+                    lbsr      L3B5D
+                    bra       L4034
+
+L4024               leax      ,s
+                    pshs      x
+                    lbsr      L3B5D
+                    leas      $02,s
+                    leax      ,s
+                    pshs      x
+                    lbsr      L4207
+L4034               leas      $02,s
+                    lbra      L40BC
+
+L4039               clra
+                    clrb
+                    std       $06,s
+                    std       $04,s
+                    std       $02,s
+                    ldd       $0041
+                    std       $08,s
+                    clra
+                    clrb
+                    std       $0041
+                    lbra      L40A0
+
+L404C               ldd       $0a,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      #$0020
+                    std       $0a,s
+                    lbsr      L552E
+                    ldd       #$0004
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       $04,s
+                    bne       L4076
+                    ldd       $005F
+                    cmpd      #$002C
+                    bne       L4076
+                    clra
+                    clrb
+                    bra       L407F
+
+L4076               clra
+                    clrb
+                    pshs      d
+                    lbsr      L0A52
+                    leas      $02,s
+L407F               std       ,u
+                    ldd       $06,s
+                    beq       L408B
+                    ldx       $06,s
+                    stu       $02,x
+                    bra       L408D
+
+L408B               stu       $02,s
+L408D               stu       $06,s
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    ldd       $04,s
+                    addd      #$0001
+                    std       $04,s
+L40A0               ldd       $005F
+                    cmpd      #$002B
+                    lbeq      L404C
+                    ldd       $08,s
+                    std       $0041
+                    ldd       $02,s
+                    beq       L40BC
+                    ldd       [$12,s]
+                    std       $02,u
+                    ldd       $02,s
+                    std       [$12,s]
+L40BC               ldd       $0a,s
+                    pshs      d
+                    ldd       $16,s
+                    pshs      d
+                    bsr       L40CD
+                    leas      $04,s
+                    leas      $0C,s
+                    puls      pc,u
+L40CD               pshs      u
+                    ldd       #$FFBC
+                    lbsr      L0113
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+                    bra       L40F5
+
+L40DD               ldd       ,s
+                    pshs      d
+                    ldd       #$0002
+                    lbsr      L7660
+                    std       ,s
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0002
+                    lbsr      L7683
+                    std       $08,s
+L40F5               ldd       ,s
+                    clra
+                    andb      #$30
+                    bne       L40DD
+                    ldd       $06,s
+                    addd      $08,s
+                    lbra      L42F3
+
+L4103               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       ,u
+                    std       $02,s
+                    clra
+                    andb      #$0f
+                    tfr       d,x
+                    bra       L4138
+
+L411A               ldd       #$0001
+                    bra       L4134
+
+L411F               ldd       #$0002
+                    bra       L4134
+
+L4124               ldd       #$0004
+                    bra       L4134
+
+L4129               ldd       #$0008
+                    bra       L4134
+
+L412E               ldd       $0C,s
+                    bra       L4134
+
+L4132               clra
+                    clrb
+L4134               std       ,s
+                    bra       L416B
+
+L4138               cmpx      #$0002
+                    beq       L411A
+                    cmpx      #$0001
+                    beq       L411F
+                    cmpx      #$0007
+                    lbeq      L411F
+                    cmpx      #$0008
+                    beq       L4124
+                    cmpx      #$0005
+                    lbeq      L4124
+                    cmpx      #$0006
+                    beq       L4129
+                    cmpx      #$0003
+                    beq       L412E
+                    cmpx      #$0004
+                    lbeq      L412E
+                    cmpx      #$000A
+                    beq       L4132
+L416B               ldd       ,s
+                    beq       L4173
+                    ldd       ,s
+                    bra       L4175
+
+L4173               ldd       $0C,s
+L4175               std       $02,u
+                    ldd       $0a,s
+                    std       $04,u
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    bsr       L418D
+                    leas      $06,s
+                    leas      $04,s
+L418B               puls      pc,u
+L418D               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $08,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L41AF
+                    ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L41B5
+L41AF               ldd       #$0002
+                    lbra      L42F3
+
+L41B5               ldd       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L4202
+                    ldd       #$0001
+                    std       ,s
+L41C5               ldd       ,s
+                    pshs      d
+                    ldd       ,u
+                    lbsr      L7542
+                    std       ,s
+                    ldu       $02,u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L047A
+                    leas      $02,s
+                    std       $06,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    beq       L41C5
+                    ldd       ,s
+                    pshs      d
+                    ldd       $08,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L41FA
+                    ldd       #$0002
+                    bra       L41FC
+
+L41FA               ldd       $0a,s
+L41FC               lbsr      L7542
+                    lbra      L42F3
+
+L4202               ldd       $08,s
+                    lbra      L42F3
+
+L4207               pshs      u
+                    ldd       #$FF74
+                    lbsr      L0113
+                    leas      -$40,s
+                    ldu       [$44,s]
+                    lbra      L42C4
+
+L4218               ldd       $10,u
+                    std       $3C,s
+                    ldd       ,u
+                    cmpd      #$0009
+                    bne       L4258
+                    ldd       $0a,u
+                    clra
+                    andb      #$01
+                    bne       L4258
+                    ldd       #$0008
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    leax      $43FA,pcr
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    lbsr      $7314
+                    leas      $04,s
+                    pshs      d
+                    lbsr      $740C
+                    leas      $06,s
+                    pshs      d
+                    lbsr      L024E
+                    leas      $02,s
+L4258               ldx       $08,u
+                    bra       L4265
+
+L425C               ldd       $0003
+                    addd      #$FFFF
+                    std       $0003
+                    bra       L4271
+
+L4265               cmpx      #$006F
+                    beq       L425C
+                    cmpx      #$0076
+                    lbeq      L425C
+L4271               ldd       $0e,u
+                    std       $3e,s
+                    cmpd      L0066
+                    bls       L428C
+                    ldd       $3e,s
+                    cmpd      $0068
+                    bcc       L428C
+                    pshs      u
+                    lbsr      L01D2
+                    leas      $02,s
+                    bra       L42C1
+
+L428C               cmpu      [$3e,s]
+                    bne       L429A
+                    ldd       $12,u
+                    std       [$3e,s]
+                    bra       L42BA
+
+L429A               ldd       [$3e,s]
+                    bra       L42A5
+
+L429F               ldx       $3e,s
+                    ldd       $12,x
+L42A5               std       $3e,s
+                    ldx       $3e,s
+                    cmpu      $12,x
+                    bne       L429F
+                    ldd       $12,u
+                    ldx       $3e,s
+                    std       $12,x
+L42BA               ldd       L0019
+                    std       $12,u
+                    stu       L0019
+L42C1               ldu       $3C,s
+L42C4               stu       -$02,s
+                    lbne      L4218
+                    clra
+                    clrb
+                    std       [$44,s]
+                    leas      $40,s
+                    puls      pc,u
+L42D4               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    leax      L440D,pcr
+L42E0               bra       L42EE
+
+L42E2               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    leax      $4422,pcr
+L42EE               pshs      x
+                    lbsr      L024E
+L42F3               leas      $02,s
+                    puls      pc,u
+L42F7               lsr       $6F6F
+                    bra       $4369
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       $4363
+                    fcb       $72
+                    fcb       $61
+                    com       $0b,s
+                    fcb       $65
+                    lsr       L7300
+L4309               ror       -$0b,s
+                    jmp       $03,s
+                    lsr       L696F
+                    jmp       0,y
+                    asl       $05,s
+                    fcb       $61
+                    lsr       $05,s
+                    fcb       $72
+                    bra       L4387
+                    rol       -$0d,s
+                    com       $696E
+                    asr       0,x
+L4321               com       L746F
+                    fcb       $72
+                    fcb       $61
+                    asr       $05,s
+                    bra       L438F
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L0066
+                    fcb       $75
+                    jmp       $03,s
+                    lsr       L696F
+                    jmp       0,y
+                    lsr       L7970
+                    fcb       $65
+                    bra       $43A3
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $0061
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    bra       $43C0
+                    lsr       $6F72
+                    fcb       $61
+                    asr       $05,s
+                    neg       $0061
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    bra       $43C3
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       $006E
+                    clr       -$0C,s
+                    bra       L43C9
+                    jmp       0,y
+                    fcb       $61
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    neg       $0073
+                    lsr       $6F72
+                    fcb       $61
+                    asr       $05,s
+                    bra       $43E1
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L0064
+                    fcb       $65
+                    com       $0C,s
+                    fcb       $61
+                    fcb       $72
+L4387               fcb       $61
+                    lsr       L696F
+                    jmp       0,y
+                    tst       $09,s
+L438F               com       L6D61
+                    lsr       $6368
+                    neg       L0066
+                    fcb       $75
+                    jmp       $03,s
+                    lsr       L696F
+                    jmp       0,y
+                    fcb       $75
+                    jmp       $06,s
+                    rol       $0e,s
+                    rol       -$0d,s
+                    asl       $05,s
+                    lsr       0,x
+L43AA               jmp       $01,s
+                    tst       $05,s
+                    lsr       0,y
+                    lsr       L7769
+                    com       $05,s
+                    neg       $006E
+                    fcb       $61
+                    tst       $05,s
+                    bra       $441F
+                    inc       $01,s
+                    com       $6800
+L43C1               com       $7472
+                    fcb       $75
+                    com       -$0C,s
+                    bra       $443C
+
+L43C9               rol       L6E74
+                    fcb       $61
+                    asl       >$0073
+                    lsr       $7275
+                    com       -$0C,s
+                    bra       $4444
+                    fcb       $65
+                    tst       $02,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L444B
+                    rol       -$0d,s
+                    tst       $01,s
+                    lsr       $6368
+                    neg       $0075
+                    jmp       $04,s
+                    fcb       $65
+                    ror       $09,s
+                    jmp       $05,s
+                    lsr       0,y
+                    com       $7472
+                    fcb       $75
+                    com       -$0C,s
+                    fcb       $75
+                    fcb       $72
+                    fcb       $65
+                    neg       $006C
+                    fcb       $61
+                    fcb       $62
+                    fcb       $65
+                    inc       0,y
+                    fcb       $75
+                    jmp       $04,s
+                    fcb       $65
+                    ror       $09,s
+                    jmp       $05,s
+                    lsr       0,y
+                    abx
+                    bra       L440D
+
+L440D               com       $01,s
+                    jmp       $0e,s
+                    clr       -$0C,s
+                    bra       L447A
+                    ror       L616C
+                    fcb       $75
+                    fcb       $61
+                    lsr       $6520
+                    com       $697A
+                    fcb       $65
+                    neg       L0069
+                    lsr       $05,s
+                    jmp       -$0C,s
+                    rol       $06,s
+                    rol       $05,s
+                    fcb       $72
+                    bra       $449B
+                    rol       -$0d,s
+                    com       $696E
+                    asr       0,x
+L4435               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldx       $0a,s
+                    bra       L445B
+
+L4445               lbsr      L4980
+                    lbra      L456F
+
+L444B               ldd       #$0001
+                    bra       L4452
+
+L4450               clra
+                    clrb
+L4452               pshs      d
+                    lbsr      $6814
+                    leas      $02,s
+                    bra       L447C
+
+L445B               cmpx      #start
+                    beq       L4445
+                    cmpx      #$000E
+                    lbeq      L4445
+                    cmpx      #$0022
+                    lbeq      L4445
+                    cmpx      #$0021
+                    beq       L444B
+                    cmpx      #$0023
+                    lbeq      L444B
+L447A               bra       L4450
+
+L447C               ldd       L0051
+                    bne       L44AE
+                    leax      $14,u
+                    stx       $02,s
+                    ldd       $0a,s
+                    cmpd      #$000F
+                    beq       L449A
+                    ldd       $0a,s
+                    cmpd      #$0023
+                    beq       L449A
+                    ldd       #$0001
+                    bra       L44A1
+
+L449A               ldd       #$000C
+                    std       $08,u
+                    clra
+                    clrb
+L44A1               pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4A23
+                    leas      $04,s
+                    bra       L44BD
+
+L44AE               lbsr      L4BEF
+                    ldd       $06,u
+                    pshs      d
+                    lbsr      L4B04
+                    leas      $02,s
+                    lbsr      L4A77
+L44BD               ldd       $0C,s
+                    cmpd      #$0022
+                    bne       L4511
+                    ldd       #$0001
+                    std       $000B
+                    lbsr      L552E
+                    ldd       $005F
+                    cmpd      #$0037
+                    bne       L450A
+                    ldd       $04,u
+                    std       $02,s
+                    ldd       [$02,s]
+                    bne       L44E5
+                    ldd       L0017
+                    std       [$02,s]
+                    bra       L4502
+
+L44E5               ldd       [$02,s]
+                    subd      L0017
+                    std       ,s
+                    blt       L44F7
+                    ldd       ,s
+                    pshs      d
+                    lbsr      $603F
+                    bra       L4500
+
+L44F7               leax      L49C1,pcr
+                    pshs      x
+                    lbsr      L024E
+L4500               leas      $02,s
+L4502               lbsr      L552E
+                    leax      $04,s
+                    lbra      L4566
+
+L450A               ldd       #$0002
+                    std       $000B
+                    bra       L4519
+
+L4511               ldd       #$0002
+                    std       $000B
+                    lbsr      L552E
+L4519               ldd       $0C,s
+                    cmpd      #$0004
+                    bne       L4536
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0a,u
+L4527               pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    bsr       L4573
+                    leas      $08,s
+                    bra       L4568
+
+L4536               ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    bne       L4549
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $04,u
+                    bra       L4527
+
+L4549               ldd       #$0001
+                    pshs      d
+                    ldd       $04,u
+                    pshs      d
+                    pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    bsr       L4573
+                    leas      $08,s
+                    std       -$02,s
+                    bne       L4568
+                    lbsr      L4997
+                    bra       L4568
+
+L4566               leas      -$04,x
+L4568               lbsr      $6824
+                    clra
+                    clrb
+                    std       $000B
+L456F               leas      $04,s
+                    puls      pc,u
+L4573               pshs      u
+                    ldd       #$FFA8
+                    lbsr      L0113
+                    ldu       $06,s
+                    leas      -$0C,s
+                    ldd       $16,s
+                    bne       L4590
+                    ldd       #$0029
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+                    bra       L45A6
+
+L4590               ldd       $005F
+                    cmpd      #$0029
+                    bne       L45A2
+                    ldd       #$0001
+                    std       $0a,s
+                    lbsr      L552E
+                    bra       L45A6
+
+L45A2               clra
+                    clrb
+                    std       $0a,s
+L45A6               ldd       $10,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0020
+                    lbne      L4694
+                    ldd       [$14,s]
+                    std       $02,s
+                    bne       L45C0
+                    ldd       #$FFFF
+                    std       $02,s
+L45C0               ldd       $10,s
+                    pshs      d
+                    lbsr      L047A
+                    leas      $02,s
+                    std       $08,s
+                    cmpd      #$0004
+                    bne       L45D6
+                    ldd       $0a,u
+                    bra       L45DB
+
+L45D6               ldx       $14,s
+                    ldd       $02,x
+L45DB               std       $04,s
+                    clra
+                    clrb
+                    std       $06,s
+                    bra       L4619
+
+L45E3               ldd       $16,s
+                    addd      #$0001
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L4573
+                    leas      $08,s
+                    std       -$02,s
+                    lbeq      L474B
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    cmpd      $02,s
+                    bcc       L4621
+                    ldd       $005F
+                    cmpd      #$0030
+                    bne       L4621
+                    lbsr      L552E
+                    bra       L4619
+
+L4619               ldd       $005F
+                    cmpd      #$002A
+                    bne       L45E3
+L4621               ldd       $02,s
+                    cmpd      #$FFFF
+                    bne       L4630
+                    ldd       $06,s
+                    std       [$14,s]
+                    bra       L465F
+
+L4630               ldd       $06,s
+                    cmpd      $02,s
+                    bcc       L465F
+                    ldx       $14,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L418D
+                    leas      $06,s
+                    pshs      d
+                    ldd       $04,s
+                    subd      $08,s
+                    lbsr      L7542
+                    pshs      d
+                    lbsr      L4751
+                    leas      $02,s
+                    bra       L465F
+
+L465D               leas      -$0C,x
+L465F               ldd       $16,s
+                    beq       L466A
+                    ldd       $0a,s
+                    lbeq      L4738
+L466A               ldd       $005F
+                    cmpd      #$0030
+                    bne       L4675
+                    lbsr      L552E
+L4675               ldd       $005F
+                    cmpd      #$002A
+                    bne       L4683
+                    lbsr      L552E
+                    lbra      L4738
+
+L4683               leax      L49CA,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbsr      L4997
+                    lbra      L4738
+
+L4694               ldd       $10,s
+                    cmpd      #$0004
+                    lbne      L471F
+                    ldd       $14,s
+                    std       ,s
+                    bne       L46ED
+                    leax      $49DC,pcr
+                    lbra      L4741
+
+L46AD               ldx       ,s
+                    ldu       $02,x
+                    ldd       $16,s
+                    addd      #$0001
+                    pshs      d
+                    ldd       ,u
+                    cmpd      #$0004
+                    bne       L46C5
+                    ldd       $0a,u
+                    bra       L46C7
+
+L46C5               ldd       $04,u
+L46C7               pshs      d
+                    pshs      u
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L4573
+                    leas      $08,s
+                    std       -$02,s
+                    lbeq      L474B
+                    ldd       [,s]
+                    std       ,s
+                    beq       L4716
+                    ldd       $005F
+                    cmpd      #$0030
+                    bne       L4716
+                    lbsr      L552E
+                    bra       L46ED
+
+L46ED               ldd       $005F
+                    cmpd      #$002A
+                    bne       L46AD
+                    bra       L4716
+
+L46F7               ldx       ,s
+                    ldu       $02,x
+                    ldd       $04,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    lbsr      L418D
+                    leas      $06,s
+                    pshs      d
+                    bsr       L4751
+                    leas      $02,s
+                    ldd       [,s]
+                    std       ,s
+L4716               ldd       ,s
+                    bne       L46F7
+                    leax      $0C,s
+                    lbra      L465D
+
+L471F               ldd       $10,s
+                    pshs      d
+                    bsr       L4775
+                    std       ,s++
+                    beq       L473D
+                    ldd       $0a,s
+                    beq       L4738
+                    ldd       #$002A
+                    pshs      d
+                    lbsr      L04BF
+                    leas      $02,s
+L4738               ldd       #$0001
+                    bra       L474D
+
+L473D               leax      L49EF,pcr
+L4741               pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbsr      L4997
+L474B               clra
+                    clrb
+L474D               leas      $0C,s
+                    puls      pc,u
+L4751               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    lbsr      L4BEF
+                    leax      L4A0C,pcr
+                    pshs      x
+                    lbsr      L4A47
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4AB4
+                    leas      $02,s
+                    lbsr      L4A77
+                    puls      pc,u
+L4775               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0113
+                    leas      -$08,s
+                    ldd       #$0002
+                    pshs      d
+                    lbsr      L0583
+                    std       ,s
+                    lbsr      L0F1B
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L4799
+                    clra
+                    clrb
+                    lbra      L4912
+
+L4799               clra
+                    clrb
+                    std       $04,s
+                    ldd       #$0001
+                    std       $02,s
+                    ldd       ,u
+                    std       ,s
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L47D8
+                    ldx       ,s
+                    bra       L47C7
+
+L47B5               ldd       #$0001
+                    bra       L4801
+
+L47BA               ldd       ,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L480A
+                    bra       L47EE
+
+L47C7               cmpx      #$0008
+                    beq       L47B5
+                    cmpx      #$0001
+                    beq       L480A
+                    cmpx      #$0007
+                    beq       L480A
+                    bra       L47BA
+
+L47D8               ldd       ,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L47F2
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L2630
+                    std       ,s++
+                    bne       L480A
+L47EE               leax      $08,s
+                    bra       L482A
+
+L47F2               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L47FF
+                    ldd       #$0006
+                    bra       L4801
+
+L47FF               ldd       $0C,s
+L4801               pshs      d
+                    pshs      u
+                    lbsr      L202A
+                    leas      $04,s
+L480A               ldd       $06,u
+                    cmpd      #$0050
+                    beq       L481A
+                    ldd       $06,u
+                    cmpd      #$0051
+                    bne       L4863
+L481A               ldd       $0C,u
+                    std       $06,s
+                    tfr       d,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    beq       L4835
+                    bra       L482C
+
+L482A               leas      -$08,x
+L482C               clra
+                    clrb
+                    std       $02,s
+                    leax      $08,s
+                    lbra      L4907
+
+L4835               ldd       $06,u
+                    cmpd      #$0051
+                    bne       L4847
+                    ldx       $06,s
+                    ldd       $08,x
+                    nega
+                    negb
+                    sbca      #$00
+                    bra       L484B
+
+L4847               ldx       $06,s
+                    ldd       $08,x
+L484B               std       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L0396
+                    leas      $02,s
+                    stu       $06,s
+                    ldu       $0a,u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L03B7
+                    leas      $02,s
+L4863               ldd       $06,u
+                    cmpd      #$0041
+                    bne       L48BA
+                    ldd       $0a,u
+                    std       $06,s
+                    tfr       d,x
+                    ldx       $08,x
+                    ldx       $08,x
+                    bra       L4897
+
+L4877               clra
+                    clrb
+                    std       $02,s
+                    lbra      L4909
+
+L487E               ldd       #$0001
+                    std       $000D
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L50A1
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $000D
+                    lbra      L4909
+
+L4897               cmpx      #$000F
+                    beq       L487E
+                    cmpx      #$000E
+                    lbeq      L487E
+                    cmpx      #$000C
+                    lbeq      L487E
+                    cmpx      #$0021
+                    lbeq      L487E
+                    cmpx      #$0022
+                    lbeq      L487E
+                    bra       L4877
+
+L48BA               ldx       $06,u
+                    bra       L48EE
+
+L48BE               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L48D2
+                    ldx       $08,u
+                    pshs      x
+                    ldx       $08,u
+                    lbsr      L695C
+                    lbsr      $6A02
+L48D2               ldd       $0C,s
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    bsr       L4916
+                    leas      $04,s
+                    bra       L4909
+
+L48E0               lbsr      $67F2
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L4AEB
+                    leas      $02,s
+                    bra       L4909
+
+L48EE               cmpx      #$004B
+                    beq       L48BE
+                    cmpx      #$0036
+                    beq       L48D2
+                    cmpx      #$004A
+                    lbeq      L48D2
+                    cmpx      #$0037
+                    beq       L48E0
+                    lbra      L4877
+
+L4907               leas      -$08,x
+L4909               pshs      u
+                    lbsr      L0396
+                    leas      $02,s
+                    ldd       $02,s
+L4912               leas      $08,s
+                    puls      pc,u
+L4916               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldx       $08,s
+                    bra       L494C
+
+L4926               lbsr      $67E7
+                    pshs      u
+                    lbsr      L4AB4
+                    leas      $02,s
+                    lbsr      L4A77
+                    bra       L497C
+
+L4935               ldd       #$0001
+                    bra       L493D
+
+L493A               ldd       #$0002
+L493D               std       ,s
+                    bra       L4971
+
+L4941               ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L5069
+                    bra       L497A
+
+L494C               cmpx      #$0002
+                    beq       L4926
+                    cmpx      #$0001
+                    beq       L4935
+                    cmpx      #$0007
+                    lbeq      L4935
+                    cmpx      #$0008
+                    beq       L493A
+                    cmpx      #$0005
+                    beq       L4941
+                    cmpx      #$0006
+                    lbeq      L4941
+                    lbra      L4935
+
+L4971               ldd       ,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4FE1
+L497A               leas      $04,s
+L497C               leas      $02,s
+                    puls      pc,u
+L4980               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    leax      $4A11,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    bsr       L4997
+                    puls      pc,u
+L4997               pshs      u
+                    ldd       #$FFBC
+                    lbsr      L0113
+L499F               ldx       $005F
+                    bra       L49AA
+
+L49A3               puls      pc,u
+L49A5               lbsr      L552E
+                    bra       L499F
+
+L49AA               cmpx      #$0030
+                    beq       L49A3
+                    cmpx      #$0028
+                    lbeq      L49A3
+                    cmpx      #$FFFF
+                    lbeq      L49A3
+                    bra       L49A5
+                    puls      pc,u
+L49C1               lsr       $6F6F
+                    bra       L4A32
+                    clr       $0e,s
+                    asr       0,x
+L49CA               lsr       $6F6F
+                    bra       $4A3C
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       L4A39
+                    inc       $05,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    com       >$0075
+                    jmp       $09,s
+                    clr       $0e,s
+                    com       $206E
+                    clr       -$0C,s
+                    bra       L4A49
+                    inc       $0C,s
+                    clr       -$09,s
+                    fcb       $65
+                    lsr       0,x
+L49EF               com       $0f,s
+                    jmp       -$0d,s
+                    lsr       $616E
+                    lsr       L2065
+                    asl       L7072
+                    fcb       $65
+                    com       $7369
+                    clr       $0e,s
+                    bra       $4A76
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    rol       -$0e,s
+                    fcb       $65
+                    lsr       0,x
+L4A0C               fcb       $72
+                    dec       L6220
+                    neg       $0063
+                    fcb       $61
+                    jmp       $0e,s
+                    clr       -$0C,s
+                    bra       $4A82
+                    jmp       $09,s
+                    lsr       $6961
+                    inc       $09,s
+                    dec       $6500
+L4A23               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    lbsr      L4BEF
+                    ldd       $04,s
+                    pshs      d
+L4A32               lbsr      L4B20
+                    leas      $02,s
+                    ldd       $06,s
+L4A39               lbeq      L4AFF
+                    ldd       #$003A
+                    pshs      d
+                    bsr       L4A88
+                    lbra      L4AFD
+
+L4A47               pshs      u
+L4A49               ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L4A9E
+                    lbra      L5065
+                    pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L4A47
+                    lbra      L4AFD
+
+L4A77               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$000D
+                    bra       L4A96
+
+L4A88               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       $0025
+                    pshs      d
+                    ldd       $06,s
+L4A96               pshs      d
+                    lbsr      $6F04
+                    lbra      L4BC4
+
+L4A9E               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $0025
+                    pshs      d
+                    lbsr      L50E6
+                    lbra      L4BC4
+
+L4AB4               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    leax      L50C1,pcr
+                    lbra      L4C12
+
+L4AC7               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       #$006C
+                    pshs      d
+                    bsr       L4A88
+                    leas      $02,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       L004F
+                    puls      pc,u
+L4AEB               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    clra
+                    clrb
+                    std       L004F
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L4B04
+L4AFD               leas      $02,s
+L4AFF               lbsr      L4A77
+                    puls      pc,u
+L4B04               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldd       #$005F
+                    pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4AB4
+                    lbra      L5065
+
+L4B20               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    leax      $50C4,pcr
+                    lbra      L4C12
+
+L4B33               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    leas      -$02,s
+                    ldd       $06,s
+                    subd      $002F
+                    std       ,s
+                    beq       L4B5C
+                    ldd       #$004D
+                    pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+L4B5C               ldd       $06,s
+                    lbra      L5065
+
+L4B61               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $0025
+                    ldx       $04,s
+                    lbra      L4BC8
+
+L4B70               ldd       #$004A
+                    pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+                    pshs      u
+                    ldd       $0a,s
+                    bra       L4BA3
+
+L4B80               ldd       #$0072
+                    lbra      L4BFA
+
+L4B86               ldd       #$0047
+                    bra       L4BB4
+
+L4B8B               ldd       #$006A
+                    bra       L4BB4
+
+L4B90               ldd       #$0044
+                    pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+                    pshs      u
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+L4BA3               pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    bra       L4BBB
+
+L4BAC               ldd       #$0059
+                    bra       L4BB4
+
+L4BB1               ldd       #$0055
+L4BB4               pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+L4BBB               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $6FA9
+L4BC4               leas      $04,s
+                    puls      pc,u
+L4BC8               cmpx      #$007D
+                    lbeq      L4B70
+                    cmpx      #$0012
+                    beq       L4B80
+                    cmpx      #$001D
+                    beq       L4B86
+                    cmpx      #$007C
+                    beq       L4B8B
+                    cmpx      #$0009
+                    beq       L4B90
+                    cmpx      #$0076
+                    beq       L4BAC
+                    cmpx      #$006F
+                    beq       L4BB1
+                    puls      pc,u
+L4BEF               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldd       #$002A
+L4BFA               pshs      d
+                    lbsr      L4A88
+                    lbra      L5065
+                    pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    leax      $50C9,pcr
+L4C12               pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      L50E6
+                    lbra      L4E18
+
+L4C1E               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0001
+                    bra       L4C61
+
+L4C2F               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L0113
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       #$0002
+                    pshs      d
+                    bsr       L4C6B
+                    leas      $0a,s
+                    bra       L4C67
+
+L4C52               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0004
+L4C61               pshs      d
+                    bsr       L4C6B
+                    leas      $04,s
+L4C67               ldd       $04,s
+                    puls      pc,u
+L4C6B               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0113
+                    ldu       $0025
+                    pshs      u
+                    ldd       #$0054
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    pshs      u
+                    ldd       L002B
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    pshs      u
+                    ldd       $002F
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldx       $04,s
+                    bra       L4CDA
+
+L4CA6               pshs      u
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    pshs      u
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    pshs      u
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      $6F04
+                    bra       L4CD6
+
+L4CC7               pshs      u
+                    ldd       $000D
+                    bra       L4CD1
+
+L4CCD               pshs      u
+                    ldd       $0a,s
+L4CD1               pshs      d
+                    lbsr      $6FA9
+L4CD6               leas      $04,s
+                    bra       L4CE9
+
+L4CDA               cmpx      #$0002
+                    beq       L4CA6
+                    cmpx      #$0005
+                    beq       L4CC7
+                    cmpx      #$0012
+                    beq       L4CCD
+L4CE9               ldd       L002B
+                    pshs      d
+                    ldd       $06,s
+                    cmpd      #$0002
+                    bne       L4CFA
+                    ldd       #$0001
+                    bra       L4CFC
+
+L4CFA               clra
+                    clrb
+L4CFC               pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    bsr       L4D0F
+                    leas      $04,s
+                    addd      ,s++
+                    std       L002B
+                    ldd       $06,s
+                    lbra      L4E3C
+
+L4D0F               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$06,s
+                    stu       -$02,s
+                    lbeq      L4E16
+                    ldx       $06,u
+                    lbra      L4D81
+
+L4D26               ldd       $0C,s
+                    beq       L4D2F
+                    ldd       #$0001
+                    bra       L4D32
+
+L4D2F               ldd       #$0004
+L4D32               std       $04,s
+                    ldd       #$0001
+                    bra       L4D6E
+
+L4D39               ldd       #$0003
+                    std       $04,s
+                    ldd       #$0001
+                    bra       L4D70
+
+L4D43               ldd       $0C,s
+                    beq       L4D4B
+                    clra
+                    clrb
+                    bra       L4D4E
+
+L4D4B               ldd       #$0003
+L4D4E               std       $04,s
+                    clra
+                    clrb
+                    bra       L4D6E
+
+L4D54               ldd       #$0003
+                    std       $04,s
+                    ldd       #$0001
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    lbra      L4DF4
+
+L4D65               ldd       #$0001
+                    std       $04,s
+                    clra
+                    clrb
+                    std       $0C,s
+L4D6E               std       ,s
+L4D70               std       $02,s
+                    lbra      L4DF4
+
+L4D75               clra
+                    clrb
+                    std       $0C,s
+                    std       ,s
+                    std       $02,s
+                    std       $04,s
+                    bra       L4DF4
+
+L4D81               cmpx      #$0047
+                    lbeq      L4D26
+                    cmpx      #$0048
+                    lbeq      L4D26
+                    cmpx      #$0040
+                    lbeq      L4D39
+                    cmpx      #$005A
+                    lbeq      L4D43
+                    cmpx      #$005B
+                    lbeq      L4D43
+                    cmpx      #$005C
+                    lbeq      L4D43
+                    cmpx      #$005D
+                    lbeq      L4D43
+                    cmpx      #$005E
+                    lbeq      L4D43
+                    cmpx      #$005F
+                    lbeq      L4D43
+                    cmpx      #$0060
+                    lbeq      L4D43
+                    cmpx      #$0061
+                    lbeq      L4D43
+                    cmpx      #$0062
+                    lbeq      L4D43
+                    cmpx      #$0063
+                    lbeq      L4D43
+                    cmpx      #$0064
+                    lbeq      L4D54
+                    cmpx      #$004B
+                    lbeq      L4D65
+                    cmpx      #$004A
+                    lbeq      L4D65
+                    lbra      L4D75
+
+L4DF4               ldd       $02,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L4D0F
+                    leas      $04,s
+                    addd      $04,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L4D0F
+                    leas      $04,s
+                    addd      ,s++
+                    bra       L4E18
+
+L4E16               clra
+                    clrb
+L4E18               leas      $06,s
+                    puls      pc,u
+L4E1C               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0113
+                    ldu       $04,s
+                    stu       -$02,s
+                    lbeq      L5067
+                    pshs      u
+                    bsr       L4E44
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L4E1C
+                    leas      $02,s
+                    ldd       $0C,u
+L4E3C               pshs      d
+                    lbsr      L4E1C
+                    lbra      L5065
+
+L4E44               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $0a,u
+                    beq       L4E5D
+                    ldd       $0C,u
+                    beq       L4E5D
+                    ldd       #$0042
+                    bra       L4E72
+
+L4E5D               ldd       $0a,u
+                    beq       L4E66
+                    ldd       #$004C
+                    bra       L4E72
+
+L4E66               ldd       $0C,u
+                    beq       L4E6F
+                    ldd       #$0052
+                    bra       L4E72
+
+L4E6F               ldd       #$004E
+L4E72               std       ,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $0e,u
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    leax      $060C,y
+                    pshs      x
+                    ldd       $10,u
+                    subd      ,s++
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $12,u
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $14,u
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldd       $06,u
+                    cmpd      #$0034
+                    lbne      L4F52
+                    ldu       $08,u
+                    ldd       $0025
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      $6F04
+                    leas      $04,s
+                    ldx       $08,u
+                    bra       L4F36
+
+L4F11               pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    lbsr      L4B20
+                    leas      $02,s
+                    ldd       $0025
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      $6F04
+                    lbra      L4FDC
+
+L4F2D               ldd       $0025
+                    pshs      d
+                    ldd       $06,u
+                    lbra      L4FD7
+
+L4F36               cmpx      #$000E
+                    beq       L4F11
+                    cmpx      #$000C
+                    lbeq      L4F11
+                    cmpx      #$0021
+                    lbeq      L4F11
+                    cmpx      #$0022
+                    lbeq      L4F11
+                    bra       L4F2D
+
+L4F52               ldd       $06,u
+                    cmpd      #$004A
+                    bne       L4F8E
+                    leas      -$04,s
+                    leax      ,s
+                    pshs      x
+                    bsr       L4F66
+                    neg       $0000
+                    neg       $0000
+L4F66               puls      x
+                    lbsr      L74D6
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0004
+                    pshs      d
+                    ldu       $08,u
+                    beq       L4F81
+                    tfr       u,d
+                    bra       L4F85
+
+L4F81               leax      $06,s
+                    tfr       x,d
+L4F85               pshs      d
+                    lbsr      L6EBA
+                    leas      $08,s
+                    bra       L4FDC
+
+L4F8E               ldd       $06,u
+                    cmpd      #$004B
+                    bne       L4FD1
+                    leas      -$08,s
+                    leax      ,s
+                    pshs      x
+                    bsr       L4FA6
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L4FA6               puls      x
+                    lbsr      $6A02
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0008
+                    pshs      d
+                    ldu       $08,u
+                    beq       L4FC1
+                    tfr       u,d
+                    bra       L4FC5
+
+L4FC1               leax      $06,s
+                    tfr       x,d
+L4FC5               pshs      d
+                    lbsr      L6EBA
+                    leas      $08,s
+                    leas      $08,s
+                    lbra      L5065
+
+L4FD1               ldd       $0025
+                    pshs      d
+                    ldd       $08,u
+L4FD7               pshs      d
+                    lbsr      $6FA9
+L4FDC               leas      $04,s
+                    lbra      L5065
+
+L4FE1               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $04,s
+                    leas      -$02,s
+                    lbsr      $67F2
+                    ldd       $08,s
+                    cmpd      #$0001
+                    bne       L5002
+                    pshs      u
+                    lbsr      L4AB4
+L4FFD               leas      $02,s
+                    lbra      L5062
+
+L5002               cmpu      #$0000
+                    bne       L5033
+                    ldd       #$0001
+                    std       ,s
+                    bra       L501A
+
+L500F               leax      L50CE,pcr
+                    pshs      x
+                    lbsr      L4A9E
+                    leas      $02,s
+L501A               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      $08,s
+                    blt       L500F
+                    ldd       #$0030
+                    pshs      d
+                    lbsr      L4A88
+                    bra       L4FFD
+
+L5033               clra
+                    clrb
+                    bra       L5059
+
+L5037               ldd       ,u++
+                    pshs      d
+                    lbsr      L4AB4
+                    leas      $02,s
+                    ldd       $08,s
+                    addd      #$FFFF
+                    cmpd      ,s
+                    beq       L5054
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+L5054               ldd       ,s
+                    addd      #$0001
+L5059               std       ,s
+                    ldd       ,s
+                    cmpd      $08,s
+                    blt       L5037
+L5062               lbsr      L4A77
+L5065               leas      $02,s
+L5067               puls      pc,u
+L5069               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       #$0066
+                    pshs      d
+                    lbsr      L4A88
+                    leas      $02,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      $6FA9
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0008
+                    pshs      d
+                    pshs      u
+                    lbsr      L6EBA
+                    leas      $08,s
+                    puls      pc,u
+L50A1               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0113
+                    ldu       $04,s
+                    ldd       $14,u
+                    addd      $06,s
+                    std       $14,u
+                    pshs      u
+                    ldd       #$0005
+                    pshs      d
+                    lbsr      L4C6B
+                    leas      $04,s
+                    puls      pc,u
+L50C1               bcs       $5127
+                    neg       $0025
+                    bgt       L50FF
+                    com       >$0046
+                    bcs       $513F
+                    tst       $0000
+L50CE               leax      $0C,y
+                    neg       $0034
+L50D2               nega
+                    leax      $01C1,y
+                    stx       $000F
+                    ldd       #$0001
+                    std       L0015
+                    leax      $06,s
+                    pshs      x
+                    ldd       $06,s
+L50E4               bra       L50F7
+
+L50E6               pshs      u
+                    ldd       $04,s
+                    std       $000F
+                    ldd       #$0001
+                    std       L0015
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L50F7               pshs      d
+                    bsr       L511E
+                    leas      $04,s
+                    puls      pc,u
+L50FF               pshs      u
+                    ldd       $04,s
+                    std       $000F
+                    ldd       #$0002
+                    std       L0015
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L511E
+                    leas      $04,s
+                    clra
+                    clrb
+                    stb       [$000F,y]
+                    puls      pc,u
+L511E               pshs      u
+                    ldu       $04,s
+                    leas      -$0b,s
+                    bra       L5136
+
+L5126               ldb       $08,s
+                    lbeq      L5294
+                    ldb       $08,s
+                    sex
+                    pshs      d
+                    lbsr      L5473
+                    leas      $02,s
+L5136               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    bne       L5126
+                    ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L5159
+                    ldd       #$0001
+                    std       $0011
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L515D
+
+L5159               clra
+                    clrb
+                    std       $0011
+L515D               ldb       $08,s
+                    cmpb      #$30
+                    bne       L5168
+                    ldd       #$0030
+                    bra       L516B
+
+L5168               ldd       #$0020
+L516B               std       $0013
+                    bra       L5189
+
+L516F               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L7542
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+L5189               ldb       $08,s
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L516F
+                    ldb       $08,s
+                    cmpb      #$2e
+                    bne       L51D0
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L51BB
+
+L51A5               ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L7542
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+L51BB               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L51A5
+                    bra       L51D4
+
+L51D0               clra
+                    clrb
+                    std       $04,s
+L51D4               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L5276
+
+L51DC               ldd       $06,s
+                    pshs      d
+                    ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L5298
+                    bra       L5204
+
+L51F1               ldd       $06,s
+                    pshs      d
+                    ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L5359
+L5204               std       ,s
+                    lbra      L5261
+
+L5209               ldx       $11,s
+                    leax      $02,x
+                    stx       $11,s
+                    ldd       -$02,x
+                    lbra      L526C
+
+L5216               ldx       $11,s
+                    leax      $02,x
+                    stx       $11,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L5259
+                    ldd       $09,s
+                    std       $04,s
+                    bra       L5238
+
+L522C               ldb       [$09,s]
+                    beq       L5244
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+L5238               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L522C
+L5244               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L5418
+                    leas      $06,s
+                    bra       L5266
+
+L5259               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    pshs      d
+L5261               lbsr      L53B8
+                    leas      $04,s
+L5266               lbra      L5136
+
+L5269               ldb       $08,s
+                    sex
+L526C               pshs      d
+                    lbsr      L5473
+                    leas      $02,s
+                    lbra      L5136
+
+L5276               cmpx      #$0064
+                    lbeq      L51DC
+                    cmpx      #$0078
+                    lbeq      L51F1
+                    cmpx      #$0063
+                    lbeq      L5209
+                    cmpx      #$0073
+                    lbeq      L5216
+                    bra       L5269
+
+L5294               leas      $0b,s
+                    puls      pc,u
+L5298               pshs      u,d
+                    leax      $02DA,y
+                    stx       ,s
+                    ldd       $06,s
+                    bge       L52CD
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+                    bge       L52C2
+                    leax      L5498,pcr
+                    pshs      x
+                    leax      $02DA,y
+                    pshs      x
+                    lbsr      $7314
+                    leas      $04,s
+                    lbra      L546F
+
+L52C2               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L52CD               ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L52E2
+                    leas      $04,s
+                    leax      $02DA,y
+                    tfr       x,d
+                    lbra      L546F
+
+L52E2               pshs      u,y,x,d
+                    ldu       $0a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L52FF
+
+L52F0               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      $0081,y
+                    std       $0C,s
+L52FF               ldd       $0C,s
+                    blt       L52F0
+                    leax      $0081,y
+                    stx       $04,s
+                    bra       L5341
+
+L530B               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L5312               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    bge       L530B
+                    ldd       $0C,s
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L532B
+                    ldd       #$0001
+                    std       $02,s
+L532B               ldd       $02,s
+                    beq       L5336
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L5336               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+L5341               ldd       $04,s
+                    cmpd      $0001
+                    bne       L5312
+                    ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $06,s
+                    puls      pc,u
+L5359               pshs      u,x,d
+                    leax      $02DA,y
+                    stx       $02,s
+                    leau      $02E4,y
+L5365               ldd       $08,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L537B
+                    ldd       #$0057
+                    bra       L537E
+
+L537B               ldd       #$0030
+L537E               addd      ,s++
+                    stb       ,u+
+                    ldd       $08,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $08,s
+                    bne       L5365
+                    bra       L539E
+
+L5394               ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+L539E               leau      -$01,u
+                    pshs      u
+                    leax      $02E4,y
+                    cmpx      ,s++
+                    bls       L5394
+                    clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $02DA,y
+                    tfr       x,d
+                    lbra      L5494
+
+L53B8               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $7303
+                    leas      $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    leau      d,u
+                    ldd       $0011
+                    bne       L53EF
+                    bra       L53DC
+
+L53D3               ldd       $0013
+                    pshs      d
+                    lbsr      L5473
+                    leas      $02,s
+L53DC               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bgt       L53D3
+                    bra       L53EF
+
+L53E6               ldd       ,s
+                    pshs      d
+                    lbsr      L5473
+                    leas      $02,s
+L53EF               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    sex
+                    std       ,s
+                    bne       L53E6
+                    ldd       $0011
+                    lbeq      L546F
+                    bra       L540D
+
+L5404               ldd       $0013
+                    pshs      d
+                    lbsr      L5473
+                    leas      $02,s
+L540D               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bgt       L5404
+                    lbra      L546F
+
+L5418               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       ,s
+                    ldd       $0011
+                    bne       L5449
+                    bra       L5432
+
+L542A               ldd       $0013
+                    pshs      d
+                    bsr       L5473
+                    leas      $02,s
+L5432               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bgt       L542A
+                    bra       L5449
+
+L5440               ldb       ,u+
+                    sex
+                    pshs      d
+                    bsr       L5473
+                    leas      $02,s
+L5449               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L5440
+                    ldd       $0011
+                    beq       L546F
+                    bra       L5463
+
+L545B               ldd       $0013
+                    pshs      d
+                    bsr       L5473
+                    leas      $02,s
+L5463               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bgt       L545B
+L546F               leas      $02,s
+                    puls      pc,u
+L5473               pshs      u
+                    ldd       L0015
+                    cmpd      #$0002
+                    bne       L5489
+                    ldd       $04,s
+                    ldx       $000F
+                    leax      $01,x
+                    stx       $000F
+                    stb       -$01,x
+                    bra       L5496
+
+L5489               ldd       $000F
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $6F04
+L5494               leas      $04,s
+L5496               puls      pc,u
+L5498               blt       $54CD
+                    leas      -$09,y
+                    pshu      y,x,dp
+                    neg       $00AE
+                    fcb       $62
+                    leas      -$08,s
+                    ldd       $05,x
+                    aslb
+                    rola
+                    std       $05,x
+                    std       $05,s
+                    ldd       $03,x
+                    rolb
+                    rola
+                    std       $03,x
+                    std       $03,s
+                    ldd       $01,x
+                    rolb
+                    rola
+                    std       $01,x
+                    std       $01,s
+                    lda       ,x
+                    rola
+                    sta       ,x
+                    sta       ,s
+                    asl       $06,x
+                    rol       $05,x
+                    rol       $04,x
+                    rol       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    bcs       L5528
+                    asl       $06,x
+                    rol       $05,x
+                    rol       $04,x
+                    rol       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    bcs       L5528
+                    ldd       $05,x
+                    addd      $05,s
+                    std       $05,x
+                    ldd       $03,x
+                    adcb      $04,s
+                    adca      $03,s
+                    std       $03,x
+                    ldd       $01,x
+                    adcb      $02,s
+                    adca      $01,s
+                    std       $01,x
+                    ldb       ,x
+                    adcb      ,s
+                    stb       ,x
+                    bcs       L5528
+                    ldb       $0d,s
+                    andb      #$0f
+                    clra
+                    addd      $05,x
+                    std       $05,x
+                    ldd       #$0000
+                    adcb      $04,x
+                    adca      $03,x
+                    std       $03,x
+                    ldd       #$0000
+                    adcb      $02,x
+                    adca      $01,x
+                    std       $01,x
+                    lda       #$00
+                    adca      ,x
+                    sta       ,x
+                    bcs       L5528
+                    leas      $08,s
+                    clra
+                    clrb
+                    rts
+
+L5528               ldd       #$0001
+                    leas      $08,s
+                    rts
+
+L552E               pshs      u
+                    leas      -$15,s
+                    lbsr      $6348
+                    ldb       $0065
+                    sex
+                    cmpd      #$FFFF
+                    bne       L5549
+                    ldd       #$FFFF
+                    std       $005F
+                    leas      $15,s
+                    puls      pc,u
+L5549               ldd       $006A
+                    addd      #$FFFF
+                    std       $0063
+                    ldd       L0027
+                    std       L003F
+                    bra       L5568
+
+L5556               leax      $61EC,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbsr      $635E
+                    ldd       $006A
+                    std       $0063
+L5568               ldb       $0065
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    std       $005F
+                    beq       L5556
+                    ldb       $0065
+                    sex
+                    leax      $0109,y
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    std       $0061
+                    ldx       $005F
+                    lbra      L5876
+
+L558B               leax      $0a,s
+                    pshs      x
+                    lbsr      L5ABF
+                    leas      $02,s
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      L5B36
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       ,u
+                    std       $005F
+                    cmpd      #$0033
+                    bne       L55C2
+                    ldd       $08,u
+                    std       $0061
+                    cmpd      #$003B
+                    lbne      L5895
+                    ldd       #$003B
+                    std       $005F
+                    ldd       #$000E
+                    std       $0061
+                    lbra      L5895
+
+L55C2               ldd       #$0034
+                    std       $005F
+                    stu       $0061
+                    lbra      L5895
+
+L55CC               leax      ,s
+                    pshs      x
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L5C5C
+                    leas      $04,s
+                    std       $13,s
+                    bra       L55E2
+
+L55DF               leas      -$15,x
+L55E2               leax      ,s
+                    stx       $08,s
+                    ldx       $13,s
+                    bra       L5640
+
+L55EB               ldd       [$08,s]
+                    bra       L5636
+
+L55F0               ldd       #$0004
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    tfr       d,u
+                    leax      ,u
+                    pshs      x
+                    ldx       $0a,s
+                    lbsr      L74D6
+                    stu       $0061
+                    ldd       #$004A
+                    bra       L563B
+
+L560C               ldd       #$0008
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    tfr       d,u
+                    leax      ,u
+                    pshs      x
+                    ldx       $0a,s
+                    lbsr      $6A02
+                    stu       $0061
+                    ldd       #$004B
+                    bra       L563B
+
+L5628               leax      L61FA,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    ldd       #$0001
+L5636               std       $0061
+                    ldd       #$0036
+L563B               std       $005F
+                    lbra      L5895
+
+L5640               cmpx      #$0001
+                    beq       L55EB
+                    cmpx      #$0008
+                    beq       L55F0
+                    cmpx      #$0006
+                    beq       L560C
+                    bra       L5628
+
+L5651               lbsr      L5F03
+                    ldd       #$0036
+                    bra       L565F
+
+L5659               lbsr      L5F33
+                    ldd       #$0037
+L565F               std       $005F
+                    lbra      L5895
+
+L5664               lbsr      $635E
+                    ldx       $005F
+                    lbra      L5819
+
+L566C               ldb       $0065
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    lbne      L5895
+                    leax      ,s
+                    pshs      x
+                    ldd       #$0006
+                    pshs      d
+                    lbsr      L5C5C
+                    leas      $04,s
+                    std       $13,s
+                    leax      $15,s
+                    lbra      L55DF
+
+L5694               ldb       $0065
+                    sex
+                    tfr       d,x
+                    bra       L56B3
+
+L569B               ldd       #$0047
+                    std       $005F
+                    lbsr      $635E
+                    ldd       #$0005
+                    bra       L56F2
+
+L56A8               ldd       #$00A7
+                    std       $005F
+                    ldd       #$0002
+                    lbra      L57FF
+
+L56B3               cmpx      #$0026
+                    beq       L569B
+                    cmpx      #$003D
+                    beq       L56A8
+                    lbra      L5895
+
+L56C0               ldb       $0065
+                    cmpb      #$3d
+                    lbne      L5895
+                    ldd       #$005A
+                    std       $005F
+                    ldd       #$0009
+                    lbra      L57FF
+
+L56D3               ldb       $0065
+                    sex
+                    tfr       d,x
+                    bra       L56F7
+
+L56DA               ldd       #$0048
+                    std       $005F
+                    lbsr      $635E
+                    ldd       #$0004
+                    bra       L56F2
+
+L56E7               ldd       #$00A8
+L56EA               std       $005F
+                    lbsr      $635E
+                    ldd       #$0002
+L56F2               std       $0061
+                    lbra      L5895
+
+L56F7               cmpx      #$007C
+                    beq       L56DA
+                    cmpx      #$003D
+                    beq       L56E7
+                    lbra      L5895
+
+L5704               ldb       $0065
+                    cmpb      #$3d
+                    lbne      L5895
+                    ldd       #$005B
+                    std       $005F
+                    lbsr      $635E
+                    ldd       #$0009
+                    bra       L56F2
+
+L5719               ldb       $0065
+                    cmpb      #$3d
+                    lbne      L5895
+                    ldd       #$00A2
+                    bra       L56EA
+
+L5726               ldb       $0065
+                    cmpb      #$3d
+                    lbne      L5895
+                    ldd       $005F
+                    addd      #$0050
+                    lbra      L56EA
+
+L5736               ldb       $0065
+                    sex
+                    tfr       d,x
+                    bra       L5768
+
+L573D               ldd       #$0056
+                    std       $005F
+                    ldd       #$000B
+                    std       $0061
+                    lbsr      $635E
+                    ldb       $0065
+                    cmpb      #$3d
+                    lbne      L5895
+                    ldd       #$00A6
+                    std       $005F
+                    ldd       #$0002
+                    lbra      L57FF
+
+L575D               ldd       #$005C
+                    std       $005F
+                    ldd       #$000A
+                    lbra      L57FF
+
+L5768               cmpx      #$003C
+                    beq       L573D
+                    cmpx      #$003D
+                    beq       L575D
+                    lbra      L5895
+
+L5775               ldb       $0065
+                    sex
+                    tfr       d,x
+                    bra       L57A7
+
+L577C               ldd       #$0055
+                    std       $005F
+                    ldd       #$000B
+                    std       $0061
+                    lbsr      $635E
+                    ldb       $0065
+                    cmpb      #$3d
+                    lbne      L5895
+                    ldd       #$00A5
+                    std       $005F
+                    ldd       #$0002
+                    lbra      L57FF
+
+L579C               ldd       #$005E
+                    std       $005F
+                    ldd       #$000A
+                    lbra      L57FF
+
+L57A7               cmpx      #$003E
+                    beq       L577C
+                    cmpx      #$003D
+                    beq       L579C
+                    lbra      L5895
+
+L57B4               ldb       $0065
+                    sex
+                    tfr       d,x
+                    bra       L57CF
+
+L57BB               ldd       #$003C
+                    std       $005F
+                    ldd       #$000E
+                    bra       L57FF
+
+L57C5               ldd       #$00A0
+                    std       $005F
+                    ldd       #$0002
+                    bra       L57FF
+
+L57CF               cmpx      #$002B
+                    beq       L57BB
+                    cmpx      #$003D
+                    beq       L57C5
+                    lbra      L5895
+
+L57DC               ldb       $0065
+                    sex
+                    tfr       d,x
+                    bra       L5807
+
+L57E3               ldd       #$003D
+                    std       $005F
+                    ldd       #$000E
+                    bra       L57FF
+
+L57ED               ldd       #$00A1
+                    std       $005F
+                    ldd       #$0002
+                    bra       L57FF
+
+L57F7               ldd       #$0046
+                    std       $005F
+                    ldd       #$000F
+L57FF               std       $0061
+                    lbsr      $635E
+                    lbra      L5895
+
+L5807               cmpx      #$002D
+                    beq       L57E3
+                    cmpx      #$003D
+                    beq       L57ED
+                    cmpx      #$003E
+                    beq       L57F7
+                    lbra      L5895
+
+L5819               cmpx      #$0045
+                    lbeq      L566C
+                    cmpx      #$0041
+                    lbeq      L5694
+                    cmpx      #$0078
+                    lbeq      L56C0
+                    cmpx      #$0058
+                    lbeq      L56D3
+                    cmpx      #$0040
+                    lbeq      L5704
+                    cmpx      #$0042
+                    lbeq      L5719
+                    cmpx      #$0053
+                    lbeq      L5726
+                    cmpx      #$0054
+                    lbeq      L5726
+                    cmpx      #$0059
+                    lbeq      L5726
+                    cmpx      #$005D
+                    lbeq      L5736
+                    cmpx      #$005F
+                    lbeq      L5775
+                    cmpx      #$0050
+                    lbeq      L57B4
+                    cmpx      #$0043
+                    lbeq      L57DC
+                    bra       L5895
+
+L5876               cmpx      #$006A
+                    lbeq      L558B
+                    cmpx      #$006B
+                    lbeq      L55CC
+                    cmpx      #$0068
+                    lbeq      L5651
+                    cmpx      #$0069
+                    lbeq      L5659
+                    lbra      L5664
+
+L5895               leas      $15,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       #$0006
+                    pshs      d
+                    leax      L620C,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0005
+                    pshs      d
+                    leax      L6213,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #start
+                    pshs      d
+                    leax      $6219,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$000F
+                    pshs      d
+                    leax      $6221,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$003B
+                    pshs      d
+                    leax      L6228,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0001
+                    pshs      d
+                    leax      L622F,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0001
+                    std       $0041
+                    ldd       #$0001
+                    pshs      d
+                    leax      L6233,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0005
+                    pshs      d
+                    leax      L6237,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $0041
+                    ldd       #$0002
+                    pshs      d
+                    leax      $623D,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$000A
+                    pshs      d
+                    leax      L6242,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$000D
+                    pshs      d
+                    leax      $6248,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$000E
+                    pshs      d
+                    leax      $624D,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0021
+                    pshs      d
+                    leax      $6254,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0010
+                    pshs      d
+                    leax      L625B,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$001D
+                    pshs      d
+                    leax      L6264,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0012
+                    pshs      d
+                    leax      $6269,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0013
+                    pshs      d
+                    leax      $6270,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0014
+                    pshs      d
+                    leax      L6273,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0015
+                    pshs      d
+                    leax      L6279,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0016
+                    pshs      d
+                    leax      L627E,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0017
+                    pshs      d
+                    leax      L6285,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0018
+                    pshs      d
+                    leax      $628A,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0019
+                    pshs      d
+                    leax      L6290,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$001A
+                    pshs      d
+                    leax      L6299,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$001B
+                    pshs      d
+                    leax      $629C,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$001C
+                    pshs      d
+                    leax      L62A4,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0004
+                    pshs      d
+                    leax      L62A8,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0003
+                    pshs      d
+                    leax      L62AF,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0007
+                    pshs      d
+                    leax      L62B5,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    ldd       #$0008
+                    pshs      d
+                    leax      $62BE,pcr
+                    pshs      x
+                    lbsr      L5BD8
+                    leas      $04,s
+                    leax      L62C3,pcr
+                    pshs      x
+                    lbsr      L5B36
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       #$0001
+                    std       ,u
+                    ldd       #$000E
+                    std       $08,u
+                    ldd       #$0002
+                    std       $02,u
+                    leax      L62C9,pcr
+                    pshs      x
+                    lbsr      L5B36
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       #$0038
+                    std       ,u
+                    ldd       #$000C
+                    std       $08,u
+                    ldd       #$0004
+                    std       $02,u
+                    puls      pc,u
+L5ABF               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       #$0001
+                    bra       L5AD6
+
+L5ACA               ldb       $0065
+                    stb       ,u+
+                    lbsr      $635E
+                    ldd       ,s
+                    addd      #$0001
+L5AD6               std       ,s
+                    ldb       $0065
+                    sex
+                    pshs      d
+                    bsr       L5B0F
+                    std       ,s++
+                    beq       L5AEB
+                    ldd       ,s
+                    cmpd      #$0008
+                    ble       L5ACA
+L5AEB               ldd       ,s
+                    cmpd      #$0002
+                    bne       L5AF8
+                    ldd       #$005F
+                    stb       ,u+
+L5AF8               clra
+                    clrb
+                    stb       ,u
+                    bra       L5B01
+
+L5AFE               lbsr      $635E
+L5B01               ldb       $0065
+                    sex
+                    pshs      d
+                    bsr       L5B0F
+                    std       ,s++
+                    bne       L5AFE
+                    lbra      L5C58
+
+L5B0F               pshs      u
+                    ldd       $04,s
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6a
+                    beq       L5B2D
+                    ldd       $04,s
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    bne       L5B32
+L5B2D               ldd       #$0001
+                    bra       L5B34
+
+L5B32               clra
+                    clrb
+L5B34               puls      pc,u
+L5B36               pshs      u,y,x,d
+                    ldd       $0041
+                    beq       L5B42
+                    leax      $050C,y
+                    bra       L5B46
+
+L5B42               leax      $040C,y
+L5B46               tfr       x,d
+                    std       $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L5C0A
+                    leas      $02,s
+                    aslb
+                    rola
+                    addd      $02,s
+                    std       $04,s
+                    ldu       [$04,s]
+                    bra       L5B8B
+
+L5B5E               ldb       $14,u
+                    sex
+                    pshs      d
+                    ldb       [$0C,s]
+                    sex
+                    cmpd      ,s++
+                    bne       L5B88
+                    ldd       #$0008
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      $73C7
+                    leas      $06,s
+                    std       -$02,s
+                    beq       L5BD2
+L5B88               ldu       $12,u
+L5B8B               stu       -$02,s
+                    bne       L5B5E
+                    ldu       L0019
+                    beq       L5B9A
+                    ldd       $12,u
+                    std       L0019
+                    bra       L5BA6
+
+L5B9A               ldd       #$001C
+                    pshs      d
+                    lbsr      L5C2A
+                    leas      $02,s
+                    tfr       d,u
+L5BA6               ldd       #$0008
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    addd      ,s++
+                    pshs      d
+                    lbsr      $738A
+                    leas      $06,s
+                    clra
+                    clrb
+                    std       ,u
+                    clra
+                    clrb
+                    std       $08,u
+                    ldd       [$04,s]
+                    std       $12,u
+                    stu       [$04,s]
+                    ldd       $04,s
+                    std       $0e,u
+L5BD2               tfr       u,d
+                    leas      $06,s
+                    puls      pc,u
+L5BD8               pshs      u
+                    leas      -$09,s
+                    ldd       #$0008
+                    pshs      d
+                    ldd       $0f,s
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      $738A
+                    leas      $06,s
+                    clra
+                    clrb
+                    stb       $08,s
+                    leax      ,s
+                    pshs      x
+                    lbsr      L5B36
+                    leas      $02,s
+                    tfr       d,u
+                    ldd       #$0033
+                    std       ,u
+                    ldd       $0f,s
+                    std       $08,u
+                    leas      $09,s
+                    puls      pc,u
+L5C0A               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L5C18
+
+L5C14               ldd       $02,s
+                    addd      ,s
+L5C18               std       $02,s
+                    ldb       ,u+
+                    sex
+                    std       ,s
+                    bne       L5C14
+                    ldd       $02,s
+                    clra
+                    andb      #$7f
+                    leas      $04,s
+L5C28               puls      pc,u
+L5C2A               pshs      u,d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $784A
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L5C48
+                    leax      L62CF,pcr
+                    pshs      x
+                    lbsr      L022B
+                    leas      $02,s
+L5C48               ldd       L0066
+                    bne       L5C50
+                    ldd       ,s
+                    std       L0066
+L5C50               ldd       ,s
+                    addd      $06,s
+                    std       $0068
+                    ldd       ,s
+L5C58               leas      $02,s
+                    puls      pc,u
+L5C5C               pshs      u
+                    ldu       $06,s
+                    leas      -$10,s
+                    clra
+                    clrb
+                    std       $02,s
+                    leax      $08,s
+                    pshs      x
+                    bsr       L5C74
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L5C74               puls      x
+                    lbsr      $6A02
+                    leax      $08,s
+                    stx       ,s
+                    ldd       $14,s
+                    cmpd      #$0006
+                    bne       L5C8C
+                    leax      $10,s
+                    lbra      L5DC7
+
+L5C8C               ldb       $0065
+                    cmpb      #$30
+                    lbne      L5D99
+                    leas      -$06,s
+                    lbsr      $635E
+                    ldb       $0065
+                    cmpb      #$2e
+                    bne       L5CA8
+                    lbsr      $635E
+                    leax      $16,s
+                    lbra      L5DC7
+
+L5CA8               leax      $02,s
+                    pshs      x
+                    bsr       L5CB2
+                    neg       $0000
+                    neg       $0000
+L5CB2               puls      x
+                    lbsr      L74D6
+                    ldb       $0065
+                    cmpb      #$78
+                    beq       L5CC5
+                    ldb       $0065
+                    cmpb      #$58
+                    lbne      L5D3B
+L5CC5               leas      -$02,s
+                    bra       L5CFE
+
+L5CC9               leax      $04,s
+                    pshs      x
+                    leax      $06,s
+                    pshs      x
+                    ldd       #$0004
+                    lbsr      L74EC
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $06,s
+                    cmpd      #$0041
+                    blt       L5CEC
+                    ldd       #$0037
+                    bra       L5CEF
+
+L5CEC               ldd       #$0030
+L5CEF               pshs      d
+                    ldd       $08,s
+                    subd      ,s++
+                    lbsr      L74BD
+                    lbsr      $746C
+                    lbsr      L74D6
+L5CFE               lbsr      $635E
+                    ldb       $0065
+                    sex
+                    pshs      d
+                    lbsr      $61BF
+                    leas      $02,s
+                    std       ,s
+                    bne       L5CC9
+                    leas      $02,s
+                    bra       L5D47
+
+L5D13               leax      $02,s
+                    pshs      x
+                    leax      $04,s
+                    pshs      x
+                    ldd       #$0003
+                    lbsr      L74EC
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldb       $0065
+                    sex
+                    addd      #$FFD0
+                    lbsr      L74BD
+                    lbsr      $746C
+                    lbsr      L74D6
+                    lbsr      $635E
+L5D3B               ldb       $0065
+                    sex
+                    pshs      d
+                    lbsr      $61AC
+                    std       ,s++
+                    bne       L5D13
+L5D47               leax      $02,s
+                    stx       ,s
+                    ldb       $0065
+                    cmpb      #$4C
+                    beq       L5D57
+                    ldb       $0065
+                    cmpb      #$6C
+                    bne       L5D5F
+L5D57               lbsr      $635E
+                    leax      $16,s
+                    bra       L5D6E
+
+L5D5F               ldd       [,s]
+                    bne       L5D71
+                    ldd       $04,s
+                    std       ,u
+                    ldd       #$0001
+                    bra       L5D7D
+                    bra       L5D71
+
+L5D6E               leas      -$16,x
+L5D71               leax      ,u
+                    pshs      x
+                    leax      $04,s
+                    lbsr      L74D6
+                    ldd       #$0008
+L5D7D               leas      $16,s
+                    puls      pc,u
+                    bra       L5D99
+
+L5D84               ldb       $0065
+                    sex
+                    pshs      d
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      $549F
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L5DDD
+                    lbsr      $635E
+L5D99               ldb       $0065
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L5D84
+                    ldb       $0065
+                    cmpb      #$2e
+                    beq       L5DBC
+                    ldb       $0065
+                    cmpb      #$65
+                    beq       L5DBC
+                    ldb       $0065
+                    cmpb      #$45
+                    lbne      L5E98
+L5DBC               ldb       $0065
+                    cmpb      #$2e
+                    bne       L5DFC
+                    lbsr      $635E
+                    bra       L5DED
+
+L5DC7               leas      -$10,x
+                    bra       L5DED
+
+L5DCB               ldb       $0065
+                    sex
+                    pshs      d
+                    leax      $0a,s
+                    pshs      x
+                    lbsr      $549F
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L5DE3
+L5DDD               lbsr      $635E
+                    lbra      L5EA8
+
+L5DE3               lbsr      $635E
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+L5DED               ldb       $0065
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L5DCB
+L5DFC               ldb       $0065
+                    cmpb      #$45
+                    beq       L5E0A
+                    ldb       $0065
+                    cmpb      #$65
+                    lbne      L5E78
+L5E0A               ldd       #$0001
+                    std       $04,s
+                    lbsr      $635E
+                    ldb       $0065
+                    cmpb      #$2b
+                    bne       L5E1D
+                    lbsr      $635E
+                    bra       L5E2A
+
+L5E1D               ldb       $0065
+                    cmpb      #$2d
+                    bne       L5E2A
+                    lbsr      $635E
+                    clra
+                    clrb
+                    std       $04,s
+L5E2A               clra
+                    clrb
+                    std       $06,s
+                    bra       L5E49
+
+L5E30               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L7542
+                    pshs      d
+                    ldb       $0065
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    lbsr      $635E
+L5E49               ldb       $0065
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L5E30
+                    ldd       $06,s
+                    cmpd      #$0028
+                    lbge      L5EA8
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $06,s
+                    beq       L5E72
+                    ldd       $08,s
+                    nega
+                    negb
+                    sbca      #$00
+                    bra       L5E74
+
+L5E72               ldd       $08,s
+L5E74               addd      ,s++
+                    std       $02,s
+L5E78               ldd       $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    ldx       ,s
+                    stb       $07,x
+                    ldb       [,s]
+                    clra
+                    andb      #$7f
+                    stb       [,s]
+                    leax      ,u
+                    pshs      x
+                    leax      $0a,s
+                    lbsr      $6A02
+                    ldd       #$0006
+                    lbra      L5EFE
+
+L5E98               ldb       [,s]
+                    bne       L5EA8
+                    ldx       ,s
+                    ldb       $01,x
+                    bne       L5EA8
+                    ldx       ,s
+                    ldb       $02,x
+                    beq       L5EAD
+L5EA8               clra
+                    clrb
+                    lbra      L5EFE
+
+L5EAD               ldb       $0065
+                    cmpb      #$6C
+                    beq       L5EB9
+                    ldb       $0065
+                    cmpb      #$4C
+                    bne       L5ED8
+L5EB9               leas      -$02,s
+                    lbsr      $635E
+                    bra       L5EC3
+
+L5EC0               leas      -$12,x
+L5EC3               ldd       $02,s
+                    addd      #$0003
+                    std       ,s
+                    leax      ,u
+                    pshs      x
+                    ldx       $02,s
+                    lbsr      L74D6
+                    ldd       #$0008
+                    bra       L5EF9
+
+L5ED8               ldx       ,s
+                    ldb       $03,x
+                    bne       L5EE4
+                    ldx       ,s
+                    ldb       $04,x
+                    beq       L5EE9
+L5EE4               leax      $10,s
+                    bra       L5EC0
+
+L5EE9               leas      -$02,s
+                    ldd       $02,s
+                    addd      #$0005
+                    std       ,s
+                    ldd       [,s]
+                    std       ,u
+                    ldd       #$0001
+L5EF9               leas      $12,s
+                    puls      pc,u
+L5EFE               leas      $10,s
+                    puls      pc,u
+L5F03               pshs      u
+                    lbsr      $635E
+                    ldb       $0065
+                    cmpb      #$5C
+                    bne       L5F15
+                    lbsr      $6059
+                    std       $0061
+                    bra       L5F1D
+
+L5F15               ldb       $0065
+                    sex
+                    std       $0061
+                    lbsr      $635E
+L5F1D               ldb       $0065
+                    cmpb      #$27
+                    lbeq      $6008
+                    leax      $62DD,pcr
+                    pshs      x
+                    lbsr      L024E
+                    leas      $02,s
+                    lbra      $600B
+
+L5F33               pshs      u
+                    ldx       $000B
+                    bra       $5F67
+                    ldd       $006C
+                    bne       $5F5D
+                    leax      L62FD,pcr
+                    pshs      x
+                    leax      $01A9,y
+                    pshs      x
+                    lbsr      $6DF0
+                    leas      $04,s
+                    std       $006C
+                    bne       $5F5D
+                    leax      $0d,y
+                    bsr       L5F59
+                    ora       -$0C,y
+                    fcb       $10
+L5F59               lbsr      $022C
+                    leas      $02,s
+                    ldd       $006C
+                    bra       L5F64
+
+L5F62               ldd       $0025
+L5F64               std       L001B
+                    bra       L5F78
+                    stx       -$02,s
+                    beq       $5F3A
+                    cmpx      #$0002
+                    lbeq      $5F3A
+                    cmpx      #$0001
+                    beq       L5F62
+L5F78               clra
+                    clrb
+                    std       L0017
+                    ldd       $000B
+                    cmpd      #$0001
+                    beq       L5FA6
+                    ldd       L001B
+                    pshs      d
+                    ldd       #$006C
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldd       L001B
+                    pshs      d
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    std       $0061
+                    pshs      d
+                    lbsr      L6FAA
+                    leas      $04,s
+L5FA6               lbsr      L635F
+                    ldd       L001B
+                    pshs      d
+                    ldd       #$0073
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    bra       L5FEF
+
+L5FB9               leax      $060C,y
+                    pshs      x
+                    ldd       $006A
+                    subd      ,s++
+                    bne       L5FD2
+                    leax      $6319,pcr
+                    pshs      x
+                    lbsr      $024F
+                    leas      $02,s
+                    bra       L5FF5
+
+L5FD2               ldb       $0065
+                    cmpb      #$5C
+                    bne       L5FE3
+                    lbsr      L605A
+                    pshs      d
+                    bsr       L600E
+                    leas      $02,s
+                    bra       L5FEF
+
+L5FE3               ldb       $0065
+                    sex
+                    pshs      d
+                    bsr       L600E
+                    leas      $02,s
+                    lbsr      L635F
+L5FEF               ldb       $0065
+                    cmpb      #$22
+                    bne       L5FB9
+L5FF5               ldd       L001B
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldd       L0017
+                    addd      #$0001
+                    std       L0017
+                    lbsr      L635F
+                    puls      pc,u
+L600E               pshs      u
+                    ldd       $04,s
+                    beq       L601C
+                    ldd       $04,s
+                    cmpd      #$005C
+                    bne       L602A
+L601C               ldd       L001B
+                    pshs      d
+                    ldd       #$005C
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+L602A               ldd       L001B
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldd       L0017
+                    addd      #$0001
+                    std       L0017
+                    puls      pc,u
+                    pshs      u
+                    lbsr      $4BF0
+                    ldd       $04,s
+                    pshs      d
+                    leax      $632D,pcr
+                    pshs      x
+                    ldd       L001B
+                    pshs      d
+                    lbsr      $50E7
+                    leas      $06,s
+                    puls      pc,u
+L605A               pshs      u,d
+                    lbsr      L635F
+                    ldb       $0065
+                    sex
+                    tfr       d,u
+                    lbsr      L635F
+                    leax      ,u
+                    bra       L6095
+
+L606B               ldd       #$000A
+                    lbra      L61A9
+
+L6071               ldd       #$0009
+                    lbra      L61A9
+
+L6077               ldd       #$0008
+                    lbra      L61A9
+
+L607D               ldd       #$000B
+                    lbra      L61A9
+
+L6083               ldd       #$000D
+                    lbra      L61A9
+
+L6089               ldd       #$000C
+                    lbra      L61A9
+
+L608F               ldd       #$0020
+                    lbra      L61A9
+
+L6095               cmpx      #$006E
+                    beq       L6083
+                    cmpx      #$006C
+                    beq       L606B
+                    cmpx      #$0074
+                    beq       L6071
+                    cmpx      #$0062
+                    beq       L6077
+                    cmpx      #$0076
+                    beq       L607D
+                    cmpx      #$0072
+                    lbeq      L6083
+                    cmpx      #$0066
+                    beq       L6089
+                    cmpx      #$000D
+                    beq       L608F
+                    cmpu      #$0078
+                    lbne      L611B
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       $02,s
+                    tfr       d,u
+                    bra       L60F8
+
+L60D1               tfr       u,d
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0041
+                    bge       L60EC
+                    ldd       $02,s
+                    addd      #$FFD0
+                    bra       L60F1
+
+L60EC               ldd       $02,s
+                    addd      #$FFC9
+L60F1               addd      ,s++
+                    tfr       d,u
+                    lbsr      L635F
+L60F8               ldb       $0065
+                    sex
+                    pshs      d
+                    lbsr      L61C0
+                    leas      $02,s
+                    std       ,s
+                    beq       L6116
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+                    subd      #$0001
+                    cmpd      #$0002
+                    blt       L60D1
+L6116               leas      $02,s
+                    lbra      L61A7
+
+L611B               cmpu      #$0064
+                    bne       L6163
+                    clra
+                    clrb
+                    std       ,s
+                    tfr       d,u
+                    bra       L6140
+
+L6129               pshs      u
+                    ldd       #$000A
+                    lbsr      L7543
+                    pshs      d
+                    ldb       $0065
+                    sex
+                    addd      ,s++
+                    addd      #$FFD0
+                    tfr       d,u
+                    lbsr      L635F
+L6140               ldb       $0065
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    lbne      L61A7
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0003
+                    blt       L6129
+                    bra       L61A7
+
+L6163               pshs      u
+                    lbsr      L61AD
+                    std       ,s++
+                    beq       L61A7
+L616C               leau      -$30,u
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L618C
+
+L6175               tfr       u,d
+                    aslb
+L6178               rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    pshs      d
+                    ldb       $0065
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    tfr       d,u
+                    lbsr      L635F
+L618C               ldb       $0065
+                    sex
+                    pshs      d
+                    bsr       L61AD
+                    std       ,s++
+                    beq       L61A7
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0003
+                    blt       L6175
+L61A7               tfr       u,d
+L61A9               leas      $02,s
+                    puls      pc,u
+L61AD               pshs      u
+                    ldb       $05,s
+                    cmpb      #$37
+                    bgt       L61E9
+                    ldb       $05,s
+                    cmpb      #$30
+                    blt       L61E9
+                    ldd       #$0001
+                    bra       L61EB
+
+L61C0               pshs      u
+                    ldb       $05,s
+                    sex
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L61E4
+                    ldb       $05,s
+                    clra
+                    andb      #$5f
+                    stb       $05,s
+                    cmpd      #$0041
+                    blt       L61E9
+                    ldb       $05,s
+                    cmpb      #$46
+                    bgt       L61E9
+L61E4               ldb       $05,s
+                    sex
+                    bra       L61EB
+
+L61E9               clra
+                    clrb
+L61EB               puls      pc,u
+                    fcb       $62
+                    fcb       $61
+                    lsr       0,y
+                    com       $08,s
+                    fcb       $61
+                    fcb       $72
+                    fcb       $61
+                    com       -$0C,s
+                    fcb       $65
+                    fcb       $72
+L61FA               neg       $0063
+                    clr       $0e,s
+                    com       L7461
+                    jmp       -$0C,s
+                    bra       $6274
+                    ror       $6572
+                    ror       $0C,s
+                    clr       -$09,s
+L620C               neg       L0064
+                    clr       -$0b,s
+                    fcb       $62
+                    inc       $05,s
+L6213               neg       L0066
+                    inc       $0f,s
+                    fcb       $61
+                    lsr       >$0074
+                    rol       $7065
+                    lsr       $05,s
+L6220               ror       0,x
+                    com       L7461
+                    lsr       L6963
+L6228               neg       $0073
+                    rol       -$06,s
+                    fcb       $65
+                    clr       $06,s
+L622F               neg       L0069
+                    jmp       -$0C,s
+
+L6233               neg       L0069
+                    jmp       -$0C,s
+
+L6237               neg       L0066
+                    inc       $0f,s
+                    fcb       $61
+                    lsr       >$0063
+                    asl       $01,s
+                    fcb       $72
+L6242               neg       $0073
+                    asl       $0f,s
+                    fcb       $72
+                    lsr       >$0061
+                    fcb       $75
+                    lsr       $6F00
+                    fcb       $65
+                    asl       L7465
+                    fcb       $72
+                    jmp       0,x
+                    lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+L625B               neg       $0072
+                    fcb       $65
+                    asr       $09,s
+                    com       L7465
+                    fcb       $72
+L6264               neg       $0067
+                    clr       -$0C,s
+                    clr       0,x
+                    fcb       $72
+                    fcb       $65
+                    lsr       $7572
+                    jmp       0,x
+                    rol       $06,s
+L6273               neg       $0077
+                    asl       $09,s
+                    inc       $05,s
+L6279               neg       $0065
+                    inc       -$0d,s
+                    fcb       $65
+L627E               neg       $0073
+                    asr       $6974
+                    com       $08,s
+L6285               neg       $0063
+                    fcb       $61
+                    com       $6500
+                    fcb       $62
+                    fcb       $72
+                    fcb       $65
+                    fcb       $61
+                    fcb       $6b
+L6290               neg       $0063
+                    clr       $0e,s
+                    lsr       $696E
+                    fcb       $75
+                    fcb       $65
+L6299               neg       L0064
+                    clr       0,x
+                    lsr       $05,s
+                    ror       $01,s
+                    fcb       $75
+                    inc       -$0C,s
+L62A4               neg       L0066
+                    clr       -$0e,s
+L62A8               neg       $0073
+                    lsr       $7275
+                    com       -$0C,s
+L62AF               neg       $0075
+                    jmp       $09,s
+                    clr       $0e,s
+L62B5               neg       $0075
+                    jmp       -$0d,s
+                    rol       $07,s
+                    jmp       $05,s
+                    lsr       0,x
+                    inc       $0f,s
+                    jmp       $07,s
+
+L62C3               neg       $0065
+                    fcb       $72
+                    fcb       $72
+                    jmp       $0f,s
+
+L62C9               neg       $006C
+                    com       L6565
+                    fcb       $6b
+L62CF               neg       $006F
+                    fcb       $75
+                    lsr       $206F
+                    ror       0,y
+                    tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       >$0075
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    tst       $09,s
+                    jmp       $01,s
+                    lsr       $6564
+                    bra       L634F
+                    asl       $01,s
+                    fcb       $72
+                    fcb       $61
+                    com       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    bra       L6359
+                    clr       $0e,s
+                    com       L7461
+                    jmp       -$0C,s
+
+L62FD               neg       $0077
+                    bmi       L6301
+L6301               com       $01,s
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L6380
+                    lsr       $7269
+                    jmp       $07,s
+                    com       $2066
+                    rol       $0C,s
+                    fcb       $65
+                    neg       $0075
+                    jmp       -$0C,s
+                    fcb       $65
+                    fcb       $72
+                    tst       $09,s
+                    jmp       $01,s
+                    lsr       $6564
+                    bra       $639A
+                    lsr       $7269
+                    jmp       $07,s
+                    neg       L0020
+                    fcb       $72
+                    dec       L6220
+                    bcs       $6398
+                    tst       $0000
+L6336               pshs      u
+                    leax      $060C,y
+                    stx       $006A
+                    clra
+                    clrb
+                    stb       $060C,y
+                    ldd       #$0020
+                    bra       L636F
+                    pshs      u
+                    bra       L634F
+
+L634D               bsr       L635F
+L634F               ldb       $0065
+                    cmpb      #$20
+                    beq       L634D
+                    ldb       $0065
+                    cmpb      #$09
+L6359               lbeq      L634D
+                    puls      pc,u
+L635F               pshs      u
+                    ldx       $006A
+                    leax      $01,x
+                    stx       $006A
+                    ldb       -$01,x
+                    stb       $0065
+                    bne       L6371
+                    bsr       L6373
+L636F               stb       $0065
+L6371               puls      pc,u
+L6373               pshs      u
+                    leas      -$08,s
+                    ldd       L001D
+                    bne       L6389
+                    ldd       #$0001
+                    std       L001D
+L6380               leax      L6635,pcr
+                    stx       $006A
+                    lbra      L656A
+
+L6389               clra
+                    clrb
+                    std       L001D
+                    leax      $060C,y
+                    pshs      x
+                    leax      $070C,y
+                    pshs      x
+                    lbsr      L7315
+                    leas      $04,s
+L639E               lbsr      L65A7
+                    std       $006A
+                    lbeq      L64A8
+                    ldb       [$006A,y]
+                    cmpb      #$23
+                    lbne      L6563
+                    ldx       $006A
+                    ldb       $01,x
+                    sex
+                    std       $04,s
+                    lbsr      L65A7
+                    std       -$02,s
+                    lbeq      L64A8
+                    ldx       $04,s
+                    lbra      L652F
+
+L63C6               leax      $060C,y
+                    pshs      x
+                    lbsr      L6571
+                    leas      $02,s
+                    std       L0027
+                    bra       L639E
+
+L63D5               lbsr      L6804
+L63D8               lbsr      $4BF0
+                    leax      $060C,y
+                    pshs      x
+                    leax      $6636,pcr
+                    lbra      L645A
+
+L63E8               leax      $060C,y
+                    pshs      x
+                    leax      $03EE,y
+                    pshs      x
+                    lbsr      L7315
+                    leas      $04,s
+                    leax      $03EE,y
+                    pshs      x
+                    lbsr      $4C03
+                    leas      $02,s
+                    lbsr      L65A7
+                    std       -$02,s
+                    lbne      L639E
+                    lbra      L64A8
+
+L6410               leax      $060C,y
+                    pshs      x
+                    leax      $02EE,y
+                    pshs      x
+                    lbsr      L7315
+                    leas      $04,s
+                    lbsr      L65A7
+                    std       -$02,s
+                    lbeq      L64A8
+                    lbsr      $4BF0
+                    leax      $060C,y
+                    pshs      x
+                    lbsr      L6571
+                    std       ,s
+                    leax      $02EE,y
+                    pshs      x
+                    leax      L663A,pcr
+                    pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      $50E7
+                    leas      $08,s
+                    lbsr      $4BF0
+                    leax      $02EE,y
+                    pshs      x
+                    leax      L6650,pcr
+L645A               pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      $50E7
+                    leas      $06,s
+                    lbra      L639E
+
+L6468               leax      $060C,y
+                    pshs      x
+                    leax      $02EE,y
+                    pshs      x
+                    lbsr      L7315
+                    leas      $04,s
+                    lbsr      L65A7
+                    std       -$02,s
+                    beq       L64A8
+                    leax      $060C,y
+                    pshs      x
+                    lbsr      L6571
+                    leas      $02,s
+                    std       $06,s
+                    lbsr      L65A7
+                    std       -$02,s
+                    beq       L64A8
+                    leax      $060C,y
+                    pshs      x
+                    lbsr      L6571
+                    leas      $02,s
+                    std       $02,s
+                    lbsr      L65A7
+                    std       -$02,s
+                    bne       L64AE
+L64A8               ldd       #$FFFF
+                    lbra      L656D
+
+L64AE               ldd       $06,s
+                    beq       L64C9
+                    ldd       $06,s
+                    pshs      d
+                    leax      $03EE,y
+                    pshs      x
+                    leax      L6659,pcr
+                    pshs      x
+                    lbsr      L50D2
+                    leas      $06,s
+                    bra       L64D4
+
+L64C9               leax      $6667,pcr
+                    pshs      x
+                    lbsr      L50D2
+                    leas      $02,s
+L64D4               leax      $060C,y
+                    pshs      x
+                    leax      L6673,pcr
+                    pshs      x
+                    lbsr      L50D2
+                    leas      $04,s
+                    ldb       $02EE,y
+                    beq       L651F
+                    leax      $02EE,y
+                    pshs      x
+                    lbsr      L6E43
+                    leas      $02,s
+                    bra       L6508
+
+L64F8               leax      $01C1,y
+                    pshs      x
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+L6508               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L64F8
+                    leax      $6681,pcr
+                    pshs      x
+                    lbsr      L6E43
+                    leas      $02,s
+L651F               ldd       $04,s
+                    cmpd      #$0031
+                    lbne      L639E
+                    lbsr      L68C5
+                    lbra      L639E
+
+L652F               cmpx      #$0035
+                    lbeq      L63C6
+                    cmpx      #$0036
+                    lbeq      L63D5
+                    cmpx      #$0032
+                    lbeq      L63D8
+                    cmpx      #$0037
+                    lbeq      L63E8
+                    cmpx      #$0050
+                    lbeq      L6410
+                    cmpx      #$0030
+                    lbeq      L6468
+                    cmpx      #$0031
+                    lbeq      L6468
+                    lbra      L639E
+
+L6563               ldd       L0027
+L6565               addd      #$0001
+                    std       L0027
+L656A               ldd       #$0020
+L656D               leas      $08,s
+                    puls      pc,u
+L6571               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L658E
+
+L657B               ldd       ,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L7543
+                    pshs      d
+                    ldd       $04,s
+                    addd      #$FFD0
+                    addd      ,s++
+L658E               std       ,s
+                    ldb       ,u+
+                    sex
+                    std       $02,s
+                    leax      $0089,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$6b
+                    beq       L657B
+                    ldd       ,s
+                    leas      $04,s
+                    puls      pc,u
+L65A7               pshs      u,d
+                    leau      $060C,y
+                    ldd       L0023
+                    pshs      d
+                    lbsr      L7120
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    lbne      L6610
+                    ldx       L0023
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L65DD
+                    leax      $01CE,y
+                    pshs      x
+                    leax      $6683,pcr
+                    pshs      x
+                    lbsr      L6E65
+                    leas      $04,s
+                    lbsr      L68C5
+L65DD               clra
+                    clrb
+                    bra       L6631
+
+L65E1               ldx       ,s
+                    bra       L6602
+
+L65E5               clra
+                    clrb
+                    stb       ,u
+                    leax      $060C,y
+                    tfr       x,d
+                    bra       L6631
+
+L65F1               ldd       ,s
+                    stb       ,u+
+                    ldd       L0023
+                    pshs      d
+                    lbsr      L7120
+                    leas      $02,s
+                    std       ,s
+                    bra       L6610
+
+L6602               cmpx      #$000D
+                    beq       L65E5
+                    cmpx      #$FFFF
+                    lbeq      L65E5
+                    bra       L65F1
+
+L6610               cmpu      $0189,y
+                    bne       L65E1
+                    ldd       L0027
+                    addd      #$0001
+                    std       L0027
+                    std       L003F
+                    leax      $060C,y
+                    stx       $0063
+                    leax      >L66A6,pcr
+                    pshs      x
+                    lbsr      $022C
+                    leas      $02,s
+L6631               leas      $02,s
+                    puls      pc,u
+L6635               neg       $0025
+                    com       L0D00
+L663A               bra       $66AC
+                    fcb       $73,$65,$63,$74,$20,$25,$73,$2C
+                    fcb       $30,$2C,$30,$2C,$25,$64,$2C,$30
+                    fcb       $2C,$30,$0d,$00
+L6650               bra       $66C0
+                    fcb       $61
+                    tst       0,y
+                    bcs       $66CA
+                    tst       $0000
+L6659               bcs       $66CE
+                    bra       L6697
+                    bra       L66CB
+                    rol       $0e,s
+                    fcb       $65
+                    bra       L6689
+                    lsr       0,y
+                    neg       $0061
+                    fcb       $72
+                    asr       -$0b,s
+                    tst       $05,s
+                    jmp       -$0C,s
+                    bra       L66AB
+                    bra       L6673
+
+L6673               bpl       L669F
+                    bpl       L66A1
+                    bra       L669E
+                    com       L202A
+                    bpl       L66A8
+                    bpl       L668D
+                    neg       $005E
+                    neg       L0049
+                    fcb       $4e,$50,$55,$54,$20
+L6689               fcb       $46,$49,$4C,$45
+L668D               fcb       $20,$45,$52,$52,$4f,$52,$20,$3a
+                    fcb       $20,$54
+L6697               fcb       $45,$4d,$50,$4f,$52,$41,$52
+L669E               fcb       $59
+L669F               fcb       $20,$46
+L66A1               fcb       $49,$4C,$45,$0d,$00
+L66A6               rol       $0e,s
+L66A8               neg       $7574
+L66AB               bra       $6719
+                    rol       $0e,s
+                    fcb       $65
+                    bra       L6726
+                    clr       $0f,s
+                    bra       L6722
+                    clr       $0e,s
+                    asr       0,x
+L66BA               pshs      u
+                    lbsr      L6871
+                    lbra      L6718
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6815
+L66CB               leas      $02,s
+                    lbsr      $4BF0
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      $4B05
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    leax      L691E,pcr
+                    pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      $50E7
+                    bra       L6716
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6815
+                    leas      $02,s
+                    ldd       #$003A
+                    bra       L670A
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6815
+                    leas      $02,s
+                    ldd       #$0020
+L670A               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L671D
+L6716               leas      $06,s
+L6718               lbsr      L6825
+                    puls      pc,u
+L671D               pshs      u
+                    lbsr      $4BF0
+L6722               ldd       $06,s
+                    pshs      d
+L6726               ldb       $0b,s
+                    sex
+                    pshs      d
+                    ldd       $08,s
+                    addd      #$0014
+                    pshs      d
+                    leax      $6927,pcr
+                    pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      $50E7
+                    leas      $0a,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$0053
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldd       $0035
+                    bne       L6776
+                    ldd       $0025
+                    pshs      d
+                    ldd       L002B
+                    addd      #$0001
+                    std       L002B
+                    pshs      d
+                    lbsr      L6FAA
+                    leas      $04,s
+L6776               clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $6936,pcr
+                    pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      $50E7
+                    leas      $08,s
+                    ldd       L0037
+                    lbeq      L67E6
+                    ldd       $0025
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L6FAA
+                    bra       L67E4
+                    pshs      u
+                    ldd       #$0070
+                    pshs      d
+                    lbsr      $4A89
+                    leas      $02,s
+                    ldd       $0025
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6FAA
+                    leas      $04,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $693D,pcr
+                    pshs      x
+                    ldd       $0025
+                    pshs      d
+                    lbsr      $50E7
+                    leas      $08,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $0035
+                    bne       L67E6
+                    ldd       $0025
+                    pshs      d
+                    ldd       #$0045
+                    pshs      d
+                    lbsr      L6F05
+L67E4               leas      $04,s
+L67E6               puls      pc,u
+                    pshs      u
+                    lbsr      $4BF0
+                    leax      $6944,pcr
+                    bra       L67FC
+                    pshs      u
+                    lbsr      $4BF0
+                    leax      L6949,pcr
+L67FC               pshs      x
+                    lbsr      $4A48
+                    lbra      L691A
+
+L6804               pshs      u
+                    lbsr      $4BF0
+                    leax      L694E,pcr
+                    pshs      x
+                    lbsr      $4A9F
+                    lbra      L691A
+
+L6815               pshs      u
+                    ldd       $04,s
+                    beq       L6820
+                    ldd       #$0064
+                    bra       L682A
+
+L6820               ldd       #$0076
+                    bra       L682A
+
+L6825               pshs      u
+                    ldd       #$0065
+L682A               pshs      d
+                    lbsr      $4A89
+                    lbra      L691A
+
+L6832               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L7030
+                    leas      $02,s
+                    ldx       $04,s
+                    ldd       $02,x
+                    ldx       $04,s
+                    addd      $0b,x
+                    ldx       $04,s
+                    std       $04,x
+                    std       [$04,s]
+                    ldx       $04,s
+                    ldd       $06,x
+                    anda      #$FE
+                    andb      #$EF
+                    std       $06,x
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldx       $0a,s
+                    ldd       $08,x
+                    pshs      d
+                    lbsr      L77E4
+L6869               leas      $08,s
+                    ldd       $02C8,y
+                    puls      pc,u
+L6871               pshs      u
+                    ldd       $006C
+                    lbeq      L691C
+                    ldd       $006C
+                    pshs      d
+                    bsr       L6832
+                    leas      $02,s
+                    bra       L688E
+
+L6883               ldd       $0025
+                    pshs      d
+                    pshs      u
+                    lbsr      L6F05
+                    leas      $04,s
+L688E               ldd       $006C
+                    pshs      d
+                    lbsr      L7120
+                    leas      $02,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L6883
+                    ldx       $006C
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L68B1
+                    leax      $6951,pcr
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+L68B1               ldd       $006C
+                    pshs      d
+                    lbsr      L6FF6
+                    leas      $02,s
+                    leax      $01A9,y
+                    pshs      x
+                    lbsr      L7775
+                    bra       L691A
+
+L68C5               pshs      u,d
+                    ldd       $02D2,y
+                    beq       L68D3
+                    ldd       $02D2,y
+                    bra       L68D6
+
+L68D3               ldd       #$0001
+L68D6               std       ,s
+                    leax      $01C1,y
+                    pshs      x
+                    lbsr      L7030
+                    leas      $02,s
+                    ldd       $006C
+                    beq       L68FB
+                    ldd       $006C
+                    pshs      d
+                    lbsr      L6FF6
+                    leas      $02,s
+                    leax      $01A9,y
+                    pshs      x
+                    lbsr      L7775
+                    leas      $02,s
+L68FB               ldd       $001F
+                    beq       L6911
+                    ldd       L0023
+                    pshs      d
+                    lbsr      L6FF6
+                    leas      $02,s
+                    ldd       $001F
+                    pshs      d
+                    lbsr      L7775
+                    leas      $02,s
+L6911               ldd       ,s
+                    pshs      d
+                    lbsr      L794A
+                    leas      $02,s
+L691A               leas      $02,s
+L691C               puls      pc,u
+L691E               bra       $6992
+                    tst       $02,s
+                    bra       L6949
+                    lsr       $0d,x
+                    neg       $0025
+                    bgt       $6962
+                    com       $2563
+                    bra       L69A1
+                    tst       $02,s
+                    bra       L6958
+                    lsr       $0d,x
+                    neg       $0025
+                    bgt       L6971
+                    com       $2563
+                    neg       $0025
+                    bgt       $6978
+                    com       $2563
+                    neg       L0066
+                    com       $02,s
+                    bra       L6949
+
+L6949               ror       $04,s
+                    fcb       $62
+                    bra       L694E
+
+L694E               bpl       $6970
+                    neg       L0064
+                    fcb       $75
+                    tst       -$10,s
+                    com       $7472
+L6958               rol       $0e,s
+                    asr       -$0d,s
+L695C               neg       $0034
+                    nega
+                    leau      $02C6,y
+L6963               ldd       ,x
+                    std       ,u
+                    ldd       $02,x
+                    std       $02,u
+                    ldd       $04,x
+                    std       $04,u
+L696F               ldd       $06,x
+L6971               std       $06,u
+                    tfr       u,x
+                    puls      pc,u
+                    bsr       $695D
+                    lda       ,x
+                    eora      #$80
+                    sta       ,x
+L697F               rts
+                    bsr       L6985
+                    ldd       $02,x
+L6984               rts
+
+L6985               lda       ,x
+                    pshs      a
+                    bsr       $695D
+                    bsr       L6997
+                    leax      $03,x
+                    lda       ,s+
+                    bpl       L6996
+                    lbra      L749A
+
+L6996               rts
+
+L6997               lda       $07,x
+                    blt       L69C5
+                    pshs      x
+                    leax      $07,x
+                    pshs      x,a
+L69A1               bra       L69BD
+
+L69A3               ldx       $01,s
+                    ldb       #$06
+                    pshs      b
+                    clra
+L69AA               pshs      a
+                    lda       #$0a
+                    ldb       ,-x
+                    mul
+                    addb      ,s+
+                    adca      #$00
+                    stb       ,x
+                    dec       ,s
+                    bpl       L69AA
+                    leas      $01,s
+L69BD               dec       ,s
+                    bge       L69A3
+                    leas      $03,s
+                    puls      pc,x
+L69C5               pshs      u,x,a
+                    leau      $07,x
+                    pshs      u
+L69CB               cmpx      ,s
+                    bcc       L69FF
+                    lda       ,x+
+                    beq       L69CB
+                    leax      -$01,x
+                    pshs      x
+                    clrb
+                    asl       ,x
+                    rolb
+                    asl       ,x
+                    rolb
+                    asl       ,x
+                    rolb
+                    lda       #$05
+L69E3               asl       ,x
+                    rolb
+                    cmpb      #$0a
+                    bcs       L69EE
+                    subb      #$0a
+                    inc       ,x
+L69EE               deca
+                    bne       L69E3
+                    lda       #$08
+                    leax      $01,x
+                    cmpx      $02,s
+                    bcs       L69E3
+                    puls      x
+                    inc       $02,s
+                    bne       L69CB
+L69FF               leas      $03,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+                    exg       x,u
+                    ldd       ,u
+                    std       ,x
+                    ldd       $02,u
+                    std       $02,x
+                    ldd       $04,u
+                    std       $04,x
+                    ldd       $06,u
+                    std       $06,x
+                    puls      u
+                    puls      d
+                    std       ,s
+L6A1F               rts
+                    leax      $02C6,y
+                    std       -$02,s
+                    bpl       L6A3B
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $05,x
+                    lda       #$80
+L6A30               sta       ,x
+                    clra
+                    clrb
+                    std       $01,x
+                    std       $03,x
+                    sta       $07,x
+                    rts
+
+L6A3B               std       $05,x
+                    clra
+                    bra       L6A30
+                    pshs      u
+                    leau      $02C6,y
+                    clra
+                    clrb
+                    std       ,u
+                    std       $02,u
+                    ldd       ,x
+                    pshs      d
+                    std       $03,u
+                    ldd       $02,x
+                    std       $05,u
+                    clr       $07,u
+                    ldd       ,s++
+                    bpl       L6A70
+                    lda       #$80
+                    sta       ,u
+                    ldd       #$0000
+                    subd      $05,u
+                    std       $05,u
+                    ldd       #$0000
+                    sbcb      $04,u
+                    sbca      $03,u
+                    std       $03,u
+L6A70               tfr       u,x
+                    puls      pc,u
+                    pshs      u
+                    leax      L68C5,pcr
+                    pshs      x
+                    lbsr      L7914
+                    leas      $02,s
+                    leax      $01A9,y
+                    pshs      x
+                    lbsr      L6E85
+                    leas      $02,s
+                    leax      L6C19,pcr
+                    pshs      x
+                    ldd       $01A7,y
+                    pshs      d
+                    lbsr      L7315
+                    leas      $04,s
+                    lbsr      $589B
+                    leax      $01B4,y
+                    stx       L0023
+                    leax      $01C1,y
+                    stx       $0025
+                    lbra      L6BA1
+
+L6AAF               ldx       $06,s
+                    leax      $02,x
+                    stx       $06,s
+                    ldu       ,x
+                    ldb       ,u
+                    cmpb      #$2d
+                    lbne      L6B6C
+                    lbra      L6B5E
+
+L6AC2               ldb       ,u
+                    sex
+                    tfr       d,x
+                    lbra      L6B3B
+
+L6ACA               ldd       #$0001
+                    std       $0021
+                    lbra      L6B5E
+
+L6AD2               ldd       #$0001
+                    std       $0035
+                    lbra      L6B5E
+
+L6ADA               ldd       L0039
+                    addd      #$0001
+                    std       L0039
+                    lbra      L6B5E
+
+L6AE4               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L6B15
+                    leax      L6C21,pcr
+                    pshs      x
+                    leau      $01,u
+                    pshs      u
+                    lbsr      L6DF1
+                    leas      $04,s
+                    std       $0025
+                    bne       L6B15
+                    pshs      u
+                    leax      $6C23,pcr
+                    pshs      x
+                    leax      $01CE,y
+                    pshs      x
+                    lbsr      $50E7
+                    leas      $06,s
+                    lbsr      L6BFE
+L6B15               leax      ,s
+                    bra       L6B68
+
+L6B19               ldd       #$0001
+                    std       L0037
+                    bra       L6B5E
+
+L6B20               ldb       ,u
+                    sex
+                    pshs      d
+                    leax      L6C32,pcr
+                    pshs      x
+                    leax      $01CE,y
+                    pshs      x
+                    lbsr      $50E7
+                    leas      $06,s
+                    lbsr      L6BFE
+                    bra       L6B5E
+
+L6B3B               cmpx      #$0065
+                    lbeq      L6ACA
+                    cmpx      #$0073
+                    lbeq      L6AD2
+                    cmpx      #$006E
+                    lbeq      L6ADA
+                    cmpx      #$006F
+                    lbeq      L6AE4
+                    cmpx      #$0070
+                    beq       L6B19
+                    bra       L6B20
+
+L6B5E               leau      $01,u
+                    ldb       ,u
+                    lbne      L6AC2
+                    bra       L6BA1
+
+L6B68               leas      ,x
+                    bra       L6BA1
+
+L6B6C               ldd       $0072
+                    bne       L6BA1
+                    ldd       $0072
+                    addd      #$0001
+                    std       $0072
+                    leax      $01B4,y
+                    pshs      x
+                    leax      L6C46,pcr
+                    pshs      x
+                    ldd       [$0a,s]
+                    pshs      d
+                    lbsr      L6E10
+                    leas      $06,s
+                    std       L0023
+                    bne       L6B9C
+                    leax      $6C48,pcr
+                    pshs      x
+                    lbsr      $022C
+                    leas      $02,s
+L6B9C               ldd       [$06,s]
+                    std       $001F
+L6BA1               ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    lbgt      L6AAF
+                    lbsr      L6336
+                    lbsr      $552F
+                    bra       L6BB7
+
+L6BB4               lbsr      $322B
+L6BB7               ldd       $005F
+                    cmpd      #$FFFF
+                    bne       L6BB4
+                    lbsr      L66BA
+                    ldx       $0025
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    beq       L6BD6
+                    leax      $6C5E,pcr
+                    pshs      x
+                    lbsr      $022C
+                    leas      $02,s
+L6BD6               leax      $01C1,y
+                    pshs      x
+                    lbsr      L7030
+                    leas      $02,s
+                    ldd       L0029
+                    beq       L6BFC
+                    ldd       L0029
+                    pshs      d
+                    leax      $6C7F,pcr
+                    pshs      x
+                    leax      $01CE,y
+                    pshs      x
+                    lbsr      $50E7
+                    leas      $06,s
+                    bsr       L6BFE
+L6BFC               puls      pc,u
+L6BFE               pshs      u
+                    ldd       $001F
+                    beq       L6C0D
+                    ldd       $001F
+                    pshs      d
+                    lbsr      L7775
+                    leas      $02,s
+L6C0D               ldd       #$0001
+                    pshs      d
+                    lbsr      L7944
+                    leas      $02,s
+                    puls      pc,u
+L6C19               clrb
+                    lsr       -$0b,s
+                    tst       $0d,s
+                    rol       $5F00
+L6C21               asr       >$0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L6C54
+                    com       L0D00
+L6C32               fcb       $75,$6e,$6b,$6e,$6f,$77,$6e,$20
+                    fcb       $66,$6C,$61,$67,$20,$3a,$20,$2d
+                    fcb       $25,$63,$0d,$00
+L6C46               fcb       $72
+                    neg       $0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L6CBD
+
+L6C54               jmp       -$10,s
+                    fcb       $75
+                    lsr       $2066
+                    rol       $0C,s
+                    fcb       $65
+                    neg       $0065
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       L6CDC
+                    fcb       $72
+                    rol       -$0C,s
+                    rol       $0e,s
+                    asr       0,y
+                    fcb       $61
+                    com       $7365
+                    tst       $02,s
+                    inc       -$07,s
+                    bra       $6CD9
+                    clr       $04,s
+                    fcb       $65
+                    bra       $6CE1
+                    rol       $0C,s
+                    fcb       $65
+                    neg       $0065
+                    fcb       $72,$72,$6f,$72,$73,$20,$69,$6e
+                    fcb       $20,$63,$6f,$6d,$70,$69,$6C,$61
+                    fcb       $74,$69,$6f,$6e,$20,$3a,$20,$25
+                    fcb       $64,$0d,$00
+L6C9B               pshs      u
+                    leau      $01B4,y
+L6CA1               ldd       $06,u
+                    clra
+                    andb      #$03
+                    lbeq      L6D12
+                    leau      $0d,u
+                    pshs      u
+                    leax      $0284,y
+                    cmpx      ,s++
+                    bhi       L6CA1
+                    ldd       #$00C8
+                    std       $02D2,y
+L6CBD               lbra      L6D16
+                    puls      pc,u
+L6CC2               pshs      u
+                    ldu       $08,s
+                    bne       L6CCC
+                    bsr       L6C9B
+                    tfr       d,u
+L6CCC               stu       -$02,s
+                    beq       L6D16
+                    ldd       $04,s
+                    std       $08,u
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$2b
+                    beq       L6CE4
+L6CDC               ldx       $06,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L6CEA
+L6CE4               ldd       $06,u
+                    orb       #$03
+                    bra       L6D08
+
+L6CEA               ldd       $06,u
+                    pshs      d
+                    ldb       [$08,s]
+                    cmpb      #$72
+                    beq       L6CFC
+                    ldb       [$08,s]
+                    cmpb      #$64
+                    bne       L6D01
+L6CFC               ldd       #$0001
+                    bra       L6D04
+
+L6D01               ldd       #$0002
+L6D04               ora       ,s+
+                    orb       ,s+
+L6D08               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+L6D12               tfr       u,d
+                    puls      pc,u
+L6D16               clra
+                    clrb
+                    puls      pc,u
+L6D1A               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $0a,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L6D4B
+
+L6D2D               ldx       $0a,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L6D3A
+                    ldd       #$0007
+                    bra       L6D42
+
+L6D3A               ldd       #$0004
+                    bra       L6D42
+
+L6D3F               ldd       #$0003
+L6D42               std       ,s
+                    bra       L6D5B
+
+L6D46               leax      $04,s
+                    lbra      L6DB3
+
+L6D4B               stx       -$02,s
+                    beq       L6D5B
+                    cmpx      #$0078
+                    beq       L6D2D
+                    cmpx      #$002B
+                    beq       L6D3F
+                    bra       L6D46
+
+L6D5B               ldb       [$0a,s]
+                    sex
+                    tfr       d,x
+L6D61               lbra      L6DC0
+
+L6D64               ldd       ,s
+                    orb       #$01
+                    bra       L6DA6
+
+L6D6A               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      L770E
+                    leas      $04,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L6D95
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L77E4
+                    leas      $08,s
+                    bra       L6DDA
+
+L6D95               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      L772F
+                    bra       L6DAD
+
+L6DA2               ldd       ,s
+                    orb       #$81
+L6DA6               pshs      d
+                    pshs      u
+                    lbsr      L770E
+L6DAD               leas      $04,s
+                    std       $02,s
+                    bra       L6DDA
+
+L6DB3               leas      -$04,x
+L6DB5               ldd       #$00CB
+                    std       $02D2,y
+                    clra
+                    clrb
+                    bra       L6DDC
+
+L6DC0               cmpx      #$0072
+                    lbeq      L6D64
+                    cmpx      #$0061
+                    lbeq      L6D6A
+                    cmpx      #$0077
+                    beq       L6D95
+                    cmpx      #$0064
+                    beq       L6DA2
+                    bra       L6DB5
+
+L6DDA               ldd       $02,s
+L6DDC               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      L6E3C
+
+L6DF1               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L6D1A
+                    leas      $04,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L6E0C
+                    clra
+                    clrb
+                    bra       L6E41
+
+L6E0C               clra
+                    clrb
+                    bra       L6E34
+
+L6E10               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6FF6
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L6D1A
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L6E32
+                    clra
+                    clrb
+                    bra       L6E41
+
+L6E32               ldd       $08,s
+L6E34               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+L6E3C               lbsr      L6CC2
+                    leas      $06,s
+L6E41               puls      pc,u
+L6E43               pshs      u
+                    leax      $01C1,y
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    bsr       L6E65
+                    leas      $04,s
+                    leax      $01C1,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    puls      pc,u
+L6E65               pshs      u
+                    ldu       $04,s
+                    leas      -$01,s
+                    bra       L6E7B
+
+L6E6D               ldd       $07,s
+                    pshs      d
+                    ldb       $02,s
+                    sex
+L6E74               pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+L6E7B               ldb       ,u+
+                    stb       ,s
+                    bne       L6E6D
+                    leas      $01,s
+                    puls      pc,u
+L6E85               pshs      u,d
+                    ldu       $06,s
+                    bra       L6E8D
+
+L6E8B               leau      $01,u
+L6E8D               ldb       ,u
+                    sex
+                    std       ,s
+                    beq       L6E9C
+                    ldd       ,s
+                    cmpd      #$0058
+                    bne       L6E8B
+L6E9C               ldd       ,s
+                    beq       L6EB2
+                    lbsr      L78CF
+                    pshs      d
+                    leax      >L6EB8,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      $5100
+                    leas      $06,s
+L6EB2               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+L6EB8               bcs       L6F1E
+L6EBA               neg       $0034
+                    nega
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    bra       L6EF6
+
+L6EC5               clra
+                    clrb
+                    std       ,s
+                    bra       L6EE2
+
+L6ECB               ldd       $0e,s
+                    pshs      d
+                    ldb       ,u+
+                    sex
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldx       $0e,s
+                    ldd       $06,x
+                    clra
+                    andb      #$20
+                    bne       L6EFF
+L6EE2               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      $0a,s
+                    blt       L6ECB
+                    ldd       $02,s
+                    addd      #$0001
+L6EF6               std       $02,s
+                    ldd       $02,s
+                    cmpd      $0C,s
+                    blt       L6EC5
+L6EFF               ldd       $02,s
+                    leas      $04,s
+                    puls      pc,u
+L6F05               pshs      u
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       L6F29
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+L6F1E               lbne      L7041
+                    pshs      u
+                    lbsr      L7274
+                    leas      $02,s
+L6F29               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       L6F65
+                    ldd       #$0001
+                    pshs      d
+                    leax      $07,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L6F4A
+                    leax      L77D4,pcr
+                    bra       L6F4E
+
+L6F4A               leax      L77BB,pcr
+L6F4E               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       L6FA6
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      L7041
+
+L6F65               ldd       $06,u
+                    anda      #$01
+L6F69               clrb
+                    std       -$02,s
+                    bne       L6F75
+                    pshs      u
+                    lbsr      L705E
+                    leas      $02,s
+L6F75               ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L6F9B
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L6FA6
+                    ldd       $04,s
+                    cmpd      #$000D
+                    bne       L6FA6
+L6F9B               pshs      u
+                    lbsr      L705E
+                    std       ,s++
+                    lbne      L7041
+L6FA6               ldd       $04,s
+                    puls      pc,u
+L6FAA               pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      L766D
+                    pshs      d
+                    lbsr      L6F05
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L6F05
+                    lbra      L7118
+
+L6FCD               pshs      u,d
+                    leau      $01B4,y
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L6FE3
+
+L6FD9               tfr       u,d
+                    leau      $0d,u
+                    pshs      d
+                    bsr       L6FF6
+                    leas      $02,s
+L6FE3               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    blt       L6FD9
+                    lbra      L705A
+
+L6FF6               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       L7006
+                    ldd       $06,u
+                    bne       L700C
+L7006               ldd       #$FFFF
+                    lbra      L705A
+
+L700C               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       L701B
+                    pshs      u
+                    bsr       L7030
+                    leas      $02,s
+                    bra       L701D
+
+L701B               clra
+                    clrb
+L701D               std       ,s
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L771D
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $06,u
+                    ldd       ,s
+                    bra       L705A
+
+L7030               pshs      u
+                    ldu       $04,s
+                    beq       L7041
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       L7046
+L7041               ldd       #$FFFF
+                    puls      pc,u
+L7046               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L7056
+                    pshs      u
+                    lbsr      L7274
+                    leas      $02,s
+L7056               pshs      u
+                    bsr       L705E
+L705A               leas      $02,s
+                    puls      pc,u
+L705E               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L7090
+                    ldd       ,u
+                    cmpd      $04,u
+L7072               beq       L7090
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L711C
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L77E4
+                    leas      $08,s
+L7090               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      L7108
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L7108
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L70DF
+                    ldd       $02,u
+                    bra       L70D7
+
+L70B0               ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L77D4
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L70CD
+                    leax      $04,s
+                    bra       L70F7
+
+L70CD               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+L70D7               std       ,u
+                    ldd       $02,s
+                    bne       L70B0
+                    bra       L7108
+
+L70DF               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L77BB
+                    leas      $06,s
+                    cmpd      $02,s
+                    beq       L7108
+                    bra       L70F9
+
+L70F7               leas      -$04,x
+L70F9               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       L7118
+
+L7108               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+L7118               leas      $04,s
+                    puls      pc,u
+L711C               pshs      u
+                    puls      pc,u
+L7120               pshs      u
+                    ldu       $04,s
+                    beq       L716C
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L716C
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L7148
+                    ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldb       ,x
+                    clra
+                    lbra      L7272
+
+L7148               pshs      u
+                    lbsr      L71BB
+                    lbra      L7270
+                    pshs      u
+                    ldu       $06,s
+                    beq       L716C
+                    ldd       $06,u
+                    clra
+                    andb      #$01
+                    beq       L716C
+                    ldd       $04,s
+                    cmpd      #$FFFF
+                    beq       L716C
+                    ldd       ,u
+                    cmpd      $02,u
+                    bhi       L7171
+L716C               ldd       #$FFFF
+                    puls      pc,u
+L7171               ldd       ,u
+                    addd      #$FFFF
+                    std       ,u
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      L7120
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L71A6
+                    pshs      u
+                    lbsr      L7120
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L71AB
+L71A6               ldd       #$FFFF
+                    bra       L71B7
+
+L71AB               ldd       $02,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      L7684
+                    addd      ,s
+L71B7               leas      $04,s
+                    puls      pc,u
+L71BB               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$31
+                    cmpd      #$8001
+                    beq       L71E1
+                    ldd       $06,u
+                    clra
+                    andb      #$31
+                    cmpd      #$0001
+                    lbne      L725A
+                    pshs      u
+                    lbsr      L7274
+                    leas      $02,s
+L71E1               leax      $01B4,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L71FE
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L71FE
+                    leax      $01C1,y
+                    pshs      x
+                    lbsr      L7030
+                    leas      $02,s
+L71FE               ldd       $06,u
+                    clra
+                    andb      #$08
+                    beq       L722A
+                    ldd       $0b,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L721E
+                    leax      L77AB,pcr
+                    bra       L7222
+
+L721E               leax      L778A,pcr
+L7222               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    bra       L723C
+
+L722A               ldd       #$0001
+                    pshs      d
+                    leax      $0a,u
+                    stx       $02,u
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L778A
+L723C               leas      $06,s
+                    std       ,s
+                    ldd       ,s
+                    bgt       L725F
+                    ldd       $06,u
+                    pshs      d
+                    ldd       $02,s
+                    beq       L7251
+                    ldd       #$0020
+                    bra       L7254
+
+L7251               ldd       #$0010
+L7254               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+L725A               ldd       #$FFFF
+                    bra       L7270
+
+L725F               ldd       $02,u
+                    addd      #$0001
+                    std       ,u
+                    ldd       $02,u
+                    addd      ,s
+                    std       $04,u
+                    ldb       [$02,u]
+                    clra
+L7270               leas      $02,s
+L7272               puls      pc,u
+L7274               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       L72AC
+                    leas      -$20,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L769F
+                    leas      $06,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       L72A0
+                    ldd       #$0040
+                    bra       L72A3
+
+L72A0               ldd       #$0080
+L72A3               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $20,s
+L72AC               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       L72B9
+                    puls      pc,u
+L72B9               ldd       $0b,u
+                    bne       L72CE
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L72C9
+                    ldd       #$0080
+                    bra       L72CC
+
+L72C9               ldd       #$0100
+L72CC               std       $0b,u
+L72CE               ldd       $02,u
+                    bne       L72E3
+                    ldd       $0b,u
+                    pshs      d
+                    lbsr      L78A2
+                    leas      $02,s
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       L72EB
+L72E3               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       L72FA
+
+L72EB               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+L72FA               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+L7300               std       ,u
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+L7308               ldb       ,u+
+                    bne       L7308
+                    tfr       u,d
+                    subd      $04,s
+                    addd      #$FFFF
+                    puls      pc,u
+L7315               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L731F               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L731F
+                    bra       L7354
+                    pshs      u
+                    ldu       $06,s
+L7331               leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L7337               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L7337
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L7348               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L7348
+L7354               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    bra       L7370
+
+L7360               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L736E
+                    clra
+                    clrb
+                    puls      pc,u
+L736E               leau      $01,u
+L7370               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L7360
+                    ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+                    puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L7395               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L73B9
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L7395
+                    bra       L73B9
+
+L73AF               clra
+                    clrb
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L73B9               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L73AF
+                    lbra      L7448
+                    pshs      u
+                    ldu       $04,s
+                    bra       L73DE
+
+L73CE               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L73DC
+                    clra
+                    clrb
+                    puls      pc,u
+L73DC               leau      $01,u
+L73DE               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    ble       L73F8
+                    ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L73CE
+L73F8               ldd       $08,s
+                    bge       L7400
+                    clra
+                    clrb
+                    bra       L740B
+
+L7400               ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+L740B               puls      pc,u
+                    pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L7417               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L7417
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L7428               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L7440
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L7428
+L7440               ldd       $0a,s
+                    bge       L7448
+                    clra
+                    clrb
+                    stb       [,s]
+L7448               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+L7452               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    stb       ,u+
+                    bgt       L7452
+                    ldb       -$01,u
+                    clra
+L7461               andb      #$7f
+                    stb       -$01,u
+L7465               clra
+                    clrb
+                    stb       ,u
+                    ldd       $04,s
+                    puls      pc,u
+                    ldd       $04,s
+L746F               addd      $02,x
+                    std       $02C8,y
+                    ldd       $02,s
+                    adcb      $01,x
+                    adca      ,x
+                    std       $02C6,y
+                    lbra      L7525
+                    ldd       $04,s
+                    subd      $02,x
+                    std       $02C8,y
+                    ldd       $02,s
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       $02C6,y
+L7494               lbra      L7525
+                    lbsr      L7534
+L749A               ldd       #$0000
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+L74A8               std       ,x
+                    rts
+                    ldd       ,x
+                    coma
+                    comb
+                    std       $02C6,y
+                    ldd       $02,x
+                    coma
+                    comb
+                    leax      $02C6,y
+                    std       $02,x
+L74BD               rts
+                    leax      $02C6,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+                    rts
+                    leax      $02C6,y
+                    std       $02,x
+                    clr       ,x
+L74D4               clr       $01,x
+L74D6               rts
+                    pshs      y
+                    ldy       $04,s
+                    ldd       ,x
+                    std       ,y
+                    ldd       $02,x
+                    std       $02,y
+                    puls      x
+                    exg       y,x
+                    puls      d
+                    std       ,s
+L74EC               rts
+                    ldx       $02,s
+                    pshs      b
+                    lbsr      L7534
+                    puls      b
+                    tstb
+                    beq       L7504
+L74F9               asl       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    decb
+                    bne       L74F9
+L7504               puls      d
+                    std       ,s
+                    rts
+                    ldx       $02,s
+                    pshs      b
+                    lbsr      L7534
+                    puls      b
+                    tstb
+                    beq       L7520
+L7515               asr       ,x
+                    ror       $01,x
+                    ror       $02,x
+                    ror       $03,x
+                    decb
+                    bne       L7515
+L7520               puls      d
+                    std       ,s
+                    rts
+
+L7525               tfr       cc,a
+                    puls      x
+                    stx       $02,s
+                    leas      $02,s
+                    leax      $02C6,y
+                    tfr       a,cc
+                    rts
+
+L7534               ldd       ,x
+                    std       $02C6,y
+                    ldd       $02,x
+                    leax      $02C6,y
+L7540               std       $02,x
+L7542               rts
+
+L7543               tsta
+                    bne       L7558
+                    tst       $02,s
+                    bne       L7558
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+L7558               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L7575
+                    inc       ,s
+L7575               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L7582
+                    inc       ,s
+L7582               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+                    rts
+                    clr       $080C,y
+                    leax      >L75DE,pcr
+                    stx       $080d,y
+                    bra       L75B8
+                    leax      >L75F7,pcr
+                    stx       $080d,y
+                    clr       $080C,y
+                    tst       $02,s
+                    bpl       L75B8
+                    inc       $080C,y
+L75B8               subd      #$0000
+                    bne       L75C3
+                    puls      x
+                    ldd       ,s++
+                    jmp       ,x
+
+L75C3               ldx       $02,s
+                    pshs      x
+                    jsr       [$080d,y]
+                    ldd       ,s
+                    std       $02,s
+                    tfr       x,d
+                    tst       $080C,y
+                    beq       L75DB
+                    nega
+                    negb
+                    sbca      #$00
+L75DB               std       ,s++
+                    rts
+
+L75DE               subd      #$0000
+                    beq       L75ED
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    bra       L761B
+
+L75ED               puls      d
+                    std       ,s
+                    ldd       #$002D
+L75F4               lbra      L7690
+
+L75F7               subd      #$0000
+                    beq       L75ED
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    tsta
+                    bpl       L760F
+                    nega
+                    negb
+                    sbca      #$00
+                    inc       $01,s
+                    std       $02,s
+L760F               ldd       $06,s
+                    bpl       L761B
+                    nega
+                    negb
+                    sbca      #$00
+                    com       $01,s
+                    std       $06,s
+L761B               lda       #$01
+L761D               inca
+                    asl       $03,s
+                    rol       $02,s
+                    bpl       L761D
+                    sta       ,s
+                    ldd       $06,s
+                    clr       $06,s
+                    clr       $07,s
+L762C               subd      $02,s
+                    bcc       L7636
+                    addd      $02,s
+                    andcc     #$FE
+                    bra       L7638
+
+L7636               orcc      #$01
+L7638               rol       $07,s
+                    rol       $06,s
+                    lsr       $02,s
+                    ror       $03,s
+                    dec       ,s
+                    bne       L762C
+                    std       $02,s
+                    tst       $01,s
+                    beq       L7652
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+L7652               ldx       $04,s
+                    ldd       $06,s
+                    std       $04,s
+                    stx       $06,s
+                    ldx       $02,s
+                    ldd       $04,s
+L765E               leas      $06,s
+L7660               rts
+                    tstb
+                    beq       L7677
+L7664               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L7664
+                    bra       L7677
+
+L766D               tstb
+                    beq       L7677
+L7670               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L7670
+L7677               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+L7681               leas      $04,s
+L7683               rts
+
+L7684               tstb
+                    beq       L7677
+L7687               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       L7687
+                    bra       L7677
+
+L7690               std       $02D2,y
+                    pshs      y,b
+                    os9       F$ID
+                    puls      y,b
+                    os9       F$Send
+                    rts
+
+L769F               lda       $05,s
+                    ldb       $03,s
+                    beq       L76D2
+                    cmpb      #$01
+                    beq       L76D4
+                    cmpb      #$06
+                    beq       L76D4
+                    cmpb      #$02
+                    beq       L76BA
+                    cmpb      #$05
+                    beq       L76BA
+                    ldb       #$D0
+                    lbra      L7936
+
+L76BA               pshs      u
+                    os9       I$GetStt
+                    bcc       L76C6
+                    puls      u
+                    lbra      L7936
+
+L76C6               stx       [$08,s]
+                    ldx       $08,s
+                    stu       $02,x
+                    puls      u
+                    clra
+                    clrb
+                    rts
+
+L76D2               ldx       $06,s
+L76D4               os9       I$GetStt
+                    lbra      L793F
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       L76E9
+                    cmpb      #$02
+                    beq       L76F1
+                    ldb       #$D0
+                    lbra      L7936
+
+L76E9               ldx       $06,s
+                    os9       I$SetStt
+                    lbra      L793F
+
+L76F1               pshs      u
+                    ldx       $08,s
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u
+                    lbra      L793F
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    bcs       L770B
+                    os9       I$Close
+L770B               lbra      L793F
+
+L770E               ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    lbcs      L7936
+                    tfr       a,b
+                    clra
+                    rts
+
+L771D               lda       $03,s
+                    os9       I$Close
+                    lbra      L793F
+                    ldx       $02,s
+                    ldb       $05,s
+                    os9       I$MakDir
+                    lbra      L793F
+
+L772F               ldx       $02,s
+                    lda       $05,s
+                    tfr       a,b
+                    andb      #$24
+                    orb       #$0b
+                    os9       I$Create
+                    bcs       L7742
+L773E               tfr       a,b
+                    clra
+                    rts
+
+L7742               cmpb      #$DA
+                    lbne      L7936
+                    lda       $05,s
+                    bita      #$80
+                    lbne      L7936
+                    anda      #$07
+                    ldx       $02,s
+                    os9       I$Open
+                    lbcs      L7936
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+L7769               bcc       L773E
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+                    lbra      L7936
+
+L7775               ldx       $02,s
+                    os9       I$Delete
+                    lbra      L793F
+                    lda       $03,s
+                    os9       I$Dup
+                    lbcs      L7936
+                    tfr       a,b
+                    clra
+                    rts
+
+L778A               pshs      y
+                    ldx       $06,s
+                    lda       $05,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$Read
+L7798               bcc       L77A7
+                    cmpb      #$D3
+                    bne       L77A2
+                    clra
+                    clrb
+                    puls      pc,y,x
+L77A2               puls      y,x
+                    lbra      L7936
+
+L77A7               tfr       y,d
+                    puls      pc,y,x
+L77AB               pshs      y
+                    lda       $05,s
+                    ldx       $06,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$ReadLn
+                    bra       L7798
+
+L77BB               pshs      y
+                    ldy       $08,s
+                    beq       L77D0
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$Write
+L77C9               bcc       L77D0
+                    puls      y
+                    lbra      L7936
+
+L77D0               tfr       y,d
+                    puls      pc,y
+L77D4               pshs      y
+                    ldy       $08,s
+                    beq       L77D0
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$WritLn
+                    bra       L77C9
+
+L77E4               pshs      u
+                    ldd       $0a,s
+                    bne       L77F2
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       L7826
+
+L77F2               cmpd      #$0001
+                    beq       L781D
+                    cmpd      #$0002
+                    beq       L7812
+                    ldb       #$F7
+L7800               clra
+                    std       $02D2,y
+                    ldd       #$FFFF
+                    leax      $02C6,y
+                    std       ,x
+                    std       $02,x
+                    puls      pc,u
+L7812               lda       $05,s
+                    ldb       #$02
+                    os9       I$GetStt
+                    bcs       L7800
+                    bra       L7826
+
+L781D               lda       $05,s
+                    ldb       #$05
+                    os9       I$GetStt
+                    bcs       L7800
+L7826               tfr       u,d
+                    addd      $08,s
+                    std       $02C8,y
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       L7800
+                    tfr       d,x
+                    std       $02C6,y
+                    lda       $05,s
+                    os9       I$Seek
+                    bcs       L7800
+                    leax      $02C6,y
+                    puls      pc,u
+                    ldd       $02C4,y
+                    pshs      d
+                    ldd       $04,s
+                    cmpd      $080f,y
+                    bcs       L787F
+                    addd      $02C4,y
+                    pshs      y
+                    subd      ,s
+                    os9       F$Mem
+                    tfr       y,d
+                    puls      y
+                    bcc       L7871
+                    ldd       #$FFFF
+                    leas      $02,s
+                    rts
+
+L7871               std       $02C4,y
+                    addd      $080f,y
+                    subd      ,s
+                    std       $080f,y
+L787F               leas      $02,s
+                    ldd       $080f,y
+                    pshs      d
+                    subd      $04,s
+                    std       $080f,y
+                    ldd       $02C4,y
+                    subd      ,s++
+                    pshs      d
+                    clra
+                    ldx       ,s
+L7898               sta       ,x+
+                    cmpx      $02C4,y
+                    bcs       L7898
+                    puls      pc,d
+L78A2               ldd       $02,s
+                    addd      $02CE,y
+                    bcs       L78CB
+                    cmpd      $02D0,y
+                    bcc       L78CB
+                    pshs      d
+                    ldx       $02CE,y
+                    clra
+L78B8               cmpx      ,s
+                    bcc       L78C0
+                    sta       ,x+
+                    bra       L78B8
+
+L78C0               ldd       $02CE,y
+                    puls      x
+                    stx       $02CE,y
+                    rts
+
+L78CB               ldd       #$FFFF
+                    rts
+
+L78CF               pshs      y
+                    os9       F$ID
+                    puls      y
+                    bcc       L78DC
+                    lbcs      L7936
+L78DC               tfr       a,b
+                    clra
+                    rts
+
+L78E0               pshs      y
+                    os9       F$ID
+                    bcc       L78EC
+L78E7               puls      y
+                    lbra      L7936
+
+L78EC               tfr       y,d
+                    puls      pc,y
+                    pshs      y
+                    bsr       L78E0
+                    std       -$02,s
+                    beq       L78FC
+                    ldb       #$D6
+                    bra       L78E7
+
+L78FC               ldy       $04,s
+                    os9       F$SUser
+                    bcc       L7910
+                    cmpb      #$D0
+                    bne       L78E7
+                    tfr       y,d
+                    ldy       >$004B
+                    std       $09,y
+L7910               clra
+                    clrb
+                    puls      pc,y
+L7914               pshs      u
+                    tfr       y,u
+                    ldx       $04,s
+                    stx       $0811,y
+                    leax      >L792A,pcr
+                    os9       F$Icpt
+                    puls      u
+                    lbra      L793F
+
+L792A               tfr       u,y
+                    clra
+                    pshs      d
+                    jsr       [$0811,y]
+                    leas      $02,s
+                    rti
+
+L7936               clra
+                    std       $02D2,y
+                    ldd       #$FFFF
+                    rts
+
+L793F               bcs       L7936
+L7941               clra
+                    clrb
+                    rts
+
+L7944               lbsr      L794F
+L7947               lbsr      L6FCD
+L794A               ldd       $02,s
+L794C               os9       F$Exit
+L794F               rts
+                    neg       $0003
+                    neg       $0000
+                    adca      #$02
+                    jmp       $0078
+                    bra       $79BF
+                    asl       $7065
+                    com       -$0C,s
+                    fcb       $65
+                    lsr       0,x
+                    beq       L7974
+                    com       $00E8
+                    neg       L0064
+                    neg       $000A
+                    neg       $0000
+                    neg       $0000
+L796E               neg       $0000
+L7970               neg       $0000
+                    neg       $0000
+L7974               neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    tst       0,u
+                    rol       0,x
+                    neg       $0054
+                    fcb       $41
+                    asl       $0d,y
+                    bgt       L79D7
+                    negb
+                    leax      $03,u
+                    fcb       $45
+                    comb
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    fcb       $6b
+                    ble       $79CE
+                    tstb
+                    asl       L5F64
+                    neg       $006A
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0b,y
+                    ror       $0C,y
+                    rolb
+                    dec       0,x
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+L79D7               dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    dec       $0a,s
+                    bvs       $7A3F
+                    bpl       $7A2D
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    rol       $0000
+                    neg       $0000
+                    tst       $000E
+                    neg       $0000
+                    neg       $000E
+                    inc       $0001
+                    jmp       $000F
+                    tst       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0003
+                    neg       $000A
+                    fcb       $02
+                    dec       $0003
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    asr       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    ror       $0000
+                    jmp       $0000
+                    asr       $000B
+                    neg       $0001
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $000C
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    stx       $0063
+                    com       $7472
+                    bgt       $7AE8
+                    aslb
+                    aslb
+                    aslb
+                    aslb
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0003
+                    neg       $0001
+                    fcb       $01
+                    adca      #$01
+                    sta       $03,s
+                    bgt       $7BE2
+                    fcb       $61
+
+                    emod
+eom                 equ       *
+                    end

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -8683,8 +8683,7 @@ L4F4F               ldd       $06,u
                     leax      ,s
                     pshs      x
                     bsr       L4F63
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00
 L4F63               puls      x
                     lbsr      L74D3
                     ldd       $0025
@@ -8712,10 +8711,7 @@ L4F8B               ldd       $06,u
                     leax      ,s
                     pshs      x
                     bsr       L4FA3
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
 L4FA3               puls      x
                     lbsr      L69FF
                     ldd       $0025
@@ -10217,10 +10213,7 @@ L5C59               pshs      u
                     leax      $08,s
                     pshs      x
                     bsr       L5C71
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
 L5C71               puls      x
                     lbsr      L69FF
                     leax      $08,s
@@ -10246,8 +10239,7 @@ L5C89               ldb       $0065
 L5CA5               leax      $02,s
                     pshs      x
                     bsr       L5CAF
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00
 L5CAF               puls      x
                     lbsr      L74D3
                     ldb       $0065

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       3987
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.pass1/
                     fcb       edition
 
-L0015               lda       ,y+
+copybytes           lda       ,y+
 L0017               sta       ,u+
 L0019               leax      -$01,x
-L001B               bne       L0015
+L001B               bne       copybytes
 L001D               rts
 
-start               pshs      y
+_start              pshs      y
 L0020               pshs      u
 L0022               clra
 L0023               clrb
@@ -37,12 +37,12 @@ L0031               pshs      x
 L0033               leay      L794C,pcr
 L0037               ldx       ,y++
 L0039               beq       L003F
-L003B               bsr       L0015
+L003B               bsr       copybytes
 L003D               ldu       $02,s
 L003F               leau      >$0076,u
 L0043               ldx       ,y++
 L0045               beq       L004A
-L0047               bsr       L0015
+L0047               bsr       copybytes
 L0049               clra
 L004A               cmpu      ,s
 L004D               beq       L0053
@@ -60,7 +60,7 @@ L0064               leax      ,u
 L0066               lbsr      L0163
 L0069               leas      $04,s
 L006B               puls      x
-L006D               stx       $02C4,u
+                    stx       $02C4,u
                     sty       $0284,u
 L0076               ldd       #$0001
                     std       $02C0,u
@@ -125,23 +125,21 @@ L00E1               leax      $0284,u
                     rol       -$04,s
                     clr       ,-s
                     clr       ,-s
-                    lbsr      L7941
+                    lbsr      exit
                     leax      $0813,y
 L0100               stx       $02CE,y
                     sts       $02C2,y
                     sts       $02D0,y
                     ldd       #$FF82
-L0111               leax      d,s
+stkcheck            leax      d,s
 L0113               cmpx      $02D0,y
                     bcc       L0123
                     cmpx      $02CE,y
                     bcs       L013D
                     stx       $02D0,y
 L0123               rts
-L0124               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+L0124               fcc       /**** STACK OVERFLOW ****/
+                    fcb       $0D
 L013D               leax      L0124,pcr
                     ldb       #$CF
                     pshs      b
@@ -362,7 +360,7 @@ L0314               cmpu      #$0000
 L0324               ldd       L0029
                     addd      #$0001
                     std       L0029
-                    cmpd      #start
+                    cmpd      #_start
                     ble       L0349
                     leax      $01CE,y
                     pshs      x
@@ -471,7 +469,7 @@ L0429               ldd       $005F
                     lbne      L04C9
                     ldx       $0061
                     ldd       $08,x
-                    cmpd      #start
+                    cmpd      #_start
                     bra       L0471
                     pshs      u
 L043F               ldd       $005F
@@ -482,7 +480,7 @@ L043F               ldd       $005F
                     lbeq      L04FB
                     cmpx      #$000D
                     lbeq      L04FB
-                    cmpx      #start
+                    cmpx      #_start
                     lbeq      L04FB
                     cmpx      #$0010
                     lbeq      L04FB
@@ -577,70 +575,34 @@ L051F               puls      pc,u
 L0521               bcs       L0596
                     bra       L055F
                     bra       L0527
-
-L0527               tst       -$0b,s
-                    inc       -$0C,s
-                    rol       -$10,s
-                    inc       $05,s
-                    bra       L0595
-                    fcb       $65
-                    ror       $09,s
-                    jmp       $09,s
-                    lsr       L696F
-                    jmp       0,x
-
-L053B               com       $0f,s
-                    tst       -$10,s
-                    rol       $0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L05AA
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       $0578
-                    bra       L054D
-
-L054D               inc       $09,s
-                    jmp       $05,s
-                    bra       $0578
-                    lsr       0,y
-                    bra       L0557
-
+L0527               fcc       /multiple definition/
+                    fcb       $00
+L053B               fcc       /compiler error - /
+                    fcb       $00
+L054D               fcc       /line %d  /
+                    fcb       $00
 L0557               bpl       L0583
                     bpl       $0585
                     bra       L057D
                     bcs       $05D2
-L055F               bra       $0581
+L055F               bra       L0581
                     bpl       $058D
                     bpl       $058F
                     tst       $0000
-L0567               fcb       $5e
+L0567               fcb       $5E
                     neg       $0074
-                    clr       $0f,s
-                    bra       $05DB
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       L05D8
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    com       $202D
-                    bra       L05BD
-                    fcb       $42
-L057D               clra
-                    fcb       $52
-                    lsrb
-                    neg       $0034
-                    nega
+                    fcc       /oo many errors - AB/
+L057D               fcb       $4F,$52,$54
+                    fcb       $00
+L0581               pshs      u
 L0583               ldd       #$FFA2
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L0695
                     std       $0C,s
                     lbne      L067A
                     clra
-L0595               clrb
+                    clrb
 L0596               lbra      L0691
                     lbra      L067A
 
@@ -651,7 +613,7 @@ L059C               ldd       $005F
                     std       ,s
                     ldd       L003F
                     std       $04,s
-L05AA               ldd       $0063
+                    ldd       $0063
                     std       $02,s
                     lbsr      $552C
                     ldx       $0a,s
@@ -660,7 +622,7 @@ L05AA               ldd       $0063
 L05B5               ldd       $0a,s
                     cmpd      #$00A0
                     blt       L05C5
-L05BD               ldd       $0a,s
+                    ldd       $0a,s
                     cmpd      #$00A9
                     ble       L05DA
 L05C5               ldd       $08,s
@@ -672,11 +634,11 @@ L05CE               cmpx      #$0064
                     beq       L05DA
                     cmpx      #$0078
                     beq       L05DA
-L05D8               bra       L05B5
+                    bra       L05B5
 
 L05DA               ldd       ,s
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
@@ -695,7 +657,7 @@ L05DA               ldd       ,s
                     std       $04,s
                     ldd       #$0003
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     leas      $02,s
                     std       $06,s
                     beq       L0638
@@ -759,7 +721,7 @@ L0691               leas      $0e,s
                     puls      pc,u
 L0695               pshs      u
                     ldd       #$FFA4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$0C,s
                     ldu       #$0000
                     ldx       $005F
@@ -807,7 +769,7 @@ L06CC               lbsr      $552C
 L06FA               clra
                     clrb
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
@@ -891,7 +853,7 @@ L0782               ldd       L003F
 L07A6               clra
                     clrb
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     leas      $02,s
                     std       $0a,s
                     bne       L07B8
@@ -995,7 +957,7 @@ L086F               ldd       $0063
 L08A0               lbsr      $552C
                     ldd       #$0002
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     leas      $02,s
                     std       $0a,s
                     bne       L08D4
@@ -1154,7 +1116,7 @@ L09F1               leas      $0C,s
                     puls      pc,u
 L09F5               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldu       #$0000
                     bra       L0A04
@@ -1164,7 +1126,7 @@ L0A04               ldd       $005F
                     beq       L0A4C
                     ldd       #$0002
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     leas      $02,s
                     std       ,s
                     beq       L0A3F
@@ -1196,11 +1158,11 @@ L0A4C               tfr       u,d
                     bra       L0A98
                     pshs      u
 L0A52               ldd       #$FFB8
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      $0581
+                    lbsr      L0581
                     std       ,s
                     lbsr      L0F19
                     leas      $02,s
@@ -1231,7 +1193,7 @@ L0A98               leas      $02,s
                     puls      pc,u
 L0A9C               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $005F
                     bra       L0AF5
 
@@ -1284,7 +1246,7 @@ L0AF5               cmpx      #$0041
                     puls      pc,u
 L0B22               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     lbra      L0C94
 
@@ -1508,7 +1470,7 @@ L0D00               lbeq      L0BE3
                     puls      pc,u
 L0D48               pshs      u
                     ldd       #$FFA2
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$0e,s
                     ldd       L003F
                     std       $04,s
@@ -1537,7 +1499,7 @@ L0D48               pshs      u
                     leas      $02,s
                     ldd       $06,s
                     beq       L0D99
-                    leax      $0EF7,pcr
+                    leax      L0EF7,pcr
                     pshs      x
                     lbsr      L024C
                     leas      $02,s
@@ -1574,7 +1536,7 @@ L0D99               ldd       $02,s
                     puls      pc,u
 L0DD4               pshs      u
 L0DD6               ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       L002D
                     beq       L0DE8
                     ldu       L002D
@@ -1606,7 +1568,7 @@ L0DF4               ldd       $04,s
                     puls      pc,u
 L0E16               pshs      u
 L0E18               ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leax      L0F06,pcr
                     pshs      x
                     lbsr      L024C
@@ -1614,7 +1576,7 @@ L0E18               ldd       #$FFBA
 
 L0E2A               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       [$04,s]
                     ldx       $06,u
                     bra       L0E7D
@@ -1662,74 +1624,23 @@ L0E7D               cmpx      #$0034
                     lbeq      L0E6E
                     lbra      L0E39
                     puls      pc,u
-L0E98               lsr       L6869
-                    fcb       $72
-                    lsr       0,y
-                    fcb       $65
-                    asl       L7072
-                    fcb       $65
-                    com       $7369
-                    clr       $0e,s
-                    bra       L0F17
-                    rol       -$0d,s
-                    com       $696E
-                    asr       0,x
-L0EB1               clr       -$10,s
-                    fcb       $65
-                    fcb       $72
-                    fcb       $61
-                    jmp       $04,s
-                    bra       $0F1F
-                    asl       $7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-L0EC2               neg       $7269
-                    tst       $01,s
-                    fcb       $72
-                    rol       L2065
-                    asl       $7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-L0ED3               com       $0f,s
-                    jmp       -$0d,s
-                    lsr       $616E
-                    lsr       L2072
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L0EE5               com       $0f,s
-                    jmp       -$0d,s
-                    lsr       $616E
-                    lsr       $206F
-                    neg       $6572
-                    fcb       $61
-                    lsr       $6F72
-                    neg       $006E
-                    fcb       $61
-                    tst       $05,s
-                    bra       L0F66
-                    jmp       0,y
-                    fcb       $61
-                    bra       $0F65
-                    fcb       $61
-                    com       L7400
-L0F06               fcb       $65
-                    asl       L7072
-                    fcb       $65
-                    com       $7369
-                    clr       $0e,s
-                    bra       $0F7F
-                    rol       -$0d,s
-                    com       $696E
-L0F17               asr       0,x
+L0E98               fcc       /third expression missing/
+                    fcb       $00
+L0EB1               fcc       /operand expected/
+                    fcb       $00
+L0EC2               fcc       /primary expected/
+                    fcb       $00
+L0ED3               fcc       /constant required/
+                    fcb       $00
+L0EE5               fcc       /constant operator/
+                    fcb       $00
+L0EF7               fcc       /name in a cast/
+                    fcb       $00
+L0F06               fcc       /expression missing/
+                    fcb       $00
 L0F19               pshs      u
 L0F1B               ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0C,s
                     stu       -$02,s
@@ -1762,7 +1673,7 @@ L0F57               pshs      u
                     ldd       $0a,u
                     std       $0a,s
                     ldd       $0C,u
-L0F66               std       $08,s
+                    std       $08,s
                     ldd       $06,u
                     std       $04,s
                     cmpd      #$0064
@@ -1838,7 +1749,7 @@ L1000               tfr       u,d
                     puls      pc,u
 L1006               pshs      u
 L1008               ldd       #$FFA8
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0e,s
                     stu       -$02,s
@@ -2204,7 +2115,7 @@ L1320               leas      $0e,s
                     puls      pc,u
 L1324               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L136A
@@ -2232,7 +2143,7 @@ L136A               clra
                     puls      pc,u
 L136E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leax      L2676,pcr
                     pshs      x
                     lbsr      L024C
@@ -2240,7 +2151,7 @@ L136E               pshs      u
                     puls      pc,u
 L1383               pshs      u
 L1385               ldd       #$FF9C
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$14,s
                     ldx       $18,s
                     ldu       $0a,x
@@ -2265,7 +2176,7 @@ L1385               ldd       #$FF9C
                     std       $10,s
                     ldx       $10,s
                     ldd       $08,x
-                    cmpd      #start
+                    cmpd      #_start
                     bne       L13E7
                     leax      L2685,pcr
                     pshs      x
@@ -2423,7 +2334,7 @@ L150A               lbsr      $24D4
                     andb      #$30
                     cmpd      #$0020
                     bne       L1543
-L1528               leax      $269E,pcr
+L1528               leax      L269E,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -2475,7 +2386,7 @@ L1569               ldx       $18,s
                     ldd       $06,u
                     cmpd      #$006F
                     bne       L15BA
-L15A3               leax      $26AA,pcr
+L15A3               leax      L26AA,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -2527,7 +2438,7 @@ L15D7               std       $06,s
                     stu       $18,s
                     bra       L163B
 
-L1619               leax      $26BD,pcr
+L1619               leax      L26BD,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0294
@@ -3345,7 +3256,7 @@ L1D55               ldd       $02,u
                     lbra      L1E26
 
 L1D69               leas      -$14,x
-                    leax      $2722,pcr
+                    leax      L2722,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3376,7 +3287,7 @@ L1D7D               ldd       ,u
                     ldx       $12,s
                     cmpd      $02,x
                     beq       L1DC8
-L1DB5               leax      $2730,pcr
+L1DB5               leax      L2730,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3437,7 +3348,7 @@ L1E2B               ldd       $0e,s
                     leax      $14,s
                     lbra      $1C74
 
-L1E39               leax      $2741,pcr
+L1E39               leax      L2741,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
@@ -3551,7 +3462,7 @@ L1F91               pshs      u
                     bne       L1FA7
                     ldd       $08,u
                     beq       L1FBD
-L1FA7               leax      $274C,pcr
+L1FA7               leax      L274C,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0296
@@ -3586,7 +3497,7 @@ L1FE2               std       ,s
                     leas      $04,s
                     bra       L2022
 
-L1FEE               leax      $275B,pcr
+L1FEE               leax      L275B,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0296
@@ -3643,17 +3554,17 @@ L205B               ldd       #$0001
                     pshs      d
                     pshs      u
                     lbsr      L202A
-L2065               leas      $04,s
+                    leas      $04,s
                     ldd       $0a,s
                     pshs      d
                     pshs      u
                     lbsr      L202A
                     leas      $04,s
-L2072               lbra      L2306
+                    lbra      L2306
 
 L2075               cmpx      #$0001
                     beq       L2043
-L207A               cmpx      #$0007
+                    cmpx      #$0007
                     lbeq      L2043
                     cmpx      #$0008
                     beq       L2048
@@ -4148,7 +4059,7 @@ L24B3               bne       L24BF
                     ldd       ,u
                     cmpd      #$0004
                     lbne      L25B4
-L24BF               leax      $2766,pcr
+L24BF               leax      L2766,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0296
@@ -4237,7 +4148,7 @@ L256A               ldd       #$0036
                     bra       L2589
 
 L2587               leas      -$02,x
-L2589               leax      $278A,pcr
+L2589               leax      L278A,pcr
                     pshs      x
                     pshs      u
                     lbsr      L0296
@@ -4337,204 +4248,52 @@ L265F               pshs      u
                     lbsr      L0296
                     leas      $04,s
 L2676               puls      pc,u
-                    lsr       $09,s
-                    ror       $6964
-                    fcb       $65
-                    bra       L26E2
-                    rol       L207A
-                    fcb       $65
-                    fcb       $72
-L2685               clr       0,x
-                    lsr       L7970
-                    fcb       $65
-                    lsr       $05,s
-                    ror       0,y
-                    blt       $26B1
-                    jmp       $0f,s
-                    lsr       $2061
-                    bra       L270E
-                    fcb       $61
-                    fcb       $72
-                    rol       $01,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       $0063
-                    fcb       $61
-                    jmp       $0e,s
-                    clr       -$0C,s
-                    bra       L270B
-                    fcb       $61
-                    com       L7400
-                    com       $01,s
-                    jmp       $07,y
-                    lsr       $2074
-                    fcb       $61
-                    fcb       $6b
-                    fcb       $65
-                    bra       $2719
-                    lsr       $04,s
-                    fcb       $72
-                    fcb       $65
-                    com       L7300
-                    neg       L6F69
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $273A
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-L26CE               lsr       0,x
-                    neg       L6F69
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $2748
-                    fcb       $72
-                    bra       L2745
-                    jmp       -$0C,s
-                    fcb       $65
-                    asr       $05,s
-                    fcb       $72
-L26E2               bra       $2756
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-L26EA               lsr       0,x
-                    jmp       $0f,s
-                    lsr       $2061
-                    bra       L2759
-                    fcb       $75
-                    jmp       $03,s
-                    lsr       L696F
-L26F9               jmp       0,x
-                    fcb       $62
-                    clr       -$0C,s
-                    asl       0,y
-                    tst       -$0b,s
-                    com       $7420
-                    fcb       $62
-                    fcb       $65
-                    bra       $2772
-                    jmp       -$0C,s
-L270B               fcb       $65
-                    asr       -$0e,s
-L270E               fcb       $61
-L270F               inc       0,x
-                    neg       L6F69
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L2787
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       $6368
-                    neg       $0074
-                    rol       $7065
-                    bra       L2795
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       $6368
-                    neg       $0070
-                    clr       $09,s
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       $27A6
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       $6368
-                    neg       $0074
-                    rol       $7065
-L2745               bra       L27AA
-                    asl       $05,s
-                    com       $0b,s
-                    neg       $0073
-                    asl       $0f,s
-                    fcb       $75
-                    inc       $04,s
-                    bra       $27B6
-                    fcb       $65
-                    bra       L27A5
-                    fcb       $55
-                    inca
-L2759               inca
-                    neg       $0074
-                    rol       $7065
-                    bra       $27C6
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $006C
-                    ror       L616C
-                    fcb       $75
-                    fcb       $65
-                    bra       $27E0
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L2776               fcb       $75
-                    jmp       $04,s
-                    fcb       $65
-                    com       $0C,s
-                    fcb       $61
-                    fcb       $72
-                    fcb       $65
-                    lsr       0,y
-                    ror       $6172
-                    rol       $01,s
-                    fcb       $62
-L2787               inc       $05,s
-                    neg       $0073
-                    lsr       $7275
-                    com       -$0C,s
-                    bra       $27FF
-                    fcb       $65
-                    tst       $02,s
-L2795               fcb       $65
-                    fcb       $72
-                    bra       $280B
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L27A1               com       $7472
-                    fcb       $75
-L27A5               com       -$0C,s
-                    fcb       $75
-                    fcb       $72
-                    fcb       $65
-L27AA               bra       $281B
-                    fcb       $72
-                    bra       L2824
-                    jmp       $09,s
-                    clr       $0e,s
-                    bra       $281E
-                    jmp       $01,s
-                    neg       L7072
-                    clr       -$10,s
-                    fcb       $72
-                    rol       $01,s
-                    lsr       $6500
-L27C2               tst       -$0b,s
-                    com       $7420
-                    fcb       $62
-                    fcb       $65
-                    bra       L2834
-                    jmp       -$0C,s
-                    fcb       $65
-                    asr       -$0e,s
-                    fcb       $61
-                    inc       0,x
+                    fcc       /divide by zer/
+L2685               fcb       $6F
+                    fcb       $00
+                    fcc       /typedef - not a variabl/
+L269E               fcb       $65
+                    fcb       $00
+                    fcc       /cannot cas/
+L26AA               fcb       $74
+                    fcb       $00
+                    fcc       /can't take addres/
+L26BD               fcb       $73
+                    fcb       $00
+                    fcc       /pointer require/
+L26CE               fcb       $64
+                    fcb       $00
+                    fcc       /pointer or integer require/
+L26EA               fcb       $64
+                    fcb       $00
+                    fcc       /not a functio/
+L26F9               fcb       $6E
+                    fcb       $00
+                    fcc       /both must be integra/
+L270F               fcb       $6C
+                    fcb       $00
+                    fcc       /pointer mismatch/
+                    fcb       $00
+L2722               fcc       /type mismatch/
+                    fcb       $00
+L2730               fcc       /pointer mismatch/
+                    fcb       $00
+L2741               fcc       /type check/
+                    fcb       $00
+L274C               fcc       /should be NULL/
+                    fcb       $00
+L275B               fcc       /type error/
+                    fcb       $00
+L2766               fcc       /lvalue required/
+                    fcb       $00
+L2776               fcc       /undeclared variable/
+                    fcb       $00
+L278A               fcc       /struct member required/
+                    fcb       $00
+L27A1               fcc       /structure or union inappropriate/
+                    fcb       $00
+L27C2               fcc       /must be integral/
+                    fcb       $00
 L27D3               pshs      u
                     ldd       #$FFBA
                     lbsr      L0113
@@ -4581,7 +4340,7 @@ L282A               lbsr      L2FA1
                     lbra      L290E
 
 L2830               leax      L316D,pcr
-L2834               pshs      x
+                    pshs      x
                     lbsr      L024E
                     leas      $02,s
                     lbsr      L552E
@@ -4895,7 +4654,7 @@ L2A8D               pshs      u
 
 L2AFB               ldd       #$0001
                     pshs      d
-                    pshs      u
+L2B00               pshs      u
                     lbsr      L202A
                     leas      $04,s
                     bra       L2B31
@@ -5069,7 +4828,7 @@ L2C5C               pshs      u
                     bsr       L2C9A
 L2C6D               ldd       $02D4,y
                     beq       L2C7E
-                    leax      $31A1,pcr
+                    leax      L31A1,pcr
                     pshs      x
                     lbsr      L024E
                     bra       L2C8E
@@ -5089,7 +4848,7 @@ L2C93               pshs      d
 L2C9A               pshs      u
                     ldd       #$FFBA
                     lbsr      L0113
-                    leax      $31B3,pcr
+                    leax      L31B3,pcr
                     pshs      x
                     lbsr      L024E
 L2CAB               leas      $02,s
@@ -5132,7 +4891,7 @@ L2CAF               pshs      u
                     ldd       $0061
                     cmpd      #$0014
                     beq       L2D1A
-L2D0F               leax      $31C7,pcr
+L2D0F               leax      L31C7,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -5409,7 +5168,7 @@ L2F63               pshs      u
                     lbsr      L552E
                     ldd       L0055
                     bne       L2F7F
-                    leax      $31E2,pcr
+                    leax      L31E2,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -5438,7 +5197,7 @@ L2FA1               pshs      u
                     ldd       $005F
                     cmpd      #$0034
                     beq       L2FC1
-                    leax      $31F1,pcr
+                    leax      L31F1,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -5614,7 +5373,7 @@ L3111               pshs      u
                     lbsr      L24D6
                     bra       L313D
 
-L3134               leax      $3219,pcr
+L3134               leax      L3219,pcr
                     pshs      x
                     lbsr      L024E
 L313D               leas      $02,s
@@ -5639,115 +5398,28 @@ L3143               pshs      u
                     lbsr      L0396
 L3169               leas      $02,s
 L316B               puls      pc,u
-L316D               jmp       $0f,s
-                    bra       $3198
-                    rol       $06,s
-                    beq       $3195
-                    ror       $0f,s
-                    fcb       $72
-                    bra       $31A1
-                    fcb       $65
-                    inc       -$0d,s
-                    fcb       $65
-                    beq       L3180
-L3180               rol       $0C,s
-                    inc       $05,s
-                    asr       $01,s
-                    inc       0,y
-                    lsr       $05,s
-                    com       $0C,s
-                    fcb       $61
-                    fcb       $72
-                    fcb       $61
-                    lsr       L696F
-                    jmp       0,x
-
-L3194               com       L796E
-                    lsr       L6178
-                    bra       L3201
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L006D
-                    fcb       $75
-                    inc       -$0C,s
-                    rol       -$10,s
-                    inc       $05,s
-                    bra       $320F
-                    fcb       $65
-                    ror       $01,s
-                    fcb       $75
-                    inc       -$0C,s
-                    com       >$006E
-                    clr       0,y
-                    com       L7769
-                    lsr       $6368
-                    bra       $3231
-                    lsr       $6174
-                    fcb       $65
-                    tst       $05,s
-                    jmp       -$0C,s
-                    neg       $0077
-                    asl       $09,s
-                    inc       $05,s
-                    bra       $3233
-                    asl       $7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-L31D6               fcb       $62
-                    fcb       $72
-                    fcb       $65
-                    fcb       $61
-                    fcb       $6b
-                    bra       L3242
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $0063
-                    clr       $0e,s
-                    lsr       $696E
-                    fcb       $75
-                    fcb       $65
-                    bra       $3251
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $006C
-                    fcb       $61
-                    fcb       $62
-                    fcb       $65
-                    inc       0,y
-                    fcb       $72
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L3200               fcb       $61
-L3201               inc       -$0e,s
-                    fcb       $65
-                    fcb       $61
-                    lsr       -$07,s
-                    bra       $326A
-                    bra       L3277
-                    clr       $03,s
-                    fcb       $61
-                    inc       0,y
-                    ror       $6172
-                    rol       $01,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       $0063
-                    clr       $0e,s
-                    lsr       $09,s
-                    lsr       L696F
-                    jmp       0,y
-                    jmp       $05,s
-                    fcb       $65
-                    lsr       $05,s
-                    lsr       0,x
+L316D               fcc       /no 'if' for 'else'/
+                    fcb       $00
+L3180               fcc       /illegal declaration/
+                    fcb       $00
+L3194               fcc       /syntax error/
+                    fcb       $00
+L31A1               fcc       /multiple defaults/
+                    fcb       $00
+L31B3               fcc       /no switch statement/
+                    fcb       $00
+L31C7               fcc       /while expected/
+                    fcb       $00
+L31D6               fcc       /break error/
+                    fcb       $00
+L31E2               fcc       /continue error/
+                    fcb       $00
+L31F1               fcc       /label required/
+                    fcb       $00
+L3200               fcc       /already a local variable/
+                    fcb       $00
+L3219               fcc       /condition needed/
+                    fcb       $00
                     pshs      u
                     ldd       #$FFA2
                     lbsr      L0113
@@ -5758,7 +5430,7 @@ L3237               leax      L42F7,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
-L3242               lbsr      L552E
+                    lbsr      L552E
 L3245               ldd       $005F
                     cmpd      #$002A
                     beq       L3237
@@ -5779,7 +5451,7 @@ L3245               ldd       $005F
                     lbsr      L4207
                     leas      $02,s
                     lbsr      L552E
-L3277               lbra      L34D4
+                    lbra      L34D4
 
 L327A               lbsr      L3BE9
                     std       $0a,s
@@ -6008,7 +5680,7 @@ L343B               ldd       $06,s
                     ldd       $06,s
                     cmpd      #$0003
                     bne       L348C
-L3477               leax      $432F,pcr
+L3477               leax      L432F,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -6059,7 +5731,7 @@ L34D9               pshs      u
                     tfr       d,x
                     bra       L3501
 
-L34EE               leax      $4343,pcr
+L34EE               leax      L4343,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -6108,7 +5780,7 @@ L3526               ldd       $0a,s
                     ldd       $04,s
                     cmpd      #$000A
                     bne       L3567
-L355A               leax      $4354,pcr
+L355A               leax      L4354,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -6169,7 +5841,7 @@ L35B2               ldd       $04,s
 L35D6               lbsr      L0241
                     bra       L35FE
 
-L35DB               leax      $4363,pcr
+L35DB               leax      L4363,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -6211,7 +5883,7 @@ L362B               pshs      u
                     tfr       d,x
                     bra       L3653
 
-L3640               leax      $4373,pcr
+L3640               leax      L4373,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -6483,7 +6155,7 @@ L387E               pshs      u
                     ldd       $0a,u
                     cmpd      $08,s
                     beq       L38AE
-L389E               leax      $4381,pcr
+L389E               leax      L4381,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -6678,7 +6350,7 @@ L3A2A               clra
                     ldd       $005F
                     cmpd      #$FFFF
                     bne       L3A48
-                    leax      $4396,pcr
+                    leax      L4396,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -7000,7 +6672,7 @@ L3D08               ldx       $18,s
                     ldd       $08,x
                     cmpd      #$0008
                     beq       L3D1E
-                    leax      $43B6,pcr
+                    leax      L43B6,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -7105,7 +6777,7 @@ L3DF4               ldd       ,u
                     ldd       $06,u
                     cmpd      $1a,s
                     beq       L3E29
-L3E17               leax      $43CF,pcr
+L3E17               leax      L43CF,pcr
                     pshs      x
                     lbsr      L024E
                     bra       L3E27
@@ -7116,7 +6788,7 @@ L3E27               leas      $02,s
 L3E29               ldd       $12,s
                     cmpd      #$000A
                     bne       L3E3D
-                    leax      $43E6,pcr
+                    leax      L43E6,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -7241,7 +6913,7 @@ L3F54               ldd       $005F
                     bne       L3F7C
                     ldu       $0061
                     ldd       $08,u
-                    cmpd      #start
+                    cmpd      #_start
                     bne       L3F7C
                     ldd       $02,u
                     std       [$1e,s]
@@ -7585,7 +7257,7 @@ L4218               ldd       $10,u
                     ldd       #$0014
                     addd      ,s++
                     pshs      d
-                    leax      $43FA,pcr
+                    leax      L43FA,pcr
                     pshs      x
                     leax      $06,s
                     pshs      x
@@ -7659,185 +7331,47 @@ L42E0               bra       L42EE
 L42E2               pshs      u
                     ldd       #$FFBA
                     lbsr      L0113
-                    leax      $4422,pcr
+                    leax      L4422,pcr
 L42EE               pshs      x
                     lbsr      L024E
 L42F3               leas      $02,s
                     puls      pc,u
-L42F7               lsr       $6F6F
-                    bra       $4369
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       $4363
-                    fcb       $72
-                    fcb       $61
-                    com       $0b,s
-                    fcb       $65
-                    lsr       L7300
-L4309               ror       -$0b,s
-                    jmp       $03,s
-                    lsr       L696F
-                    jmp       0,y
-                    asl       $05,s
-                    fcb       $61
-                    lsr       $05,s
-                    fcb       $72
-                    bra       L4387
-                    rol       -$0d,s
-                    com       $696E
-                    asr       0,x
-L4321               com       L746F
-                    fcb       $72
-                    fcb       $61
-                    asr       $05,s
-                    bra       L438F
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L0066
-                    fcb       $75
-                    jmp       $03,s
-                    lsr       L696F
-                    jmp       0,y
-                    lsr       L7970
-                    fcb       $65
-                    bra       $43A3
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $0061
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    bra       $43C0
-                    lsr       $6F72
-                    fcb       $61
-                    asr       $05,s
-                    neg       $0061
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    bra       $43C3
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       $006E
-                    clr       -$0C,s
-                    bra       L43C9
-                    jmp       0,y
-                    fcb       $61
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    neg       $0073
-                    lsr       $6F72
-                    fcb       $61
-                    asr       $05,s
-                    bra       $43E1
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L0064
-                    fcb       $65
-                    com       $0C,s
-                    fcb       $61
-                    fcb       $72
-L4387               fcb       $61
-                    lsr       L696F
-                    jmp       0,y
-                    tst       $09,s
-L438F               com       L6D61
-                    lsr       $6368
-                    neg       L0066
-                    fcb       $75
-                    jmp       $03,s
-                    lsr       L696F
-                    jmp       0,y
-                    fcb       $75
-                    jmp       $06,s
-                    rol       $0e,s
-                    rol       -$0d,s
-                    asl       $05,s
-                    lsr       0,x
-L43AA               jmp       $01,s
-                    tst       $05,s
-                    lsr       0,y
-                    lsr       L7769
-                    com       $05,s
-                    neg       $006E
-                    fcb       $61
-                    tst       $05,s
-                    bra       $441F
-                    inc       $01,s
-                    com       $6800
-L43C1               com       $7472
-                    fcb       $75
-                    com       -$0C,s
-                    bra       $443C
-
-L43C9               rol       L6E74
-                    fcb       $61
-                    asl       >$0073
-                    lsr       $7275
-                    com       -$0C,s
-                    bra       $4444
-                    fcb       $65
-                    tst       $02,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L444B
-                    rol       -$0d,s
-                    tst       $01,s
-                    lsr       $6368
-                    neg       $0075
-                    jmp       $04,s
-                    fcb       $65
-                    ror       $09,s
-                    jmp       $05,s
-                    lsr       0,y
-                    com       $7472
-                    fcb       $75
-                    com       -$0C,s
-                    fcb       $75
-                    fcb       $72
-                    fcb       $65
-                    neg       $006C
-                    fcb       $61
-                    fcb       $62
-                    fcb       $65
-                    inc       0,y
-                    fcb       $75
-                    jmp       $04,s
-                    fcb       $65
-                    ror       $09,s
-                    jmp       $05,s
-                    lsr       0,y
-                    abx
-                    bra       L440D
-
-L440D               com       $01,s
-                    jmp       $0e,s
-                    clr       -$0C,s
-                    bra       L447A
-                    ror       L616C
-                    fcb       $75
-                    fcb       $61
-                    lsr       $6520
-                    com       $697A
-                    fcb       $65
-                    neg       L0069
-                    lsr       $05,s
-                    jmp       -$0C,s
-                    rol       $06,s
-                    rol       $05,s
-                    fcb       $72
-                    bra       $449B
-                    rol       -$0d,s
-                    com       $696E
-                    asr       0,x
+L42F7               fcc       /too many brackets/
+                    fcb       $00
+L4309               fcc       /function header missing/
+                    fcb       $00
+L4321               fcc       /storage error/
+                    fcb       $00
+L432F               fcc       /function type error/
+                    fcb       $00
+L4343               fcc       /argument storage/
+                    fcb       $00
+L4354               fcc       /argument error/
+                    fcb       $00
+L4363               fcc       /not an argument/
+                    fcb       $00
+L4373               fcc       /storage error/
+                    fcb       $00
+L4381               fcc       /declaration mismatch/
+                    fcb       $00
+L4396               fcc       /function unfinished/
+                    fcb       $00
+L43AA               fcc       /named twice/
+                    fcb       $00
+L43B6               fcc       /name clash/
+                    fcb       $00
+L43C1               fcc       /struct syntax/
+                    fcb       $00
+L43CF               fcc       /struct member mismatch/
+                    fcb       $00
+L43E6               fcc       /undefined structure/
+                    fcb       $00
+L43FA               fcc       /label undefined : /
+                    fcb       $00
+L440D               fcc       /cannot evaluate size/
+                    fcb       $00
+L4422               fcc       /identifier missing/
+                    fcb       $00
 L4435               pshs      u
                     ldd       #$FFB0
                     lbsr      L0113
@@ -7859,7 +7393,7 @@ L4452               pshs      d
                     leas      $02,s
                     bra       L447C
 
-L445B               cmpx      #start
+L445B               cmpx      #_start
                     beq       L4445
                     cmpx      #$000E
                     lbeq      L4445
@@ -7869,7 +7403,7 @@ L445B               cmpx      #start
                     beq       L444B
                     cmpx      #$0023
                     lbeq      L444B
-L447A               bra       L4450
+                    bra       L4450
 
 L447C               ldd       L0051
                     bne       L44AE
@@ -8123,7 +7657,7 @@ L4694               ldd       $10,s
                     ldd       $14,s
                     std       ,s
                     bne       L46ED
-                    leax      $49DC,pcr
+                    leax      L49DC,pcr
                     lbra      L4741
 
 L46AD               ldx       ,s
@@ -8470,7 +8004,7 @@ L497C               leas      $02,s
 L4980               pshs      u
                     ldd       #$FFBA
                     lbsr      L0113
-                    leax      $4A11,pcr
+                    leax      L4A11,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -8494,71 +8028,35 @@ L49AA               cmpx      #$0030
                     lbeq      L49A3
                     bra       L49A5
                     puls      pc,u
-L49C1               lsr       $6F6F
-                    bra       L4A32
-                    clr       $0e,s
-                    asr       0,x
-L49CA               lsr       $6F6F
-                    bra       $4A3C
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       L4A39
-                    inc       $05,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    com       >$0075
-                    jmp       $09,s
-                    clr       $0e,s
-                    com       $206E
-                    clr       -$0C,s
-                    bra       L4A49
-                    inc       $0C,s
-                    clr       -$09,s
-                    fcb       $65
-                    lsr       0,x
-L49EF               com       $0f,s
-                    jmp       -$0d,s
-                    lsr       $616E
-                    lsr       L2065
-                    asl       L7072
-                    fcb       $65
-                    com       $7369
-                    clr       $0e,s
-                    bra       $4A76
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    rol       -$0e,s
-                    fcb       $65
-                    lsr       0,x
-L4A0C               fcb       $72
-                    dec       L6220
-                    neg       $0063
-                    fcb       $61
-                    jmp       $0e,s
-                    clr       -$0C,s
-                    bra       $4A82
-                    jmp       $09,s
-                    lsr       $6961
-                    inc       $09,s
-                    dec       $6500
+L49C1               fcc       /too long/
+                    fcb       $00
+L49CA               fcc       /too many elements/
+                    fcb       $00
+L49DC               fcc       /unions not allowed/
+                    fcb       $00
+L49EF               fcc       /constant expression required/
+                    fcb       $00
+L4A0C               fcc       /rzb /
+                    fcb       $00
+L4A11               fcc       /cannot initialize/
+                    fcb       $00
 L4A23               pshs      u
                     ldd       #$FFBA
                     lbsr      L0113
                     lbsr      L4BEF
                     ldd       $04,s
                     pshs      d
-L4A32               lbsr      L4B20
+                    lbsr      L4B20
                     leas      $02,s
                     ldd       $06,s
-L4A39               lbeq      L4AFF
+                    lbeq      L4AFF
                     ldd       #$003A
                     pshs      d
                     bsr       L4A88
                     lbra      L4AFD
 
 L4A47               pshs      u
-L4A49               ldd       #$FFB8
+                    ldd       #$FFB8
                     lbsr      L0113
                     ldd       $0025
                     pshs      d
@@ -9321,7 +8819,7 @@ L50D2               nega
                     leax      $01C1,y
                     stx       $000F
                     ldd       #$0001
-                    std       L0015
+                    std       copybytes
                     leax      $06,s
                     pshs      x
                     ldd       $06,s
@@ -9331,30 +8829,30 @@ L50E6               pshs      u
                     ldd       $04,s
                     std       $000F
                     ldd       #$0001
-                    std       L0015
+                    std       copybytes
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
 L50F7               pshs      d
-                    bsr       L511E
+                    bsr       doprnt
                     leas      $04,s
                     puls      pc,u
 L50FF               pshs      u
                     ldd       $04,s
                     std       $000F
                     ldd       #$0002
-                    std       L0015
+                    std       copybytes
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       L511E
+                    bsr       doprnt
                     leas      $04,s
                     clra
                     clrb
                     stb       [$000F,y]
                     puls      pc,u
-L511E               pshs      u
+doprnt              pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L5136
@@ -9778,7 +9276,7 @@ L5463               ldd       ,s
 L546F               leas      $02,s
                     puls      pc,u
 L5473               pshs      u
-                    ldd       L0015
+                    ldd       copybytes
                     cmpd      #$0002
                     bne       L5489
                     ldd       $04,s
@@ -10278,15 +9776,15 @@ L5895               leas      $15,s
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
-                    ldd       #start
+                    ldd       #_start
                     pshs      d
-                    leax      $6219,pcr
+                    leax      L6219,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
                     ldd       #$000F
                     pshs      d
-                    leax      $6221,pcr
+                    leax      L6221,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10306,7 +9804,7 @@ L5895               leas      $15,s
                     std       $0041
                     ldd       #$0001
                     pshs      d
-                    leax      L6233,pcr
+                    leax      $6233,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10321,7 +9819,7 @@ L5895               leas      $15,s
                     std       $0041
                     ldd       #$0002
                     pshs      d
-                    leax      $623D,pcr
+                    leax      L623D,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10333,19 +9831,19 @@ L5895               leas      $15,s
                     leas      $04,s
                     ldd       #$000D
                     pshs      d
-                    leax      $6248,pcr
+                    leax      L6248,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
                     ldd       #$000E
                     pshs      d
-                    leax      $624D,pcr
+                    leax      L624D,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
                     ldd       #$0021
                     pshs      d
-                    leax      $6254,pcr
+                    leax      L6254,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10363,13 +9861,13 @@ L5895               leas      $15,s
                     leas      $04,s
                     ldd       #$0012
                     pshs      d
-                    leax      $6269,pcr
+                    leax      L6269,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
                     ldd       #$0013
                     pshs      d
-                    leax      $6270,pcr
+                    leax      L6270,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10399,7 +9897,7 @@ L5895               leas      $15,s
                     leas      $04,s
                     ldd       #$0018
                     pshs      d
-                    leax      $628A,pcr
+                    leax      L628A,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10417,7 +9915,7 @@ L5895               leas      $15,s
                     leas      $04,s
                     ldd       #$001B
                     pshs      d
-                    leax      $629C,pcr
+                    leax      L629C,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -10447,7 +9945,7 @@ L5895               leas      $15,s
                     leas      $04,s
                     ldd       #$0008
                     pshs      d
-                    leax      $62BE,pcr
+                    leax      L62BE,pcr
                     pshs      x
                     lbsr      L5BD8
                     leas      $04,s
@@ -11018,7 +10516,7 @@ L5F15               ldb       $0065
 L5F1D               ldb       $0065
                     cmpb      #$27
                     lbeq      $6008
-                    leax      $62DD,pcr
+                    leax      L62DD,pcr
                     pshs      x
                     lbsr      L024E
                     leas      $02,s
@@ -11090,7 +10588,7 @@ L5FB9               leax      $060C,y
                     ldd       $006A
                     subd      ,s++
                     bne       L5FD2
-                    leax      $6319,pcr
+                    leax      L6319,pcr
                     pshs      x
                     lbsr      $024F
                     leas      $02,s
@@ -11152,7 +10650,7 @@ L602A               ldd       L001B
                     lbsr      $4BF0
                     ldd       $04,s
                     pshs      d
-                    leax      $632D,pcr
+                    leax      L632D,pcr
                     pshs      x
                     ldd       L001B
                     pshs      d
@@ -11289,7 +10787,7 @@ L6163               pshs      u
                     lbsr      L61AD
                     std       ,s++
                     beq       L61A7
-L616C               leau      -$30,u
+                    leau      -$30,u
                     clra
                     clrb
                     std       ,s
@@ -11297,7 +10795,7 @@ L616C               leau      -$30,u
 
 L6175               tfr       u,d
                     aslb
-L6178               rola
+                    rola
                     aslb
                     rola
                     aslb
@@ -11358,182 +10856,87 @@ L61E4               ldb       $05,s
 L61E9               clra
                     clrb
 L61EB               puls      pc,u
-                    fcb       $62
-                    fcb       $61
-                    lsr       0,y
-                    com       $08,s
-                    fcb       $61
-                    fcb       $72
-                    fcb       $61
-                    com       -$0C,s
-                    fcb       $65
-                    fcb       $72
-L61FA               neg       $0063
-                    clr       $0e,s
-                    com       L7461
-                    jmp       -$0C,s
-                    bra       $6274
-                    ror       $6572
-                    ror       $0C,s
-                    clr       -$09,s
-L620C               neg       L0064
-                    clr       -$0b,s
-                    fcb       $62
-                    inc       $05,s
-L6213               neg       L0066
-                    inc       $0f,s
-                    fcb       $61
-                    lsr       >$0074
-                    rol       $7065
-                    lsr       $05,s
-L6220               ror       0,x
-                    com       L7461
-                    lsr       L6963
-L6228               neg       $0073
-                    rol       -$06,s
-                    fcb       $65
-                    clr       $06,s
-L622F               neg       L0069
-                    jmp       -$0C,s
-
-L6233               neg       L0069
+                    fcc       /bad character/
+L61FA               fcb       $00
+                    fcc       /constant overflow/
+L620C               fcb       $00
+                    fcc       /double/
+L6213               fcb       $00
+                    fcc       /float/
+L6219               fcb       $00
+                    fcc       /typede/
+L6220               fcb       $66
+L6221               fcb       $00
+                    fcc       /static/
+L6228               fcb       $00
+                    fcc       /sizeof/
+L622F               fcb       $00
+                    rol       $0e,s
+                    lsr       >L0069
                     jmp       -$0C,s
 
 L6237               neg       L0066
-                    inc       $0f,s
-                    fcb       $61
-                    lsr       >$0063
-                    asl       $01,s
-                    fcb       $72
-L6242               neg       $0073
-                    asl       $0f,s
-                    fcb       $72
-                    lsr       >$0061
-                    fcb       $75
-                    lsr       $6F00
-                    fcb       $65
-                    asl       L7465
-                    fcb       $72
-                    jmp       0,x
-                    lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-L625B               neg       $0072
-                    fcb       $65
-                    asr       $09,s
-                    com       L7465
-                    fcb       $72
-L6264               neg       $0067
-                    clr       -$0C,s
-                    clr       0,x
-                    fcb       $72
-                    fcb       $65
-                    lsr       $7572
-                    jmp       0,x
+                    fcc       /loat/
+L623D               fcb       $00
+                    fcc       /char/
+L6242               fcb       $00
+                    fcc       /short/
+L6248               fcb       $00
+                    fcc       /auto/
+L624D               fcb       $00
+                    fcc       /extern/
+L6254               fcb       $00
+                    fcc       /direct/
+L625B               fcb       $00
+                    fcc       /register/
+L6264               fcb       $00
+                    fcc       /goto/
+L6269               fcb       $00
+                    fcc       /return/
+L6270               fcb       $00
                     rol       $06,s
 L6273               neg       $0077
-                    asl       $09,s
-                    inc       $05,s
-L6279               neg       $0065
-                    inc       -$0d,s
-                    fcb       $65
-L627E               neg       $0073
-                    asr       $6974
-                    com       $08,s
-L6285               neg       $0063
-                    fcb       $61
-                    com       $6500
-                    fcb       $62
+                    fcc       /hile/
+L6279               fcb       $00
+                    fcc       /else/
+L627E               fcb       $00
+                    fcc       /switch/
+L6285               fcb       $00
+                    fcc       /case/
+L628A               fcb       $00
+                    fcc       /break/
+L6290               fcb       $00
+                    fcc       /continue/
+L6299               fcb       $00
+                    lsr       $0f,s
+L629C               neg       L0064
+                    fcc       /efault/
+L62A4               fcb       $00
+                    ror       $0f,s
                     fcb       $72
-                    fcb       $65
-                    fcb       $61
-                    fcb       $6b
-L6290               neg       $0063
-                    clr       $0e,s
-                    lsr       $696E
-                    fcb       $75
-                    fcb       $65
-L6299               neg       L0064
-                    clr       0,x
-                    lsr       $05,s
-                    ror       $01,s
-                    fcb       $75
-                    inc       -$0C,s
-L62A4               neg       L0066
-                    clr       -$0e,s
 L62A8               neg       $0073
-                    lsr       $7275
-                    com       -$0C,s
-L62AF               neg       $0075
-                    jmp       $09,s
-                    clr       $0e,s
-L62B5               neg       $0075
-                    jmp       -$0d,s
-                    rol       $07,s
-                    jmp       $05,s
-                    lsr       0,x
-                    inc       $0f,s
-                    jmp       $07,s
-
-L62C3               neg       $0065
-                    fcb       $72
-                    fcb       $72
-                    jmp       $0f,s
-
-L62C9               neg       $006C
-                    com       L6565
-                    fcb       $6b
-L62CF               neg       $006F
-                    fcb       $75
-                    lsr       $206F
-                    ror       0,y
-                    tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       >$0075
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    tst       $09,s
-                    jmp       $01,s
-                    lsr       $6564
-                    bra       L634F
-                    asl       $01,s
-                    fcb       $72
-                    fcb       $61
-                    com       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    bra       L6359
-                    clr       $0e,s
-                    com       L7461
-                    jmp       -$0C,s
-
-L62FD               neg       $0077
-                    bmi       L6301
-L6301               com       $01,s
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       L6380
-                    lsr       $7269
-                    jmp       $07,s
-                    com       $2066
-                    rol       $0C,s
-                    fcb       $65
-                    neg       $0075
-                    jmp       -$0C,s
-                    fcb       $65
-                    fcb       $72
-                    tst       $09,s
-                    jmp       $01,s
-                    lsr       $6564
-                    bra       $639A
-                    lsr       $7269
-                    jmp       $07,s
-                    neg       L0020
-                    fcb       $72
+                    fcc       /truct/
+L62AF               fcb       $00
+                    fcc       /union/
+L62B5               fcb       $00
+                    fcc       /unsigned/
+L62BE               fcb       $00
+                    fcc       /long/
+L62C3               fcb       $00
+                    fcc       /errno/
+L62C9               fcb       $00
+                    fcc       /lseek/
+L62CF               fcb       $00
+                    fcc       /out of memory/
+L62DD               fcb       $00
+                    fcc       /unterminated character constant/
+L62FD               fcb       $00
+                    asr       L2B00
+                    fcc       /can't open strings file/
+                    fcb       $00
+L6319               fcc       /unterminated string/
+                    fcb       $00
+L632D               bra       L63A1
                     dec       L6220
                     bcs       $6398
                     tst       $0000
@@ -11554,7 +10957,7 @@ L634F               ldb       $0065
                     beq       L634D
                     ldb       $0065
                     cmpb      #$09
-L6359               lbeq      L634D
+                    lbeq      L634D
                     puls      pc,u
 L635F               pshs      u
                     ldx       $006A
@@ -11572,7 +10975,7 @@ L6373               pshs      u
                     bne       L6389
                     ldd       #$0001
                     std       L001D
-L6380               leax      L6635,pcr
+                    leax      L6635,pcr
                     stx       $006A
                     lbra      L656A
 
@@ -11586,7 +10989,7 @@ L6389               clra
                     lbsr      L7315
                     leas      $04,s
 L639E               lbsr      L65A7
-                    std       $006A
+L63A1               std       $006A
                     lbeq      L64A8
                     ldb       [$006A,y]
                     cmpb      #$23
@@ -11703,7 +11106,7 @@ L64AE               ldd       $06,s
                     leas      $06,s
                     bra       L64D4
 
-L64C9               leax      $6667,pcr
+L64C9               leax      L6667,pcr
                     pshs      x
                     lbsr      L50D2
                     leas      $02,s
@@ -11759,7 +11162,7 @@ L652F               cmpx      #$0035
                     lbra      L639E
 
 L6563               ldd       L0027
-L6565               addd      #$0001
+                    addd      #$0001
                     std       L0027
 L656A               ldd       #$0020
 L656D               leas      $08,s
@@ -11857,30 +11260,18 @@ L6631               leas      $02,s
                     puls      pc,u
 L6635               neg       $0025
                     com       L0D00
-L663A               bra       $66AC
-                    fcb       $73,$65,$63,$74,$20,$25,$73,$2C
-                    fcb       $30,$2C,$30,$2C,$25,$64,$2C,$30
-                    fcb       $2C,$30,$0d,$00
+L663A               bra       L66AC
+                    fcc       /sect %s,0,0,%d,0,0/
+                    fcb       $0D,$00
 L6650               bra       $66C0
                     fcb       $61
                     tst       0,y
                     bcs       $66CA
                     tst       $0000
-L6659               bcs       $66CE
-                    bra       L6697
-                    bra       L66CB
-                    rol       $0e,s
-                    fcb       $65
-                    bra       L6689
-                    lsr       0,y
-                    neg       $0061
-                    fcb       $72
-                    asr       -$0b,s
-                    tst       $05,s
-                    jmp       -$0C,s
-                    bra       L66AB
-                    bra       L6673
-
+L6659               fcc       /%s : line %d /
+                    fcb       $00
+L6667               fcc       /argument : /
+                    fcb       $00
 L6673               bpl       L669F
                     bpl       L66A1
                     bra       L669E
@@ -11889,24 +11280,16 @@ L6673               bpl       L669F
                     bpl       L668D
                     neg       $005E
                     neg       L0049
-                    fcb       $4e,$50,$55,$54,$20
-L6689               fcb       $46,$49,$4C,$45
-L668D               fcb       $20,$45,$52,$52,$4f,$52,$20,$3a
-                    fcb       $20,$54
-L6697               fcb       $45,$4d,$50,$4f,$52,$41,$52
+                    fcc       /NPUT FILE/
+L668D               fcc       / ERROR : TEMPORAR/
 L669E               fcb       $59
 L669F               fcb       $20,$46
-L66A1               fcb       $49,$4C,$45,$0d,$00
-L66A6               rol       $0e,s
-L66A8               neg       $7574
-L66AB               bra       $6719
-                    rol       $0e,s
-                    fcb       $65
-                    bra       L6726
-                    clr       $0f,s
-                    bra       L6722
-                    clr       $0e,s
-                    asr       0,x
+L66A1               fcb       $49,$4C,$45
+                    fcb       $0D,$00
+L66A6               fcb       $69,$6E
+L66A8               fcc       /put /
+L66AC               fcc       /line too long/
+                    fcb       $00
 L66BA               pshs      u
                     lbsr      L6871
                     lbra      L6718
@@ -11914,7 +11297,7 @@ L66BA               pshs      u
                     ldd       $08,s
                     pshs      d
                     lbsr      L6815
-L66CB               leas      $02,s
+                    leas      $02,s
                     lbsr      $4BF0
                     ldd       $04,s
                     pshs      d
@@ -11952,9 +11335,9 @@ L6718               lbsr      L6825
                     puls      pc,u
 L671D               pshs      u
                     lbsr      $4BF0
-L6722               ldd       $06,s
+                    ldd       $06,s
                     pshs      d
-L6726               ldb       $0b,s
+                    ldb       $0b,s
                     sex
                     pshs      d
                     ldd       $08,s
@@ -12025,7 +11408,7 @@ L6776               clra
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      $693D,pcr
+                    leax      L693D,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
@@ -12044,7 +11427,7 @@ L67E4               leas      $04,s
 L67E6               puls      pc,u
                     pshs      u
                     lbsr      $4BF0
-                    leax      $6944,pcr
+                    leax      L6944,pcr
                     bra       L67FC
                     pshs      u
                     lbsr      $4BF0
@@ -12103,7 +11486,7 @@ L6832               pshs      u
                     ldd       $08,x
                     pshs      d
                     lbsr      L77E4
-L6869               leas      $08,s
+                    leas      $08,s
                     ldd       $02C8,y
                     puls      pc,u
 L6871               pshs      u
@@ -12195,40 +11578,32 @@ L691E               bra       $6992
                     bra       L6958
                     lsr       $0d,x
                     neg       $0025
-                    bgt       L6971
-                    com       $2563
-                    neg       $0025
-                    bgt       $6978
-                    com       $2563
-                    neg       L0066
-                    com       $02,s
-                    bra       L6949
-
-L6949               ror       $04,s
-                    fcb       $62
-                    bra       L694E
-
+                    fcc       /.8s%c/
+                    fcb       $00
+L693D               fcc       /%.8s%c/
+                    fcb       $00
+L6944               fcc       /fcb /
+                    fcb       $00
+L6949               fcc       /fdb /
+                    fcb       $00
 L694E               bpl       $6970
                     neg       L0064
-                    fcb       $75
-                    tst       -$10,s
-                    com       $7472
-L6958               rol       $0e,s
-                    asr       -$0d,s
-L695C               neg       $0034
-                    nega
+                    fcc       /umpstr/
+L6958               fcc       /ings/
+L695C               fcb       $00
+L695D               pshs      u
                     leau      $02C6,y
-L6963               ldd       ,x
+                    ldd       ,x
                     std       ,u
                     ldd       $02,x
                     std       $02,u
                     ldd       $04,x
                     std       $04,u
-L696F               ldd       $06,x
-L6971               std       $06,u
+                    ldd       $06,x
+                    std       $06,u
                     tfr       u,x
                     puls      pc,u
-                    bsr       $695D
+                    bsr       L695D
                     lda       ,x
                     eora      #$80
                     sta       ,x
@@ -12239,7 +11614,7 @@ L6984               rts
 
 L6985               lda       ,x
                     pshs      a
-                    bsr       $695D
+                    bsr       L695D
                     bsr       L6997
                     leax      $03,x
                     lda       ,s+
@@ -12513,7 +11888,7 @@ L6BB7               ldd       $005F
                     clra
                     andb      #$20
                     beq       L6BD6
-                    leax      $6C5E,pcr
+                    leax      L6C5E,pcr
                     pshs      x
                     lbsr      $022C
                     leas      $02,s
@@ -12525,7 +11900,7 @@ L6BD6               leax      $01C1,y
                     beq       L6BFC
                     ldd       L0029
                     pshs      d
-                    leax      $6C7F,pcr
+                    leax      L6C7F,pcr
                     pshs      x
                     leax      $01CE,y
                     pshs      x
@@ -12546,9 +11921,8 @@ L6C0D               ldd       #$0001
                     leas      $02,s
                     puls      pc,u
 L6C19               clrb
-                    lsr       -$0b,s
-                    tst       $0d,s
-                    rol       $5F00
+                    fcc       /dummy_/
+                    fcb       $00
 L6C21               asr       >$0063
                     fcb       $61
                     jmp       $07,y
@@ -12556,46 +11930,17 @@ L6C21               asr       >$0063
                     neg       $656E
                     bra       L6C54
                     com       L0D00
-L6C32               fcb       $75,$6e,$6b,$6e,$6f,$77,$6e,$20
-                    fcb       $66,$6C,$61,$67,$20,$3a,$20,$2d
-                    fcb       $25,$63,$0d,$00
+L6C32               fcc       /unknown flag : -%c/
+                    fcb       $0D,$00
 L6C46               fcb       $72
                     neg       $0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       L6CBD
-
-L6C54               jmp       -$10,s
-                    fcb       $75
-                    lsr       $2066
-                    rol       $0C,s
-                    fcb       $65
-                    neg       $0065
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       L6CDC
-                    fcb       $72
-                    rol       -$0C,s
-                    rol       $0e,s
-                    asr       0,y
-                    fcb       $61
-                    com       $7365
-                    tst       $02,s
-                    inc       -$07,s
-                    bra       $6CD9
-                    clr       $04,s
-                    fcb       $65
-                    bra       $6CE1
-                    rol       $0C,s
-                    fcb       $65
-                    neg       $0065
-                    fcb       $72,$72,$6f,$72,$73,$20,$69,$6e
-                    fcb       $20,$63,$6f,$6d,$70,$69,$6C,$61
-                    fcb       $74,$69,$6f,$6e,$20,$3a,$20,$25
-                    fcb       $64,$0d,$00
+                    fcc       /an't open i/
+L6C54               fcc       /nput file/
+                    fcb       $00
+L6C5E               fcc       /error writing assembly code file/
+                    fcb       $00
+L6C7F               fcc       /errors in compilation : %d/
+                    fcb       $0D,$00
 L6C9B               pshs      u
                     leau      $01B4,y
 L6CA1               ldd       $06,u
@@ -12609,7 +11954,7 @@ L6CA1               ldd       $06,u
                     bhi       L6CA1
                     ldd       #$00C8
                     std       $02D2,y
-L6CBD               lbra      L6D16
+                    lbra      L6D16
                     puls      pc,u
 L6CC2               pshs      u
                     ldu       $08,s
@@ -12624,7 +11969,7 @@ L6CCC               stu       -$02,s
                     ldb       $01,x
                     cmpb      #$2b
                     beq       L6CE4
-L6CDC               ldx       $06,s
+                    ldx       $06,s
                     ldb       $02,x
                     cmpb      #$2b
                     bne       L6CEA
@@ -12696,7 +12041,7 @@ L6D4B               stx       -$02,s
 L6D5B               ldb       [$0a,s]
                     sex
                     tfr       d,x
-L6D61               lbra      L6DC0
+                    lbra      L6DC0
 
 L6D64               ldd       ,s
                     orb       #$01
@@ -12836,7 +12181,7 @@ L6E6D               ldd       $07,s
                     pshs      d
                     ldb       $02,s
                     sex
-L6E74               pshs      d
+                    pshs      d
                     lbsr      L6F05
                     leas      $04,s
 L6E7B               ldb       ,u+
@@ -12955,7 +12300,7 @@ L6F4E               tfr       x,d
 
 L6F65               ldd       $06,u
                     anda      #$01
-L6F69               clrb
+                    clrb
                     std       -$02,s
                     bne       L6F75
                     pshs      u
@@ -13084,7 +12429,7 @@ L705E               pshs      u
                     bne       L7090
                     ldd       ,u
                     cmpd      $04,u
-L7072               beq       L7090
+                    beq       L7090
                     clra
                     clrb
                     pshs      d
@@ -13401,7 +12746,7 @@ L72EB               ldd       $06,u
 L72FA               ldd       $02,u
                     addd      $0b,u
                     std       $04,u
-L7300               std       ,u
+                    std       ,u
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
@@ -13582,15 +12927,15 @@ L7452               ldx       $06,s
                     bgt       L7452
                     ldb       -$01,u
                     clra
-L7461               andb      #$7f
+                    andb      #$7f
                     stb       -$01,u
-L7465               clra
+                    clra
                     clrb
                     stb       ,u
                     ldd       $04,s
                     puls      pc,u
                     ldd       $04,s
-L746F               addd      $02,x
+                    addd      $02,x
                     std       $02C8,y
                     ldd       $02,s
                     adcb      $01,x
@@ -13973,7 +13318,7 @@ L7742               cmpb      #$DA
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-L7769               bcc       L773E
+                    bcc       L773E
                     pshs      b
                     os9       I$Close
                     puls      b
@@ -14190,7 +13535,7 @@ L7936               clra
                     rts
 
 L793F               bcs       L7936
-L7941               clra
+exit                clra
                     clrb
                     rts
 
@@ -14198,294 +13543,81 @@ L7944               lbsr      L794F
 L7947               lbsr      L6FCD
 L794A               ldd       $02,s
 L794C               os9       F$Exit
-L794F               rts
-                    neg       $0003
-                    neg       $0000
-                    adca      #$02
-                    jmp       $0078
-                    bra       $79BF
-                    asl       $7065
-                    com       -$0C,s
-                    fcb       $65
-                    lsr       0,x
-                    beq       L7974
-                    com       $00E8
-                    neg       L0064
-                    neg       $000A
-                    neg       $0000
-                    neg       $0000
-L796E               neg       $0000
-L7970               neg       $0000
-                    neg       $0000
-L7974               neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    tst       0,u
-                    rol       0,x
-                    neg       $0054
-                    fcb       $41
-                    asl       $0d,y
-                    bgt       L79D7
-                    negb
-                    leax      $03,u
-                    fcb       $45
-                    comb
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    fcb       $6b
-                    ble       $79CE
-                    tstb
-                    asl       L5F64
-                    neg       $006A
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0b,y
-                    ror       $0C,y
-                    rolb
-                    dec       0,x
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-L79D7               dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    dec       $0a,s
-                    bvs       $7A3F
-                    bpl       $7A2D
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    rol       $0000
-                    neg       $0000
-                    tst       $000E
-                    neg       $0000
-                    neg       $000E
-                    inc       $0001
-                    jmp       $000F
-                    tst       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0003
-                    neg       $000A
-                    fcb       $02
-                    dec       $0003
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    asr       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    ror       $0000
-                    jmp       $0000
-                    asr       $000B
-                    neg       $0001
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $000C
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    stx       $0063
-                    com       $7472
-                    bgt       $7AE8
-                    aslb
-                    aslb
-                    aslb
-                    aslb
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+* ------------------------------------------------------------------
+* L794F - cc1-style init image for the work block (see _start);
+* pure data: rts stub + count/block table + reloc dirs + module name.
+* ------------------------------------------------------------------
+L794F               fcb       $39       init table / work-block image
+                    fcb       $00,$03,$00,$00,$89,$02,$0E
+                    fcc       /x expected/
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
+                    fcb       $6D,$40,$69
+                    fcb       $00,$00
+                    fcc       |TAh-.BP0CESkkkkkkkkkk/(]x_d|
+                    fcb       $00
+                    fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj+f,Yj/
+                    fcb       $00
+                    fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj)X*D/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$09,$00,$00,$00,$0D,$0E
+                    fcb       $00,$00,$00,$0E,$0C,$01,$0E,$0F
+                    fcb       $0D,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$03,$00,$0A,$02,$0A
+                    fcb       $03,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$07
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$06,$00,$0E
+                    fcb       $00,$07,$0B,$00,$01,$00,$02,$00
+                    fcb       $00,$00,$00,$00,$0C,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$01
+                    fcb       $9F
+                    fcc       /cstr.XXXXX/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0003
-                    neg       $0001
-                    fcb       $01
-                    adca      #$01
-                    sta       $03,s
-                    bgt       $7BE2
-                    fcb       $61
-
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$03,$00,$01,$01,$89,$01,$A7
+                    fcc       /c.pa/
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -136,22 +136,38 @@ stkcheck            leax      d,s
                     bcs       L013C
                     stx       $02D0,y
 L0122               rts
-L0123               fcc       /**** STACK OVERFLOW ****/
-                    fcb       $0D
+
+L0123               bpl       $014F
+                    bpl       L0151
+                    bra       L017C
+                    lsrb
+                    fcb       $41
+                    coma
+                    fcb       $4B
+                    bra       $017E
+                    rorb
+                    fcb       $45,$52
+                    rora
+                    inca
+                    clra
+                    asrb
+                    bra       L0162
+                    bpl       $0164
+                    bpl       L0149
 L013C               leax      L0123,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
-                    os9       I$WritLn
+L0149               os9       I$WritLn
                     clr       ,-s
                     lbsr      L7946
-                    ldd       $02C2,y
+L0151               ldd       $02C2,y
                     subd      $02D0,y
                     rts
                     ldd       $02D0,y
                     subd      $02CE,y
-                    rts
+L0162               rts
 
 L0163               pshs      x
                     leax      d,y
@@ -165,7 +181,7 @@ L016B               ldd       ,y++
                     cmpy      ,s
                     bne       L016B
                     leas      $04,s
-                    rts
+L017C               rts
 
 L017D               pshs      u
                     ldu       $04,s
@@ -370,7 +386,7 @@ L0323               ldd       L0029
                     pshs      x
                     lbsr      L702C
                     leas      $02,s
-                    leax      $0568,pcr
+                    leax      L0568,pcr
                     pshs      x
                     bsr       L0365
 L0343               leas      $02,s
@@ -577,30 +593,22 @@ L0506               ldd       $005F
                     cmpd      #$FFFF
                     bne       L0503
 L051E               puls      pc,u
-L0520               bcs       L0595
-                    bra       L055E
-                    bra       L0526
+L0520               fcc       /%s : /
+                    fcb       $00
 L0526               fcc       /multiple definition/
                     fcb       $00
 L053A               fcc       /compiler error - /
                     fcb       $00
 L054C               fcc       /line %d  /
                     fcb       $00
-L0556               bpl       L0582
-                    bpl       $0584
-                    bra       L057C
-                    bcs       $05D1
-L055E               bra       L0580
-                    bpl       $058C
-                    bpl       $058E
-                    tst       $0000
+L0556               fcc       /****  %s  ****/
+                    fcb       $0D,$00
 L0566               fcb       $5E
-                    neg       $0074
-                    fcc       /oo many errors - AB/
-L057C               fcb       $4F,$52,$54
+                    fcb       $00
+L0568               fcc       /too many errors - ABORT/
                     fcb       $00
 L0580               pshs      u
-L0582               ldd       #$FFA2
+                    ldd       #$FFA2
                     lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L0694
@@ -608,7 +616,7 @@ L0582               ldd       #$FFA2
                     lbne      L0679
                     clra
                     clrb
-L0595               lbra      L0690
+                    lbra      L0690
                     lbra      L0679
 
 L059B               ldd       $005F
@@ -3593,7 +3601,7 @@ L2058               ldd       #$0001
                     pshs      u
                     lbsr      L2027
                     leas      $04,s
-L206F               lbra      L2303
+                    lbra      L2303
 
 L2072               cmpx      #$0001
                     beq       L2040
@@ -4163,7 +4171,7 @@ L2546               pshs      u
                     ldd       $08,x
                     cmpd      #$0011
                     beq       L2567
-L2563               leax      $02,s
+                    leax      $02,s
                     bra       L2584
 
 L2567               ldd       #$0036
@@ -8184,7 +8192,7 @@ L4B1D               pshs      u
                     lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
-                    leax      $50C1,pcr
+                    leax      L50C1,pcr
                     lbra      L4C0F
 
 L4B30               pshs      u
@@ -8286,7 +8294,7 @@ L4BFF               pshs      u
                     lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
-                    leax      $50C6,pcr
+                    leax      L50C6,pcr
 L4C0F               pshs      x
                     ldd       $0025
                     pshs      d
@@ -8834,15 +8842,15 @@ L509E               pshs      u
                     lbsr      L4C68
                     leas      $04,s
                     puls      pc,u
-L50BE               bcs       $5124
-                    neg       $0025
-                    bgt       L50FC
-                    com       >$0046
-                    bcs       $513C
-                    tst       $0000
-L50CB               leax      $0C,y
-                    neg       $0034
-                    nega
+L50BE               fcb       $25,$64
+                    fcb       $00
+L50C1               fcc       /%.8s/
+                    fcb       $00
+L50C6               fcb       $46,$25,$73
+                    fcb       $0D,$00
+L50CB               fcb       $30,$2C
+                    fcb       $00
+L50CE               pshs      u
                     leax      $01C1,y
                     stx       $000F
                     ldd       #$0001
@@ -9831,13 +9839,13 @@ L5897               pshs      u
                     std       $0041
                     ldd       #$0001
                     pshs      d
-                    leax      $6230,pcr
+                    leax      L6230,pcr
                     pshs      x
                     lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0005
                     pshs      d
-                    leax      $6234,pcr
+                    leax      L6234,pcr
                     pshs      x
                     lbsr      L5BD5
                     leas      $04,s
@@ -9900,7 +9908,7 @@ L5897               pshs      u
                     leas      $04,s
                     ldd       #$0014
                     pshs      d
-                    leax      $6270,pcr
+                    leax      L6270,pcr
                     pshs      x
                     lbsr      L5BD5
                     leas      $04,s
@@ -9942,7 +9950,7 @@ L5897               pshs      u
                     leas      $04,s
                     ldd       #$001B
                     pshs      d
-                    leax      $6299,pcr
+                    leax      L6299,pcr
                     pshs      x
                     lbsr      L5BD5
                     leas      $04,s
@@ -9954,7 +9962,7 @@ L5897               pshs      u
                     leas      $04,s
                     ldd       #$0004
                     pshs      d
-                    leax      $62A5,pcr
+                    leax      L62A5,pcr
                     pshs      x
                     lbsr      L5BD5
                     leas      $04,s
@@ -10893,16 +10901,15 @@ L6210               fcc       /float/
                     fcb       $00
 L6216               fcc       /typedef/
                     fcb       $00
-L621E               fcb       $73,$74
-L6220               fcc       /atic/
+L621E               fcc       /static/
                     fcb       $00
 L6225               fcc       /sizeof/
                     fcb       $00
-L622C               rol       $0e,s
-                    lsr       >L0069
-                    jmp       -$0C,s
-                    neg       L0066
-                    fcc       /loat/
+L622C               fcb       $69,$6E,$74
+                    fcb       $00
+L6230               fcb       $69,$6E,$74
+                    fcb       $00
+L6234               fcc       /float/
                     fcb       $00
 L623A               fcc       /char/
                     fcb       $00
@@ -10920,9 +10927,9 @@ L6261               fcc       /goto/
                     fcb       $00
 L6266               fcc       /return/
                     fcb       $00
-L626D               rol       $06,s
-                    neg       $0077
-                    fcc       /hile/
+L626D               fcb       $69,$66
+                    fcb       $00
+L6270               fcc       /while/
                     fcb       $00
 L6276               fcc       /else/
                     fcb       $00
@@ -10934,14 +10941,13 @@ L6287               fcc       /break/
                     fcb       $00
 L628D               fcc       /continue/
                     fcb       $00
-L6296               lsr       $0f,s
-                    neg       L0064
-                    fcc       /efault/
+L6296               fcb       $64,$6F
                     fcb       $00
-L62A1               ror       $0f,s
-                    fcb       $72
-                    neg       $0073
-                    fcc       /truct/
+L6299               fcc       /default/
+                    fcb       $00
+L62A1               fcb       $66,$6F,$72
+                    fcb       $00
+L62A5               fcc       /struct/
                     fcb       $00
 L62AC               fcc       /union/
                     fcb       $00
@@ -10957,15 +10963,14 @@ L62CC               fcc       /out of memory/
                     fcb       $00
 L62DA               fcc       /unterminated character constant/
                     fcb       $00
-L62FA               asr       $2B00
+L62FA               fcb       $77,$2B
+                    fcb       $00
 L62FD               fcc       /can't open strings file/
                     fcb       $00
 L6315               fcc       /unterminated string/
                     fcb       $00
-L6329               bra       L639D
-                    dec       L6220
-                    bcs       $6394
-                    tst       $0000
+L6329               fcc       / rzb %d/
+                    fcb       $0D,$00
 L6332               pshs      u
                     leax      $060C,y
                     stx       $006A
@@ -11016,7 +11021,7 @@ L6385               clra
                     lbsr      L7311
                     leas      $04,s
 L639A               lbsr      L65A3
-L639D               std       $006A
+                    std       $006A
                     lbeq      L64A4
                     ldb       [$006A,y]
                     cmpb      #$23
@@ -11042,7 +11047,7 @@ L63D1               lbsr      L6800
 L63D4               lbsr      L4BEC
                     leax      $060C,y
                     pshs      x
-                    leax      $6632,pcr
+                    leax      L6632,pcr
                     lbra      L6456
 
 L63E4               leax      $060C,y
@@ -11129,19 +11134,19 @@ L64AA               ldd       $06,s
                     pshs      x
                     leax      L6655,pcr
                     pshs      x
-                    lbsr      $50CE
+                    lbsr      L50CE
                     leas      $06,s
                     bra       L64D0
 
 L64C5               leax      L6663,pcr
                     pshs      x
-                    lbsr      $50CE
+                    lbsr      L50CE
                     leas      $02,s
 L64D0               leax      $060C,y
                     pshs      x
                     leax      L666F,pcr
                     pshs      x
-                    lbsr      $50CE
+                    lbsr      L50CE
                     leas      $04,s
                     ldb       $02EE,y
                     beq       L651B
@@ -11162,7 +11167,7 @@ L6504               ldd       $02,s
                     std       $02,s
                     subd      #$FFFF
                     bne       L64F4
-                    leax      $667D,pcr
+                    leax      L667D,pcr
                     pshs      x
                     lbsr      L6E3F
                     leas      $02,s
@@ -11237,7 +11242,7 @@ L65A3               pshs      u,d
                     beq       L65D9
                     leax      $01CE,y
                     pshs      x
-                    leax      $667F,pcr
+                    leax      L667F,pcr
                     pshs      x
                     lbsr      L6E61
                     leas      $04,s
@@ -11285,37 +11290,24 @@ L660C               cmpu      $0189,y
                     leas      $02,s
 L662D               leas      $02,s
                     puls      pc,u
-L6631               neg       $0025
-                    com       $0D00
-L6636               bra       L66A8
-                    fcc       /sect %s,0,0,%d,0,0/
+L6631               fcb       $00
+L6632               fcb       $25,$73
                     fcb       $0D,$00
-L664C               bra       $66BC
-                    fcb       $61
-                    tst       0,y
-                    bcs       $66C6
-                    tst       $0000
+L6636               fcc       / psect %s,0,0,%d,0,0/
+                    fcb       $0D,$00
+L664C               fcc       / nam %s/
+                    fcb       $0D,$00
 L6655               fcc       /%s : line %d /
                     fcb       $00
 L6663               fcc       /argument : /
                     fcb       $00
-L666F               bpl       L669B
-                    bpl       L669D
-                    bra       L669A
-                    com       $202A
-                    bpl       L66A4
-                    bpl       L6689
-                    neg       $005E
-                    neg       L0049
-                    fcc       /NPUT FILE/
-L6689               fcc       / ERROR : TEMPORAR/
-L669A               fcb       $59
-L669B               fcb       $20,$46
-L669D               fcb       $49,$4C,$45
+L666F               fcc       /**** %s ****/
                     fcb       $0D,$00
-L66A2               fcb       $69,$6E
-L66A4               fcc       /put /
-L66A8               fcc       /line too long/
+L667D               fcb       $5E
+                    fcb       $00
+L667F               fcc       /INPUT FILE ERROR : TEMPORARY FILE/
+                    fcb       $0D,$00
+L66A2               fcc       /input line too long/
                     fcb       $00
 L66B6               pshs      u
                     lbsr      L686D
@@ -11373,7 +11365,7 @@ L6719               pshs      u
                     ldd       $08,s
                     addd      #$0014
                     pshs      d
-                    leax      $6923,pcr
+                    leax      L6923,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
@@ -11408,7 +11400,7 @@ L6772               clra
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      $6932,pcr
+                    leax      L6932,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
@@ -11547,7 +11539,7 @@ L688A               ldd       $006C
                     clra
                     andb      #$20
                     beq       L68AD
-                    leax      $694D,pcr
+                    leax      L694D,pcr
                     ldd       $06,x
                     clra
                     andb      #$20
@@ -11598,19 +11590,11 @@ L690D               ldd       ,s
                     leas      $02,s
 L6916               leas      $02,s
 L6918               puls      pc,u
-L691A               bra       $698E
-                    tst       $02,s
-                    bra       L6945
-                    lsr       $0d,x
-                    neg       $0025
-                    bgt       $695E
-                    com       L2563
-                    bra       L699D
-                    tst       $02,s
-                    bra       L6954
-                    lsr       $0d,x
-                    neg       $0025
-                    fcc       /.8s%c/
+L691A               fcc       / rmb %d/
+                    fcb       $0D,$00
+L6923               fcc       /%.8s%c rmb %d/
+                    fcb       $0D,$00
+L6932               fcc       /%.8s%c/
                     fcb       $00
 L6939               fcc       /%.8s%c/
                     fcb       $00
@@ -11618,10 +11602,9 @@ L6940               fcc       /fcb /
                     fcb       $00
 L6945               fcc       /fdb /
                     fcb       $00
-L694A               bpl       $696C
-                    neg       L0064
-                    fcc       /umpstr/
-L6954               fcc       /ings/
+L694A               fcb       $2A,$20
+                    fcb       $00
+L694D               fcc       /dumpstrings/
                     fcb       $00
 L6959               pshs      u
                     leau      $02C6,y
@@ -11661,7 +11644,7 @@ L6993               lda       $07,x
                     pshs      x
                     leax      $07,x
                     pshs      x,a
-L699D               bra       L69B9
+                    bra       L69B9
 
 L699F               ldx       $01,s
                     ldb       #$06
@@ -11838,7 +11821,7 @@ L6AE0               leau      $01,u
                     std       $0025
                     bne       L6B11
                     pshs      u
-                    leax      $6C1F,pcr
+                    leax      L6C1F,pcr
                     pshs      x
                     leax      $01CE,y
                     pshs      x
@@ -11899,7 +11882,7 @@ L6B68               ldd       $0072
                     leas      $06,s
                     std       L0023
                     bne       L6B98
-                    leax      $6C44,pcr
+                    leax      L6C44,pcr
                     pshs      x
                     lbsr      L0228
                     leas      $02,s
@@ -11955,22 +11938,17 @@ L6C09               ldd       #$0001
                     lbsr      exit
                     leas      $02,s
                     puls      pc,u
-L6C15               clrb
-                    fcc       /dummy_/
+L6C15               fcc       /_dummy_/
                     fcb       $00
-L6C1D               asr       >$0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       L206F
-                    neg       $656E
-                    bra       L6C50
-                    com       $0D00
+L6C1D               fcb       $77
+                    fcb       $00
+L6C1F               fcc       /can't open %s/
+                    fcb       $0D,$00
 L6C2E               fcc       /unknown flag : -%c/
                     fcb       $0D,$00
 L6C42               fcb       $72
-                    neg       $0063
-                    fcc       /an't open i/
-L6C50               fcc       /nput file/
+                    fcb       $00
+L6C44               fcc       /can't open input file/
                     fcb       $00
 L6C5A               fcc       /error writing assembly code file/
                     fcb       $00

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       3987
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.pass1/
                     fcb       edition
 
-L0015               lda       ,y+
+copybytes           lda       ,y+
 L0017               sta       ,u+
 L0019               leax      -$01,x
-L001B               bne       L0015
+L001B               bne       copybytes
 L001D               rts
 
-start               pshs      y
+_start              pshs      y
 L0020               pshs      u
 L0022               clra
 L0023               clrb
@@ -37,12 +37,12 @@ L0031               pshs      x
 L0033               leay      L794C,pcr
 L0037               ldx       ,y++
 L0039               beq       L003F
-L003B               bsr       L0015
+L003B               bsr       copybytes
 L003D               ldu       $02,s
 L003F               leau      >$0076,u
 L0043               ldx       ,y++
 L0045               beq       L004A
-L0047               bsr       L0015
+L0047               bsr       copybytes
 L0049               clra
 L004A               cmpu      ,s
 L004D               beq       L0053
@@ -119,17 +119,17 @@ L00E1               leax      $0284,u
                     ldd       $02C0,u
                     pshs      d
                     leay      ,u
-                    bsr       L00FB
-                    lbsr      L6A70
+                    bsr       stkinit
+                    lbsr      main
                     clr       ,-s
                     clr       ,-s
-                    lbsr      L7940
-L00FB               leax      $0813,y
+                    lbsr      exit
+stkinit             leax      $0813,y
                     stx       $02CE,y
                     sts       $02C2,y
                     sts       $02D0,y
                     ldd       #$FF82
-L0110               leax      d,s
+stkcheck            leax      d,s
                     cmpx      $02D0,y
                     bcc       L0122
                     cmpx      $02CE,y
@@ -364,7 +364,7 @@ L0313               cmpu      #$0000
 L0323               ldd       L0029
                     addd      #$0001
                     std       L0029
-                    cmpd      #start
+                    cmpd      #_start
                     ble       L0348
                     leax      $01CE,y
                     pshs      x
@@ -385,7 +385,7 @@ L034A               pshs      u
                     pshs      d
                     leax      $01CE,y
                     pshs      x
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
 L0365               pshs      u
@@ -473,7 +473,7 @@ L0428               ldd       $005F
                     lbne      L04C8
                     ldx       $0061
                     ldd       $08,x
-                    cmpd      #start
+                    cmpd      #_start
                     bra       L0470
 
 L043C               pshs      u
@@ -485,7 +485,7 @@ L043C               pshs      u
                     lbeq      L04FA
                     cmpx      #$000D
                     lbeq      L04FA
-                    cmpx      #start
+                    cmpx      #_start
                     lbeq      L04FA
                     cmpx      #$0010
                     lbeq      L04FA
@@ -601,7 +601,7 @@ L057C               fcb       $4F,$52,$54
                     fcb       $00
 L0580               pshs      u
 L0582               ldd       #$FFA2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L0694
                     std       $0C,s
@@ -726,7 +726,7 @@ L0690               leas      $0e,s
                     puls      pc,u
 L0694               pshs      u
                     ldd       #$FFA4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0C,s
                     ldu       #$0000
                     ldx       $005F
@@ -1121,7 +1121,7 @@ L09F0               leas      $0C,s
                     puls      pc,u
 L09F4               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldu       #$0000
                     bra       L0A03
@@ -1164,7 +1164,7 @@ L0A4B               tfr       u,d
 
 L0A4F               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
@@ -1199,7 +1199,7 @@ L0A97               leas      $02,s
                     puls      pc,u
 L0A9B               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $005F
                     bra       L0AF4
 
@@ -1252,7 +1252,7 @@ L0AF4               cmpx      #$0041
                     puls      pc,u
 L0B21               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     lbra      L0C93
 
@@ -1476,7 +1476,7 @@ L0C93               cmpx      #$0050
                     puls      pc,u
 L0D47               pshs      u
                     ldd       #$FFA2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0e,s
                     ldd       L003F
                     std       $04,s
@@ -1542,7 +1542,7 @@ L0D98               ldd       $02,s
                     puls      pc,u
 L0DD3               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       L002D
                     beq       L0DE7
                     ldu       L002D
@@ -1574,7 +1574,7 @@ L0DF3               ldd       $04,s
                     puls      pc,u
 L0E15               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L0F05,pcr
                     pshs      x
                     lbsr      L024B
@@ -1582,7 +1582,7 @@ L0E15               pshs      u
 
 L0E29               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       [$04,s]
                     ldx       $06,u
                     bra       L0E7C
@@ -1646,7 +1646,7 @@ L0F05               fcc       /expression missing/
                     fcb       $00
 L0F18               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0C,s
                     stu       -$02,s
@@ -1755,7 +1755,7 @@ L0FFF               tfr       u,d
                     puls      pc,u
 L1005               pshs      u
                     ldd       #$FFA8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$0e,s
                     stu       -$02,s
@@ -2121,7 +2121,7 @@ L131F               leas      $0e,s
                     puls      pc,u
 L1323               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L1369
@@ -2149,7 +2149,7 @@ L1369               clra
                     puls      pc,u
 L136D               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L2675,pcr
                     pshs      x
                     lbsr      L024B
@@ -2157,7 +2157,7 @@ L136D               pshs      u
                     puls      pc,u
 L1382               pshs      u
                     ldd       #$FF9C
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$14,s
                     ldx       $18,s
                     ldu       $0a,x
@@ -2183,7 +2183,7 @@ L13B6               ldx       $18,s
                     std       $10,s
                     ldx       $10,s
                     ldd       $08,x
-                    cmpd      #start
+                    cmpd      #_start
                     bne       L13E6
                     leax      L2684,pcr
                     pshs      x
@@ -3488,7 +3488,7 @@ L1F6B               ldd       $0C,s
                     puls      pc,u
 L1F8E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -3508,7 +3508,7 @@ L1FA4               leax      L2749,pcr
 L1FBA               puls      pc,u
 L1FBC               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     pshs      u
@@ -3559,7 +3559,7 @@ L201F               ldd       ,s
                     puls      pc,u
 L2027               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -3925,7 +3925,7 @@ L233B               ldd       $0a,s
 
 L2340               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
@@ -3984,7 +3984,7 @@ L23C0               leas      $04,s
                     puls      pc,u
 L23C4               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $08,s
                     pshs      d
                     ldd       $06,s
@@ -4058,7 +4058,7 @@ L2452               std       $12,u
                     puls      pc,u
 L2463               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -4104,7 +4104,7 @@ L24BC               leax      L2763,pcr
 
 L24D3               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0034
@@ -4122,7 +4122,7 @@ L24D3               pshs      u
 
 L2502               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       ,u
@@ -4205,7 +4205,7 @@ L25B1               leas      $02,s
 L25B3               puls      pc,u
 L25B5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       ,u
                     cmpd      #$0004
@@ -4225,7 +4225,7 @@ L25E2               ldd       ,u
                     puls      pc,u
 L25E6               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       #$0006
                     pshs      d
@@ -4255,7 +4255,7 @@ L25E6               pshs      u
                     puls      pc,u
 L262D               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L263E
 
@@ -4274,7 +4274,7 @@ L263E               cmpx      #$0001
                     puls      pc,u
 L265C               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L27BF,pcr
                     pshs      x
                     ldd       $06,s
@@ -4322,7 +4322,7 @@ L27BF               fcc       /must be integral/
                     fcb       $00
 L27D0               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $005F
                     cmpd      #$0028
                     beq       L27E8
@@ -4467,7 +4467,7 @@ L290B               ldd       #$0028
                     puls      pc,u
 L2917               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$06,s
                     lbsr      L552B
                     lbsr      L30E7
@@ -4553,7 +4553,7 @@ L29CD               ldd       $02,s
                     puls      pc,u
 L29DA               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       L0053
                     std       $08,s
@@ -4630,7 +4630,7 @@ L2A4D               ldd       L0055
                     puls      pc,u
 L2A8A               pshs      u
                     ldd       #$FFA8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0e,s
                     lbsr      L552B
                     ldd       L0057
@@ -4795,7 +4795,7 @@ L2BC6               ldd       L0053
 
 L2BF1               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     lbsr      L552B
                     clra
@@ -4847,7 +4847,7 @@ L2C55               bsr       L2C97
 
 L2C59               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L552B
                     ldd       L0057
                     bne       L2C6A
@@ -4873,7 +4873,7 @@ L2C90               pshs      d
 
 L2C97               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L31B0,pcr
                     pshs      x
                     lbsr      L024B
@@ -4881,7 +4881,7 @@ L2CA8               leas      $02,s
                     puls      pc,u
 L2CAC               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       L0053
                     std       $08,s
@@ -4953,7 +4953,7 @@ L2D17               lbsr      L552B
                     puls      pc,u
 L2D5A               pshs      u
                     ldd       #$FFA6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0e,s
                     clra
                     clrb
@@ -5096,7 +5096,7 @@ L2E8F               leas      $0e,s
                     puls      pc,u
 L2E93               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L552B
                     ldd       $005F
                     cmpd      #$0028
@@ -5162,7 +5162,7 @@ L2F00               clra
 
 L2F21               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L552B
                     ldd       L0053
                     bne       L2F3D
@@ -5190,7 +5190,7 @@ L2F5A               ldd       #$0018
 
 L2F60               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L552B
                     ldd       L0055
                     bne       L2F7C
@@ -5218,7 +5218,7 @@ L2F99               ldd       #$0019
 
 L2F9E               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L552B
                     ldd       $005F
                     cmpd      #$0034
@@ -5251,7 +5251,7 @@ L2FE5               std       L004F
                     puls      pc,u
 L2FE9               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     bsr       L302B
                     tfr       d,u
                     stu       -$02,s
@@ -5281,7 +5281,7 @@ L3023               lbsr      L552B
                     puls      pc,u
 L302B               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $0061
                     ldd       ,u
                     cmpd      #$0009
@@ -5320,7 +5320,7 @@ L305D               ldd       #$0009
 
 L3082               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     lbsr      L0580
@@ -5338,7 +5338,7 @@ L3082               pshs      u
 
 L30AB               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L24D3
@@ -5367,7 +5367,7 @@ L30D6               pshs      u
 
 L30E7               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       #$002D
                     pshs      d
@@ -5384,7 +5384,7 @@ L30E7               pshs      u
 
 L310E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     clra
                     clrb
                     pshs      d
@@ -5407,7 +5407,7 @@ L313C               tfr       u,d
                     puls      pc,u
 L3140               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     beq       L3168
@@ -5448,7 +5448,7 @@ L3216               fcc       /condition needed/
                     fcb       $00
 L3227               pshs      u
                     ldd       #$FFA2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$14,s
                     bra       L3242
 
@@ -5750,7 +5750,7 @@ L34D1               leas      $14,s
                     puls      pc,u
 L34D6               pshs      u
                     ldd       #$FFA4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$12,s
                     lbsr      L3BE6
                     std       $10,s
@@ -5902,7 +5902,7 @@ L3614               ldd       #$0028
 
 L3628               pshs      u
                     ldd       #$FF9E
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$12,s
                     lbsr      L3BE6
                     std       $10,s
@@ -6170,7 +6170,7 @@ L3876               leas      $12,s
                     puls      pc,u
 L387B               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       ,u
                     cmpd      $06,s
@@ -6192,7 +6192,7 @@ L38AB               clra
                     puls      pc,u
 L38AF               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$0010
                     bne       L3900
@@ -6229,7 +6229,7 @@ L3900               ldd       $04,s
                     puls      pc,u
 L3904               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       #$0001
                     std       L0051
@@ -6385,7 +6385,7 @@ L3A45               lbsr      L552B
                     puls      pc,u
 L3A4C               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldd       $004B
                     std       $02,s
@@ -6509,7 +6509,7 @@ L3B54               std       $002F
                     puls      pc,u
 L3B5A               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     clra
                     clrb
@@ -6569,7 +6569,7 @@ L3BDA               ldd       #$002E
 
 L3BE6               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     lbsr      L043C
                     std       -$02,s
@@ -6607,7 +6607,7 @@ L3C31               leas      $02,s
                     puls      pc,u
 L3C35               pshs      u
                     ldd       #$FF98
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$1a,s
                     clra
                     clrb
@@ -6939,7 +6939,7 @@ L3F51               ldd       $005F
                     bne       L3F79
                     ldu       $0061
                     ldd       $08,u
-                    cmpd      #start
+                    cmpd      #_start
                     bne       L3F79
                     ldd       $02,u
                     std       [$1e,s]
@@ -6961,7 +6961,7 @@ L3F85               leas      $1a,s
                     puls      pc,u
 L3F8A               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0C,s
                     clra
                     clrb
@@ -7112,7 +7112,7 @@ L40B9               ldd       $0a,s
                     puls      pc,u
 L40CA               pshs      u
                     ldd       #$FFBC
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
@@ -7138,7 +7138,7 @@ L40F2               ldd       ,s
 
 L4100               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       ,u
@@ -7206,7 +7206,7 @@ L4172               std       $02,u
                     puls      pc,u
 L418A               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $08,s
                     leas      -$02,s
                     ldd       $06,s
@@ -7263,7 +7263,7 @@ L41FF               ldd       $08,s
 
 L4204               pshs      u
                     ldd       #$FF74
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$40,s
                     ldu       [$44,s]
                     lbra      L42C1
@@ -7350,13 +7350,13 @@ L42C1               stu       -$02,s
                     puls      pc,u
 L42D1               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L440A,pcr
                     bra       L42EB
 
 L42DF               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L441F,pcr
 L42EB               pshs      x
                     lbsr      L024B
@@ -7400,7 +7400,7 @@ L441F               fcc       /identifier missing/
                     fcb       $00
 L4432               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldx       $0a,s
@@ -7419,7 +7419,7 @@ L444F               pshs      d
                     leas      $02,s
                     bra       L4479
 
-L4458               cmpx      #start
+L4458               cmpx      #_start
                     beq       L4442
                     cmpx      #$000E
                     lbeq      L4442
@@ -7551,7 +7551,7 @@ L456C               leas      $04,s
                     puls      pc,u
 L4570               pshs      u
                     ldd       #$FFA8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $06,s
                     leas      -$0C,s
                     ldd       $16,s
@@ -7765,7 +7765,7 @@ L474A               leas      $0C,s
                     puls      pc,u
 L474E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L4BEC
                     leax      L4A09,pcr
                     pshs      x
@@ -7779,7 +7779,7 @@ L474E               pshs      u
                     puls      pc,u
 L4772               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldd       #$0002
                     pshs      d
@@ -7980,7 +7980,7 @@ L490F               leas      $08,s
                     puls      pc,u
 L4913               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $08,s
@@ -8029,7 +8029,7 @@ L4979               leas      $02,s
                     puls      pc,u
 L497D               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leax      L4A0E,pcr
                     pshs      x
                     lbsr      L024B
@@ -8038,7 +8038,7 @@ L497D               pshs      u
                     puls      pc,u
 L4994               pshs      u
                     ldd       #$FFBC
-                    lbsr      L0110
+                    lbsr      stkcheck
 L499C               ldx       $005F
                     bra       L49A7
 
@@ -8068,7 +8068,7 @@ L4A0E               fcc       /cannot initialize/
                     fcb       $00
 L4A20               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     lbsr      L4BEC
                     ldd       $04,s
                     pshs      d
@@ -8083,7 +8083,7 @@ L4A20               pshs      u
 
 L4A44               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $0025
                     pshs      d
                     ldd       #$0020
@@ -8096,7 +8096,7 @@ L4A44               pshs      u
                     lbra      L5062
                     pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L4A44
@@ -8104,7 +8104,7 @@ L4A44               pshs      u
 
 L4A74               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $0025
                     pshs      d
                     ldd       #$000D
@@ -8112,7 +8112,7 @@ L4A74               pshs      u
 
 L4A85               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $0025
                     pshs      d
                     ldd       $06,s
@@ -8122,17 +8122,17 @@ L4A93               pshs      d
 
 L4A9B               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     lbra      L4BC1
 
 L4AB1               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     leax      L50BE,pcr
@@ -8140,7 +8140,7 @@ L4AB1               pshs      u
 
 L4AC4               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       #$006C
                     pshs      d
                     bsr       L4A85
@@ -8157,7 +8157,7 @@ L4AC4               pshs      u
                     puls      pc,u
 L4AE8               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     clra
                     clrb
                     std       L004F
@@ -8169,7 +8169,7 @@ L4AFC               lbsr      L4A74
                     puls      pc,u
 L4B01               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       #$005F
                     pshs      d
                     lbsr      L4A85
@@ -8181,7 +8181,7 @@ L4B01               pshs      u
 
 L4B1D               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     leax      $50C1,pcr
@@ -8189,7 +8189,7 @@ L4B1D               pshs      u
 
 L4B30               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$02,s
                     ldd       $06,s
                     subd      $002F
@@ -8210,7 +8210,7 @@ L4B59               ldd       $06,s
 
 L4B5E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $0025
                     ldx       $04,s
                     lbra      L4BC5
@@ -8275,7 +8275,7 @@ L4BC5               cmpx      #$007D
                     puls      pc,u
 L4BEC               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       #$002A
 L4BF7               pshs      d
                     lbsr      L4A85
@@ -8283,19 +8283,19 @@ L4BF7               pshs      d
 
 L4BFF               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     leax      $50C6,pcr
 L4C0F               pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     lbra      L4E15
 
 L4C1B               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     ldd       #$0001
@@ -8303,7 +8303,7 @@ L4C1B               pshs      u
 
 L4C2C               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $0a,s
                     pshs      d
                     ldd       $0a,s
@@ -8320,7 +8320,7 @@ L4C2C               pshs      u
 
 L4C4F               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     ldd       #$0004
@@ -8331,7 +8331,7 @@ L4C64               ldd       $04,s
                     puls      pc,u
 L4C68               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $0025
                     pshs      u
                     ldd       #$0054
@@ -8411,7 +8411,7 @@ L4CF9               pshs      d
 
 L4D0C               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     stu       -$02,s
@@ -8529,7 +8529,7 @@ L4E15               leas      $06,s
                     puls      pc,u
 L4E19               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     stu       -$02,s
                     lbeq      L5064
@@ -8547,7 +8547,7 @@ L4E39               pshs      d
 
 L4E41               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $0a,u
@@ -8739,7 +8739,7 @@ L4FD9               leas      $04,s
 
 L4FDE               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     lbsr      L67EF
@@ -8799,7 +8799,7 @@ L5062               leas      $02,s
 L5064               puls      pc,u
 L5066               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       #$0066
                     pshs      d
@@ -8823,7 +8823,7 @@ L5066               pshs      u
                     puls      pc,u
 L509E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $14,u
                     addd      $06,s
@@ -8846,40 +8846,40 @@ L50CB               leax      $0C,y
                     leax      $01C1,y
                     stx       $000F
                     ldd       #$0001
-                    std       L0015
+                    std       copybytes
                     leax      $06,s
                     pshs      x
                     ldd       $06,s
                     bra       L50F4
 
-L50E3               pshs      u
+fprintf             pshs      u
                     ldd       $04,s
                     std       $000F
                     ldd       #$0001
-                    std       L0015
+                    std       copybytes
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
 L50F4               pshs      d
-                    bsr       L511B
+                    bsr       doprnt
                     leas      $04,s
                     puls      pc,u
 L50FC               pshs      u
                     ldd       $04,s
                     std       $000F
                     ldd       #$0002
-                    std       L0015
+                    std       copybytes
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       L511B
+                    bsr       doprnt
                     leas      $04,s
                     clra
                     clrb
                     stb       [$000F,y]
                     puls      pc,u
-L511B               pshs      u
+doprnt              pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L5133
@@ -9303,7 +9303,7 @@ L5460               ldd       ,s
 L546C               leas      $02,s
                     puls      pc,u
 L5470               pshs      u
-                    ldd       L0015
+                    ldd       copybytes
                     cmpd      #$0002
                     bne       L5486
                     ldd       $04,s
@@ -9803,7 +9803,7 @@ L5897               pshs      u
                     pshs      x
                     lbsr      L5BD5
                     leas      $04,s
-                    ldd       #start
+                    ldd       #_start
                     pshs      d
                     leax      L6216,pcr
                     pshs      x
@@ -10681,7 +10681,7 @@ L603C               pshs      u
                     pshs      x
                     ldd       L001B
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L6056               pshs      u,d
@@ -11080,7 +11080,7 @@ L640C               leax      $060C,y
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $08,s
                     lbsr      L4BEC
                     leax      $02EE,y
@@ -11089,7 +11089,7 @@ L640C               leax      $060C,y
 L6456               pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L639A
 
@@ -11337,7 +11337,7 @@ L66BE               pshs      u
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     bra       L6712
 
 L66E8               pshs      u
@@ -11377,7 +11377,7 @@ L6719               pshs      u
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $0a,s
                     puls      pc,u
 L673F               pshs      u
@@ -11412,7 +11412,7 @@ L6772               clra
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $08,s
                     ldd       L0037
                     lbeq      L67E2
@@ -11443,7 +11443,7 @@ L679C               pshs      u
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
 L67CE               pshs      u
@@ -11776,7 +11776,7 @@ L6A3C               pshs      u
                     std       $03,u
 L6A6C               tfr       u,x
                     puls      pc,u
-L6A70               pshs      u
+main                pshs      u
                     leax      L68C1,pcr
                     pshs      x
                     lbsr      L7910
@@ -11842,7 +11842,7 @@ L6AE0               leau      $01,u
                     pshs      x
                     leax      $01CE,y
                     pshs      x
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L6BFA
 L6B11               leax      ,s
@@ -11859,7 +11859,7 @@ L6B1C               ldb       ,u
                     pshs      x
                     leax      $01CE,y
                     pshs      x
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L6BFA
                     bra       L6B5A
@@ -11939,7 +11939,7 @@ L6BD2               leax      $01C1,y
                     pshs      x
                     leax      $01CE,y
                     pshs      x
-                    lbsr      L50E3
+                    lbsr      fprintf
                     leas      $06,s
                     bsr       L6BFA
 L6BF8               puls      pc,u
@@ -11952,7 +11952,7 @@ L6BFA               pshs      u
                     leas      $02,s
 L6C09               ldd       #$0001
                     pshs      d
-                    lbsr      L7940
+                    lbsr      exit
                     leas      $02,s
                     puls      pc,u
 L6C15               clrb
@@ -13583,242 +13583,87 @@ L793B               bcs       L7932
                     clrb
                     rts
 
-L7940               lbsr      L794B
+exit                lbsr      L794B
                     lbsr      L6FC9
 L7946               ldd       $02,s
                     os9       F$Exit
 L794B               rts
 
-L794C               neg       $0003
-                    neg       $0000
-                    adca      #$02
-                    jmp       $0078
-                    fcc       / expected/
+* ------------------------------------------------------------------
+* L794C - cc1-style init image for the work block (see _start):
+* rts stub + count/block table + relocation dirs + module-name string.
+* ------------------------------------------------------------------
+L794C               fcb       $00,$03,$00,$00,$89,$02,$0E init table / work-block image
+                    fcc       /x expected/
                     fcb       $00
-                    beq       L7970
-                    com       $00E8
-                    neg       L0064
-                    neg       $000A
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-L7970               neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    tst       0,u
-                    rol       0,x
-                    neg       $0054
-                    fcc       |Ah-.BP0CESkkkkkkkkkk/(]x_d|
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
+                    fcb       $6D,$40,$69
+                    fcb       $00,$00
+                    fcc       |TAh-.BP0CESkkkkkkkkkk/(]x_d|
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj+f,Yj/
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj)X*D/
-                    fcb       $00,$00,$00
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0009
-                    neg       $0000
-                    neg       $000D
-                    jmp       $0000
-                    neg       $0000
-                    jmp       $000C
-                    fcb       $01
-                    jmp       $000F
-                    tst       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0003
-                    neg       $000A
-                    fcb       $02
-                    dec       $0003
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    asr       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    ror       $0000
-                    jmp       $0000
-                    asr       $000B
-                    neg       $0001
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $000C
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    stx       $0063
-                    fcc       /str.XXXXX/
-                    fcb       $00,$00,$00,$00,$00
-                    neg       $0000
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$09,$00,$00,$00,$0D,$0E
+                    fcb       $00,$00,$00,$0E,$0C,$01,$0E,$0F
+                    fcb       $0D,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$03,$00,$0A,$02,$0A
+                    fcb       $03,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$07
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$06,$00,$0E
+                    fcb       $00,$07,$0B,$00,$01,$00,$02,$00
+                    fcb       $00,$00,$00,$00,$0C,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$01
+                    fcb       $9F
+                    fcc       /cstr.XXXXX/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0003
-                    neg       $0001
-                    fcb       $01
-                    adca      #$01
-                    sta       $03,s
-                    fcc       /.pass1/
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$03,$00,$01,$01,$89,$01,$A7
+                    fcc       /c.pass1/
                     fcb       $00
-
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -114,6 +114,16 @@ L00CD               cmpa      #$0d
 L00DD               clr       -$01,x
                     bra       L0085
 
+* ------------------------------------------------------------------
+* SPURIOUS $00 below (defect in the c.pass1 FCB source, shared with
+* c.pass2; cc1/c.comp/c.opt are clean).  cstart.a shows the real crt0
+* tail is:  leax argv,u / pshs x / ldd argc,u / pshs d / leay 0,u /
+* bsr stkinit / lbsr main / lbsr exit.  A stray $00 turns
+* 'ldd argc,u' (EC C9 02 C0) into 'ldd 0,x' + 'adcb #2' (EC 00 C9 02 ..);
+* the following $C0 (SUBB #, 2 bytes) then swallows the 'pshs d' opcode
+* and derails 'lbsr main'.  The bytes below are byte-faithful to the
+* defective FCB; the genuine binary uses the clean form above.
+* ------------------------------------------------------------------
 L00E1               leax      $0284,u
                     pshs      x
                     ldd       0,x

--- a/3rdparty/packages/ccompiler/c.pass1_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass1_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,_start,size
+                    mod       eom,name,tylg,atrv,start,size
 
 u0000               rmb       3987
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.pass1/
                     fcb       edition
 
-copybytes           lda       ,y+
+L0015               lda       ,y+
 L0017               sta       ,u+
 L0019               leax      -$01,x
-L001B               bne       copybytes
+L001B               bne       L0015
 L001D               rts
 
-_start              pshs      y
+start               pshs      y
 L0020               pshs      u
 L0022               clra
 L0023               clrb
@@ -37,12 +37,12 @@ L0031               pshs      x
 L0033               leay      L794C,pcr
 L0037               ldx       ,y++
 L0039               beq       L003F
-L003B               bsr       copybytes
+L003B               bsr       L0015
 L003D               ldu       $02,s
 L003F               leau      >$0076,u
 L0043               ldx       ,y++
 L0045               beq       L004A
-L0047               bsr       copybytes
+L0047               bsr       L0015
 L0049               clra
 L004A               cmpu      ,s
 L004D               beq       L0053
@@ -114,111 +114,102 @@ L00CD               cmpa      #$0d
 L00DD               clr       -$01,x
                     bra       L0085
 
-* ------------------------------------------------------------------
-* SPURIOUS $00 below (defect in the c.pass1 FCB source, shared with
-* c.pass2; cc1/c.comp/c.opt are clean).  cstart.a shows the real crt0
-* tail is:  leax argv,u / pshs x / ldd argc,u / pshs d / leay 0,u /
-* bsr stkinit / lbsr main / lbsr exit.  A stray $00 turns
-* 'ldd argc,u' (EC C9 02 C0) into 'ldd 0,x' + 'adcb #2' (EC 00 C9 02 ..);
-* the following $C0 (SUBB #, 2 bytes) then swallows the 'pshs d' opcode
-* and derails 'lbsr main'.  The bytes below are byte-faithful to the
-* defective FCB; the genuine binary uses the clean form above.
-* ------------------------------------------------------------------
 L00E1               leax      $0284,u
                     pshs      x
-                    ldd       0,x
-                    adcb      #$02
-                    subb      #$34
-                    ror       L0031
-                    andb      #$8d
-                    dec       L0017
-                    rol       -$04,s
+                    ldd       $02C0,u
+                    pshs      d
+                    leay      ,u
+                    bsr       L00FB
+                    lbsr      L6A70
                     clr       ,-s
                     clr       ,-s
-                    lbsr      exit
-                    leax      $0813,y
-L0100               stx       $02CE,y
+                    lbsr      L7940
+L00FB               leax      $0813,y
+                    stx       $02CE,y
                     sts       $02C2,y
                     sts       $02D0,y
                     ldd       #$FF82
-stkcheck            leax      d,s
-L0113               cmpx      $02D0,y
-                    bcc       L0123
+L0110               leax      d,s
+                    cmpx      $02D0,y
+                    bcc       L0122
                     cmpx      $02CE,y
-                    bcs       L013D
+                    bcs       L013C
                     stx       $02D0,y
-L0123               rts
-L0124               fcc       /**** STACK OVERFLOW ****/
+L0122               rts
+L0123               fcc       /**** STACK OVERFLOW ****/
                     fcb       $0D
-L013D               leax      L0124,pcr
+L013C               leax      L0123,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
                     os9       I$WritLn
                     clr       ,-s
-                    lbsr      L7947
+                    lbsr      L7946
                     ldd       $02C2,y
                     subd      $02D0,y
                     rts
                     ldd       $02D0,y
                     subd      $02CE,y
-L0163               rts
-                    pshs      x
+                    rts
+
+L0163               pshs      x
                     leax      d,y
                     leax      d,x
                     pshs      x
-L016C               ldd       ,y++
+L016B               ldd       ,y++
                     leax      d,u
                     ldd       ,x
                     addd      $02,s
                     std       ,x
                     cmpy      ,s
-                    bne       L016C
+                    bne       L016B
                     leas      $04,s
                     rts
-                    pshs      u
-L0180               ldu       $04,s
+
+L017D               pshs      u
+                    ldu       $04,s
                     leas      -$06,s
                     ldd       L0043
                     std       $02,s
-                    beq       L0193
+                    beq       L0192
                     ldx       $02,s
                     ldd       $10,x
                     std       L0043
-                    bra       L019F
+                    bra       L019E
 
-L0193               ldd       #$0012
+L0192               ldd       #$0012
                     pshs      d
-                    lbsr      L5C28
+                    lbsr      L5C27
                     leas      $02,s
                     std       $02,s
-L019F               ldd       #$0012
+L019E               ldd       #$0012
                     pshs      d
                     ldd       $04,s
                     pshs      d
                     stu       $08,s
                     pshs      u
-                    bsr       L01F7
+                    bsr       L01F6
                     leas      $06,s
                     ldd       #$0009
                     std       ,s
-                    bra       L01BB
+                    bra       L01BA
 
-L01B7               clra
+L01B6               clra
                     clrb
                     std       ,u++
-L01BB               ldd       ,s
+L01BA               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bne       L01B7
+                    bne       L01B6
                     ldd       $02,s
                     ldx       $04,s
                     std       $0e,x
-                    lbra      L03D7
-                    pshs      u
-L01D2               ldu       $04,s
+                    lbra      L03D6
+
+L01CF               pshs      u
+                    ldu       $04,s
                     leas      -$02,s
                     ldd       $0e,u
                     std       ,s
@@ -227,85 +218,88 @@ L01D2               ldu       $04,s
                     pshs      u
                     ldd       $04,s
                     pshs      d
-                    bsr       L01F7
+                    bsr       L01F6
                     leas      $06,s
                     ldd       L0043
                     ldx       ,s
                     std       $10,x
                     ldd       ,s
                     std       L0043
-                    lbra      L03B1
+                    lbra      L03B0
 
-L01F7               pshs      u
-L01F9               ldu       $04,s
-                    bra       L0207
+L01F6               pshs      u
+                    ldu       $04,s
+                    bra       L0206
 
-L01FD               ldb       ,u+
+L01FC               ldb       ,u+
                     ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     stb       -$01,x
-L0207               ldd       $08,s
+L0206               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L01FD
+                    bne       L01FC
                     puls      pc,u
-L0215               pshs      u
+L0214               pshs      u
                     leax      $03EE,y
                     pshs      x
-                    leax      L0521,pcr
+                    leax      L0520,pcr
                     pshs      x
-                    lbsr      L034B
-                    lbra      L0390
-                    pshs      u
-L022B               ldd       $04,s
+                    lbsr      L034A
+                    lbra      L038F
+
+L0228               pshs      u
+                    ldd       $04,s
                     pshs      d
-                    bsr       L024C
+                    bsr       L024B
                     leas      $02,s
                     leax      $01CE,y
                     pshs      x
-                    lbsr      $702D
-                    lbra      L0344
-                    pshs      u
-L0241               leax      L0527,pcr
-                    pshs      x
-                    bsr       L024C
-                    lbra      L03B1
+                    lbsr      L702C
+                    lbra      L0343
 
-L024C               pshs      u
-L024E               ldd       L003F
+L023E               pshs      u
+                    leax      L0526,pcr
+                    pshs      x
+                    bsr       L024B
+                    lbra      L03B0
+
+L024B               pshs      u
+                    ldd       L003F
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     leax      $060C,y
                     pshs      x
                     ldd       $0063
-                    bra       L02A9
-                    pshs      u
-L0262               leas      -$32,s
-                    leax      L053B,pcr
+                    bra       L02A8
+
+L025F               pshs      u
+                    leas      -$32,s
+                    leax      L053A,pcr
                     pshs      x
                     leax      $02,s
                     pshs      x
-                    lbsr      $7312
+                    lbsr      L7311
                     leas      $04,s
                     ldd       $38,s
                     pshs      d
                     leax      $02,s
                     pshs      x
-                    lbsr      $732A
+                    lbsr      L7329
                     leas      $04,s
                     leax      ,s
                     pshs      x
                     ldd       $38,s
                     pshs      d
-                    bsr       L0294
+                    bsr       L0293
                     leas      $04,s
                     leas      $32,s
                     puls      pc,u
-L0294               pshs      u
-L0296               ldu       $04,s
+L0293               pshs      u
+                    ldu       $04,s
                     ldd       $0e,u
                     pshs      d
                     ldd       $08,s
@@ -313,76 +307,76 @@ L0296               ldu       $04,s
                     leax      $060C,y
                     pshs      x
                     ldd       $10,u
-L02A9               subd      ,s++
+L02A8               subd      ,s++
                     pshs      d
-                    bsr       L02B2
-                    lbra      L03D7
+                    bsr       L02B1
+                    lbra      L03D6
 
-L02B2               pshs      u
+L02B1               pshs      u
                     ldu       $04,s
-                    lbsr      L0215
+                    lbsr      L0214
                     ldd       $08,s
                     pshs      d
-                    leax      L054D,pcr
+                    leax      L054C,pcr
                     pshs      x
-                    lbsr      L034B
+                    lbsr      L034A
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
-                    leax      L0557,pcr
+                    leax      L0556,pcr
                     pshs      x
-                    lbsr      L034B
+                    lbsr      L034A
                     leas      $04,s
                     ldd       $08,s
                     cmpd      L0027
-                    bne       L02ED
+                    bne       L02EC
                     leax      $060C,y
                     pshs      x
-                    lbsr      L0366
+                    lbsr      L0365
                     leas      $02,s
                     leax      ,s
-                    bra       L0304
+                    bra       L0303
 
-L02ED               ldd       L0027
+L02EC               ldd       L0027
                     addd      #$FFFF
                     cmpd      $08,s
-                    bne       L0324
+                    bne       L0323
                     leax      $070C,y
                     pshs      x
-                    lbsr      L0366
+                    lbsr      L0365
                     leas      $02,s
-                    bra       L0314
+                    bra       L0313
 
-L0304               leas      ,x
-                    bra       L0314
+L0303               leas      ,x
+                    bra       L0313
 
-L0308               ldd       #$0020
+L0307               ldd       #$0020
                     pshs      d
-                    lbsr      L0380
+                    lbsr      L037F
                     leas      $02,s
                     leau      -$01,u
-L0314               cmpu      #$0000
-                    bgt       L0308
-                    leax      L0567,pcr
+L0313               cmpu      #$0000
+                    bgt       L0307
+                    leax      L0566,pcr
                     pshs      x
-                    bsr       L0366
+                    bsr       L0365
                     leas      $02,s
-L0324               ldd       L0029
+L0323               ldd       L0029
                     addd      #$0001
                     std       L0029
-                    cmpd      #_start
-                    ble       L0349
+                    cmpd      #start
+                    ble       L0348
                     leax      $01CE,y
                     pshs      x
-                    lbsr      $702D
+                    lbsr      L702C
                     leas      $02,s
-                    leax      $0569,pcr
+                    leax      $0568,pcr
                     pshs      x
-                    bsr       L0366
-L0344               leas      $02,s
-                    lbsr      $68C2
-L0349               puls      pc,u
-L034B               pshs      u
+                    bsr       L0365
+L0343               leas      $02,s
+                    lbsr      L68C1
+L0348               puls      pc,u
+L034A               pshs      u
                     ldd       $08,s
                     pshs      d
                     ldd       $08,s
@@ -391,232 +385,233 @@ L034B               pshs      u
                     pshs      d
                     leax      $01CE,y
                     pshs      x
-                    lbsr      L50E4
+                    lbsr      L50E3
                     leas      $08,s
                     puls      pc,u
-L0366               pshs      u
+L0365               pshs      u
                     leax      $01CE,y
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    lbsr      $6E62
+                    lbsr      L6E61
                     leas      $04,s
                     ldd       #$000D
                     pshs      d
-                    bsr       L0380
-                    bra       L03B1
+                    bsr       L037F
+                    bra       L03B0
 
-L0380               pshs      u
+L037F               pshs      u
                     leax      $01CE,y
                     pshs      x
                     ldb       $07,s
                     sex
                     pshs      d
-                    lbsr      $6F02
-L0390               leas      $04,s
+                    lbsr      L6F01
+L038F               leas      $04,s
                     puls      pc,u
-L0394               pshs      u
-L0396               ldu       $04,s
+L0393               pshs      u
+                    ldu       $04,s
                     stu       -$02,s
-                    beq       L03B3
+                    beq       L03B2
                     ldd       $0a,u
                     pshs      d
-                    bsr       L0394
+                    bsr       L0393
                     leas      $02,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L0394
+                    lbsr      L0393
                     leas      $02,s
                     pshs      u
-                    bsr       L03B5
-L03B1               leas      $02,s
-L03B3               puls      pc,u
-L03B5               pshs      u
-L03B7               ldu       $04,s
+                    bsr       L03B4
+L03B0               leas      $02,s
+L03B2               puls      pc,u
+L03B4               pshs      u
+                    ldu       $04,s
                     stu       -$02,s
-                    beq       L03C3
+                    beq       L03C2
                     ldd       L002D
                     std       $0a,u
                     stu       L002D
-L03C3               puls      pc,u
-                    pshs      u
-L03C7               ldd       #$0016
+L03C2               puls      pc,u
+L03C4               pshs      u
+                    ldd       #$0016
                     pshs      d
                     ldd       $08,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L01F7
-L03D7               leas      $06,s
+                    lbsr      L01F6
+L03D6               leas      $06,s
                     puls      pc,u
-L03DB               pshs      u
-L03DD               ldd       $005F
+L03DA               pshs      u
+                    ldd       $005F
                     cmpd      #$0033
-                    bne       L0429
+                    bne       L0428
                     ldx       $0061
                     cmpx      #$0001
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0002
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0007
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$000A
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0008
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0004
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0003
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0006
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0005
-                    lbeq      L04FB
-                    lbra      L04C9
+                    lbeq      L04FA
+                    lbra      L04C8
 
-L0429               ldd       $005F
+L0428               ldd       $005F
                     cmpd      #$0034
-                    lbne      L04C9
+                    lbne      L04C8
                     ldx       $0061
                     ldd       $08,x
-                    cmpd      #_start
-                    bra       L0471
-                    pshs      u
-L043F               ldd       $005F
+                    cmpd      #start
+                    bra       L0470
+
+L043C               pshs      u
+                    ldd       $005F
                     cmpd      #$0033
-                    lbne      L04C9
+                    lbne      L04C8
                     ldx       $0061
                     cmpx      #$000E
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$000D
-                    lbeq      L04FB
-                    cmpx      #_start
-                    lbeq      L04FB
+                    lbeq      L04FA
+                    cmpx      #start
+                    lbeq      L04FA
                     cmpx      #$0010
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$000F
-                    lbeq      L04FB
+                    lbeq      L04FA
                     cmpx      #$0021
-L0471               lbeq      L04FB
-                    lbra      L04C9
+L0470               lbeq      L04FA
+                    lbra      L04C8
 
-L0478               pshs      u
-L047A               ldd       $04,s
+L0477               pshs      u
+                    ldd       $04,s
                     asra
                     rorb
                     asra
                     rorb
                     andb      #$F0
-                    bra       L0491
+                    bra       L0490
 
-L0484               pshs      u
-L0486               ldd       $04,s
+L0483               pshs      u
+                    ldd       $04,s
                     andb      #$F0
                     aslb
                     rola
                     aslb
                     rola
                     addd      #$0010
-L0491               pshs      d
+L0490               pshs      d
                     ldd       $06,s
                     clra
                     andb      #$0f
                     addd      ,s++
                     puls      pc,u
-L049C               pshs      u
+L049B               pshs      u
                     ldu       $04,s
                     cmpu      #$004C
-                    blt       L04C9
+                    blt       L04C8
                     cmpu      #$0063
-                    bgt       L04C9
+                    bgt       L04C8
                     ldd       #$0001
-                    bra       L04CB
+                    bra       L04CA
 
-L04B1               pshs      u
+L04B0               pshs      u
                     ldu       $04,s
                     stu       -$02,s
-                    beq       L04C9
+                    beq       L04C8
                     ldd       $02,u
-                    bra       L04CB
+                    bra       L04CA
 
-L04BD               pshs      u
-L04BF               ldd       $005F
+L04BC               pshs      u
+                    ldd       $005F
                     cmpd      $04,s
-                    bne       L04CD
-                    lbsr      $552C
-L04C9               clra
+                    bne       L04CC
+                    lbsr      L552B
+L04C8               clra
                     clrb
-L04CB               puls      pc,u
-L04CD               ldu       #$0000
-                    bra       L04E4
+L04CA               puls      pc,u
+L04CC               ldu       #$0000
+                    bra       L04E3
 
-L04D2               tfr       u,d
+L04D1               tfr       u,d
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     sex
                     cmpd      $04,s
-                    beq       L04EA
+                    beq       L04E9
                     leau      $01,u
-L04E4               cmpu      #$0080
-                    blt       L04D2
-L04EA               tfr       u,d
+L04E3               cmpu      #$0080
+                    blt       L04D1
+L04E9               tfr       u,d
                     stb       >$0076,y
                     leax      >$0076,y
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
-L04FB               ldd       #$0001
+L04FA               ldd       #$0001
                     puls      pc,u
-                    pshs      u
-L0502               bra       L0507
+L04FF               pshs      u
+                    bra       L0506
 
-L0504               lbsr      $552C
-L0507               ldd       $005F
+L0503               lbsr      L552B
+L0506               ldd       $005F
                     cmpd      #$0028
-                    beq       L051F
+                    beq       L051E
                     ldd       $005F
                     cmpd      #$002A
-                    beq       L051F
+                    beq       L051E
                     ldd       $005F
                     cmpd      #$FFFF
-                    bne       L0504
-L051F               puls      pc,u
-L0521               bcs       L0596
-                    bra       L055F
-                    bra       L0527
-L0527               fcc       /multiple definition/
+                    bne       L0503
+L051E               puls      pc,u
+L0520               bcs       L0595
+                    bra       L055E
+                    bra       L0526
+L0526               fcc       /multiple definition/
                     fcb       $00
-L053B               fcc       /compiler error - /
+L053A               fcc       /compiler error - /
                     fcb       $00
-L054D               fcc       /line %d  /
+L054C               fcc       /line %d  /
                     fcb       $00
-L0557               bpl       L0583
-                    bpl       $0585
-                    bra       L057D
-                    bcs       $05D2
-L055F               bra       L0581
-                    bpl       $058D
-                    bpl       $058F
+L0556               bpl       L0582
+                    bpl       $0584
+                    bra       L057C
+                    bcs       $05D1
+L055E               bra       L0580
+                    bpl       $058C
+                    bpl       $058E
                     tst       $0000
-L0567               fcb       $5E
+L0566               fcb       $5E
                     neg       $0074
                     fcc       /oo many errors - AB/
-L057D               fcb       $4F,$52,$54
+L057C               fcb       $4F,$52,$54
                     fcb       $00
-L0581               pshs      u
-L0583               ldd       #$FFA2
-                    lbsr      stkcheck
+L0580               pshs      u
+L0582               ldd       #$FFA2
+                    lbsr      L0110
                     leas      -$0e,s
-                    lbsr      L0695
+                    lbsr      L0694
                     std       $0C,s
-                    lbne      L067A
+                    lbne      L0679
                     clra
                     clrb
-L0596               lbra      L0691
-                    lbra      L067A
+L0595               lbra      L0690
+                    lbra      L0679
 
-L059C               ldd       $005F
+L059B               ldd       $005F
                     std       $0a,s
                     ldd       $0061
                     std       $08,s
@@ -625,52 +620,52 @@ L059C               ldd       $005F
                     std       $04,s
                     ldd       $0063
                     std       $02,s
-                    lbsr      $552C
+                    lbsr      L552B
                     ldx       $0a,s
-                    bra       L05CE
+                    bra       L05CD
 
-L05B5               ldd       $0a,s
+L05B4               ldd       $0a,s
                     cmpd      #$00A0
-                    blt       L05C5
+                    blt       L05C4
                     ldd       $0a,s
                     cmpd      #$00A9
-                    ble       L05DA
-L05C5               ldd       $08,s
+                    ble       L05D9
+L05C4               ldd       $08,s
                     addd      #$0001
                     std       ,s
-                    bra       L05DA
+                    bra       L05D9
 
-L05CE               cmpx      #$0064
-                    beq       L05DA
+L05CD               cmpx      #$0064
+                    beq       L05D9
                     cmpx      #$0078
-                    beq       L05DA
-                    bra       L05B5
+                    beq       L05D9
+                    bra       L05B4
 
-L05DA               ldd       ,s
+L05D9               ldd       ,s
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    lbeq      L066F
+                    lbeq      L066E
                     ldd       $0a,s
                     cmpd      #$0064
-                    lbne      L064E
+                    lbne      L064D
                     ldd       #$002F
                     pshs      d
-                    lbsr      L04BD
+                    lbsr      L04BC
                     std       ,s++
-                    bne       L0643
+                    bne       L0642
                     ldd       $0063
                     std       $02,s
                     ldd       L003F
                     std       $04,s
                     ldd       #$0003
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     leas      $02,s
                     std       $06,s
-                    beq       L0638
+                    beq       L0637
                     ldd       $02,s
                     pshs      d
                     ldd       $06,s
@@ -682,22 +677,22 @@ L05DA               ldd       ,s
                     pshs      u
                     ldd       #$002F
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
-                    bra       L064E
+                    bra       L064D
 
-L0638               leax      L0E98,pcr
+L0637               leax      L0E97,pcr
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
-L0643               pshs      u
-                    lbsr      L0394
+L0642               pshs      u
+                    lbsr      L0393
                     leas      $02,s
                     leax      $0e,s
-                    bra       L068D
+                    bra       L068C
 
-L064E               ldd       $02,s
+L064D               ldd       $02,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
@@ -708,36 +703,36 @@ L064E               ldd       $02,s
                     pshs      d
                     ldd       $14,s
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $0C,s
-                    bra       L067A
+                    bra       L0679
 
-L066F               leax      L0EB1,pcr
+L066E               leax      L0EB0,pcr
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
-L067A               lbsr      L0A9C
+L0679               lbsr      L0A9B
                     std       -$02,s
-                    beq       L068F
+                    beq       L068E
                     ldd       $12,s
                     cmpd      $0061
-                    lble      L059C
-                    bra       L068F
+                    lble      L059B
+                    bra       L068E
 
-L068D               leas      -$0e,x
-L068F               ldd       $0C,s
-L0691               leas      $0e,s
+L068C               leas      -$0e,x
+L068E               ldd       $0C,s
+L0690               leas      $0e,s
                     puls      pc,u
-L0695               pshs      u
+L0694               pshs      u
                     ldd       #$FFA4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$0C,s
                     ldu       #$0000
                     ldx       $005F
-                    lbra      L07FD
+                    lbra      L07FC
 
-L06A7               ldd       $0063
+L06A6               ldd       $0063
                     pshs      d
                     ldd       L003F
                     pshs      d
@@ -751,43 +746,43 @@ L06A7               ldd       $0063
                     pshs      d
                     ldd       $005F
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
-                    lbsr      $552C
-                    lbra      L085F
+                    lbsr      L552B
+                    lbra      L085E
 
-L06CC               lbsr      $552C
-                    lbsr      L03DB
+L06CB               lbsr      L552B
+                    lbsr      L03DA
                     std       -$02,s
-                    beq       L06FA
-                    lbsr      L0D48
+                    beq       L06F9
+                    lbsr      L0D47
                     tfr       d,u
                     ldd       #$002E
                     pshs      d
-                    lbsr      L04BD
+                    lbsr      L04BC
                     leas      $02,s
-                    bsr       L0695
+                    bsr       L0694
                     std       $0a,u
-                    lbne      L085F
+                    lbne      L085E
                     pshs      u
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldu       #$0000
-                    lbra      L085F
+                    lbra      L085E
 
-L06FA               clra
+L06F9               clra
                     clrb
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    bne       L0730
-                    bra       L070D
+                    bne       L072F
+                    bra       L070C
 
-L070B               leas      -$0C,x
-L070D               lbsr      L0E16
+L070A               leas      -$0C,x
+L070C               lbsr      L0E15
                     ldd       $0063
                     pshs      d
                     ldd       L003F
@@ -803,24 +798,24 @@ L070D               lbsr      L0E16
                     pshs      d
                     ldd       #$0036
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
-L0730               ldd       #$002E
+L072F               ldd       #$002E
                     pshs      d
-                    lbsr      L04BD
-                    lbra      L07F9
+                    lbsr      L04BC
+                    lbra      L07F8
 
-L073B               ldd       $005F
+L073A               ldd       $005F
                     std       $08,s
                     ldd       L003F
                     std       $06,s
                     ldd       $0063
                     std       $04,s
-                    lbsr      $552C
-                    lbsr      L0695
+                    lbsr      L552B
+                    lbsr      L0694
                     std       $0a,s
-                    beq       L0776
+                    beq       L0775
                     ldd       $04,s
                     pshs      d
                     ldd       $08,s
@@ -834,51 +829,51 @@ L073B               ldd       $005F
                     pshs      d
                     ldd       $12,s
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
-                    lbra      L085F
+                    lbra      L085E
 
-L0776               leax      L0EC2,pcr
+L0775               leax      L0EC1,pcr
                     pshs      x
-                    lbsr      L024C
-                    lbra      L07F9
+                    lbsr      L024B
+                    lbra      L07F8
 
-L0782               ldd       L003F
+L0781               ldd       L003F
                     std       $06,s
                     ldd       $0063
                     std       $04,s
-                    lbsr      $552C
+                    lbsr      L552B
                     ldd       $005F
                     cmpd      #$002D
-                    bne       L07C4
-                    lbsr      $552C
-                    lbsr      L03DB
+                    bne       L07C3
+                    lbsr      L552B
+                    lbsr      L03DA
                     std       -$02,s
-                    beq       L07A6
-                    lbsr      L0D48
+                    beq       L07A5
+                    lbsr      L0D47
                     std       $0a,s
-                    bra       L07B8
+                    bra       L07B7
 
-L07A6               clra
+L07A5               clra
                     clrb
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     leas      $02,s
                     std       $0a,s
-                    bne       L07B8
+                    bne       L07B7
                     leax      $0C,s
-                    lbra      L070B
+                    lbra      L070A
 
-L07B8               ldd       #$002E
+L07B7               ldd       #$002E
                     pshs      d
-                    lbsr      L04BD
+                    lbsr      L04BC
                     leas      $02,s
-                    bra       L07C9
+                    bra       L07C8
 
-L07C4               lbsr      L0695
+L07C3               lbsr      L0694
                     std       $0a,s
-L07C9               ldd       $0a,s
+L07C8               ldd       $0a,s
                     std       ,s
                     ldd       $04,s
                     pshs      d
@@ -886,7 +881,7 @@ L07C9               ldd       $0a,s
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    lbsr      L0E2A
+                    lbsr      L0E29
                     std       ,s
                     clra
                     clrb
@@ -896,82 +891,82 @@ L07C9               ldd       $0a,s
                     pshs      d
                     ldd       #$0036
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     ldd       ,s
                     pshs      d
-                    lbsr      L0394
-L07F9               leas      $02,s
-                    bra       L085F
+                    lbsr      L0393
+L07F8               leas      $02,s
+                    bra       L085E
 
-L07FD               cmpx      #$0037
-                    lbeq      L06A7
+L07FC               cmpx      #$0037
+                    lbeq      L06A6
                     cmpx      #$0034
-                    lbeq      L06A7
+                    lbeq      L06A6
                     cmpx      #$004A
-                    lbeq      L06A7
+                    lbeq      L06A6
                     cmpx      #$004B
-                    lbeq      L06A7
+                    lbeq      L06A6
                     cmpx      #$0036
-                    lbeq      L06A7
+                    lbeq      L06A6
                     cmpx      #$002D
-                    lbeq      L06CC
+                    lbeq      L06CB
                     cmpx      #$0040
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$0043
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$0044
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$0042
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$003D
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$003C
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$0041
-                    lbeq      L073B
+                    lbeq      L073A
                     cmpx      #$003B
-                    lbeq      L0782
-L085F               cmpu      #$0000
-                    bne       L086A
+                    lbeq      L0781
+L085E               cmpu      #$0000
+                    bne       L0869
                     clra
                     clrb
-                    lbra      L09F1
+                    lbra      L09F0
 
-L086A               ldx       $005F
-                    lbra      L0990
+L0869               ldx       $005F
+                    lbra      L098F
 
-L086F               ldd       $0063
+L086E               ldd       $0063
                     std       $04,s
                     ldd       L003F
                     std       $06,s
-                    lbsr      $552C
+                    lbsr      L552B
                     ldd       $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
                     ldd       #$000F
                     pshs      d
-                    lbsr      L09F5
+                    lbsr      L09F4
                     pshs      d
                     pshs      u
                     ldd       #$0065
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     ldd       #$002E
-                    lbra      L0916
+                    lbra      L0915
 
-L08A0               lbsr      $552C
+L089F               lbsr      L552B
                     ldd       #$0002
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     leas      $02,s
                     std       $0a,s
-                    bne       L08D4
-                    lbsr      L0E16
+                    bne       L08D3
+                    lbsr      L0E15
                     ldd       $0063
                     pshs      d
                     ldd       L003F
@@ -987,10 +982,10 @@ L08A0               lbsr      $552C
                     pshs      d
                     ldd       #$0036
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $0a,s
-L08D4               ldd       $0063
+L08D3               ldd       $0063
                     pshs      d
                     ldd       L003F
                     pshs      d
@@ -1001,7 +996,7 @@ L08D4               ldd       $0063
                     pshs      u
                     ldd       #$0050
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     ldd       $0063
@@ -1016,16 +1011,16 @@ L08D4               ldd       $0063
                     pshs      u
                     ldd       #$0042
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     ldd       #$002C
-L0916               pshs      d
-                    lbsr      L04BD
+L0915               pshs      d
+                    lbsr      L04BC
                     leas      $02,s
-                    lbra      L086A
+                    lbra      L0869
 
-L0920               ldd       $005F
+L091F               ldd       $005F
                     std       $08,s
                     ldd       L003F
                     std       $06,s
@@ -1034,17 +1029,17 @@ L0920               ldd       $005F
                     ldd       $0041
                     addd      #$0001
                     std       $0041
-                    lbsr      $552C
+                    lbsr      L552B
                     ldd       $0041
                     addd      #$FFFF
                     std       $0041
                     ldd       $005F
                     cmpd      #$0034
-                    beq       L094B
-                    lbsr      L42E0
-                    lbra      L09AC
+                    beq       L094A
+                    lbsr      L42DF
+                    lbra      L09AB
 
-L094B               ldd       $0063
+L094A               ldd       $0063
                     pshs      d
                     ldd       L003F
                     pshs      d
@@ -1058,7 +1053,7 @@ L094B               ldd       $0063
                     pshs      d
                     ldd       $005F
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $0a,s
                     ldd       $04,s
@@ -1072,34 +1067,34 @@ L094B               ldd       $0063
                     pshs      u
                     ldd       $12,s
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
-                    lbsr      $552C
-                    lbra      L086A
+                    lbsr      L552B
+                    lbra      L0869
 
-L0990               cmpx      #$002D
-                    lbeq      L086F
+L098F               cmpx      #$002D
+                    lbeq      L086E
                     cmpx      #$002B
-                    lbeq      L08A0
+                    lbeq      L089F
                     cmpx      #$0045
-                    lbeq      L0920
+                    lbeq      L091F
                     cmpx      #$0046
-                    lbeq      L0920
-L09AC               ldx       $005F
-                    bra       L09E5
+                    lbeq      L091F
+L09AB               ldx       $005F
+                    bra       L09E4
 
-L09B0               ldd       #$003E
+L09AF               ldd       #$003E
                     std       $005F
                     leax      $0C,s
-                    bra       L09C0
+                    bra       L09BF
 
-L09B9               ldd       #$003F
+L09B8               ldd       #$003F
                     std       $005F
-                    bra       L09C2
+                    bra       L09C1
 
-L09C0               leas      -$0C,x
-L09C2               ldd       $0063
+L09BF               leas      -$0C,x
+L09C1               ldd       $0063
                     pshs      d
                     ldd       L003F
                     pshs      d
@@ -1111,35 +1106,35 @@ L09C2               ldd       $0063
                     pshs      u
                     ldd       $005F
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
-                    lbsr      $552C
-                    bra       L09EF
+                    lbsr      L552B
+                    bra       L09EE
 
-L09E5               cmpx      #$003C
-                    beq       L09B0
+L09E4               cmpx      #$003C
+                    beq       L09AF
                     cmpx      #$003D
-                    beq       L09B9
-L09EF               tfr       u,d
-L09F1               leas      $0C,s
+                    beq       L09B8
+L09EE               tfr       u,d
+L09F0               leas      $0C,s
                     puls      pc,u
-L09F5               pshs      u
+L09F4               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$02,s
                     ldu       #$0000
-                    bra       L0A04
+                    bra       L0A03
 
-L0A04               ldd       $005F
+L0A03               ldd       $005F
                     cmpd      #$002E
-                    beq       L0A4C
+                    beq       L0A4B
                     ldd       #$0002
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     leas      $02,s
                     std       ,s
-                    beq       L0A3F
+                    beq       L0A3E
                     ldx       ,s
                     ldd       $10,x
                     pshs      d
@@ -1154,333 +1149,334 @@ L0A04               ldd       $005F
                     pshs      d
                     ldd       #$000B
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       ,s
                     ldu       ,s
-L0A3F               ldd       $005F
+L0A3E               ldd       $005F
                     cmpd      #$0030
-                    bne       L0A4C
-                    lbsr      $552C
-                    bra       L0A04
+                    bne       L0A4B
+                    lbsr      L552B
+                    bra       L0A03
 
-L0A4C               tfr       u,d
-                    bra       L0A98
-                    pshs      u
-L0A52               ldd       #$FFB8
-                    lbsr      stkcheck
+L0A4B               tfr       u,d
+                    bra       L0A97
+
+L0A4F               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0110
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      L0581
+                    lbsr      L0580
                     std       ,s
-                    lbsr      L0F19
+                    lbsr      L0F18
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L0A7C
+                    beq       L0A7B
                     ldd       $06,u
                     cmpd      #$0036
-                    bne       L0A7C
+                    bne       L0A7B
                     ldd       $08,u
                     std       ,s
-                    bra       L0A8B
+                    bra       L0A8A
 
-L0A7C               clra
+L0A7B               clra
                     clrb
                     std       ,s
-                    leax      L0ED3,pcr
+                    leax      L0ED2,pcr
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
-L0A8B               stu       -$02,s
-                    beq       L0A96
+L0A8A               stu       -$02,s
+                    beq       L0A95
                     pshs      u
-                    lbsr      L0394
+                    lbsr      L0393
                     leas      $02,s
-L0A96               ldd       ,s
-L0A98               leas      $02,s
+L0A95               ldd       ,s
+L0A97               leas      $02,s
                     puls      pc,u
-L0A9C               pshs      u
+L0A9B               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $005F
-                    bra       L0AF5
+                    bra       L0AF4
 
-L0AA8               ldd       #$0057
+L0AA7               ldd       #$0057
                     std       $005F
                     ldd       #$0008
-                    bra       L0AC4
+                    bra       L0AC3
 
-L0AB2               ldd       #$0052
+L0AB1               ldd       #$0052
                     std       $005F
                     ldd       #$000D
-                    bra       L0AC4
+                    bra       L0AC3
 
-L0ABC               ldd       #$0051
+L0ABB               ldd       #$0051
                     std       $005F
                     ldd       #$000C
-L0AC4               std       $0061
-L0AC6               ldd       #$0001
+L0AC3               std       $0061
+L0AC5               ldd       #$0001
                     puls      pc,u
-L0ACB               ldd       $005F
+L0ACA               ldd       $005F
                     cmpd      #$0047
-                    blt       L0ADB
+                    blt       L0ADA
                     ldd       $005F
                     cmpd      #$005F
-                    ble       L0AEF
-L0ADB               ldd       $005F
+                    ble       L0AEE
+L0ADA               ldd       $005F
                     cmpd      #$00A0
-                    lblt      L0C90
+                    lblt      L0C8F
                     ldd       $005F
                     cmpd      #$00A9
-                    lbgt      L0C90
-L0AEF               ldd       #$0001
-                    lbra      L0C92
+                    lbgt      L0C8F
+L0AEE               ldd       #$0001
+                    lbra      L0C91
 
-L0AF5               cmpx      #$0041
-                    beq       L0AA8
+L0AF4               cmpx      #$0041
+                    beq       L0AA7
                     cmpx      #$0042
-                    beq       L0AB2
+                    beq       L0AB1
                     cmpx      #$0043
-                    beq       L0ABC
+                    beq       L0ABB
                     cmpx      #$0030
-                    beq       L0AC6
+                    beq       L0AC5
                     cmpx      #$0078
-                    lbeq      L0AC6
+                    lbeq      L0AC5
                     cmpx      #$0064
-                    lbeq      L0AC6
+                    lbeq      L0AC5
                     cmpx      #$002F
-                    lbeq      L0C90
-                    bra       L0ACB
+                    lbeq      L0C8F
+                    bra       L0ACA
                     puls      pc,u
-L0B22               pshs      u
+L0B21               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
-                    lbra      L0C94
+                    lbra      L0C93
 
-L0B2F               ldd       $06,s
+L0B2E               ldd       $06,s
                     addd      $08,s
                     puls      pc,u
-L0B35               ldd       $06,s
+L0B34               ldd       $06,s
                     subd      $08,s
                     puls      pc,u
-L0B3B               ldd       $06,s
+L0B3A               ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      L7540
+                    lbsr      L753F
                     puls      pc,u
-L0B46               ldd       $08,s
-                    beq       L0B64
+L0B45               ldd       $08,s
+                    beq       L0B63
                     ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      L75F4
-                    bra       L0B62
+                    lbsr      L75F3
+                    bra       L0B61
 
-L0B55               ldd       $08,s
-                    beq       L0B64
+L0B54               ldd       $08,s
+                    beq       L0B63
                     ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      $75A1
-L0B62               puls      pc,u
-L0B64               lbsr      L136E
-                    lbra      L0C90
+                    lbsr      L75A0
+L0B61               puls      pc,u
+L0B63               lbsr      L136D
+                    lbra      L0C8F
 
-L0B6A               ldd       $06,s
+L0B69               ldd       $06,s
                     anda      $08,s
                     andb      $09,s
                     puls      pc,u
-L0B72               ldd       $06,s
+L0B71               ldd       $06,s
                     ora       $08,s
                     orb       $09,s
                     puls      pc,u
-L0B7A               ldd       $06,s
+L0B79               ldd       $06,s
                     eora      $08,s
                     eorb      $09,s
                     puls      pc,u
-L0B82               ldd       $06,s
+L0B81               ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      L7681
+                    lbsr      L7680
                     puls      pc,u
-L0B8D               ldd       $06,s
+L0B8C               ldd       $06,s
                     pshs      d
                     ldd       $0a,s
-                    lbsr      L765E
+                    lbsr      L765D
                     puls      pc,u
-L0B98               ldd       $06,s
+L0B97               ldd       $06,s
                     cmpd      $08,s
-                    lbne      L0C90
+                    lbne      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0BA7               ldd       $06,s
+L0BA6               ldd       $06,s
                     cmpd      $08,s
-                    lbeq      L0C90
+                    lbeq      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0BB6               ldd       $06,s
+L0BB5               ldd       $06,s
                     cmpd      $08,s
-                    lble      L0C90
+                    lble      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0BC5               ldd       $06,s
+L0BC4               ldd       $06,s
                     cmpd      $08,s
-                    lbge      L0C90
+                    lbge      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0BD4               ldd       $06,s
+L0BD3               ldd       $06,s
                     cmpd      $08,s
-                    lblt      L0C90
+                    lblt      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0BE3               ldd       $06,s
+L0BE2               ldd       $06,s
                     cmpd      $08,s
-                    lbgt      L0C90
+                    lbgt      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0BF2               ldd       $06,s
+L0BF1               ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     puls      pc,u
-L0BFA               ldd       $06,s
-                    lbne      L0C90
+L0BF9               ldd       $06,s
+                    lbne      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0C06               ldd       $06,s
+L0C05               ldd       $06,s
                     coma
                     comb
                     puls      pc,u
-L0C0C               ldd       $06,s
-                    lbeq      L0C90
+L0C0B               ldd       $06,s
+                    lbeq      L0C8F
                     ldd       $08,s
-                    lbeq      L0C90
+                    lbeq      L0C8F
                     ldd       #$0001
-                    lbra      L0C92
+                    lbra      L0C91
 
-L0C1E               ldd       $06,s
-                    bne       L0C28
+L0C1D               ldd       $06,s
+                    bne       L0C27
                     ldd       $08,s
-                    lbeq      L0C90
-L0C28               ldd       #$0001
-                    lbra      L0C92
+                    lbeq      L0C8F
+L0C27               ldd       #$0001
+                    lbra      L0C91
 
-L0C2E               leas      -$04,s
+L0C2D               leas      -$04,s
                     ldd       $0C,s
                     std       $02,s
                     ldd       $0a,s
                     std       ,s
                     ldx       $08,s
-                    bra       L0C72
+                    bra       L0C71
 
-L0C3C               ldd       ,s
+L0C3B               ldd       ,s
                     cmpd      $02,s
-                    bhi       L0C6C
+                    bhi       L0C6B
                     ldd       #$0001
-                    bra       L0C6E
+                    bra       L0C6D
 
-L0C48               ldd       ,s
+L0C47               ldd       ,s
                     cmpd      $02,s
-                    bcc       L0C6C
+                    bcc       L0C6B
                     ldd       #$0001
-                    bra       L0C6E
+                    bra       L0C6D
 
-L0C54               ldd       ,s
+L0C53               ldd       ,s
                     cmpd      $02,s
-                    bcs       L0C6C
+                    bcs       L0C6B
                     ldd       #$0001
-                    bra       L0C6E
+                    bra       L0C6D
 
-L0C60               ldd       ,s
+L0C5F               ldd       ,s
                     cmpd      $02,s
-                    bls       L0C6C
+                    bls       L0C6B
                     ldd       #$0001
-                    bra       L0C6E
+                    bra       L0C6D
 
-L0C6C               clra
+L0C6B               clra
                     clrb
-L0C6E               leas      $04,s
+L0C6D               leas      $04,s
                     puls      pc,u
-L0C72               cmpx      #$0060
-                    beq       L0C3C
+L0C71               cmpx      #$0060
+                    beq       L0C3B
                     cmpx      #$0061
-                    beq       L0C48
+                    beq       L0C47
                     cmpx      #$0062
-                    beq       L0C54
-                    bra       L0C60
+                    beq       L0C53
+                    bra       L0C5F
                     leas      $04,s
-L0C85               leax      L0EE5,pcr
+L0C84               leax      L0EE4,pcr
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
-L0C90               clra
+L0C8F               clra
                     clrb
-L0C92               puls      pc,u
-L0C94               cmpx      #$0050
-                    lbeq      L0B2F
+L0C91               puls      pc,u
+L0C93               cmpx      #$0050
+                    lbeq      L0B2E
                     cmpx      #$0051
-                    lbeq      L0B35
+                    lbeq      L0B34
                     cmpx      #$0052
-                    lbeq      L0B3B
+                    lbeq      L0B3A
                     cmpx      #$0053
-                    lbeq      L0B46
+                    lbeq      L0B45
                     cmpx      #$0054
-                    lbeq      L0B55
+                    lbeq      L0B54
                     cmpx      #$0057
-                    lbeq      L0B6A
+                    lbeq      L0B69
                     cmpx      #$0058
-                    lbeq      L0B72
+                    lbeq      L0B71
                     cmpx      #$0059
-                    lbeq      L0B7A
+                    lbeq      L0B79
                     cmpx      #$0056
-                    lbeq      L0B82
+                    lbeq      L0B81
                     cmpx      #$0055
-                    lbeq      L0B8D
+                    lbeq      L0B8C
                     cmpx      #$005A
-                    lbeq      L0B98
+                    lbeq      L0B97
                     cmpx      #$005B
-                    lbeq      L0BA7
+                    lbeq      L0BA6
                     cmpx      #$005F
-                    lbeq      L0BB6
+                    lbeq      L0BB5
                     cmpx      #$005D
-                    lbeq      L0BC5
+                    lbeq      L0BC4
                     cmpx      #$005E
-                    lbeq      L0BD4
+                    lbeq      L0BD3
                     cmpx      #$005C
-L0D00               lbeq      L0BE3
+                    lbeq      L0BE2
                     cmpx      #$0043
-                    lbeq      L0BF2
+                    lbeq      L0BF1
                     cmpx      #$0040
-                    lbeq      L0BFA
+                    lbeq      L0BF9
                     cmpx      #$0044
-                    lbeq      L0C06
+                    lbeq      L0C05
                     cmpx      #$0047
-                    lbeq      L0C0C
+                    lbeq      L0C0B
                     cmpx      #$0048
-                    lbeq      L0C1E
+                    lbeq      L0C1D
                     cmpx      #$0060
-                    lbeq      L0C2E
+                    lbeq      L0C2D
                     cmpx      #$0061
-                    lbeq      L0C2E
+                    lbeq      L0C2D
                     cmpx      #$0062
-                    lbeq      L0C2E
+                    lbeq      L0C2D
                     cmpx      #$0063
-                    lbeq      L0C2E
-                    lbra      L0C85
+                    lbeq      L0C2D
+                    lbra      L0C84
                     puls      pc,u
-L0D48               pshs      u
+L0D47               pshs      u
                     ldd       #$FFA2
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$0e,s
                     ldd       L003F
                     std       $04,s
@@ -1492,7 +1488,7 @@ L0D48               pshs      u
                     pshs      x
                     leax      $10,s
                     pshs      x
-                    lbsr      L3C36
+                    lbsr      L3C35
                     leas      $06,s
                     std       $08,s
                     pshs      d
@@ -1500,20 +1496,20 @@ L0D48               pshs      u
                     pshs      x
                     leax      $0a,s
                     pshs      x
-                    lbsr      L3F8B
+                    lbsr      L3F8A
                     leas      $06,s
                     std       $08,s
                     leax      >$0047,y
                     pshs      x
-                    lbsr      $4205
+                    lbsr      L4204
                     leas      $02,s
                     ldd       $06,s
-                    beq       L0D99
-                    leax      L0EF7,pcr
+                    beq       L0D98
+                    leax      L0EF6,pcr
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
-L0D99               ldd       $02,s
+L0D98               ldd       $02,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
@@ -1528,7 +1524,7 @@ L0D99               ldd       $02,s
                     pshs      d
                     ldd       #$0020
                     pshs      d
-                    bsr       L0DD4
+                    bsr       L0DD3
                     leas      $0C,s
                     std       $06,s
                     ldd       $08,s
@@ -1539,27 +1535,27 @@ L0D99               ldd       $02,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      $4101
+                    lbsr      L4100
                     leas      $06,s
                     ldd       $06,s
                     leas      $0e,s
                     puls      pc,u
-L0DD4               pshs      u
-L0DD6               ldd       #$FFBA
-                    lbsr      stkcheck
+L0DD3               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0110
                     ldd       L002D
-                    beq       L0DE8
+                    beq       L0DE7
                     ldu       L002D
                     ldd       $0a,u
                     std       L002D
-                    bra       L0DF4
+                    bra       L0DF3
 
-L0DE8               ldd       #$0016
+L0DE7               ldd       #$0016
                     pshs      d
-                    lbsr      L5C28
+                    lbsr      L5C27
                     leas      $02,s
                     tfr       d,u
-L0DF4               ldd       $04,s
+L0DF3               ldd       $04,s
                     std       $06,u
                     ldd       $06,s
                     std       $0a,u
@@ -1576,108 +1572,108 @@ L0DF4               ldd       $04,s
                     std       $14,u
                     tfr       u,d
                     puls      pc,u
-L0E16               pshs      u
-L0E18               ldd       #$FFBA
-                    lbsr      stkcheck
-                    leax      L0F06,pcr
+L0E15               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0110
+                    leax      L0F05,pcr
                     pshs      x
-                    lbsr      L024C
-                    lbra      L0E79
+                    lbsr      L024B
+                    lbra      L0E78
 
-L0E2A               pshs      u
+L0E29               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       [$04,s]
                     ldx       $06,u
-                    bra       L0E7D
+                    bra       L0E7C
 
-L0E39               pshs      u
-                    lbsr      L0F19
+L0E38               pshs      u
+                    lbsr      L0F18
                     leas      $02,s
                     std       [$04,s]
                     tfr       d,u
                     leax      ,s
-                    bra       L0E59
+                    bra       L0E58
 
-L0E49               ldd       [$08,u]
+L0E48               ldd       [$08,u]
                     std       ,u
                     pshs      u
-                    lbsr      $24D4
+                    lbsr      L24D3
                     leas      $02,s
                     ldu       $08,u
-                    bra       L0E5B
+                    bra       L0E5A
 
-L0E59               leas      ,x
-L0E5B               ldd       $04,u
+L0E58               leas      ,x
+L0E5A               ldd       $04,u
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       ,u
                     pshs      d
-                    lbsr      L418B
+                    lbsr      L418A
                     leas      $06,s
                     puls      pc,u
-L0E6E               pshs      u
+L0E6D               pshs      u
                     ldd       #$000C
                     addd      ,s++
                     pshs      d
-                    bsr       L0E2A
-L0E79               leas      $02,s
+                    bsr       L0E29
+L0E78               leas      $02,s
                     puls      pc,u
-L0E7D               cmpx      #$0034
-                    beq       L0E49
+L0E7C               cmpx      #$0034
+                    beq       L0E48
                     cmpx      #$0020
-                    beq       L0E5B
+                    beq       L0E5A
                     cmpx      #$0045
-                    beq       L0E6E
+                    beq       L0E6D
                     cmpx      #$0046
-                    lbeq      L0E6E
-                    lbra      L0E39
+                    lbeq      L0E6D
+                    lbra      L0E38
                     puls      pc,u
-L0E98               fcc       /third expression missing/
+L0E97               fcc       /third expression missing/
                     fcb       $00
-L0EB1               fcc       /operand expected/
+L0EB0               fcc       /operand expected/
                     fcb       $00
-L0EC2               fcc       /primary expected/
+L0EC1               fcc       /primary expected/
                     fcb       $00
-L0ED3               fcc       /constant required/
+L0ED2               fcc       /constant required/
                     fcb       $00
-L0EE5               fcc       /constant operator/
+L0EE4               fcc       /constant operator/
                     fcb       $00
-L0EF7               fcc       /name in a cast/
+L0EF6               fcc       /name in a cast/
                     fcb       $00
-L0F06               fcc       /expression missing/
+L0F05               fcc       /expression missing/
                     fcb       $00
-L0F19               pshs      u
-L0F1B               ldd       #$FFAE
-                    lbsr      stkcheck
+L0F18               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$0C,s
                     stu       -$02,s
-                    lbeq      L1000
+                    lbeq      L0FFF
                     ldd       $0a,u
                     pshs      d
-                    bsr       L0F19
+                    bsr       L0F18
                     leas      $02,s
                     std       $0a,u
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L0F19
+                    lbsr      L0F18
                     leas      $02,s
                     std       $0C,u
                     pshs      u
-                    lbsr      L1383
+                    lbsr      L1382
                     leas      $02,s
                     tfr       d,u
                     pshs      u
-                    lbsr      L1324
+                    lbsr      L1323
                     std       ,s++
-                    beq       L0F57
+                    beq       L0F56
                     leax      $0C,s
-                    lbra      L0FFE
+                    lbra      L0FFD
 
-L0F57               pshs      u
-                    lbsr      L1006
+L0F56               pshs      u
+                    lbsr      L1005
                     leas      $02,s
                     tfr       d,u
                     ldd       $0a,u
@@ -1687,55 +1683,55 @@ L0F57               pshs      u
                     ldd       $06,u
                     std       $04,s
                     cmpd      #$0064
-                    bne       L0FB5
+                    bne       L0FB4
                     ldx       $0a,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L0FB5
+                    bne       L0FB4
                     ldx       $0a,s
                     ldd       $08,x
-                    beq       L0F8E
+                    beq       L0F8D
                     ldx       $08,s
                     ldd       $0a,x
                     std       $02,s
                     ldx       $08,s
                     ldd       $0C,x
-                    bra       L0F98
+                    bra       L0F97
 
-L0F8E               ldx       $08,s
+L0F8D               ldx       $08,s
                     ldd       $0C,x
                     std       $02,s
                     ldx       $08,s
                     ldd       $0a,x
-L0F98               pshs      d
-                    lbsr      L0394
+L0F97               pshs      d
+                    lbsr      L0393
                     leas      $02,s
                     ldd       $08,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     pshs      u
-                    bra       L0FF5
+                    bra       L0FF4
 
-L0FB5               ldd       $04,s
+L0FB4               ldd       $04,s
                     cmpd      #$0042
-                    bne       L0FC7
+                    bne       L0FC6
                     ldx       $0a,s
                     ldd       $06,x
                     cmpd      #$0041
-                    beq       L0FD9
-L0FC7               ldd       $04,s
+                    beq       L0FD8
+L0FC6               ldd       $04,s
                     cmpd      #$0041
-                    bne       L1000
+                    bne       L0FFF
                     ldx       $0a,s
                     ldd       $06,x
                     cmpd      #$0042
-                    bne       L1000
-L0FD9               ldx       $0a,s
+                    bne       L0FFF
+L0FD8               ldx       $0a,s
                     ldd       $0a,x
                     std       $02,s
                     ldd       ,u
@@ -1744,80 +1740,80 @@ L0FD9               ldx       $0a,s
                     ldx       $02,s
                     std       $02,x
                     pshs      u
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-L0FF5               lbsr      L03B5
+L0FF4               lbsr      L03B4
                     leas      $02,s
                     ldu       $02,s
-                    bra       L1000
+                    bra       L0FFF
 
-L0FFE               leas      -$0C,x
-L1000               tfr       u,d
+L0FFD               leas      -$0C,x
+L0FFF               tfr       u,d
                     leas      $0C,s
                     puls      pc,u
-L1006               pshs      u
-L1008               ldd       #$FFA8
-                    lbsr      stkcheck
+L1005               pshs      u
+                    ldd       #$FFA8
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$0e,s
                     stu       -$02,s
-                    bne       L101B
+                    bne       L101A
                     clra
                     clrb
-                    lbra      L1320
+                    lbra      L131F
 
-L101B               ldd       $0a,u
+L101A               ldd       $0a,u
                     std       $0C,s
                     ldd       $0C,u
                     std       $0a,s
                     ldd       $06,u
                     std       $06,s
                     pshs      d
-                    lbsr      L049C
+                    lbsr      L049B
                     std       ,s++
-                    bne       L1042
+                    bne       L1041
                     ldd       $06,s
                     cmpd      #$0047
-                    beq       L1042
+                    beq       L1041
                     ldd       $06,s
                     cmpd      #$0048
-                    lbne      L1259
-L1042               ldx       $0C,s
+                    lbne      L1258
+L1041               ldx       $0C,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L1051
+                    bne       L1050
                     ldd       #$0001
-                    bra       L1053
+                    bra       L1052
 
-L1051               clra
+L1050               clra
                     clrb
-L1053               std       $02,s
+L1052               std       $02,s
                     pshs      d
                     ldx       $0C,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L1066
+                    bne       L1065
                     ldd       #$0001
-                    bra       L1068
+                    bra       L1067
 
-L1066               clra
+L1065               clra
                     clrb
-L1068               std       $02,s
+L1067               std       $02,s
                     anda      ,s+
                     andb      ,s+
                     std       -$02,s
-                    beq       L1077
+                    beq       L1076
                     leax      $0e,s
-                    lbra      L126A
+                    lbra      L1269
 
-L1077               ldd       $02,s
-                    beq       L10B7
+L1076               ldd       $02,s
+                    beq       L10B6
                     ldx       $06,s
-                    bra       L1096
+                    bra       L1095
 
-L107F               ldd       $0C,s
+L107E               ldd       $0C,s
                     std       $08,s
                     ldd       $0a,s
                     std       $0C,s
@@ -1827,38 +1823,38 @@ L107F               ldd       $0C,s
                     std       $0C,u
                     ldd       #$0001
                     std       ,s
-                    bra       L10B7
+                    bra       L10B6
 
-L1096               cmpx      #$0050
-                    beq       L107F
+L1095               cmpx      #$0050
+                    beq       L107E
                     cmpx      #$0052
-                    lbeq      L107F
+                    lbeq      L107E
                     cmpx      #$0057
-                    lbeq      L107F
+                    lbeq      L107E
                     cmpx      #$0058
-                    lbeq      L107F
+                    lbeq      L107E
                     cmpx      #$0059
-                    lbeq      L107F
-L10B7               ldx       $06,s
-                    lbra      L1225
+                    lbeq      L107E
+L10B6               ldx       $06,s
+                    lbra      L1224
 
-L10BC               ldd       ,s
-                    lbeq      L131E
+L10BB               ldd       ,s
+                    lbeq      L131D
                     ldx       $0a,s
                     ldd       $08,x
-                    lbeq      L11EA
-                    lbra      L131E
+                    lbeq      L11E9
+                    lbra      L131D
 
-L10CD               ldd       ,s
-                    lbeq      L131E
+L10CC               ldd       ,s
+                    lbeq      L131D
                     ldx       $0a,s
                     ldd       $08,x
-                    lbeq      L11EA
+                    lbeq      L11E9
                     ldx       $0C,s
                     ldx       $06,x
-                    lbra      L1134
+                    lbra      L1133
 
-L10E2               ldx       $0C,s
+L10E1               ldx       $0C,s
                     ldx       $0a,x
                     ldd       $14,x
                     leax      $14,x
@@ -1867,26 +1863,26 @@ L10E2               ldx       $0C,s
                     ldd       $08,x
                     addd      ,s++
                     std       [,s++]
-                    bra       L10FA
+                    bra       L10F9
 
-L10F8               leas      -$0e,x
-L10FA               ldd       $0C,s
+L10F7               leas      -$0e,x
+L10F9               ldd       $0C,s
                     std       $08,s
                     pshs      u
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldu       $08,s
-                    lbra      L131E
+                    lbra      L131D
 
-L1113               ldx       $0C,s
+L1112               ldx       $0C,s
                     ldx       $0C,x
                     ldd       $06,x
                     cmpd      #$0036
-                    lbne      L131E
+                    lbne      L131D
                     ldx       $0C,s
                     ldx       $0C,x
                     ldd       $08,x
@@ -1895,16 +1891,16 @@ L1113               ldx       $0C,s
                     ldx       $0e,s
                     ldd       $08,x
                     addd      ,s++
-                    lbra      L11CD
+                    lbra      L11CC
 
-L1134               cmpx      #$0041
-                    lbeq      L10E2
+L1133               cmpx      #$0041
+                    lbeq      L10E1
                     cmpx      #$0050
-                    beq       L1113
-                    lbra      L131E
+                    beq       L1112
+                    lbra      L131D
 
-L1143               ldd       ,s
-                    beq       L1162
+L1142               ldd       ,s
+                    beq       L1161
                     ldx       $0a,s
                     ldd       $08,x
                     nega
@@ -1915,15 +1911,15 @@ L1143               ldd       ,s
                     ldd       #$0050
                     std       $06,u
                     pshs      u
-                    lbsr      L1006
+                    lbsr      L1005
                     leas      $02,s
-                    lbra      L1320
+                    lbra      L131F
 
-L1162               ldd       $02,s
-                    lbeq      L131E
+L1161               ldd       $02,s
+                    lbeq      L131D
                     ldx       $0C,s
                     ldd       $08,x
-                    lbne      L131E
+                    lbne      L131D
                     ldd       #$0043
                     std       $06,u
                     ldd       $0a,s
@@ -1932,33 +1928,33 @@ L1162               ldd       $02,s
                     clrb
                     std       $0C,u
                     ldd       $0C,s
-                    lbra      L121B
+                    lbra      L121A
 
-L1182               ldd       ,s
-                    lbeq      L131E
+L1181               ldd       ,s
+                    lbeq      L131D
                     ldx       $0a,s
                     ldd       $08,x
-                    beq       L119D
-                    lbra      L131E
+                    beq       L119C
+                    lbra      L131D
 
-L1191               ldd       ,s
-                    lbeq      L131E
+L1190               ldd       ,s
+                    lbeq      L131D
                     ldx       $0a,s
                     ldx       $08,x
-                    bra       L11D1
+                    bra       L11D0
 
-L119D               leax      $0e,s
-                    lbra      L11FF
+L119C               leax      $0e,s
+                    lbra      L11FE
 
-L11A2               ldx       $0C,s
+L11A1               ldx       $0C,s
                     ldd       $06,x
                     cmpd      #$0052
-                    lbne      L131E
+                    lbne      L131D
                     ldx       $0C,s
                     ldx       $0C,x
                     ldd       $06,x
                     cmpd      #$0036
-                    lbne      L131E
+                    lbne      L131D
                     ldx       $0C,s
                     ldx       $0C,x
                     ldd       $08,x
@@ -1966,79 +1962,79 @@ L11A2               ldx       $0C,s
                     pshs      x,d
                     ldx       $0e,s
                     ldd       $08,x
-                    lbsr      L7540
-L11CD               std       [,s++]
-                    bra       L11EA
+                    lbsr      L753F
+L11CC               std       [,s++]
+                    bra       L11E9
 
-L11D1               stx       -$02,s
-                    beq       L119D
+L11D0               stx       -$02,s
+                    beq       L119C
                     cmpx      #$0001
-                    beq       L11EA
-                    bra       L11A2
+                    beq       L11E9
+                    bra       L11A1
 
-L11DC               ldd       ,s
-                    beq       L11EF
+L11DB               ldd       ,s
+                    beq       L11EE
                     ldx       $0a,s
                     ldd       $08,x
                     cmpd      #$0001
-                    bne       L11EF
-L11EA               leax      $0e,s
-                    lbra      L10F8
+                    bne       L11EE
+L11E9               leax      $0e,s
+                    lbra      L10F7
 
-L11EF               ldd       $02,s
-                    lbeq      L131E
+L11EE               ldd       $02,s
+                    lbeq      L131D
                     ldx       $0C,s
                     ldd       $08,x
-                    lbne      L131E
-                    bra       L1201
+                    lbne      L131D
+                    bra       L1200
 
-L11FF               leas      -$0e,x
-L1201               ldd       #$0036
+L11FE               leas      -$0e,x
+L1200               ldd       #$0036
                     std       $06,u
                     clra
                     clrb
-L1208               std       $08,u
+L1207               std       $08,u
                     clra
                     clrb
                     std       $0C,u
                     std       $0a,u
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldd       $0a,s
-L121B               pshs      d
-                    lbsr      L03B5
-L1220               leas      $02,s
-                    lbra      L131E
+L121A               pshs      d
+                    lbsr      L03B4
+L121F               leas      $02,s
+                    lbra      L131D
 
-L1225               cmpx      #$0058
-                    lbeq      L10BC
+L1224               cmpx      #$0058
+                    lbeq      L10BB
                     cmpx      #$0059
-                    lbeq      L10BC
+                    lbeq      L10BB
                     cmpx      #$0050
-                    lbeq      L10CD
+                    lbeq      L10CC
                     cmpx      #$0051
-                    lbeq      L1143
+                    lbeq      L1142
                     cmpx      #$0057
-                    lbeq      L1182
+                    lbeq      L1181
                     cmpx      #$0052
-                    lbeq      L1191
+                    lbeq      L1190
                     cmpx      #$0053
-                    lbeq      L11DC
-                    lbra      L131E
+                    lbeq      L11DB
+                    lbra      L131D
 
-L1259               ldx       $06,s
-                    lbra      L1309
+L1258               ldx       $06,s
+                    lbra      L1308
 
-L125E               ldx       $0C,s
+L125D               ldx       $0C,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L128E
-                    bra       L126C
+                    bne       L128D
+                    bra       L126B
 
-L126A               leas      -$0e,x
-L126C               ldd       #$0036
+L1269               leas      -$0e,x
+L126B               ldd       #$0036
                     std       $06,u
                     clra
                     clrb
@@ -2051,117 +2047,117 @@ L126C               ldd       #$0036
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L0B22
+                    lbsr      L0B21
                     leas      $06,s
-                    lbra      L1208
+                    lbra      L1207
 
-L128E               ldx       $0C,s
+L128D               ldx       $0C,s
                     ldd       $06,x
                     cmpd      #$004A
-                    bne       L12DD
+                    bne       L12DC
                     leas      -$02,s
                     ldx       $0e,s
                     ldd       $08,x
                     std       ,s
-                    bne       L12AE
+                    bne       L12AD
                     ldd       #$0004
                     pshs      d
-                    lbsr      L5C28
+                    lbsr      L5C27
                     leas      $02,s
                     std       ,s
-L12AE               ldx       $08,s
-                    bra       L12CB
+L12AD               ldx       $08,s
+                    bra       L12CA
 
-L12B2               ldx       ,s
+L12B1               ldx       ,s
                     pshs      x
                     ldx       $02,s
-                    lbsr      L7494
-                    bra       L12C6
+                    lbsr      L7493
+                    bra       L12C5
 
-L12BD               ldx       ,s
+L12BC               ldx       ,s
                     pshs      x
                     ldx       $02,s
-                    lbsr      L74A8
-L12C6               lbsr      L74D4
-                    bra       L12D5
+                    lbsr      L74A7
+L12C5               lbsr      L74D3
+                    bra       L12D4
 
-L12CB               cmpx      #$0043
-                    beq       L12B2
+L12CA               cmpx      #$0043
+                    beq       L12B1
                     cmpx      #$0044
-                    beq       L12BD
-L12D5               ldd       ,s
+                    beq       L12BC
+L12D4               ldd       ,s
                     ldx       $0e,s
                     std       $08,x
-                    bra       L12FD
+                    bra       L12FC
 
-L12DD               ldx       $0C,s
+L12DC               ldx       $0C,s
                     ldd       $06,x
                     cmpd      #$004B
-                    bne       L131E
+                    bne       L131D
                     leas      -$02,s
                     ldx       $0e,s
                     ldd       $08,x
                     std       ,s
-                    beq       L12FD
+                    beq       L12FC
                     ldx       ,s
                     pshs      x
                     ldx       $02,s
-                    lbsr      $6974
-                    lbsr      $6A00
-L12FD               pshs      u
-                    lbsr      L03B5
+                    lbsr      L6973
+                    lbsr      L69FF
+L12FC               pshs      u
+                    lbsr      L03B4
                     leas      $02,s
                     ldu       $0e,s
-                    lbra      L1220
+                    lbra      L121F
 
-L1309               cmpx      #$0040
-                    lbeq      L125E
+L1308               cmpx      #$0040
+                    lbeq      L125D
                     cmpx      #$0044
-                    lbeq      L125E
+                    lbeq      L125D
                     cmpx      #$0043
-                    lbeq      L125E
-L131E               tfr       u,d
-L1320               leas      $0e,s
+                    lbeq      L125D
+L131D               tfr       u,d
+L131F               leas      $0e,s
                     puls      pc,u
-L1324               pshs      u
+L1323               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     stu       -$02,s
-                    beq       L136A
+                    beq       L1369
                     ldx       $06,u
-                    bra       L133B
+                    bra       L133A
 
-L1336               ldd       #$0001
+L1335               ldd       #$0001
                     puls      pc,u
-L133B               cmpx      #$0076
-                    beq       L1336
+L133A               cmpx      #$0076
+                    beq       L1335
                     cmpx      #$006F
-                    lbeq      L1336
+                    lbeq      L1335
                     cmpx      #$0036
-                    lbeq      L1336
+                    lbeq      L1335
                     cmpx      #$004A
-                    lbeq      L1336
+                    lbeq      L1335
                     cmpx      #$004B
-                    lbeq      L1336
+                    lbeq      L1335
                     cmpx      #$0034
-                    lbeq      L1336
+                    lbeq      L1335
                     cmpx      #$0037
-                    lbeq      L1336
-L136A               clra
+                    lbeq      L1335
+L1369               clra
                     clrb
                     puls      pc,u
-L136E               pshs      u
+L136D               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
-                    leax      L2676,pcr
+                    lbsr      L0110
+                    leax      L2675,pcr
                     pshs      x
-                    lbsr      L024C
+                    lbsr      L024B
                     leas      $02,s
                     puls      pc,u
-L1383               pshs      u
-L1385               ldd       #$FF9C
-                    lbsr      stkcheck
+L1382               pshs      u
+                    ldd       #$FF9C
+                    lbsr      L0110
                     leas      -$14,s
                     ldx       $18,s
                     ldu       $0a,x
@@ -2180,27 +2176,28 @@ L1385               ldd       #$FF9C
                     ldd       $06,x
                     std       $0e,s
                     tfr       d,x
-                    lbra      $1E4A
-                    ldx       $18,s
+                    lbra      L1E49
+
+L13B6               ldx       $18,s
                     ldd       $08,x
                     std       $10,s
                     ldx       $10,s
                     ldd       $08,x
-                    cmpd      #_start
-                    bne       L13E7
-                    leax      L2685,pcr
+                    cmpd      #start
+                    bne       L13E6
+                    leax      L2684,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     ldd       $18,s
                     pshs      d
-                    lbsr      L25E7
+                    lbsr      L25E6
                     leas      $02,s
-                    lbra      $1F6C
+                    lbra      L1F6B
 
-L13E7               ldd       [$10,s]
+L13E6               ldd       [$10,s]
                     std       $0C,s
                     ldx       $10,s
                     ldd       $04,x
@@ -2209,7 +2206,7 @@ L13E7               ldd       [$10,s]
                     clra
                     andb      #$0f
                     cmpd      #$000A
-                    bne       L1428
+                    bne       L1427
                     leas      -$02,s
                     ldx       $12,s
                     ldd       $02,x
@@ -2226,23 +2223,23 @@ L13E7               ldd       [$10,s]
                     pshs      d
                     ldd       $16,s
                     pshs      d
-                    lbsr      $4101
+                    lbsr      L4100
                     leas      $06,s
                     leas      $02,s
-L1428               ldx       $10,s
+L1427               ldx       $10,s
                     ldd       $02,x
                     std       $0a,s
                     ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    beq       L1447
+                    beq       L1446
                     ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    lbne      L14AA
-L1447               ldu       $18,s
+                    lbne      L14A9
+L1446               ldu       $18,s
                     ldd       $0a,s
                     std       $02,u
                     ldx       $18,s
@@ -2260,120 +2257,125 @@ L1447               ldu       $18,s
                     pshs      u
                     ldd       #$0041
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $18,s
                     ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L1495
+                    bne       L1494
                     ldd       $06,s
                     pshs      d
-                    lbsr      L04B1
+                    lbsr      L04B0
                     leas      $02,s
                     std       $06,s
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L0478
+                    lbsr      L0477
                     leas      $02,s
-                    bra       L1497
+                    bra       L1496
 
-L1495               ldd       $0C,s
-L1497               std       ,u
+L1494               ldd       $0C,s
+L1496               std       ,u
                     pshs      d
-                    lbsr      L0484
+                    lbsr      L0483
                     leas      $02,s
                     std       $0C,s
                     ldd       #$0001
                     std       $12,u
-                    bra       L14D1
+                    bra       L14D0
 
-L14AA               ldx       $10,s
+L14A9               ldx       $10,s
                     ldd       $08,x
                     std       $04,s
                     tfr       d,x
-                    bra       L14C5
+                    bra       L14C4
 
-L14B5               ldd       $04,s
+L14B4               ldd       $04,s
                     ldx       $18,s
                     std       $06,x
                     clra
                     clrb
                     ldx       $18,s
                     std       $08,x
-                    bra       L14D1
+                    bra       L14D0
 
-L14C5               cmpx      #$0076
-                    beq       L14B5
+L14C4               cmpx      #$0076
+                    beq       L14B4
                     cmpx      #$006F
-                    lbeq      L14B5
-L14D1               ldd       #$0001
-                    bra       L14D8
-                    clra
+                    lbeq      L14B4
+L14D0               ldd       #$0001
+                    bra       L14D7
+
+L14D5               clra
                     clrb
-L14D8               std       $08,s
-                    lbra      $1F6C
-                    ldd       #$0008
+L14D7               std       $08,s
+                    lbra      L1F6B
+
+L14DC               ldd       #$0008
                     std       $0C,s
                     ldd       #$0001
                     std       $08,s
                     ldd       #$0004
-                    lbra      L1642
-                    ldd       #$0006
+                    lbra      L1641
+
+L14EC               ldd       #$0006
                     std       $0C,s
                     ldd       #$0001
                     std       $08,s
                     ldd       #$0008
-                    lbra      L1642
-                    ldd       #$0012
+                    lbra      L1641
+
+L14FC               ldd       #$0012
                     std       $0C,s
                     ldd       #$0001
-                    lbra      L1642
-                    pshs      u
-L150A               lbsr      $24D4
+                    lbra      L1641
+
+L1507               pshs      u
+                    lbsr      L24D3
                     leas      $02,s
                     ldd       [$18,s]
                     std       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    beq       L1528
+                    beq       L1527
                     ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L1543
-L1528               leax      L269E,pcr
+                    bne       L1542
+L1527               leax      L269D,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L0484
+                    lbsr      L0483
                     leas      $02,s
                     std       $0C,s
-L1543               ldd       $0C,s
+L1542               ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L155C
+                    bne       L155B
                     ldd       #$0001
                     pshs      d
                     pshs      u
-                    lbsr      L2028
+                    lbsr      L2027
                     leas      $04,s
-                    bra       L1569
+                    bra       L1568
 
-L155C               ldd       $0C,s
+L155B               ldd       $0C,s
                     pshs      d
                     pshs      u
-                    lbsr      L2028
+                    lbsr      L2027
                     leas      $04,s
                     std       $0C,s
-L1569               ldx       $18,s
+L1568               ldx       $18,s
                     ldd       $04,x
                     std       $06,s
                     ldx       $18,s
@@ -2381,80 +2383,82 @@ L1569               ldx       $18,s
                     std       $0a,s
                     ldd       $18,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     stu       $18,s
-                    lbra      $1F6C
-                    ldd       #$0001
+                    lbra      L1F6B
+
+L1586               ldd       #$0001
                     pshs      d
                     pshs      u
-                    lbsr      L2464
+                    lbsr      L2463
                     leas      $04,s
                     ldd       $06,u
                     cmpd      #$0076
-                    beq       L15A3
+                    beq       L15A2
                     ldd       $06,u
                     cmpd      #$006F
-                    bne       L15BA
-L15A3               leax      L26AA,pcr
+                    bne       L15B9
+L15A2               leax      L26A9,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     pshs      u
-                    lbsr      L25E7
+                    lbsr      L25E6
                     leas      $02,s
-L15BA               ldd       $12,u
+L15B9               ldd       $12,u
                     std       $08,s
                     ldd       $02,u
                     std       $0a,s
                     ldd       ,u
                     pshs      d
-                    lbsr      L0484
+                    lbsr      L0483
                     leas      $02,s
                     std       $0C,s
                     ldd       $04,u
                     std       $06,s
-                    lbra      $1F6C
-                    ldd       $04,u
-L15D7               std       $06,s
+                    lbra      L1F6B
+
+L15D4               ldd       $04,u
+                    std       $06,s
                     ldd       ,u
                     std       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1619
+                    bne       L1618
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L0478
+                    lbsr      L0477
                     leas      $02,s
                     std       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L163B
+                    bne       L163A
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L0478
+                    lbsr      L0477
                     std       ,s
-                    lbsr      L0484
+                    lbsr      L0483
                     leas      $02,s
                     std       $0C,s
                     ldd       $18,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     stu       $18,s
-                    bra       L163B
+                    bra       L163A
 
-L1619               leax      L26BD,pcr
+L1618               leax      L26BC,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     pshs      u
-                    lbsr      L25E7
+                    lbsr      L25E6
                     leas      $02,s
                     ldd       #$0011
                     std       ,u
@@ -2463,18 +2467,19 @@ L1619               leax      L26BD,pcr
                     clra
                     clrb
                     std       $06,s
-L163B               ldd       $12,u
+L163A               ldd       $12,u
                     std       $08,s
                     ldd       $02,u
-L1642               std       $0a,s
-                    lbra      $1F6C
-                    leax      ,s
-L1649               pshs      x
+L1641               std       $0a,s
+                    lbra      L1F6B
+
+L1646               leax      ,s
+                    pshs      x
                     leax      $0e,s
                     pshs      x
                     ldd       $16,s
                     pshs      d
-                    lbsr      $2503
+                    lbsr      L2502
                     leas      $06,s
                     std       $0a,s
                     ldx       $12,s
@@ -2483,44 +2488,44 @@ L1649               pshs      x
                     ldd       #$0001
                     pshs      d
                     pshs      u
-                    lbsr      L2464
+                    lbsr      L2463
                     leas      $04,s
                     ldx       $12,s
                     ldd       $08,x
-                    bne       L169B
+                    bne       L169A
                     ldd       ,s
-                    bne       L169B
+                    bne       L169A
                     ldd       $12,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldd       $18,s
                     pshs      d
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     stu       $18,s
                     ldx       $18,s
                     ldd       $12,x
                     std       $08,s
-                    lbra      L16FE
+                    lbra      L16FD
 
-L169B               ldd       $12,u
+L169A               ldd       $12,u
                     std       $08,s
                     ldd       $06,u
                     cmpd      #$0042
-                    bne       L16C0
+                    bne       L16BF
                     ldd       $0a,u
                     std       $10,s
                     pshs      u
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldu       $10,s
                     tfr       u,d
                     ldx       $18,s
                     std       $0a,x
-                    bra       L16F3
+                    bra       L16F2
 
-L16C0               ldd       ,u
+L16BF               ldd       ,u
                     std       $04,s
                     ldd       $10,u
                     pshs      d
@@ -2535,29 +2540,30 @@ L16C0               ldd       ,u
                     pshs      u
                     ldd       #$0041
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     ldx       $18,s
                     std       $0a,x
                     tfr       d,u
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0484
+                    lbsr      L0483
                     leas      $02,s
                     std       ,u
-L16F3               ldd       $08,s
+L16F2               ldd       $08,s
                     std       $12,u
                     leax      $14,s
-                    lbra      L175C
+                    lbra      L175B
 
-L16FE               lbra      $1F6C
-                    leax      ,s
-L1703               pshs      x
+L16FD               lbra      L1F6B
+
+L1700               leax      ,s
+                    pshs      x
                     leax      $0e,s
                     pshs      x
                     ldd       $16,s
                     pshs      d
-                    lbsr      $2503
+                    lbsr      L2502
                     leas      $06,s
                     std       $0a,s
                     ldx       $12,s
@@ -2566,22 +2572,22 @@ L1703               pshs      x
                     ldd       ,u
                     std       $04,s
                     cmpd      #$0001
-                    beq       L1755
+                    beq       L1754
                     ldd       $04,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1736
+                    bne       L1735
                     ldd       #$0001
-                    bra       L1738
+                    bra       L1737
 
-L1736               clra
+L1735               clra
                     clrb
-L1738               bne       L1755
-                    leax      L26CE,pcr
+L1737               bne       L1754
+                    leax      L26CD,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     ldd       #$0036
                     std       $06,u
@@ -2591,24 +2597,24 @@ L1738               bne       L1755
                     clra
                     clrb
                     std       $12,u
-L1755               ldd       $12,u
+L1754               ldd       $12,u
                     std       $08,s
-                    bra       L175F
+                    bra       L175E
 
-L175C               leas      -$14,x
-L175F               ldd       #$0050
+L175B               leas      -$14,x
+L175E               ldd       #$0050
                     ldx       $18,s
                     std       $06,x
                     ldd       $18,s
                     pshs      d
-                    lbsr      L1006
+                    lbsr      L1005
                     leas      $02,s
                     std       $18,s
                     ldd       ,s
-                    bne       L17BC
+                    bne       L17BB
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L0484
+                    lbsr      L0483
                     leas      $02,s
                     std       [$18,s]
                     ldd       $08,s
@@ -2633,46 +2639,47 @@ L175F               ldd       #$0050
                     pshs      d
                     ldd       #$0042
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $18,s
-L17BC               lbra      $1F6C
-                    ldd       ,u
-L17C1               std       $0C,s
+L17BB               lbra      L1F6B
+
+L17BE               ldd       ,u
+                    std       $0C,s
                     ldd       $06,u
                     cmpd      #$0041
-                    bne       L17FB
+                    bne       L17FA
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L0478
+                    lbsr      L0477
                     leas      $02,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    bne       L17FB
+                    bne       L17FA
                     ldd       $0a,u
                     ldx       $18,s
                     std       $0a,x
                     std       $10,s
                     pshs      u
-                    lbsr      L03B5
+                    lbsr      L03B4
                     leas      $02,s
                     ldd       [$10,s]
-L17F1               pshs      d
-                    lbsr      L0478
+L17F0               pshs      d
+                    lbsr      L0477
                     leas      $02,s
-                    lbra      L185F
+                    lbra      L185E
 
-L17FB               ldd       $0C,s
+L17FA               ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    bne       L180A
+                    bne       L1809
                     ldd       $0C,s
-                    bra       L17F1
+                    bra       L17F0
 
-L180A               ldd       $0C,s
-                    bne       L184D
+L1809               ldd       $0C,s
+                    bne       L184C
                     ldd       $08,u
                     std       $10,s
                     ldd       #$0031
@@ -2696,49 +2703,50 @@ L180A               ldd       $0C,s
                     pshs      u
                     ldd       $14,s
                     pshs      d
-                    lbsr      L01F7
+                    lbsr      L01F6
                     leas      $06,s
                     ldd       #$0001
-                    bra       L185F
+                    bra       L185E
 
-L184D               leax      L26EA,pcr
+L184C               leax      L26E9,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     ldd       $0C,s
                     clra
                     andb      #$0f
-L185F               std       $0C,s
+L185E               std       $0C,s
                     ldd       $04,u
                     std       $06,s
                     ldd       $02,u
                     std       $0a,s
-                    pshs      u
-L186B               lbsr      $24D4
+L1868               pshs      u
+                    lbsr      L24D3
                     leas      $02,s
                     pshs      u
-                    lbsr      L25B6
+                    lbsr      L25B5
                     leas      $02,s
                     ldx       ,u
-                    bra       L188E
+                    bra       L188D
 
-L187B               ldd       #$0001
-                    bra       L1883
+L187A               ldd       #$0001
+                    bra       L1882
 
-L1880               ldd       #$0006
-L1883               pshs      d
+L187F               ldd       #$0006
+L1882               pshs      d
                     pshs      u
-                    lbsr      L2028
+                    lbsr      L2027
                     leas      $04,s
-                    bra       L1898
+                    bra       L1897
 
-L188E               cmpx      #$0002
-                    beq       L187B
+L188D               cmpx      #$0002
+                    beq       L187A
                     cmpx      #$0005
-                    beq       L1880
-L1898               lbra      $1F6C
-                    ldx       $12,s
+                    beq       L187F
+L1897               lbra      L1F6B
+
+L189A               ldx       $12,s
                     ldd       $02,x
                     std       $0a,s
                     ldd       [$12,s]
@@ -2746,37 +2754,41 @@ L1898               lbra      $1F6C
                     ldx       $12,s
                     ldd       $04,x
                     std       $06,s
-                    lbra      $1F6C
-                    ldd       ,u
-L18B3               clra
+                    lbra      L1F6B
+
+L18B0               ldd       ,u
+                    clra
                     andb      #$30
                     cmpd      #$0010
-                    beq       L18C3
+                    beq       L18C2
                     pshs      u
-                    lbsr      L1FBD
+                    lbsr      L1FBC
                     leas      $02,s
-L18C3               ldd       #$0001
-                    lbra      L1E0E
-                    pshs      u
-L18CB               lbsr      L1FBD
+L18C2               ldd       #$0001
+                    lbra      L1E0D
+
+L18C8               pshs      u
+                    lbsr      L1FBC
                     leas      $02,s
-                    lbra      L1E0E
-                    pshs      u
-L18D5               lbsr      L1FBD
+                    lbra      L1E0D
+
+L18D2               pshs      u
+                    lbsr      L1FBC
                     leas      $02,s
                     std       $0C,s
                     cmpd      #$0006
-                    lbne      L19C4
+                    lbne      L19C3
                     pshs      u
-                    lbsr      L265D
+                    lbsr      L265C
                     leas      $02,s
                     pshs      u
-                    lbra      L19BF
-                    clra
+                    lbra      L19BE
+
+L18EF               clra
                     clrb
-L18F2               pshs      d
+                    pshs      d
                     pshs      u
-                    lbsr      L2464
+                    lbsr      L2463
                     leas      $04,s
                     ldd       $02,u
                     std       $0a,s
@@ -2784,152 +2796,158 @@ L18F2               pshs      d
                     std       $0C,s
                     clra
                     andb      #$30
-                    beq       L1921
+                    beq       L1920
                     ldd       $04,u
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L0478
+                    lbsr      L0477
                     std       ,s
-                    lbsr      L418B
+                    lbsr      L418A
                     leas      $06,s
-                    bra       L1924
+                    bra       L1923
 
-L1921               ldd       #$0001
-L1924               ldx       $18,s
+L1920               ldd       #$0001
+L1923               ldx       $18,s
                     std       $08,x
                     ldd       $12,u
                     std       $08,s
                     ldd       $06,u
                     cmpd      #$0042
-                    lbne      L1AA8
+                    lbne      L1AA7
                     ldd       $08,s
                     addd      #$0001
-                    lbra      L1AA6
-                    ldd       ,u
-L1942               clra
-                    andb      #$30
-                    cmpd      #$0010
-                    beq       L1952
-                    pshs      u
-                    lbsr      L1FBD
-                    leas      $02,s
-L1952               ldd       [$12,s]
+                    lbra      L1AA5
+
+L193F               ldd       ,u
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    lbeq      L19C4
+                    beq       L1951
+                    pshs      u
+                    lbsr      L1FBC
+                    leas      $02,s
+L1951               ldd       [$12,s]
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    lbeq      L19C3
                     ldd       $12,s
                     pshs      d
-                    lbsr      L1FBD
-                    bra       L19C2
-                    ldd       $12,s
+                    lbsr      L1FBC
+                    bra       L19C1
+
+L1969               ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      $2341
+                    lbsr      L2340
                     leas      $04,s
                     std       $0C,s
                     cmpd      #$0006
-                    bne       L1983
+                    bne       L1982
                     leax      $14,s
-                    bra       L19A7
+                    bra       L19A6
 
-L1983               lbra      $1F6C
-                    pshs      u
-L1988               lbsr      L1FBD
+L1982               lbra      L1F6B
+
+L1985               pshs      u
+                    lbsr      L1FBC
                     leas      $02,s
                     std       $0C,s
                     cmpd      #$0006
-                    beq       L19AA
+                    beq       L19A9
                     ldd       $12,s
                     pshs      d
-                    lbsr      L1FBD
+                    lbsr      L1FBC
                     leas      $02,s
                     cmpd      #$0006
-                    bne       L19C7
-                    bra       L19AA
+                    bne       L19C6
+                    bra       L19A9
 
-L19A7               leas      -$14,x
-L19AA               leax      L26F9,pcr
+L19A6               leas      -$14,x
+L19A9               leax      L26F8,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
                     ldd       $18,s
                     pshs      d
-L19BF               lbsr      L25E7
-L19C2               leas      $02,s
-L19C4               lbra      $1F6C
+L19BE               lbsr      L25E6
+L19C1               leas      $02,s
+L19C3               lbra      L1F6B
 
-L19C7               ldd       #$0001
+L19C6               ldd       #$0001
                     pshs      d
                     ldd       $14,s
                     pshs      d
-                    lbsr      L2028
-                    lbra      L1A50
-                    ldd       ,u
-L19D9               clra
+                    lbsr      L2027
+                    lbra      L1A4F
+
+L19D6               ldd       ,u
+                    clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L19EE
+                    bne       L19ED
                     ldd       [$12,s]
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    beq       L1A00
-L19EE               ldd       $12,s
+                    beq       L19FF
+L19ED               ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      $2341
+                    lbsr      L2340
                     leas      $04,s
                     cmpd      #$0007
-                    bne       L1A0A
-L1A00               ldd       $0e,s
+                    bne       L1A09
+L19FF               ldd       $0e,s
                     addd      #$0004
                     ldx       $18,s
                     std       $06,x
-L1A0A               lbra      $1F6C
-                    ldd       ,u
-L1A0F               clra
+L1A09               lbra      L1F6B
+
+L1A0C               ldd       ,u
+                    clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1A46
+                    bne       L1A45
                     ldd       [$12,s]
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1A29
+                    bne       L1A28
                     ldd       #$0001
-                    bra       L1A2B
+                    bra       L1A2A
 
-L1A29               clra
+L1A28               clra
                     clrb
-L1A2B               bne       L1A52
+L1A2A               bne       L1A51
                     ldd       $12,s
                     pshs      d
-                    lbsr      L1FBD
+                    lbsr      L1FBC
                     leas      $02,s
                     ldd       #$0001
                     pshs      d
                     ldd       $14,s
                     pshs      d
-                    lbsr      L2028
-                    bra       L1A50
+                    lbsr      L2027
+                    bra       L1A4F
 
-L1A46               ldd       $12,s
+L1A45               ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      $2341
-L1A50               leas      $04,s
-L1A52               lbra      $1F6C
-                    ldd       [$12,s]
+                    lbsr      L2340
+L1A4F               leas      $04,s
+L1A51               lbra      L1F6B
+
+L1A54               ldd       [$12,s]
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1A74
+                    bne       L1A73
                     leas      -$02,s
                     stu       ,s
                     ldu       $14,s
@@ -2938,31 +2956,32 @@ L1A52               lbra      $1F6C
                     leas      $02,s
                     ldx       $18,s
                     stu       $0a,x
-L1A74               ldd       $02,u
+L1A73               ldd       $02,u
                     std       $0a,s
                     ldd       ,u
                     std       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1A8F
+                    bne       L1A8E
                     ldd       $04,u
                     std       $06,s
                     leax      $14,s
-                    lbra      L1B8E
+                    lbra      L1B8D
 
-L1A8F               ldd       $12,s
+L1A8E               ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      $2341
+                    lbsr      L2340
                     leas      $04,s
                     std       $0C,s
                     ldd       $12,u
                     ldx       $12,s
                     addd      $12,x
-L1AA6               std       $08,s
-L1AA8               lbra      $1F6C
-                    ldd       $12,u
+L1AA5               std       $08,s
+L1AA7               lbra      L1F6B
+
+L1AAA               ldd       $12,u
                     ldx       $12,s
                     addd      $12,x
                     std       $08,s
@@ -2971,7 +2990,7 @@ L1AA8               lbra      $1F6C
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    lbne      L1E02
+                    lbne      L1E01
                     ldd       $02,u
                     std       $0a,s
                     ldd       $04,u
@@ -2980,28 +2999,28 @@ L1AA8               lbra      $1F6C
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    lbne      L1B91
+                    lbne      L1B90
                     ldd       $08,s
                     ldx       $18,s
                     std       $12,x
                     ldd       $0C,s
                     cmpd      [$12,s]
-                    bne       L1AF5
+                    bne       L1AF4
                     ldd       $0a,s
                     ldx       $12,s
                     cmpd      $02,x
-                    beq       L1B08
-L1AF5               leax      L270F,pcr
+                    beq       L1B07
+L1AF4               leax      L270E,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0294
+                    lbsr      L0293
                     leas      $04,s
-                    lbra      L1B7F
+                    lbra      L1B7E
 
-L1B08               ldd       $0C,s
+L1B07               ldd       $0C,s
                     pshs      d
-                    lbsr      L0478
+                    lbsr      L0477
                     leas      $02,s
                     std       $0C,s
                     ldd       $06,s
@@ -3010,11 +3029,11 @@ L1B08               ldd       $0C,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L418B
+                    lbsr      L418A
                     leas      $06,s
                     std       $0a,s
                     cmpd      #$0001
-                    lbeq      L1B7F
+                    lbeq      L1B7E
                     ldd       #$0002
                     std       $08,s
                     clra
@@ -3033,7 +3052,7 @@ L1B08               ldd       $0C,s
                     pshs      d
                     ldd       #$0036
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $10,s
                     ldx       $18,s
@@ -3051,40 +3070,40 @@ L1B08               ldd       $0C,s
                     pshs      d
                     ldd       #$0053
                     pshs      d
-                    lbsr      L0DD4
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $18,s
-L1B7F               ldd       #$0002
+L1B7E               ldd       #$0002
                     std       $0a,s
                     clra
                     clrb
                     std       $06,s
                     ldd       #$0001
-                    lbra      L1E0E
+                    lbra      L1E0D
 
-L1B8E               leas      -$14,x
-L1B91               ldd       $12,s
+L1B8D               leas      -$14,x
+L1B90               ldd       $12,s
                     pshs      d
-                    lbsr      L1FBD
+                    lbsr      L1FBC
                     leas      $02,s
                     ldd       [$12,s]
                     pshs      d
-                    lbsr      L262E
+                    lbsr      L262D
                     std       ,s++
-                    bne       L1BBB
+                    bne       L1BBA
                     ldd       $12,s
                     pshs      d
-                    lbsr      L265D
+                    lbsr      L265C
                     leas      $02,s
                     ldd       $12,s
                     pshs      d
-                    lbsr      L25E7
+                    lbsr      L25E6
                     leas      $02,s
-L1BBB               ldd       #$0001
+L1BBA               ldd       #$0001
                     pshs      d
                     ldd       $14,s
                     pshs      d
-                    lbsr      L2028
+                    lbsr      L2027
                     leas      $04,s
                     ldd       $12,s
                     pshs      d
@@ -3094,7 +3113,7 @@ L1BBB               ldd       #$0001
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L23C5
+                    lbsr      L23C4
                     leas      $08,s
                     ldx       $18,s
                     std       $0C,x
@@ -3102,183 +3121,186 @@ L1BBB               ldd       #$0001
                     ldx       $12,s
                     addd      $12,x
                     std       $08,s
-                    lbra      $1F6C
-                    clra
-                    clrb
-L1BF7               pshs      d
-                    pshs      u
-                    lbsr      L2464
-                    leas      $04,s
-                    ldd       $12,s
-                    pshs      d
-                    lbsr      $24D4
-                    leas      $02,s
-                    ldd       $12,s
-                    pshs      d
-                    lbsr      L25B6
-                    leas      $02,s
-                    std       $02,s
-                    ldd       ,u
-                    std       $0b,y
-                    inc       $0f,u
-                    andb      #$30
-                    cmpd      #$0010
-                    bne       L1C3C
-                    ldd       $02,s
-                    clra
-                    andb      #$30
-                    cmpd      #$0010
-                    beq       L1C3C
-                    ldd       $02,s
-                    pshs      d
-                    lbsr      $262F
-                    std       ,s++
-                    lbeq      $1CBC
-L1C3C               ldd       $02,s
-                    clra
-                    andb      #$30
-                    cmpd      #$0010
-                    bne       L1C5F
-                    ldd       $0C,s
-                    clra
-                    andb      #$30
-                    cmpd      #$0010
-                    beq       L1C5F
-                    ldd       $0C,s
-                    pshs      d
-                    lbsr      $262F
-                    std       ,s++
-                    lbeq      $1CBC
-L1C5F               ldd       $0C,s
-                    pshs      d
-                    ldd       $14,s
-                    pshs      d
-                    lbsr      $2029
-                    leas      $04,s
-                    leax      $14,s
-                    lbra      $1D51
-                    leas      -$14,x
-                    clra
-                    clrb
-                    pshs      d
-                    pshs      u
-                    lbsr      $2465
-                    leas      $04,s
-                    ldd       $12,s
-                    pshs      d
-                    lbsr      $1FBE
-                    leas      $02,s
-                    ldd       $12,s
-                    pshs      d
-                    lbsr      $25B7
-                    leas      $02,s
-                    std       $02,s
-                    ldd       ,u
-                    std       $0b,y
-                    inc       $0f,u
-                    andb      #$30
-                    cmpd      #$0010
-                    bne       L1CD1
-                    ldx       $0e,s
-                    bra       L1CC3
+                    lbra      L1F6B
 
-L1CA9               ldd       #$0001
+L1BF4               clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L2463
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L24D3
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L25B5
+                    leas      $02,s
+                    std       $02,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C3A
+                    ldd       $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1C3A
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L262D
+                    std       ,s++
+                    lbeq      L1CBA
+L1C3A               ldd       $02,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1C5D
+                    ldd       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    beq       L1C5D
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L262D
+                    std       ,s++
+                    lbeq      L1CBA
+L1C5D               ldd       $0C,s
                     pshs      d
                     ldd       $14,s
                     pshs      d
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     leax      $14,s
+                    lbra      L1D4F
+
+L1C71               leas      -$14,x
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L2463
+                    leas      $04,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L1FBC
+                    leas      $02,s
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L25B5
+                    leas      $02,s
+                    std       $02,s
+                    ldd       ,u
+                    std       $0C,s
+                    clra
+                    andb      #$30
+                    cmpd      #$0010
+                    bne       L1CCE
+                    ldx       $0e,s
+                    bra       L1CC0
+
+L1CA6               ldd       #$0001
+                    pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L2027
+                    leas      $04,s
+                    leax      $14,s
+                    bra       L1CF0
+
+L1CBA               leax      $14,s
+                    lbra      L1D66
+
+L1CC0               cmpx      #$00A1
+                    beq       L1CA6
+                    cmpx      #$00A0
+                    lbeq      L1CA6
+                    bra       L1CBA
+
+L1CCE               ldx       $0e,s
+                    lbra      L1D40
+
+L1CD3               ldd       $0C,s
+                    cmpd      #$0005
+                    bne       L1CE0
+                    ldd       #$0006
+                    bra       L1CE2
+
+L1CE0               ldd       $0C,s
+L1CE2               pshs      d
+                    ldd       $14,s
+                    pshs      d
+                    lbsr      L2027
+                    leas      $04,s
                     bra       L1CF3
 
-L1CBD               leax      $14,s
-                    lbra      L1D69
-
-L1CC3               cmpx      #$00A1
-                    beq       L1CA9
-                    cmpx      #$00A0
-                    lbeq      L1CA9
-                    bra       L1CBD
-
-L1CD1               ldx       $0e,s
-                    lbra      L1D43
-
-L1CD6               ldd       $0C,s
-                    cmpd      #$0005
-                    bne       L1CE3
-                    ldd       #$0006
-                    bra       L1CE5
-
-L1CE3               ldd       $0C,s
-L1CE5               pshs      d
-                    ldd       $14,s
-                    pshs      d
-                    lbsr      L202A
-                    leas      $04,s
-                    bra       L1CF6
-
-L1CF3               leas      -$14,x
-L1CF6               ldd       $0e,s
+L1CF0               leas      -$14,x
+L1CF3               ldd       $0e,s
                     addd      #$FFB0
                     ldx       $18,s
                     std       $06,x
                     ldd       $18,s
                     pshs      d
-                    lbsr      L1385
+                    lbsr      L1382
                     leas      $02,s
                     std       $18,s
                     ldd       $0C,s
                     cmpd      #$0002
-                    bne       L1D2D
+                    bne       L1D2A
                     ldd       $0a,u
                     ldx       $18,s
                     std       $0a,x
                     pshs      u
-                    lbsr      L03B7
+                    lbsr      L03B4
                     leas      $02,s
                     ldx       $18,s
                     ldu       $0a,x
                     ldd       #$0001
                     std       $0C,s
-L1D2D               ldd       $0e,s
+L1D2A               ldd       $0e,s
                     addd      #$FFB0
                     ldx       $18,s
                     cmpd      $06,x
-                    bne       L1D55
+                    bne       L1D52
                     ldd       $0e,s
                     ldx       $18,s
                     std       $06,x
-                    bra       L1D55
+                    bra       L1D52
 
-L1D43               cmpx      #$00A6
-                    beq       L1CF6
+L1D40               cmpx      #$00A6
+                    beq       L1CF3
                     cmpx      #$00A5
-                    lbeq      L1CF6
-                    lbra      L1CD6
-                    leas      -$14,x
-L1D55               ldd       $02,u
+                    lbeq      L1CF3
+                    lbra      L1CD3
+
+L1D4F               leas      -$14,x
+L1D52               ldd       $02,u
                     std       $0a,s
                     ldd       $12,u
                     ldx       $12,s
                     addd      $12,x
                     std       $08,s
                     ldd       $04,u
-                    lbra      L1E26
+                    lbra      L1E23
 
-L1D69               leas      -$14,x
-                    leax      L2722,pcr
+L1D66               leas      -$14,x
+                    leax      L271F,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0296
-                    lbra      L1E47
+                    lbsr      L0293
+                    lbra      L1E44
 
-L1D7D               ldd       ,u
+L1D7A               ldd       ,u
                     std       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1DDC
+                    bne       L1DD9
                     ldd       $02,u
                     std       $0a,s
                     ldd       $12,u
@@ -3289,39 +3311,39 @@ L1D7D               ldd       ,u
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1DCF
+                    bne       L1DCC
                     ldd       $0C,s
                     cmpd      [$12,s]
-                    bne       L1DB5
+                    bne       L1DB2
                     ldd       $02,u
                     ldx       $12,s
                     cmpd      $02,x
-                    beq       L1DC8
-L1DB5               leax      L2730,pcr
+                    beq       L1DC5
+L1DB2               leax      L272D,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
-                    lbra      L1F6E
+                    lbra      L1F6B
 
-L1DC8               clra
+L1DC5               clra
                     clrb
                     std       $06,s
-                    lbra      L1F6E
+                    lbra      L1F6B
 
-L1DCF               ldd       $12,s
+L1DCC               ldd       $12,s
                     pshs      d
-L1DD4               lbsr      L1F91
+L1DD1               lbsr      L1F8E
                     leas      $02,s
-                    lbra      L1F6E
+                    lbra      L1F6B
 
-L1DDC               ldd       [$12,s]
+L1DD9               ldd       [$12,s]
                     std       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L1E04
+                    bne       L1E01
                     ldx       $12,s
                     ldd       $02,x
                     std       $0a,s
@@ -3332,124 +3354,125 @@ L1DDC               ldd       [$12,s]
                     ldd       $04,x
                     std       $06,s
                     pshs      u
-L1E02               bra       L1DD4
+                    bra       L1DD1
 
-L1E04               ldd       $12,s
+L1E01               ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      L2343
-L1E0E               leas      $04,s
-                    std       $0C,s
-                    lbra      L1F6E
+                    lbsr      L2340
+                    leas      $04,s
+L1E0D               std       $0C,s
+                    lbra      L1F6B
 
-L1E15               ldd       [$12,s]
+L1E12               ldd       [$12,s]
                     std       $0C,s
                     ldx       $12,s
                     ldd       $02,x
                     std       $0a,s
                     ldx       $12,s
                     ldd       $04,x
-L1E26               std       $06,s
-                    lbra      L1F6E
+L1E23               std       $06,s
+                    lbra      L1F6B
 
-L1E2B               ldd       $0e,s
+L1E28               ldd       $0e,s
                     cmpd      #$00A0
-                    blt       L1E39
+                    blt       L1E36
                     leax      $14,s
-                    lbra      $1C74
+                    lbra      L1C71
 
-L1E39               leax      L2741,pcr
+L1E36               leax      L273E,pcr
                     pshs      x
                     ldd       $1a,s
                     pshs      d
-                    lbsr      L0262
-L1E47               leas      $04,s
-                    lbra      L1F6E
-                    cmpx      #$0034
-                    lbeq      $13B9
-                    cmpx      #$0036
-                    lbeq      L14D8
-                    cmpx      #$004A
-                    lbeq      $14DF
-                    cmpx      #$004B
-                    lbeq      $14EF
-                    cmpx      #$0037
-                    lbeq      $14FF
-                    cmpx      #$0020
-                    lbeq      L150A
-                    cmpx      #$0041
-                    lbeq      $1589
-                    cmpx      #$0042
-                    lbeq      L15D7
-                    cmpx      #$0045
-                    lbeq      L1649
-                    cmpx      #$0046
-                    lbeq      L1703
-                    cmpx      #$0065
-                    lbeq      L17C1
-                    cmpx      #$000B
-                    lbeq      L186B
-                    cmpx      #$0030
-                    lbeq      $189D
-                    cmpx      #$0040
-                    lbeq      L18B3
-                    cmpx      #$0043
-                    lbeq      L18CB
-                    cmpx      #$0044
-                    lbeq      L18D5
-                    cmpx      #$003C
-                    lbeq      L18F2
-                    cmpx      #$003E
-                    lbeq      L18F2
-                    cmpx      #$003D
-                    lbeq      L18F2
-                    cmpx      #$003F
-                    lbeq      L18F2
-                    cmpx      #$0047
-                    lbeq      L1942
-                    cmpx      #$0048
-                    lbeq      L1942
-                    cmpx      #$0053
-                    lbeq      L1E04
-                    cmpx      #$0052
-                    lbeq      L1E04
-                    cmpx      #$0057
-                    lbeq      $196C
-                    cmpx      #$0058
-                    lbeq      $196C
-                    cmpx      #$0059
-                    lbeq      $196C
-                    cmpx      #$0054
-                    lbeq      $196C
-                    cmpx      #$0056
-                    lbeq      L1988
-                    cmpx      #$0055
-                    lbeq      L1988
-                    cmpx      #$005D
-                    lbeq      L19D9
-                    cmpx      #$005F
-                    lbeq      L19D9
-                    cmpx      #$005C
-                    lbeq      L19D9
-                    cmpx      #$005E
-                    lbeq      L19D9
-                    cmpx      #$005A
-                    lbeq      L1A0F
-                    cmpx      #$005B
-                    lbeq      L1A0F
-                    cmpx      #$0050
-                    lbeq      $1A57
-                    cmpx      #$0051
-                    lbeq      $1AAD
-                    cmpx      #$0078
-                    lbeq      L1BF7
-                    cmpx      #$002F
-                    lbeq      L1D7D
-                    cmpx      #$0064
-                    lbeq      L1E15
-                    lbra      L1E2B
+                    lbsr      L025F
+L1E44               leas      $04,s
+                    lbra      L1F6B
 
-L1F6E               ldd       $0C,s
+L1E49               cmpx      #$0034
+                    lbeq      L13B6
+                    cmpx      #$0036
+                    lbeq      L14D5
+                    cmpx      #$004A
+                    lbeq      L14DC
+                    cmpx      #$004B
+                    lbeq      L14EC
+                    cmpx      #$0037
+                    lbeq      L14FC
+                    cmpx      #$0020
+                    lbeq      L1507
+                    cmpx      #$0041
+                    lbeq      L1586
+                    cmpx      #$0042
+                    lbeq      L15D4
+                    cmpx      #$0045
+                    lbeq      L1646
+                    cmpx      #$0046
+                    lbeq      L1700
+                    cmpx      #$0065
+                    lbeq      L17BE
+                    cmpx      #$000B
+                    lbeq      L1868
+                    cmpx      #$0030
+                    lbeq      L189A
+                    cmpx      #$0040
+                    lbeq      L18B0
+                    cmpx      #$0043
+                    lbeq      L18C8
+                    cmpx      #$0044
+                    lbeq      L18D2
+                    cmpx      #$003C
+                    lbeq      L18EF
+                    cmpx      #$003E
+                    lbeq      L18EF
+                    cmpx      #$003D
+                    lbeq      L18EF
+                    cmpx      #$003F
+                    lbeq      L18EF
+                    cmpx      #$0047
+                    lbeq      L193F
+                    cmpx      #$0048
+                    lbeq      L193F
+                    cmpx      #$0053
+                    lbeq      L1E01
+                    cmpx      #$0052
+                    lbeq      L1E01
+                    cmpx      #$0057
+                    lbeq      L1969
+                    cmpx      #$0058
+                    lbeq      L1969
+                    cmpx      #$0059
+                    lbeq      L1969
+                    cmpx      #$0054
+                    lbeq      L1969
+                    cmpx      #$0056
+                    lbeq      L1985
+                    cmpx      #$0055
+                    lbeq      L1985
+                    cmpx      #$005D
+                    lbeq      L19D6
+                    cmpx      #$005F
+                    lbeq      L19D6
+                    cmpx      #$005C
+                    lbeq      L19D6
+                    cmpx      #$005E
+                    lbeq      L19D6
+                    cmpx      #$005A
+                    lbeq      L1A0C
+                    cmpx      #$005B
+                    lbeq      L1A0C
+                    cmpx      #$0050
+                    lbeq      L1A54
+                    cmpx      #$0051
+                    lbeq      L1AAA
+                    cmpx      #$0078
+                    lbeq      L1BF4
+                    cmpx      #$002F
+                    lbeq      L1D7A
+                    cmpx      #$0064
+                    lbeq      L1E12
+                    lbra      L1E28
+
+L1F6B               ldd       $0C,s
                     std       [$18,s]
                     ldd       $0a,s
                     ldx       $18,s
@@ -3463,408 +3486,408 @@ L1F6E               ldd       $0C,s
                     ldd       $18,s
                     leas      $14,s
                     puls      pc,u
-L1F91               pshs      u
+L1F8E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
-                    bne       L1FA7
+                    bne       L1FA4
                     ldd       $08,u
-                    beq       L1FBD
-L1FA7               leax      L274C,pcr
+                    beq       L1FBA
+L1FA4               leax      L2749,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
                     ldd       #$0036
                     std       $06,u
                     clra
                     clrb
                     std       $08,u
-L1FBD               puls      pc,u
-L1FBF               pshs      u
+L1FBA               puls      pc,u
+L1FBC               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     pshs      u
-                    lbsr      L24D6
+                    lbsr      L24D3
                     leas      $02,s
                     ldd       ,u
                     std       ,s
                     tfr       d,x
-                    bra       L2002
+                    bra       L1FFF
 
-L1FDA               ldd       #$0001
-                    bra       L1FE2
+L1FD7               ldd       #$0001
+                    bra       L1FDF
 
-L1FDF               ldd       #$0006
-L1FE2               std       ,s
+L1FDC               ldd       #$0006
+L1FDF               std       ,s
                     pshs      d
                     pshs      u
-                    bsr       L202A
+                    bsr       L2027
                     leas      $04,s
-                    bra       L2022
+                    bra       L201F
 
-L1FEE               leax      L275B,pcr
+L1FEB               leax      L2758,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
                     ldd       #$0001
                     std       ,s
-                    bra       L2022
+                    bra       L201F
 
-L2002               cmpx      #$0002
-                    beq       L1FDA
+L1FFF               cmpx      #$0002
+                    beq       L1FD7
                     cmpx      #$0005
-                    beq       L1FDF
+                    beq       L1FDC
                     cmpx      #$0006
-                    beq       L2022
+                    beq       L201F
                     cmpx      #$0008
-                    beq       L2022
+                    beq       L201F
                     cmpx      #$0001
-                    beq       L2022
+                    beq       L201F
                     cmpx      #$0007
-                    beq       L2022
-                    bra       L1FEE
+                    beq       L201F
+                    bra       L1FEB
 
-L2022               ldd       ,s
+L201F               ldd       ,s
                     std       ,u
                     leas      $02,s
-L2028               puls      pc,u
-L202A               pshs      u
+                    puls      pc,u
+L2027               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
                     std       ,s
                     ldx       ,u
-                    lbra      L22D9
+                    lbra      L22D6
 
-L203F               ldx       $0a,s
-                    bra       L2075
+L203C               ldx       $0a,s
+                    bra       L2072
 
-L2043               ldd       #$0085
-                    bra       L2056
+L2040               ldd       #$0085
+                    bra       L2053
 
-L2048               ldd       #$0001
+L2045               ldd       #$0001
                     pshs      d
                     pshs      u
-                    bsr       L202A
+                    bsr       L2027
                     leas      $04,s
                     ldd       #$0083
-L2056               std       ,s
-                    lbra      L2306
+L2053               std       ,s
+                    lbra      L2303
 
-L205B               ldd       #$0001
+L2058               ldd       #$0001
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     ldd       $0a,s
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
-                    lbra      L2306
+L206F               lbra      L2303
 
-L2075               cmpx      #$0001
-                    beq       L2043
+L2072               cmpx      #$0001
+                    beq       L2040
                     cmpx      #$0007
-                    lbeq      L2043
+                    lbeq      L2040
                     cmpx      #$0008
-                    beq       L2048
+                    beq       L2045
                     cmpx      #$0006
-                    beq       L205B
+                    beq       L2058
                     cmpx      #$0005
-                    lbeq      L205B
-                    lbra      L2306
+                    lbeq      L2058
+                    lbra      L2303
 
-L2095               ldd       ,u
+L2092               ldd       ,u
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    lbne      L2306
-L20A2               ldx       $0a,s
-                    lbra      L213A
+                    lbne      L2303
+L209F               ldx       $0a,s
+                    lbra      L2137
 
-L20A7               ldd       $06,u
+L20A4               ldd       $06,u
                     cmpd      #$0036
-                    bne       L20E2
+                    bne       L20DF
                     ldd       #$0004
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     std       $02,s
                     ldd       $08,u
                     ldx       $02,s
                     std       $02,x
-                    bge       L20C8
+                    bge       L20C5
                     ldd       #$FFFF
-                    bra       L20CA
+                    bra       L20C7
 
-L20C8               clra
+L20C5               clra
                     clrb
-L20CA               std       [$02,s]
+L20C7               std       [$02,s]
                     ldd       $02,s
                     std       $08,u
-                    bra       L20D5
+                    bra       L20D2
 
-L20D3               leas      -$04,x
-L20D5               ldd       #$004A
+L20D0               leas      -$04,x
+L20D2               ldd       #$004A
                     std       $06,u
                     ldd       #$0004
-L20DD               std       $02,u
-                    lbra      L2306
+L20DA               std       $02,u
+                    lbra      L2303
 
-L20E2               ldd       #$0083
-                    bra       L2135
+L20DF               ldd       #$0083
+                    bra       L2132
 
-L20E7               ldd       #$0001
+L20E4               ldd       #$0001
                     std       $0a,s
-                    lbra      L2306
+                    lbra      L2303
 
-L20EF               ldd       #$0006
+L20EC               ldd       #$0006
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     ldd       #$008D
-                    bra       L2135
+                    bra       L2132
 
-L2100               ldd       $06,u
+L20FD               ldd       $06,u
                     cmpd      #$0036
-                    bne       L2132
+                    bne       L212F
                     ldd       #$0008
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     std       $02,s
                     ldx       $02,s
                     pshs      x
                     ldd       $08,u
-                    lbsr      L6A1F
-                    lbsr      $6A02
-                    bra       L2124
+                    lbsr      L6A1C
+                    lbsr      L69FF
+                    bra       L2121
 
-L2122               leas      -$04,x
-L2124               ldd       $02,s
+L211F               leas      -$04,x
+L2121               ldd       $02,s
                     std       $08,u
                     ldd       #$004B
                     std       $06,u
                     ldd       #$0008
-                    bra       L20DD
+                    bra       L20DA
 
-L2132               ldd       #$008E
-L2135               std       ,s
-                    lbra      L2306
+L212F               ldd       #$008E
+L2132               std       ,s
+                    lbra      L2303
 
-L213A               cmpx      #$0008
-                    lbeq      L20A7
+L2137               cmpx      #$0008
+                    lbeq      L20A4
                     cmpx      #$0002
-                    lbeq      L20E7
+                    lbeq      L20E4
                     cmpx      #$0005
-                    beq       L20EF
+                    beq       L20EC
                     cmpx      #$0006
-                    beq       L2100
-                    lbra      L2306
+                    beq       L20FD
+                    lbra      L2303
 
-L2155               ldx       $0a,s
-                    bra       L217F
+L2152               ldx       $0a,s
+                    bra       L217C
 
-L2159               ldd       #$0086
-                    bra       L2172
+L2156               ldd       #$0086
+                    bra       L216F
 
-L215E               ldd       #$0006
+L215B               ldd       #$0006
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     ldd       #$008D
-                    bra       L2172
+                    bra       L216F
 
-L216F               ldd       #$0092
-L2172               std       ,s
-                    lbra      L2306
+L216C               ldd       #$0092
+L216F               std       ,s
+                    lbra      L2303
 
-L2177               ldd       #$0001
+L2174               ldd       #$0001
                     std       $0a,s
-                    lbra      L2306
+                    lbra      L2303
 
-L217F               cmpx      #$0008
-                    beq       L2159
+L217C               cmpx      #$0008
+                    beq       L2156
                     cmpx      #$0005
-                    beq       L215E
+                    beq       L215B
                     cmpx      #$0006
-                    beq       L216F
+                    beq       L216C
                     cmpx      #$0002
-                    beq       L2177
-                    lbra      L2306
+                    beq       L2174
+                    lbra      L2303
 
-L2196               ldx       $0a,s
-                    lbra      L220E
+L2193               ldx       $0a,s
+                    lbra      L220B
 
-L219B               ldd       $0a,s
+L2198               ldd       $0a,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    lbne      L2306
-L21A8               ldd       $06,u
+                    lbne      L2303
+L21A5               ldd       $06,u
                     cmpd      #$004A
-                    bne       L21CB
+                    bne       L21C8
                     ldd       $08,u
                     std       $02,s
                     ldx       $02,s
                     ldd       $02,x
                     std       $08,u
-                    bra       L21BE
+                    bra       L21BB
 
-L21BC               leas      -$04,x
-L21BE               ldd       #$0036
+L21B9               leas      -$04,x
+L21BB               ldd       #$0036
                     std       $06,u
                     ldd       #$0002
                     std       $02,u
-                    lbra      L2306
+                    lbra      L2303
 
-L21CB               ldd       #$0084
-                    bra       L2209
+L21C8               ldd       #$0084
+                    bra       L2206
 
-L21D0               ldd       #$0006
+L21CD               ldd       #$0006
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     ldd       #$008D
-                    bra       L2209
+                    bra       L2206
 
-L21E1               ldd       $06,u
+L21DE               ldd       $06,u
                     cmpd      #$004A
-                    bne       L2206
+                    bne       L2203
                     ldd       #$0008
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     std       $02,s
                     ldx       $02,s
                     pshs      x
                     ldx       $08,u
-                    lbsr      $6A3F
-                    lbsr      $6A02
+                    lbsr      L6A3C
+                    lbsr      L69FF
                     leax      $04,s
-                    lbra      L2122
+                    lbra      L211F
 
-L2206               ldd       #$0090
-L2209               std       ,s
-                    lbra      L2306
+L2203               ldd       #$0090
+L2206               std       ,s
+                    lbra      L2303
 
-L220E               cmpx      #$0001
-                    lbeq      L21A8
+L220B               cmpx      #$0001
+                    lbeq      L21A5
                     cmpx      #$0007
-                    lbeq      L21A8
+                    lbeq      L21A5
                     cmpx      #$0002
-                    lbeq      L21A8
+                    lbeq      L21A5
                     cmpx      #$0005
-                    beq       L21D0
+                    beq       L21CD
                     cmpx      #$0006
-                    beq       L21E1
-                    lbra      L219B
+                    beq       L21DE
+                    lbra      L2198
 
-L2230               ldx       $0a,s
-                    bra       L2256
+L222D               ldx       $0a,s
+                    bra       L2253
 
-L2234               ldd       #$0006
+L2231               ldd       #$0006
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     ldd       $0a,s
                     pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
-                    lbra      L2306
+                    lbra      L2303
 
-L224E               ldd       #$008C
+L224B               ldd       #$008C
                     std       ,s
-                    lbra      L2306
+                    lbra      L2303
 
-L2256               cmpx      #$0008
-                    beq       L2234
+L2253               cmpx      #$0008
+                    beq       L2231
                     cmpx      #$0007
-                    lbeq      L2234
+                    lbeq      L2231
                     cmpx      #$0002
-                    lbeq      L2234
+                    lbeq      L2231
                     cmpx      #$0001
-                    lbeq      L2234
+                    lbeq      L2231
                     cmpx      #$0006
-                    beq       L224E
-                    lbra      L2306
+                    beq       L224B
+                    lbra      L2303
 
-L2278               ldx       $0a,s
-                    bra       L22BA
+L2275               ldx       $0a,s
+                    bra       L22B7
 
-L227C               ldd       $06,u
+L2279               ldd       $06,u
                     cmpd      #$004B
-                    bne       L2290
+                    bne       L228D
                     ldx       $08,u
-                    lbsr      L697F
+                    lbsr      L697C
                     std       $08,u
                     leax      $04,s
-                    lbra      L21BC
+                    lbra      L21B9
 
-L2290               ldd       #$008F
-                    bra       L22B6
+L228D               ldd       #$008F
+                    bra       L22B3
 
-L2295               ldd       $06,u
+L2292               ldd       $06,u
                     cmpd      #$004B
-                    bne       L22AE
+                    bne       L22AB
                     ldx       $08,u
                     pshs      x
                     ldx       $08,u
-                    lbsr      L6984
-                    lbsr      L74D6
+                    lbsr      L6981
+                    lbsr      L74D3
                     leax      $04,s
-                    lbra      L20D3
+                    lbra      L20D0
 
-L22AE               ldd       #$0091
-                    bra       L22B6
+L22AB               ldd       #$0091
+                    bra       L22B3
 
-L22B3               ldd       #$008D
-L22B6               std       ,s
-                    bra       L2306
+L22B0               ldd       #$008D
+L22B3               std       ,s
+                    bra       L2303
 
-L22BA               cmpx      #$0002
-                    beq       L227C
+L22B7               cmpx      #$0002
+                    beq       L2279
                     cmpx      #$0007
-                    lbeq      L227C
+                    lbeq      L2279
                     cmpx      #$0001
-                    lbeq      L227C
+                    lbeq      L2279
                     cmpx      #$0008
-                    beq       L2295
+                    beq       L2292
                     cmpx      #$0005
-                    beq       L22B3
-                    bra       L2306
+                    beq       L22B0
+                    bra       L2303
 
-L22D9               cmpx      #$0002
-                    lbeq      L203F
+L22D6               cmpx      #$0002
+                    lbeq      L203C
                     cmpx      #$0001
-                    lbeq      L20A2
+                    lbeq      L209F
                     cmpx      #$0007
-                    lbeq      L2155
+                    lbeq      L2152
                     cmpx      #$0008
-                    lbeq      L2196
+                    lbeq      L2193
                     cmpx      #$0005
-                    lbeq      L2230
+                    lbeq      L222D
                     cmpx      #$0006
-                    lbeq      L2278
-                    lbra      L2095
+                    lbeq      L2275
+                    lbra      L2092
 
-L2306               ldd       ,s
-                    beq       L233E
+L2303               ldd       ,s
+                    beq       L233B
                     clra
                     clrb
                     pshs      d
@@ -3883,12 +3906,12 @@ L2306               ldd       ,s
                     clra
                     clrb
                     pshs      d
-                    lbsr      L0DD6
+                    lbsr      L0DD3
                     leas      $0C,s
                     std       $02,s
                     pshs      d
                     pshs      u
-                    lbsr      L03C7
+                    lbsr      L03C4
                     leas      $04,s
                     ldd       ,s
                     std       $06,u
@@ -3897,87 +3920,87 @@ L2306               ldd       ,s
                     clra
                     clrb
                     std       $0C,u
-L233E               ldd       $0a,s
-                    lbra      L23BC
+L233B               ldd       $0a,s
+                    lbra      L23B9
 
-L2343               pshs      u
+L2340               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
-                    lbsr      L1FBF
+                    lbsr      L1FBC
                     leas      $02,s
                     std       $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L1FBF
+                    lbsr      L1FBC
                     leas      $02,s
                     std       ,s
                     ldd       $02,s
                     cmpd      #$0006
-                    bne       L2370
+                    bne       L236D
                     ldd       #$0006
-                    bra       L2388
+                    bra       L2385
 
-L2370               ldd       ,s
+L236D               ldd       ,s
                     cmpd      #$0006
-                    bne       L237D
+                    bne       L237A
                     ldd       #$0006
-                    bra       L239B
+                    bra       L2398
 
-L237D               ldd       $02,s
+L237A               ldd       $02,s
                     cmpd      #$0008
-                    bne       L2390
+                    bne       L238D
                     ldd       #$0008
-L2388               pshs      d
+L2385               pshs      d
                     ldd       $0C,s
                     pshs      d
-                    bra       L239F
+                    bra       L239C
 
-L2390               ldd       ,s
+L238D               ldd       ,s
                     cmpd      #$0008
-                    bne       L23A6
+                    bne       L23A3
                     ldd       #$0008
-L239B               pshs      d
+L2398               pshs      d
                     pshs      u
-L239F               lbsr      L202A
+L239C               lbsr      L2027
                     leas      $04,s
-                    bra       L23C3
+                    bra       L23C0
 
-L23A6               ldd       $02,s
+L23A3               ldd       $02,s
                     cmpd      #$0007
-                    beq       L23B6
+                    beq       L23B3
                     ldd       ,s
                     cmpd      #$0007
-                    bne       L23C0
-L23B6               ldd       #$0007
+                    bne       L23BD
+L23B3               ldd       #$0007
                     std       [$0a,s]
-L23BC               std       ,u
-                    bra       L23C3
+L23B9               std       ,u
+                    bra       L23C0
 
-L23C0               ldd       #$0001
-L23C3               leas      $04,s
-L23C5               puls      pc,u
-                    pshs      u
+L23BD               ldd       #$0001
+L23C0               leas      $04,s
+                    puls      pc,u
+L23C4               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $08,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L047A
+                    lbsr      L0477
                     std       ,s
-                    lbsr      L418D
+                    lbsr      L418A
                     leas      $06,s
                     std       $04,s
                     cmpd      #$0001
-                    bne       L23F1
+                    bne       L23EE
                     ldd       $0a,s
                     puls      pc,u
-L23F1               ldx       $0a,s
+L23EE               ldx       $0a,s
                     ldd       $10,x
                     pshs      d
                     ldx       $0C,s
@@ -3993,7 +4016,7 @@ L23F1               ldx       $0a,s
                     pshs      d
                     ldd       #$0036
                     pshs      d
-                    lbsr      L0DD6
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     ldd       #$0001
@@ -4012,100 +4035,101 @@ L23F1               ldx       $0a,s
                     pshs      d
                     ldd       #$0052
                     pshs      d
-                    lbsr      L0DD6
+                    lbsr      L0DD3
                     leas      $0C,s
                     pshs      d
-                    lbsr      L1008
+                    lbsr      L1005
                     leas      $02,s
                     tfr       d,u
                     ldd       $06,u
                     cmpd      #$0036
-                    bne       L2452
+                    bne       L244F
                     clra
                     clrb
-                    bra       L2455
+                    bra       L2452
 
-L2452               ldd       #$0002
-L2455               std       $12,u
+L244F               ldd       #$0002
+L2452               std       $12,u
                     ldd       #$0001
                     std       ,u
                     ldd       #$0002
                     std       $02,u
                     tfr       u,d
-L2464               puls      pc,u
-                    pshs      u
+                    puls      pc,u
+L2463               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     std       ,s
                     tfr       d,x
                     cmpx      #$0076
-                    lbeq      L25B4
+                    lbeq      L25B1
                     cmpx      #$006F
-                    lbeq      L25B4
+                    lbeq      L25B1
                     cmpx      #$0042
-                    lbeq      L25B4
+                    lbeq      L25B1
                     ldd       ,s
                     cmpd      #$0034
-                    bne       L24BF
+                    bne       L24BC
                     pshs      u
-                    bsr       L24D6
+                    bsr       L24D3
                     leas      $02,s
                     ldd       $08,s
-                    lbne      L25B4
+                    lbne      L25B1
                     ldd       ,u
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L24B1
+                    bne       L24AE
                     ldd       #$0001
-                    bra       L24B3
+                    bra       L24B0
 
-L24B1               clra
+L24AE               clra
                     clrb
-L24B3               bne       L24BF
+L24B0               bne       L24BC
                     ldd       ,u
                     cmpd      #$0004
-                    lbne      L25B4
-L24BF               leax      L2766,pcr
+                    lbne      L25B1
+L24BC               leax      L2763,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
                     pshs      u
-                    lbsr      L25E9
+                    lbsr      L25E6
                     leas      $02,s
-                    lbra      L25B4
+                    lbra      L25B1
 
-L24D6               pshs      u
+L24D3               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0034
-                    lbne      L25B6
+                    lbne      L25B3
                     ldd       ,u
-                    lbne      L25B6
-                    leax      L2776,pcr
+                    lbne      L25B3
+                    leax      L2773,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
                     pshs      u
-                    lbsr      L25E9
-                    lbra      L25B4
-                    pshs      u
+                    lbsr      L25E6
+                    lbra      L25B1
+
+L2502               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldd       ,u
                     std       [$08,s]
                     ldd       $06,u
                     cmpd      #$0041
-                    bne       L2544
+                    bne       L2541
                     ldd       #$0001
                     std       [$0a,s]
                     ldd       $0a,u
@@ -4116,33 +4140,33 @@ L24D6               pshs      u
                     pshs      u
                     ldd       $02,s
                     pshs      d
-                    lbsr      L03C7
+                    lbsr      L03C4
                     leas      $04,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L03B7
+                    lbsr      L03B4
                     leas      $02,s
-                    bra       L2549
+                    bra       L2546
 
-L2544               clra
+L2541               clra
                     clrb
                     std       [$0a,s]
-L2549               pshs      u
-                    lbsr      L24D6
+L2546               pshs      u
+                    lbsr      L24D3
                     leas      $02,s
                     ldd       $06,u
                     cmpd      #$0034
-                    bne       L2589
+                    bne       L2586
                     ldd       $08,u
                     std       ,s
                     ldx       ,s
                     ldd       $08,x
                     cmpd      #$0011
-                    beq       L256A
-                    leax      $02,s
-                    bra       L2587
+                    beq       L2567
+L2563               leax      $02,s
+                    bra       L2584
 
-L256A               ldd       #$0036
+L2567               ldd       #$0036
                     std       $06,u
                     ldx       ,s
                     ldd       $06,x
@@ -4154,17 +4178,17 @@ L256A               ldd       #$0036
                     std       ,u
                     ldx       ,s
                     ldd       $02,x
-                    bra       L25B4
-                    bra       L2589
+                    bra       L25B1
+                    bra       L2586
 
-L2587               leas      -$02,x
-L2589               leax      L278A,pcr
+L2584               leas      -$02,x
+L2586               leax      L2787,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
                     pshs      u
-                    lbsr      L25E9
+                    lbsr      L25E6
                     leas      $02,s
                     ldd       #$0036
                     std       $06,u
@@ -4177,48 +4201,48 @@ L2589               leax      L278A,pcr
                     ldd       #$0001
                     std       [$08,s]
                     ldd       #$0002
-L25B4               leas      $02,s
-L25B6               puls      pc,u
-L25B8               pshs      u
+L25B1               leas      $02,s
+L25B3               puls      pc,u
+L25B5               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       ,u
                     cmpd      #$0004
-                    beq       L25D2
+                    beq       L25CF
                     ldd       ,u
                     cmpd      #$0003
-                    bne       L25E5
-L25D2               leax      L27A1,pcr
+                    bne       L25E2
+L25CF               leax      L279E,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
                     pshs      u
-                    bsr       L25E9
+                    bsr       L25E6
                     leas      $02,s
-L25E5               ldd       ,u
-L25E7               puls      pc,u
-L25E9               pshs      u
+L25E2               ldd       ,u
+                    puls      pc,u
+L25E6               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       #$0006
                     pshs      d
                     pshs      u
                     leax      $018b,y
                     pshs      x
-                    lbsr      L01F9
+                    lbsr      L01F6
                     leas      $06,s
                     ldd       #$0001
                     std       $12,u
                     ldd       $0a,u
                     pshs      d
-                    lbsr      L0396
+                    lbsr      L0393
                     leas      $02,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L0396
+                    lbsr      L0393
                     leas      $02,s
                     clra
                     clrb
@@ -4228,233 +4252,225 @@ L25E9               pshs      u
                     std       $06,u
                     leax      $018b,y
                     stx       $08,u
-L262E               puls      pc,u
-L2630               pshs      u
-                    ldd       #$FFC0
-                    lbsr      L0113
-                    ldx       $04,s
-                    bra       L2641
-
-L263C               ldd       #$0001
                     puls      pc,u
-L2641               cmpx      #$0001
-                    beq       L263C
+L262D               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0110
+                    ldx       $04,s
+                    bra       L263E
+
+L2639               ldd       #$0001
+                    puls      pc,u
+L263E               cmpx      #$0001
+                    beq       L2639
                     cmpx      #$0002
-                    lbeq      L263C
+                    lbeq      L2639
                     cmpx      #$0008
-                    lbeq      L263C
+                    lbeq      L2639
                     cmpx      #$0007
-                    lbeq      L263C
+                    lbeq      L2639
                     clra
                     clrb
-L265D               puls      pc,u
-L265F               pshs      u
+                    puls      pc,u
+L265C               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
-                    leax      L27C2,pcr
+                    lbsr      L0110
+                    leax      L27BF,pcr
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    lbsr      L0296
+                    lbsr      L0293
                     leas      $04,s
-L2676               puls      pc,u
-                    fcc       /divide by zer/
-L2685               fcb       $6F
+                    puls      pc,u
+L2675               fcc       /divide by zero/
                     fcb       $00
-                    fcc       /typedef - not a variabl/
-L269E               fcb       $65
+L2684               fcc       /typedef - not a variable/
                     fcb       $00
-                    fcc       /cannot cas/
-L26AA               fcb       $74
+L269D               fcc       /cannot cast/
                     fcb       $00
-                    fcc       /can't take addres/
-L26BD               fcb       $73
+L26A9               fcc       /can't take address/
                     fcb       $00
-                    fcc       /pointer require/
-L26CE               fcb       $64
+L26BC               fcc       /pointer required/
                     fcb       $00
-                    fcc       /pointer or integer require/
-L26EA               fcb       $64
+L26CD               fcc       /pointer or integer required/
                     fcb       $00
-                    fcc       /not a functio/
-L26F9               fcb       $6E
+L26E9               fcc       /not a function/
                     fcb       $00
-                    fcc       /both must be integra/
-L270F               fcb       $6C
+L26F8               fcc       /both must be integral/
                     fcb       $00
-                    fcc       /pointer mismatch/
+L270E               fcc       /pointer mismatch/
                     fcb       $00
-L2722               fcc       /type mismatch/
+L271F               fcc       /type mismatch/
                     fcb       $00
-L2730               fcc       /pointer mismatch/
+L272D               fcc       /pointer mismatch/
                     fcb       $00
-L2741               fcc       /type check/
+L273E               fcc       /type check/
                     fcb       $00
-L274C               fcc       /should be NULL/
+L2749               fcc       /should be NULL/
                     fcb       $00
-L275B               fcc       /type error/
+L2758               fcc       /type error/
                     fcb       $00
-L2766               fcc       /lvalue required/
+L2763               fcc       /lvalue required/
                     fcb       $00
-L2776               fcc       /undeclared variable/
+L2773               fcc       /undeclared variable/
                     fcb       $00
-L278A               fcc       /struct member required/
+L2787               fcc       /struct member required/
                     fcb       $00
-L27A1               fcc       /structure or union inappropriate/
+L279E               fcc       /structure or union inappropriate/
                     fcb       $00
-L27C2               fcc       /must be integral/
+L27BF               fcc       /must be integral/
                     fcb       $00
-L27D3               pshs      u
+L27D0               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $005F
                     cmpd      #$0028
-                    beq       L27EB
+                    beq       L27E8
                     clra
                     clrb
                     std       L004F
-                    bra       L27EB
+                    bra       L27E8
 
-L27E9               leas      ,x
-L27EB               ldx       $005F
-                    lbra      L28EA
+L27E6               leas      ,x
+L27E8               ldx       $005F
+                    lbra      L28E7
 
-L27F0               ldx       $0061
-                    bra       L2846
+L27ED               ldx       $0061
+                    bra       L2843
 
-L27F4               lbsr      L291A
+L27F1               lbsr      L2917
                     puls      pc,u
-L27F9               lbsr      L29DD
+L27F6               lbsr      L29DA
                     puls      pc,u
-L27FE               lbsr      L2E96
-                    lbra      L290E
+L27FB               lbsr      L2E93
+                    lbra      L290B
 
-L2804               lbsr      L2BF4
+L2801               lbsr      L2BF1
                     puls      pc,u
-L2809               lbsr      L2A8D
+L2806               lbsr      L2A8A
                     puls      pc,u
-L280E               lbsr      L2F24
-                    lbra      L290E
+L280B               lbsr      L2F21
+                    lbra      L290B
 
-L2814               lbsr      L2F63
-                    lbra      L290E
+L2811               lbsr      L2F60
+                    lbra      L290B
 
-L281A               lbsr      L2C5C
+L2817               lbsr      L2C59
                     puls      pc,u
-L281F               lbsr      L2D5D
+L281C               lbsr      L2D5A
                     puls      pc,u
-L2824               lbsr      L2CAF
-                    lbra      L290E
+L2821               lbsr      L2CAC
+                    lbra      L290B
 
-L282A               lbsr      L2FA1
-                    lbra      L290E
+L2827               lbsr      L2F9E
+                    lbra      L290B
 
-L2830               leax      L316D,pcr
+L282D               leax      L316A,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbsr      L552E
-                    lbra      L289A
+                    lbsr      L552B
+                    lbra      L2897
 
-L2841               leax      ,s
-                    lbra      L28A3
+L283E               leax      ,s
+                    lbra      L28A0
 
-L2846               cmpx      #$0013
-                    beq       L27F4
+L2843               cmpx      #$0013
+                    beq       L27F1
                     cmpx      #$0014
-                    beq       L27F9
+                    beq       L27F6
                     cmpx      #$0012
-                    beq       L27FE
+                    beq       L27FB
                     cmpx      #$0017
-                    beq       L2804
+                    beq       L2801
                     cmpx      #$0016
-                    beq       L2809
+                    beq       L2806
                     cmpx      #$0018
-                    beq       L280E
+                    beq       L280B
                     cmpx      #$0019
-                    beq       L2814
+                    beq       L2811
                     cmpx      #$001B
-                    beq       L281A
+                    beq       L2817
                     cmpx      #$001C
-                    beq       L281F
+                    beq       L281C
                     cmpx      #$001A
-                    beq       L2824
+                    beq       L2821
                     cmpx      #$001D
-                    beq       L282A
+                    beq       L2827
                     cmpx      #$0015
-                    beq       L2830
-                    bra       L2841
+                    beq       L282D
+                    bra       L283E
 
-L2884               lbsr      L3A4F
-                    lbsr      L552E
+L2881               lbsr      L3A4C
+                    lbsr      L552B
                     puls      pc,u
-L288C               puls      pc,u
-L288E               lbsr      $6348
+L2889               puls      pc,u
+L288B               lbsr      L6345
                     ldb       $0065
                     cmpb      #$3a
-                    bne       L289F
-                    lbsr      L2FEC
-L289A               leax      ,s
-                    lbra      L27E9
+                    bne       L289C
+                    lbsr      L2FE9
+L2897               leax      ,s
+                    lbra      L27E6
 
-L289F               leax      ,s
-                    bra       L28CB
+L289C               leax      ,s
+                    bra       L28C8
 
-L28A3               leas      ,x
-L28A5               lbsr      L043F
+L28A0               leas      ,x
+L28A2               lbsr      L043C
                     std       -$02,s
-                    bne       L28B3
-                    lbsr      L03DD
+                    bne       L28B0
+                    lbsr      L03DA
                     std       -$02,s
-                    beq       L28CD
-L28B3               leax      L3180,pcr
+                    beq       L28CA
+L28B0               leax      L317D,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L28BE               lbsr      L552E
+L28BB               lbsr      L552B
                     ldd       $005F
                     cmpd      #$0028
-                    bne       L28BE
-                    bra       L290E
+                    bne       L28BB
+                    bra       L290B
 
-L28CB               leas      ,x
-L28CD               clra
+L28C8               leas      ,x
+L28CA               clra
                     clrb
                     pshs      d
-                    lbsr      L3085
+                    lbsr      L3082
                     std       ,s++
-                    bne       L290E
-                    leax      L3194,pcr
+                    bne       L290B
+                    leax      L3191,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbsr      L0502
+                    lbsr      L04FF
                     puls      pc,u
-                    bra       L290E
+                    bra       L290B
 
-L28EA               cmpx      #$0028
-                    beq       L290E
+L28E7               cmpx      #$0028
+                    beq       L290B
                     cmpx      #$0033
-                    lbeq      L27F0
+                    lbeq      L27ED
                     cmpx      #$0029
-                    lbeq      L2884
+                    lbeq      L2881
                     cmpx      #$FFFF
-                    lbeq      L288C
+                    lbeq      L2889
                     cmpx      #$0034
-                    lbeq      L288E
-                    lbra      L28A5
+                    lbeq      L288B
+                    lbra      L28A2
 
-L290E               ldd       #$0028
+L290B               ldd       #$0028
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     puls      pc,u
-L291A               pshs      u
+L2917               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$06,s
-                    lbsr      L552E
-                    lbsr      L30EA
+                    lbsr      L552B
+                    lbsr      L30E7
                     std       ,s
                     ldd       L002B
                     addd      #$0001
@@ -4466,8 +4482,8 @@ L291A               pshs      u
                     std       $04,s
                     ldd       $005F
                     cmpd      #$0028
-                    bne       L2969
-                    lbsr      L552E
+                    bne       L2966
+                    lbsr      L552B
                     clra
                     clrb
                     pshs      d
@@ -4476,42 +4492,42 @@ L291A               pshs      u
                     pshs      u
                     ldd       $06,s
                     pshs      d
-                    lbsr      L3143
+                    lbsr      L3140
                     leas      $08,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     stu       $02,s
-                    bra       L298B
+                    bra       L2988
 
-L2969               ldd       #$0001
+L2966               ldd       #$0001
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     pshs      u
                     ldd       $06,s
                     pshs      d
-                    lbsr      L3143
+                    lbsr      L3140
                     leas      $08,s
                     pshs      u
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
-                    lbsr      L27D3
+                    lbsr      L27D0
                     ldd       $04,s
                     std       $02,s
-L298B               ldd       $005F
+L2988               ldd       $005F
                     cmpd      #$0033
-                    bne       L29D0
+                    bne       L29CD
                     ldd       $0061
                     cmpd      #$0015
-                    bne       L29D0
-                    lbsr      L552E
+                    bne       L29CD
+                    lbsr      L552B
                     ldd       $005F
                     cmpd      #$0028
-                    beq       L29D0
-                    cmpu      $02,s
                     beq       L29CD
+                    cmpu      $02,s
+                    beq       L29CA
                     clra
                     clrb
                     pshs      d
@@ -4522,22 +4538,22 @@ L298B               ldd       $005F
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
-L29CD               lbsr      L27D3
-L29D0               ldd       $02,s
+L29CA               lbsr      L27D0
+L29CD               ldd       $02,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     leas      $06,s
                     puls      pc,u
-L29DD               pshs      u
+L29DA               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$0a,s
                     ldd       L0053
                     std       $08,s
@@ -4547,7 +4563,7 @@ L29DD               pshs      u
                     std       $04,s
                     ldd       $02D8,y
                     std       $02,s
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       L002B
                     addd      #$0001
                     std       L002B
@@ -4559,34 +4575,34 @@ L29DD               pshs      u
                     addd      #$0001
                     std       L002B
                     std       L0055
-                    lbsr      L30EA
+                    lbsr      L30E7
                     std       ,s
                     ldd       $005F
                     cmpd      #$0028
-                    bne       L2A2B
+                    bne       L2A28
                     ldu       L0055
-                    bra       L2A50
+                    bra       L2A4D
 
-L2A2B               clra
+L2A28               clra
                     clrb
                     pshs      d
                     ldd       L0055
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
                     ldd       L002B
                     addd      #$0001
                     std       L002B
                     tfr       d,u
                     pshs      u
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
-                    lbsr      L27D3
-L2A50               ldd       L0055
+                    lbsr      L27D0
+L2A4D               ldd       L0055
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     clra
                     clrb
@@ -4596,11 +4612,11 @@ L2A50               ldd       L0055
                     pshs      u
                     ldd       $06,s
                     pshs      d
-                    lbsr      L3143
+                    lbsr      L3140
                     leas      $08,s
                     ldd       L0053
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     ldd       $08,s
                     std       L0053
@@ -4612,11 +4628,11 @@ L2A50               ldd       L0055
                     std       $02D8,y
                     leas      $0a,s
                     puls      pc,u
-L2A8D               pshs      u
+L2A8A               pshs      u
                     ldd       #$FFA8
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$0e,s
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       L0057
                     addd      #$0001
                     std       L0057
@@ -4644,61 +4660,61 @@ L2A8D               pshs      u
                     std       $02D4,y
                     ldd       #$002D
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     clra
                     clrb
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     std       ,s
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L2B41
+                    beq       L2B3E
                     pshs      u
-                    lbsr      L24D6
+                    lbsr      L24D3
                     leas      $02,s
                     ldx       ,u
-                    bra       L2B19
+                    bra       L2B16
 
-L2AFB               ldd       #$0001
+L2AF8               ldd       #$0001
                     pshs      d
-L2B00               pshs      u
-                    lbsr      L202A
+                    pshs      u
+                    lbsr      L2027
                     leas      $04,s
-                    bra       L2B31
+                    bra       L2B2E
 
-L2B09               pshs      u
-                    lbsr      L265F
+L2B06               pshs      u
+                    lbsr      L265C
                     leas      $02,s
                     pshs      u
-                    lbsr      L25E9
+                    lbsr      L25E6
                     leas      $02,s
-                    bra       L2B31
+                    bra       L2B2E
 
-L2B19               cmpx      #$0002
-                    beq       L2AFB
+L2B16               cmpx      #$0002
+                    beq       L2AF8
                     cmpx      #$0008
-                    lbeq      L2AFB
+                    lbeq      L2AF8
                     cmpx      #$0001
-                    beq       L2B31
+                    beq       L2B2E
                     cmpx      #$0007
-                    beq       L2B31
-                    bra       L2B09
+                    beq       L2B2E
+                    bra       L2B06
 
-L2B31               pshs      u
-                    lbsr      L4C1E
+L2B2E               pshs      u
+                    lbsr      L4C1B
                     leas      $02,s
                     pshs      u
-                    lbsr      L0396
+                    lbsr      L0393
                     leas      $02,s
-                    bra       L2B44
+                    bra       L2B41
 
-L2B41               lbsr      L0E18
-L2B44               ldd       #$002E
+L2B3E               lbsr      L0E15
+L2B41               ldd       #$002E
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     clra
                     clrb
@@ -4710,11 +4726,11 @@ L2B44               ldd       #$002E
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-                    lbsr      L27D3
+                    lbsr      L27D0
                     ldd       L004F
-                    bne       L2B80
+                    bne       L2B7D
                     clra
                     clrb
                     pshs      d
@@ -4722,16 +4738,16 @@ L2B44               ldd       #$002E
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L2B80               ldd       $06,s
+L2B7D               ldd       $06,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     ldu       L0059
-                    bra       L2BAB
+                    bra       L2BA8
 
-L2B8D               ldd       ,u
+L2B8A               ldd       ,u
                     std       $04,s
                     ldd       $02,u
                     pshs      d
@@ -4739,16 +4755,16 @@ L2B8D               ldd       ,u
                     pshs      d
                     ldd       #$007D
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
                     ldd       L0045
                     std       ,u
                     stu       L0045
                     ldu       $04,s
-L2BAB               stu       -$02,s
-                    bne       L2B8D
+L2BA8               stu       -$02,s
+                    bne       L2B8A
                     ldd       $02D4,y
-                    beq       L2BC9
+                    beq       L2BC6
                     clra
                     clrb
                     pshs      d
@@ -4756,11 +4772,11 @@ L2BAB               stu       -$02,s
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L2BC9               ldd       L0053
+L2BC6               ldd       L0053
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     ldd       $0a,s
                     std       L0059
@@ -4775,43 +4791,43 @@ L2BC9               ldd       L0053
                     std       L0053
                     ldd       $02,s
                     std       $02D6,y
-                    lbra      L2E92
+                    lbra      L2E8F
 
-L2BF4               pshs      u
+L2BF1               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$02,s
-                    lbsr      L552E
+                    lbsr      L552B
                     clra
                     clrb
                     pshs      d
-                    lbsr      L0A52
+                    lbsr      L0A4F
                     leas      $02,s
                     std       ,s
                     ldd       #$002F
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     ldd       L0057
-                    beq       L2C58
+                    beq       L2C55
                     ldu       L0045
-                    beq       L2C24
+                    beq       L2C21
                     ldd       ,u
                     std       L0045
-                    bra       L2C30
+                    bra       L2C2D
 
-L2C24               ldd       #$0006
+L2C21               ldd       #$0006
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     tfr       d,u
-L2C30               ldd       L0059
-                    beq       L2C3A
+L2C2D               ldd       L0059
+                    beq       L2C37
                     stu       [$005B,y]
-                    bra       L2C3C
+                    bra       L2C39
 
-L2C3A               stu       L0059
-L2C3C               stu       $005B
+L2C37               stu       L0059
+L2C39               stu       $005B
                     clra
                     clrb
                     std       ,u
@@ -4822,50 +4838,50 @@ L2C3C               stu       $005B
                     std       L002B
                     std       $04,u
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
-                    bra       L2CAB
+                    bra       L2CA8
 
-L2C58               bsr       L2C9A
-                    bra       L2CAB
+L2C55               bsr       L2C97
+                    bra       L2CA8
 
-L2C5C               pshs      u
+L2C59               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    lbsr      L552E
+                    lbsr      L0110
+                    lbsr      L552B
                     ldd       L0057
-                    bne       L2C6D
-                    bsr       L2C9A
-L2C6D               ldd       $02D4,y
-                    beq       L2C7E
-                    leax      L31A1,pcr
+                    bne       L2C6A
+                    bsr       L2C97
+L2C6A               ldd       $02D4,y
+                    beq       L2C7B
+                    leax      L319E,pcr
                     pshs      x
-                    lbsr      L024E
-                    bra       L2C8E
+                    lbsr      L024B
+                    bra       L2C8B
 
-L2C7E               ldd       L002B
+L2C7B               ldd       L002B
                     addd      #$0001
                     std       L002B
                     std       $02D4,y
                     pshs      d
-                    lbsr      L4AC7
-L2C8E               leas      $02,s
+                    lbsr      L4AC4
+L2C8B               leas      $02,s
                     ldd       #$002F
-L2C93               pshs      d
-                    lbsr      L04BF
-                    bra       L2CAB
+L2C90               pshs      d
+                    lbsr      L04BC
+                    bra       L2CA8
 
-L2C9A               pshs      u
+L2C97               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    leax      L31B3,pcr
+                    lbsr      L0110
+                    leax      L31B0,pcr
                     pshs      x
-                    lbsr      L024E
-L2CAB               leas      $02,s
+                    lbsr      L024B
+L2CA8               leas      $02,s
                     puls      pc,u
-L2CAF               pshs      u
+L2CAC               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$0a,s
                     ldd       L0053
                     std       $08,s
@@ -4886,29 +4902,29 @@ L2CAF               pshs      u
                     addd      #$0001
                     std       L002B
                     std       L0053
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       L002B
                     addd      #$0001
                     std       L002B
                     std       $04,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
-                    lbsr      L27D3
+                    lbsr      L27D0
                     ldd       $005F
                     cmpd      #$0033
-                    bne       L2D0F
+                    bne       L2D0C
                     ldd       $0061
                     cmpd      #$0014
-                    beq       L2D1A
-L2D0F               leax      L31C7,pcr
+                    beq       L2D17
+L2D0C               leax      L31C4,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L2D1A               lbsr      L552E
+L2D17               lbsr      L552B
                     ldd       L0055
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     clra
                     clrb
@@ -4917,13 +4933,13 @@ L2D1A               lbsr      L552E
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L30EA
+                    lbsr      L30E7
                     pshs      d
-                    lbsr      L3143
+                    lbsr      L3140
                     leas      $08,s
                     ldd       L0053
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     ldd       $08,s
                     std       L0053
@@ -4935,9 +4951,9 @@ L2D1A               lbsr      L552E
                     std       $02D8,y
                     leas      $0a,s
                     puls      pc,u
-L2D5D               pshs      u
+L2D5A               pshs      u
                     ldd       #$FFA6
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$0e,s
                     clra
                     clrb
@@ -4963,24 +4979,24 @@ L2D5D               pshs      u
                     addd      #$0001
                     std       L002B
                     std       L0053
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       #$002D
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     clra
                     clrb
                     pshs      d
-                    lbsr      L3085
+                    lbsr      L3082
                     leas      $02,s
                     ldd       #$0028
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     ldd       $005F
                     cmpd      #$0028
-                    beq       L2DE3
-                    lbsr      L3111
+                    beq       L2DE0
+                    lbsr      L310E
                     std       $02,s
                     clra
                     clrb
@@ -4992,56 +5008,56 @@ L2D5D               pshs      u
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L2DE3               ldd       #$0028
+L2DE0               ldd       #$0028
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     clra
                     clrb
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     std       ,s
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     leas      $02,s
                     std       ,s
-                    beq       L2E11
+                    beq       L2E0E
                     ldd       ,s
                     pshs      d
-                    lbsr      L24D6
+                    lbsr      L24D3
                     leas      $02,s
                     ldd       L002B
                     addd      #$0001
                     std       L002B
-                    bra       L2E13
+                    bra       L2E10
 
-L2E11               ldd       $0a,s
-L2E13               std       L0055
+L2E0E               ldd       $0a,s
+L2E10               std       L0055
                     ldd       #$002E
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
-                    lbsr      L27D3
+                    lbsr      L27D0
                     ldd       ,s
-                    beq       L2E41
+                    beq       L2E3E
                     ldd       L0055
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L30AE
+                    lbsr      L30AB
                     leas      $02,s
-L2E41               ldd       $02,s
-                    beq       L2E65
+L2E3E               ldd       $02,s
+                    beq       L2E62
                     ldd       $08,s
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     clra
                     clrb
@@ -5052,22 +5068,22 @@ L2E41               ldd       $02,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L3143
+                    lbsr      L3140
                     leas      $08,s
-                    bra       L2E77
+                    bra       L2E74
 
-L2E65               clra
+L2E62               clra
                     clrb
                     pshs      d
                     ldd       $0C,s
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L2E77               ldd       L0053
+L2E74               ldd       L0053
                     pshs      d
-                    lbsr      L4AC7
+                    lbsr      L4AC4
                     leas      $02,s
                     stu       L0053
                     ldd       $0C,s
@@ -5076,60 +5092,60 @@ L2E77               ldd       L0053
                     std       $02D6,y
                     ldd       $04,s
                     std       $02D8,y
-L2E92               leas      $0e,s
+L2E8F               leas      $0e,s
                     puls      pc,u
-L2E96               pshs      u
+L2E93               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
-                    lbsr      L552E
+                    lbsr      L0110
+                    lbsr      L552B
                     ldd       $005F
                     cmpd      #$0028
-                    lbeq      L2F03
+                    lbeq      L2F00
                     clra
                     clrb
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L2F03
+                    beq       L2F00
                     pshs      u
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     leas      $02,s
                     tfr       d,u
                     pshs      u
-                    lbsr      L24D6
+                    lbsr      L24D3
                     leas      $02,s
                     pshs      u
-                    lbsr      L25B8
+                    lbsr      L25B5
                     leas      $02,s
                     ldd       L004D
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L2EE1
+                    bne       L2EDE
                     ldd       #$0001
-                    bra       L2EE3
+                    bra       L2EE0
 
-L2EE1               ldd       L004D
-L2EE3               pshs      d
+L2EDE               ldd       L004D
+L2EE0               pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
                     ldd       L004D
                     pshs      d
                     pshs      u
                     ldd       #$0012
                     pshs      d
-                    lbsr      L4C6B
+                    lbsr      L4C68
                     leas      $06,s
                     pshs      u
-                    lbsr      L0396
+                    lbsr      L0393
                     leas      $02,s
-L2F03               clra
+L2F00               clra
                     clrb
                     pshs      d
-                    lbsr      L4B33
+                    lbsr      L4B30
                     leas      $02,s
                     clra
                     clrb
@@ -5139,26 +5155,26 @@ L2F03               clra
                     pshs      d
                     ldd       #$0012
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
                     ldd       #$0012
-                    lbra      L2FE8
+                    lbra      L2FE5
 
-L2F24               pshs      u
+L2F21               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
-                    lbsr      L552E
+                    lbsr      L0110
+                    lbsr      L552B
                     ldd       L0053
-                    bne       L2F40
-                    leax      L31D6,pcr
+                    bne       L2F3D
+                    leax      L31D3,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    bra       L2F5D
+                    bra       L2F5A
 
-L2F40               ldd       $02D6,y
+L2F3D               ldd       $02D6,y
                     pshs      d
-                    lbsr      L4B33
+                    lbsr      L4B30
                     leas      $02,s
                     clra
                     clrb
@@ -5167,26 +5183,26 @@ L2F40               ldd       $02D6,y
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L2F5D               ldd       #$0018
-                    lbra      L2FE8
+L2F5A               ldd       #$0018
+                    lbra      L2FE5
 
-L2F63               pshs      u
+L2F60               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
-                    lbsr      L552E
+                    lbsr      L0110
+                    lbsr      L552B
                     ldd       L0055
-                    bne       L2F7F
-                    leax      L31E2,pcr
+                    bne       L2F7C
+                    leax      L31DF,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    bra       L2F9C
+                    bra       L2F99
 
-L2F7F               ldd       $02D8,y
+L2F7C               ldd       $02D8,y
                     pshs      d
-                    lbsr      L4B33
+                    lbsr      L4B30
                     leas      $02,s
                     clra
                     clrb
@@ -5195,28 +5211,28 @@ L2F7F               ldd       $02D8,y
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L2F9C               ldd       #$0019
-                    bra       L2FE8
-
-L2FA1               pshs      u
-                    ldd       #$FFB6
-                    lbsr      L0113
-                    lbsr      L552E
-                    ldd       $005F
-                    cmpd      #$0034
-                    beq       L2FC1
-                    leax      L31F1,pcr
-                    pshs      x
-                    lbsr      L024E
-                    leas      $02,s
+L2F99               ldd       #$0019
                     bra       L2FE5
 
-L2FC1               lbsr      L302E
+L2F9E               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0110
+                    lbsr      L552B
+                    ldd       $005F
+                    cmpd      #$0034
+                    beq       L2FBE
+                    leax      L31EE,pcr
+                    pshs      x
+                    lbsr      L024B
+                    leas      $02,s
+                    bra       L2FE2
+
+L2FBE               lbsr      L302B
                     tfr       d,u
                     stu       -$02,s
-                    beq       L2FE2
+                    beq       L2FDF
                     clra
                     clrb
                     pshs      d
@@ -5224,29 +5240,29 @@ L2FC1               lbsr      L302E
                     pshs      d
                     ldd       #$001D
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
                     ldd       $0a,u
                     orb       #$02
                     std       $0a,u
-L2FE2               lbsr      L552E
-L2FE5               ldd       #$001D
-L2FE8               std       L004F
+L2FDF               lbsr      L552B
+L2FE2               ldd       #$001D
+L2FE5               std       L004F
                     puls      pc,u
-L2FEC               pshs      u
+L2FE9               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
-                    bsr       L302E
+                    lbsr      L0110
+                    bsr       L302B
                     tfr       d,u
                     stu       -$02,s
-                    beq       L3026
+                    beq       L3023
                     ldd       $08,u
                     cmpd      #$000F
-                    bne       L3009
-                    lbsr      L0241
-                    bra       L3026
+                    bne       L3006
+                    lbsr      L023E
+                    bra       L3023
 
-L3009               ldd       #$000F
+L3006               ldd       #$000F
                     std       $08,u
                     clra
                     clrb
@@ -5255,36 +5271,36 @@ L3009               ldd       #$000F
                     pshs      d
                     ldd       #$0009
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
                     ldd       $0a,u
                     orb       #$01
                     std       $0a,u
-L3026               lbsr      L552E
-                    lbsr      L552E
+L3023               lbsr      L552B
+                    lbsr      L552B
                     puls      pc,u
-L302E               pshs      u
+L302B               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $0061
                     ldd       ,u
                     cmpd      #$0009
-                    lbeq      L313F
+                    lbeq      L313C
                     ldd       ,u
-                    beq       L3060
+                    beq       L305D
                     ldd       $0C,u
-                    beq       L3059
-                    leax      L3200,pcr
+                    beq       L3056
+                    leax      L31FD,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
                     clra
                     clrb
                     puls      pc,u
-L3059               pshs      u
-                    lbsr      L0180
+L3056               pshs      u
+                    lbsr      L017D
                     leas      $02,s
-L3060               ldd       #$0009
+L305D               ldd       #$0009
                     std       ,u
                     ldd       #$000D
                     std       $08,u
@@ -5300,101 +5316,101 @@ L3060               ldd       #$0009
                     ldd       L0049
                     std       $10,u
                     stu       L0049
-                    lbra      L313F
+                    lbra      L313C
 
-L3085               pshs      u
+L3082               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    lbeq      L313F
+                    lbeq      L313C
                     pshs      u
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     std       ,s
-                    bsr       L30AE
+                    bsr       L30AB
                     leas      $02,s
                     tfr       d,u
-                    lbra      L313F
+                    lbra      L313C
 
-L30AE               pshs      u
+L30AB               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     pshs      u
-                    lbsr      L24D6
+                    lbsr      L24D3
                     leas      $02,s
                     ldx       $06,u
-                    bra       L30CF
+                    bra       L30CC
 
-L30C3               ldd       #$003C
-                    bra       L30CB
+L30C0               ldd       #$003C
+                    bra       L30C8
 
-L30C8               ldd       #$003D
-L30CB               std       $06,u
-                    bra       L30D9
+L30C5               ldd       #$003D
+L30C8               std       $06,u
+                    bra       L30D6
 
-L30CF               cmpx      #$003E
-                    beq       L30C3
+L30CC               cmpx      #$003E
+                    beq       L30C0
                     cmpx      #$003F
-                    beq       L30C8
-L30D9               pshs      u
-                    lbsr      L4C52
+                    beq       L30C5
+L30D6               pshs      u
+                    lbsr      L4C4F
                     leas      $02,s
                     tfr       d,u
                     pshs      u
-                    lbsr      L0396
-                    lbra      L313D
+                    lbsr      L0393
+                    lbra      L313A
 
-L30EA               pshs      u
+L30E7               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$02,s
                     ldd       #$002D
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-                    bsr       L3111
+                    bsr       L310E
                     std       ,s
                     ldd       #$002E
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     ldd       ,s
-                    lbra      L3169
+                    lbra      L3166
 
-L3111               pshs      u
+L310E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     clra
                     clrb
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     std       ,s
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    beq       L3134
+                    beq       L3131
                     pshs      u
-                    lbsr      L24D6
-                    bra       L313D
+                    lbsr      L24D3
+                    bra       L313A
 
-L3134               leax      L3219,pcr
+L3131               leax      L3216,pcr
                     pshs      x
-                    lbsr      L024E
-L313D               leas      $02,s
-L313F               tfr       u,d
+                    lbsr      L024B
+L313A               leas      $02,s
+L313C               tfr       u,d
                     puls      pc,u
-L3143               pshs      u
+L3140               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     stu       -$02,s
-                    beq       L316B
+                    beq       L3168
                     ldd       $0a,s
                     pshs      d
                     ldd       $0a,s
@@ -5402,99 +5418,99 @@ L3143               pshs      u
                     ldd       $0a,s
                     pshs      d
                     pshs      u
-                    lbsr      L4C2F
+                    lbsr      L4C2C
                     leas      $08,s
                     pshs      u
-                    lbsr      L0396
-L3169               leas      $02,s
-L316B               puls      pc,u
-L316D               fcc       /no 'if' for 'else'/
+                    lbsr      L0393
+L3166               leas      $02,s
+L3168               puls      pc,u
+L316A               fcc       /no 'if' for 'else'/
                     fcb       $00
-L3180               fcc       /illegal declaration/
+L317D               fcc       /illegal declaration/
                     fcb       $00
-L3194               fcc       /syntax error/
+L3191               fcc       /syntax error/
                     fcb       $00
-L31A1               fcc       /multiple defaults/
+L319E               fcc       /multiple defaults/
                     fcb       $00
-L31B3               fcc       /no switch statement/
+L31B0               fcc       /no switch statement/
                     fcb       $00
-L31C7               fcc       /while expected/
+L31C4               fcc       /while expected/
                     fcb       $00
-L31D6               fcc       /break error/
+L31D3               fcc       /break error/
                     fcb       $00
-L31E2               fcc       /continue error/
+L31DF               fcc       /continue error/
                     fcb       $00
-L31F1               fcc       /label required/
+L31EE               fcc       /label required/
                     fcb       $00
-L3200               fcc       /already a local variable/
+L31FD               fcc       /already a local variable/
                     fcb       $00
-L3219               fcc       /condition needed/
+L3216               fcc       /condition needed/
                     fcb       $00
-                    pshs      u
+L3227               pshs      u
                     ldd       #$FFA2
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$14,s
-                    bra       L3245
+                    bra       L3242
 
-L3237               leax      L42F7,pcr
+L3234               leax      L42F4,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbsr      L552E
-L3245               ldd       $005F
+                    lbsr      L552B
+L3242               ldd       $005F
                     cmpd      #$002A
-                    beq       L3237
+                    beq       L3234
                     ldd       $005F
                     cmpd      #$0029
-                    bne       L327A
-                    leax      L4309,pcr
+                    bne       L3277
+                    leax      L4306,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
                     clra
                     clrb
                     pshs      d
-                    lbsr      L3A4F
+                    lbsr      L3A4C
                     leas      $02,s
                     leax      >$0049,y
                     pshs      x
-                    lbsr      L4207
+                    lbsr      L4204
                     leas      $02,s
-                    lbsr      L552E
-                    lbra      L34D4
+                    lbsr      L552B
+                    lbra      L34D1
 
-L327A               lbsr      L3BE9
+L3277               lbsr      L3BE6
                     std       $0a,s
                     tfr       d,x
-                    bra       L3295
+                    bra       L3292
 
-L3283               leax      L4321,pcr
+L3280               leax      L431E,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L328E               ldd       #$000C
+L328B               ldd       #$000C
                     std       $0a,s
-                    bra       L32A5
+                    bra       L32A2
 
-L3295               cmpx      #$0010
-                    beq       L3283
+L3292               cmpx      #$0010
+                    beq       L3280
                     cmpx      #$000D
-                    lbeq      L3283
+                    lbeq      L3280
                     stx       -$02,s
-                    beq       L328E
-L32A5               leax      ,s
+                    beq       L328B
+L32A2               leax      ,s
                     pshs      x
                     leax      $06,s
                     pshs      x
                     leax      $16,s
                     pshs      x
-                    lbsr      L3C38
+                    lbsr      L3C35
                     leas      $06,s
                     std       $08,s
-                    bne       L32C0
+                    bne       L32BD
                     ldd       #$0001
                     std       $08,s
-L32C0               ldd       $04,s
+L32BD               ldd       $04,s
                     std       $0C,s
                     ldd       $08,s
                     pshs      d
@@ -5502,73 +5518,73 @@ L32C0               ldd       $04,s
                     pshs      x
                     leax      $06,s
                     pshs      x
-                    lbsr      L3F8D
+                    lbsr      L3F8A
                     leas      $06,s
                     std       $06,s
                     ldu       $02,s
-                    bne       L32F4
+                    bne       L32F1
                     ldd       $06,s
                     cmpd      #$0004
-                    beq       L32EE
+                    beq       L32EB
                     ldd       $06,s
                     cmpd      #$0003
-                    beq       L32EE
-                    lbsr      L42E2
-L32EE               leax      $14,s
-                    lbra      L34B4
+                    beq       L32EB
+                    lbsr      L42DF
+L32EB               leax      $14,s
+                    lbra      L34B1
 
-L32F4               ldd       $06,s
+L32F1               ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    bne       L3319
+                    bne       L3316
                     ldd       $005F
                     cmpd      #$0030
-                    beq       L330F
+                    beq       L330C
                     ldd       $005F
                     cmpd      #$0028
-                    bne       L3314
-L330F               ldd       #$000E
-                    bra       L331B
+                    bne       L3311
+L330C               ldd       #$000E
+                    bra       L3318
 
-L3314               ldd       #$000C
-                    bra       L331B
+L3311               ldd       #$000C
+                    bra       L3318
 
-L3319               ldd       $0a,s
-L331B               std       $0e,s
+L3316               ldd       $0a,s
+L3318               std       $0e,s
                     ldd       ,u
-                    beq       L3367
+                    beq       L3364
                     ldd       ,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      L387E
+                    lbsr      L387B
                     leas      $06,s
                     std       -$02,s
-                    lbne      L343B
+                    lbne      L3438
                     ldd       $0e,s
                     cmpd      #$000E
-                    lbeq      L343B
+                    lbeq      L3438
                     ldd       $08,u
                     cmpd      #$000E
-                    beq       L3356
+                    beq       L3353
                     ldd       $08,u
                     cmpd      #$0022
-                    beq       L3356
-                    lbsr      L0241
-                    lbra      L343B
+                    beq       L3353
+                    lbsr      L023E
+                    lbra      L3438
 
-L3356               ldd       $0e,s
+L3353               ldd       $0e,s
                     std       $08,u
                     ldd       $0C,s
                     std       $04,u
                     ldd       ,s
                     std       $0a,u
                     leax      $14,s
-                    bra       L3379
+                    bra       L3376
 
-L3367               ldd       $06,s
+L3364               ldd       $06,s
                     std       ,u
                     clra
                     clrb
@@ -5577,197 +5593,197 @@ L3367               ldd       $06,s
                     std       $08,u
                     ldd       ,s
                     std       $0a,u
-                    bra       L337C
+                    bra       L3379
 
-L3379               leas      -$14,x
-L337C               ldd       $12,s
+L3376               leas      -$14,x
+L3379               ldd       $12,s
                     pshs      d
                     ldd       $0e,s
                     pshs      d
                     pshs      u
-                    lbsr      L4103
+                    lbsr      L4100
                     leas      $06,s
                     std       $10,s
                     ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    lbeq      L343B
+                    lbeq      L3438
                     ldd       $005F
                     cmpd      #$0078
-                    bne       L33B7
+                    bne       L33B4
                     ldd       $06,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
                     pshs      u
-                    lbsr      L4435
-L33B2               leas      $06,s
-                    lbra      L3421
+                    lbsr      L4432
+L33AF               leas      $06,s
+                    lbra      L341E
 
-L33B7               ldd       $10,s
-                    bne       L33CA
+L33B4               ldd       $10,s
+                    bne       L33C7
                     ldd       $0e,s
                     cmpd      #$000E
-                    beq       L33CA
-                    lbsr      L42D4
-                    lbra      L3421
+                    beq       L33C7
+                    lbsr      L42D1
+                    lbra      L341E
 
-L33CA               ldx       $0e,s
-                    bra       L3409
+L33C7               ldx       $0e,s
+                    bra       L3406
 
-L33CE               ldd       $0e,s
+L33CB               ldd       $0e,s
                     cmpd      #$0023
-                    bne       L33DB
+                    bne       L33D8
                     ldd       #$0001
-                    bra       L33DD
+                    bra       L33DA
 
-L33DB               clra
+L33D8               clra
                     clrb
-L33DD               pshs      d
+L33DA               pshs      d
                     ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      $66FB
-                    bra       L33B2
+                    lbsr      L66F8
+                    bra       L33AF
 
-L33EB               ldd       $0e,s
+L33E8               ldd       $0e,s
                     cmpd      #$0021
-                    bne       L33F8
+                    bne       L33F5
                     ldd       #$0001
-                    bra       L33FA
+                    bra       L33F7
 
-L33F8               clra
+L33F5               clra
                     clrb
-L33FA               pshs      d
+L33F7               pshs      d
                     ldd       $12,s
                     pshs      d
                     pshs      u
-                    lbsr      $66EB
-                    lbra      L33B2
+                    lbsr      L66E8
+                    lbra      L33AF
 
-L3409               cmpx      #$0023
-                    beq       L33CE
+L3406               cmpx      #$0023
+                    beq       L33CB
                     cmpx      #$000F
-                    lbeq      L33CE
+                    lbeq      L33CB
                     cmpx      #$0021
-                    beq       L33EB
+                    beq       L33E8
                     cmpx      #$000C
-                    lbeq      L33EB
-L3421               ldd       $0e,s
+                    lbeq      L33E8
+L341E               ldd       $0e,s
                     cmpd      #$000F
-                    bne       L342E
+                    bne       L342B
                     ldd       #$000C
-                    bra       L3439
+                    bra       L3436
 
-L342E               ldd       $0e,s
+L342B               ldd       $0e,s
                     cmpd      #$0023
-                    bne       L343B
+                    bne       L3438
                     ldd       #$0021
-L3439               std       $08,u
-L343B               ldd       $06,s
+L3436               std       $08,u
+L3438               ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    lbne      L34B7
+                    lbne      L34B4
                     ldd       $06,s
                     pshs      d
-                    lbsr      L047A
+                    lbsr      L0477
                     leas      $02,s
                     std       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    beq       L3477
+                    beq       L3474
                     ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    beq       L3477
+                    beq       L3474
                     ldd       $06,s
                     cmpd      #$0004
-                    beq       L3477
+                    beq       L3474
                     ldd       $06,s
                     cmpd      #$0003
-                    bne       L348C
-L3477               leax      L432F,pcr
+                    bne       L3489
+L3474               leax      L432C,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
                     ldd       #$0031
                     std       ,u
                     ldd       #$0001
                     std       $06,s
-L348C               ldd       $0e,s
+L3489               ldd       $0e,s
                     cmpd      #$000E
-                    bne       L34A1
+                    bne       L349E
                     leax      >$0047,y
                     pshs      x
-                    lbsr      L4207
+                    lbsr      L4204
                     leas      $02,s
-                    bra       L34B7
+                    bra       L34B4
 
-L34A1               ldd       $06,s
+L349E               ldd       $06,s
                     std       L004D
                     ldd       $0a,s
                     pshs      d
                     pshs      u
-                    lbsr      L3907
+                    lbsr      L3904
                     leas      $04,s
-                    bra       L34D4
-                    bra       L34B7
+                    bra       L34D1
+                    bra       L34B4
 
-L34B4               leas      -$14,x
-L34B7               ldd       $005F
+L34B1               leas      -$14,x
+L34B4               ldd       $005F
                     cmpd      #$0030
-                    bne       L34C5
-                    lbsr      L552E
-                    lbra      L32C0
+                    bne       L34C2
+                    lbsr      L552B
+                    lbra      L32BD
 
-L34C5               ldd       #$0028
+L34C2               ldd       #$0028
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     std       ,s++
-                    beq       L34D4
-                    lbsr      L0502
-L34D4               leas      $14,s
+                    beq       L34D1
+                    lbsr      L04FF
+L34D1               leas      $14,s
                     puls      pc,u
-L34D9               pshs      u
+L34D6               pshs      u
                     ldd       #$FFA4
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$12,s
-                    lbsr      L3BE9
+                    lbsr      L3BE6
                     std       $10,s
                     tfr       d,x
-                    bra       L3501
+                    bra       L34FE
 
-L34EE               leax      L4343,pcr
+L34EB               leax      L4340,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L34F9               ldd       #$000D
+L34F6               ldd       #$000D
                     std       $10,s
-                    bra       L350C
+                    bra       L3509
 
-L3501               stx       -$02,s
-                    beq       L34F9
+L34FE               stx       -$02,s
+                    beq       L34F6
                     cmpx      #$0010
-                    beq       L350C
-                    bra       L34EE
+                    beq       L3509
+                    bra       L34EB
 
-L350C               leax      ,s
+L3509               leax      ,s
                     pshs      x
                     leax      $0C,s
                     pshs      x
                     leax      $0C,s
                     pshs      x
-                    lbsr      L3C38
+                    lbsr      L3C35
                     leas      $06,s
                     std       $0e,s
-                    bne       L3526
+                    bne       L3523
                     ldd       #$0001
                     std       $0e,s
-L3526               ldd       $0a,s
+L3523               ldd       $0a,s
                     std       $0C,s
                     ldd       $0e,s
                     pshs      d
@@ -5775,7 +5791,7 @@ L3526               ldd       $0a,s
                     pshs      x
                     leax      $06,s
                     pshs      x
-                    lbsr      L3F8D
+                    lbsr      L3F8A
                     leas      $06,s
                     std       $04,s
                     ldu       $02,s
@@ -5783,54 +5799,54 @@ L3526               ldd       $0a,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    beq       L355A
+                    beq       L3557
                     ldd       $04,s
                     cmpd      #$0004
-                    beq       L355A
+                    beq       L3557
                     ldd       $04,s
                     cmpd      #$000A
-                    bne       L3567
-L355A               leax      L4354,pcr
+                    bne       L3564
+L3557               leax      L4351,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    bra       L3598
+                    bra       L3595
 
-L3567               ldd       $04,s
+L3564               ldd       $04,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L3582
+                    bne       L357F
                     ldd       $04,s
                     pshs      d
-                    lbsr      L047A
+                    lbsr      L0477
                     std       ,s
-                    lbsr      L0486
+                    lbsr      L0483
                     leas      $02,s
-                    bra       L358D
+                    bra       L358A
 
-L3582               ldd       $04,s
+L357F               ldd       $04,s
                     cmpd      #$0005
-                    bne       L358F
+                    bne       L358C
                     ldd       #$0006
-L358D               std       $04,s
-L358F               cmpu      #$0000
-                    bne       L359E
-                    lbsr      L42E2
-L3598               leax      $12,s
-                    lbra      L35FB
+L358A               std       $04,s
+L358C               cmpu      #$0000
+                    bne       L359B
+                    lbsr      L42DF
+L3595               leax      $12,s
+                    lbra      L35F8
 
-L359E               ldd       $04,s
+L359B               ldd       $04,s
                     pshs      d
                     ldd       $12,s
                     pshs      d
-                    lbsr      L38B2
+                    lbsr      L38AF
                     leas      $04,s
                     std       $06,s
                     ldx       $08,u
-                    bra       L35E8
+                    bra       L35E5
 
-L35B2               ldd       $04,s
+L35AF               ldd       $04,s
                     std       ,u
                     ldd       $06,s
                     std       $08,u
@@ -5841,83 +5857,83 @@ L35B2               ldd       $04,s
                     ldd       $0e,s
                     pshs      d
                     pshs      u
-                    lbsr      L4103
+                    lbsr      L4100
                     leas      $06,s
                     std       -$02,s
-                    bne       L35FE
-                    lbsr      L42D4
-                    bra       L35FE
+                    bne       L35FB
+                    lbsr      L42D1
+                    bra       L35FB
 
-L35D6               lbsr      L0241
-                    bra       L35FE
+L35D3               lbsr      L023E
+                    bra       L35FB
 
-L35DB               leax      L4363,pcr
+L35D8               leax      L4360,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    bra       L35FE
+                    bra       L35FB
 
-L35E8               cmpx      #$000B
-                    beq       L35B2
+L35E5               cmpx      #$000B
+                    beq       L35AF
                     cmpx      #$000D
-                    beq       L35D6
+                    beq       L35D3
                     cmpx      #$0010
-                    lbeq      L35D6
-                    bra       L35DB
+                    lbeq      L35D3
+                    bra       L35D8
 
-L35FB               leas      -$12,x
-L35FE               ldd       $005F
+L35F8               leas      -$12,x
+L35FB               ldd       $005F
                     cmpd      #$0078
-                    bne       L3609
-                    lbsr      L4980
-L3609               ldd       $005F
+                    bne       L3606
+                    lbsr      L497D
+L3606               ldd       $005F
                     cmpd      #$0030
-                    bne       L3617
-                    lbsr      L552E
-                    lbra      L3526
+                    bne       L3614
+                    lbsr      L552B
+                    lbra      L3523
 
-L3617               ldd       #$0028
+L3614               ldd       #$0028
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     std       ,s++
-                    lbeq      L3879
-                    lbsr      L0502
-                    lbra      L3879
+                    lbeq      L3876
+                    lbsr      L04FF
+                    lbra      L3876
 
-L362B               pshs      u
+L3628               pshs      u
                     ldd       #$FF9E
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$12,s
-                    lbsr      L3BE9
+                    lbsr      L3BE6
                     std       $10,s
                     tfr       d,x
-                    bra       L3653
+                    bra       L3650
 
-L3640               leax      L4373,pcr
+L363D               leax      L4370,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L364B               ldd       #$000D
+L3648               ldd       #$000D
                     std       $10,s
-                    bra       L365C
+                    bra       L3659
 
-L3653               cmpx      #$0021
-                    beq       L3640
+L3650               cmpx      #$0021
+                    beq       L363D
                     stx       -$02,s
-                    beq       L364B
-L365C               leax      $02,s
+                    beq       L3648
+L3659               leax      $02,s
                     pshs      x
                     leax      $0C,s
                     pshs      x
                     leax      $0C,s
                     pshs      x
-                    lbsr      L3C38
+                    lbsr      L3C35
                     leas      $06,s
                     std       $0e,s
-                    bne       L3676
+                    bne       L3673
                     ldd       #$0001
                     std       $0e,s
-L3676               leas      -$06,s
+L3673               leas      -$06,s
                     ldd       $10,s
                     std       ,s
                     ldd       $14,s
@@ -5926,30 +5942,30 @@ L3676               leas      -$06,s
                     pshs      x
                     leax      $0e,s
                     pshs      x
-                    lbsr      L3F8D
+                    lbsr      L3F8A
                     leas      $06,s
                     std       $12,s
                     ldu       $0a,s
-                    bne       L36B2
+                    bne       L36AF
                     ldd       $12,s
                     cmpd      #$0004
-                    lbeq      L371D
+                    lbeq      L371A
                     ldd       $12,s
                     cmpd      #$0003
-                    lbeq      L371D
-                    lbsr      L42E2
-                    lbra      L371D
+                    lbeq      L371A
+                    lbsr      L42DF
+                    lbra      L371A
 
-L36B2               ldd       $12,s
+L36AF               ldd       $12,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    beq       L36C7
+                    beq       L36C4
                     ldd       $16,s
                     cmpd      #$000E
-                    bne       L36FE
-L36C7               ldd       ,u
-                    bne       L36EC
+                    bne       L36FB
+L36C4               ldd       ,u
+                    bne       L36E9
                     ldd       $12,s
                     std       ,u
                     ldd       #$000E
@@ -5964,38 +5980,38 @@ L36C7               ldd       ,u
                     ldd       $02,s
                     pshs      d
                     pshs      u
-                    lbsr      L4103
-                    bra       L36FA
+                    lbsr      L4100
+                    bra       L36F7
 
-L36EC               ldd       $08,s
+L36E9               ldd       $08,s
                     pshs      d
                     ldd       $14,s
                     pshs      d
                     pshs      u
-                    lbsr      L387E
-L36FA               leas      $06,s
-                    bra       L371D
+                    lbsr      L387B
+L36F7               leas      $06,s
+                    bra       L371A
 
-L36FE               ldd       $12,s
+L36FB               ldd       $12,s
                     pshs      d
                     ldd       $18,s
                     pshs      d
-                    lbsr      L38B2
+                    lbsr      L38AF
                     leas      $04,s
                     std       $04,s
                     ldd       ,u
-                    beq       L372A
+                    beq       L3727
                     ldd       $0C,u
                     cmpd      L0051
-                    bne       L3723
-                    lbsr      L0241
-L371D               leax      $18,s
-                    lbra      L3858
+                    bne       L3720
+                    lbsr      L023E
+L371A               leax      $18,s
+                    lbra      L3855
 
-L3723               pshs      u
-                    lbsr      L0180
+L3720               pshs      u
+                    lbsr      L017D
                     leas      $02,s
-L372A               ldd       $12,s
+L3727               ldd       $12,s
                     std       ,u
                     ldd       $04,s
                     std       $08,u
@@ -6011,70 +6027,70 @@ L372A               ldd       $12,s
                     ldd       $02,s
                     pshs      d
                     pshs      u
-                    lbsr      L4103
+                    lbsr      L4100
                     leas      $06,s
                     std       $02,s
-                    bne       L3760
+                    bne       L375D
                     ldd       $005F
                     cmpd      #$0078
-                    beq       L3760
-                    lbsr      L42D4
-L3760               ldx       $04,s
-                    bra       L3779
+                    beq       L375D
+                    lbsr      L42D1
+L375D               ldx       $04,s
+                    bra       L3776
 
-L3764               ldd       L0031
+L3761               ldd       L0031
                     subd      $02,s
                     std       L0031
                     ldd       L0031
-                    bra       L3775
+                    bra       L3772
 
-L376E               ldd       L002B
+L376B               ldd       L002B
                     addd      #$0001
                     std       L002B
-L3775               std       $06,u
-                    bra       L378A
+L3772               std       $06,u
+                    bra       L3787
 
-L3779               cmpx      #$000D
-                    beq       L3764
+L3776               cmpx      #$000D
+                    beq       L3761
                     cmpx      #$0023
-                    beq       L376E
+                    beq       L376B
                     cmpx      #$000F
-                    lbeq      L376E
-L378A               ldd       $005F
+                    lbeq      L376B
+L3787               ldd       $005F
                     cmpd      #$0078
-                    lbne      L3827
+                    lbne      L3824
                     ldd       $04,s
                     cmpd      #$000F
-                    beq       L37A4
+                    beq       L37A1
                     ldd       $04,s
                     cmpd      #$0023
-                    bne       L37B7
-L37A4               ldd       $12,s
+                    bne       L37B4
+L37A1               ldd       $12,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      L4435
-L37B2               leas      $06,s
-                    lbra      L385B
+                    lbsr      L4432
+L37AF               leas      $06,s
+                    lbra      L3858
 
-L37B7               lbsr      L552E
+L37B4               lbsr      L552B
                     ldd       $12,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    lbeq      L3822
+                    lbeq      L381F
                     ldd       $12,s
                     cmpd      #$0004
-                    lbeq      L3822
+                    lbeq      L381F
                     ldd       #$0002
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     leas      $02,s
                     std       $0C,s
-                    beq       L3822
+                    beq       L381F
                     ldd       $0009
-                    beq       L37F6
+                    beq       L37F3
                     ldd       $0009
                     std       $06,s
                     tfr       d,x
@@ -6083,137 +6099,137 @@ L37B7               lbsr      L552E
                     clra
                     clrb
                     std       [$06,s]
-                    bra       L3802
+                    bra       L37FF
 
-L37F6               ldd       #$0006
+L37F3               ldd       #$0006
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     std       $06,s
-L3802               ldd       $0C,s
+L37FF               ldd       $0C,s
                     ldx       $06,s
                     std       $02,x
                     ldx       $06,s
                     stu       $04,x
                     ldd       $0005
-                    beq       L3818
+                    beq       L3815
                     ldd       $06,s
                     std       [$0007,y]
-                    bra       L381C
+                    bra       L3819
 
-L3818               ldd       $06,s
+L3815               ldd       $06,s
                     std       $0005
-L381C               ldd       $06,s
+L3819               ldd       $06,s
                     std       $0007
-                    bra       L385B
+                    bra       L3858
 
-L3822               lbsr      L4980
-                    bra       L385B
+L381F               lbsr      L497D
+                    bra       L3858
 
-L3827               ldx       $04,s
-                    bra       L384A
+L3824               ldx       $04,s
+                    bra       L3847
 
-L382B               ldd       $04,s
+L3828               ldd       $04,s
                     cmpd      #$0023
-                    bne       L3838
+                    bne       L3835
                     ldd       #$0001
-                    bra       L383A
+                    bra       L3837
 
-L3838               clra
+L3835               clra
                     clrb
-L383A               pshs      d
+L3837               pshs      d
                     ldd       $04,s
                     pshs      d
                     ldd       $06,u
                     pshs      d
-                    lbsr      $66C1
-                    lbra      L37B2
+                    lbsr      L66BE
+                    lbra      L37AF
 
-L384A               cmpx      #$000F
-                    beq       L382B
+L3847               cmpx      #$000F
+                    beq       L3828
                     cmpx      #$0023
-                    lbeq      L382B
-                    bra       L385B
+                    lbeq      L3828
+                    bra       L3858
 
-L3858               leas      -$18,x
-L385B               ldd       $005F
+L3855               leas      -$18,x
+L3858               ldd       $005F
                     cmpd      #$0030
-                    beq       L3867
+                    beq       L3864
                     leas      $06,s
-                    bra       L386F
+                    bra       L386C
 
-L3867               lbsr      L552E
+L3864               lbsr      L552B
                     leas      $06,s
-                    lbra      L3676
+                    lbra      L3673
 
-L386F               ldd       #$0028
+L386C               ldd       #$0028
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-L3879               leas      $12,s
+L3876               leas      $12,s
                     puls      pc,u
-L387E               pshs      u
+L387B               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       ,u
                     cmpd      $06,s
-                    bne       L389E
+                    bne       L389B
                     ldd       $06,s
                     cmpd      #$0004
-                    bne       L38AE
+                    bne       L38AB
                     ldd       $0a,u
                     cmpd      $08,s
-                    beq       L38AE
-L389E               leax      L4381,pcr
+                    beq       L38AB
+L389B               leax      L437E,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
                     ldd       #$0001
                     puls      pc,u
-L38AE               clra
+L38AB               clra
                     clrb
                     puls      pc,u
-L38B2               pshs      u
+L38AF               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     cmpd      #$0010
-                    bne       L3903
+                    bne       L3900
                     ldd       $0003
                     cmpd      #$0001
-                    bge       L38FE
+                    bge       L38FB
                     ldx       $06,s
-                    bra       L38F0
+                    bra       L38ED
 
-L38CE               ldd       $06,s
+L38CB               ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L38FE
-L38D9               ldd       $0003
+                    bne       L38FB
+L38D6               ldd       $0003
                     addd      #$0001
                     std       $0003
                     cmpd      #$0001
-                    bne       L38EB
+                    bne       L38E8
                     ldd       #$006F
-                    bra       L38EE
+                    bra       L38EB
 
-L38EB               ldd       #$0076
-L38EE               puls      pc,u
-L38F0               cmpx      #$0001
-                    beq       L38D9
+L38E8               ldd       #$0076
+L38EB               puls      pc,u
+L38ED               cmpx      #$0001
+                    beq       L38D6
                     cmpx      #$0007
-                    lbeq      L38D9
-                    bra       L38CE
+                    lbeq      L38D6
+                    bra       L38CB
 
-L38FE               ldd       #$000D
+L38FB               ldd       #$000D
                     puls      pc,u
-L3903               ldd       $04,s
+L3900               ldd       $04,s
                     puls      pc,u
-L3907               pshs      u
+L3904               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$0a,s
                     ldd       #$0001
                     std       L0051
@@ -6224,17 +6240,17 @@ L3907               pshs      u
                     std       L0031
                     std       $0003
                     std       L0033
-                    bra       L3927
+                    bra       L3924
 
-L3924               lbsr      L34D9
-L3927               ldd       $005F
+L3921               lbsr      L34D6
+L3924               ldd       $005F
                     cmpd      #$0029
-                    bne       L3924
+                    bne       L3921
                     ldd       $0e,s
                     addd      #$0014
                     std       $02,s
                     ldd       L0037
-                    beq       L394E
+                    beq       L394B
                     ldd       L002B
                     addd      #$0001
                     std       L002B
@@ -6242,104 +6258,104 @@ L3927               ldd       $005F
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      $679F
+                    lbsr      L679C
                     leas      $04,s
-L394E               ldd       ,s
+L394B               ldd       ,s
                     pshs      d
                     ldd       $12,s
                     cmpd      #$000F
-                    beq       L3960
+                    beq       L395D
                     ldd       #$0001
-                    bra       L3962
+                    bra       L395F
 
-L3960               clra
+L395D               clra
                     clrb
-L3962               pshs      d
+L395F               pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $6742
+                    lbsr      L673F
                     leas      $06,s
                     ldu       L0047
                     ldd       #$0004
                     std       $08,s
-                    lbra      L39EB
+                    lbra      L39E8
 
-L3977               leas      -$02,s
+L3974               leas      -$02,s
                     ldd       $0a,s
                     std       $06,u
                     ldx       ,u
-                    bra       L3999
+                    bra       L3996
 
-L3981               ldd       #$0004
-                    bra       L3995
-
-L3986               ldd       #$0008
-                    bra       L3995
-
-L398B               ldd       $06,u
-                    addd      #$0001
-                    std       $06,u
-L3992               ldd       #$0002
-L3995               std       ,s
-                    bra       L39B1
-
-L3999               cmpx      #$0008
-                    beq       L3981
-                    cmpx      #$0005
-                    lbeq      L3981
-                    cmpx      #$0006
-                    beq       L3986
-                    cmpx      #$0002
-                    beq       L398B
+L397E               ldd       #$0004
                     bra       L3992
 
-L39B1               ldd       $08,u
+L3983               ldd       #$0008
+                    bra       L3992
+
+L3988               ldd       $06,u
+                    addd      #$0001
+                    std       $06,u
+L398F               ldd       #$0002
+L3992               std       ,s
+                    bra       L39AE
+
+L3996               cmpx      #$0008
+                    beq       L397E
+                    cmpx      #$0005
+                    lbeq      L397E
+                    cmpx      #$0006
+                    beq       L3983
+                    cmpx      #$0002
+                    beq       L3988
+                    bra       L398F
+
+L39AE               ldd       $08,u
                     std       $08,s
                     tfr       d,x
-                    bra       L39CF
+                    bra       L39CC
 
-L39B9               ldd       $0a,s
+L39B6               ldd       $0a,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $04,s
-                    bra       L39E0
+                    bra       L39DD
 
-L39C8               ldd       #$000D
+L39C5               ldd       #$000D
                     std       $08,u
-                    bra       L39E0
+                    bra       L39DD
 
-L39CF               cmpx      #$006F
-                    beq       L39B9
+L39CC               cmpx      #$006F
+                    beq       L39B6
                     cmpx      #$0076
-                    lbeq      L39B9
+                    lbeq      L39B6
                     cmpx      #$000B
-                    beq       L39C8
-L39E0               ldd       $0a,s
+                    beq       L39C5
+L39DD               ldd       $0a,s
                     addd      ,s
                     std       $0a,s
                     ldu       $10,u
                     leas      $02,s
-L39EB               stu       -$02,s
-                    lbne      L3977
+L39E8               stu       -$02,s
+                    lbne      L3974
                     ldd       L0047
                     std       $04,s
                     clra
                     clrb
                     std       L0047
-                    lbsr      L3A4F
+                    lbsr      L3A4C
                     leax      $04,s
                     pshs      x
-                    lbsr      L4207
+                    lbsr      L4204
                     leas      $02,s
                     leax      >$0049,y
                     pshs      x
-                    lbsr      L4207
+                    lbsr      L4204
                     leas      $02,s
                     ldd       L004F
                     cmpd      #$0012
-                    beq       L3A2A
+                    beq       L3A27
                     clra
                     clrb
                     pshs      d
@@ -6348,62 +6364,62 @@ L39EB               stu       -$02,s
                     pshs      d
                     ldd       #$0012
                     pshs      d
-                    lbsr      L4B61
+                    lbsr      L4B5E
                     leas      $06,s
-L3A2A               clra
+L3A27               clra
                     clrb
                     std       L004F
-                    lbsr      $67D1
+                    lbsr      L67CE
                     clra
                     clrb
                     std       L0051
                     ldd       $005F
                     cmpd      #$FFFF
-                    bne       L3A48
-                    leax      L4396,pcr
+                    bne       L3A45
+                    leax      L4393,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L3A48               lbsr      L552E
+L3A45               lbsr      L552B
                     leas      $0a,s
                     puls      pc,u
-L3A4F               pshs      u
+L3A4C               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$06,s
                     ldd       $004B
                     std       $02,s
                     clra
                     clrb
                     std       $004B
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       L0051
                     addd      #$0001
                     std       L0051
                     ldd       L0031
                     std       ,s
-                    bra       L3A74
+                    bra       L3A71
 
-L3A71               lbsr      L362B
-L3A74               lbsr      L043F
+L3A6E               lbsr      L3628
+L3A71               lbsr      L043C
                     std       -$02,s
-                    bne       L3A71
-                    lbsr      L03DD
+                    bne       L3A6E
+                    lbsr      L03DA
                     std       -$02,s
-                    lbne      L3A71
+                    lbne      L3A6E
                     ldd       L003B
                     cmpd      L0031
-                    ble       L3A8F
+                    ble       L3A8C
                     ldd       L0031
                     std       L003B
-L3A8F               ldd       L0031
+L3A8C               ldd       L0031
                     pshs      d
-                    lbsr      L4B33
+                    lbsr      L4B30
                     leas      $02,s
                     std       $002F
-                    lbra      L3B0D
+                    lbra      L3B0A
 
-L3A9D               ldd       $0005
+L3A9A               ldd       $0005
                     std       $04,s
                     ldx       $04,s
                     ldu       $02,x
@@ -6422,7 +6438,7 @@ L3A9D               ldd       $0005
                     pshs      d
                     ldd       #$0034
                     pshs      d
-                    lbsr      L0DD6
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     ldd       $10,u
@@ -6438,15 +6454,15 @@ L3A9D               ldd       $0005
                     pshs      u
                     ldd       #$0078
                     pshs      d
-                    lbsr      L0DD6
+                    lbsr      L0DD3
                     leas      $0C,s
                     tfr       d,u
                     pshs      u
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     std       ,s
-                    lbsr      L4C52
+                    lbsr      L4C4F
                     std       ,s
-                    lbsr      L0396
+                    lbsr      L0393
                     leas      $02,s
                     ldd       [$04,s]
                     std       $04,s
@@ -6456,20 +6472,20 @@ L3A9D               ldd       $0005
                     std       $0009
                     ldd       $04,s
                     std       $0005
-L3B0D               ldd       $0005
-                    lbne      L3A9D
-                    bra       L3B18
+L3B0A               ldd       $0005
+                    lbne      L3A9A
+                    bra       L3B15
 
-L3B15               lbsr      L27D3
-L3B18               ldd       $005F
+L3B12               lbsr      L27D0
+L3B15               ldd       $005F
                     cmpd      #$002A
-                    beq       L3B28
+                    beq       L3B25
                     ldd       $005F
                     cmpd      #$FFFF
-                    bne       L3B15
-L3B28               leax      >$004b,y
+                    bne       L3B12
+L3B25               leax      >$004b,y
                     pshs      x
-                    lbsr      L4207
+                    lbsr      L4204
                     leas      $02,s
                     ldd       $02,s
                     std       $004B
@@ -6480,46 +6496,46 @@ L3B28               leax      >$004b,y
                     std       L0031
                     ldd       L004F
                     cmpd      #$0012
-                    beq       L3B55
+                    beq       L3B52
                     ldd       ,s
                     pshs      d
-                    lbsr      L4B33
+                    lbsr      L4B30
                     leas      $02,s
-                    bra       L3B57
+                    bra       L3B54
 
-L3B55               ldd       ,s
-L3B57               std       $002F
+L3B52               ldd       ,s
+L3B54               std       $002F
                     leas      $06,s
                     puls      pc,u
-L3B5D               pshs      u
+L3B5A               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$02,s
                     clra
                     clrb
                     std       [$06,s]
-L3B6C               lbsr      L552E
+L3B69               lbsr      L552B
                     ldd       $005F
                     cmpd      #$002E
-                    lbeq      L3BDD
+                    lbeq      L3BDA
                     ldd       $005F
                     cmpd      #$0034
-                    bne       L3BD0
+                    bne       L3BCD
                     ldu       $0061
                     ldd       $08,u
                     cmpd      #$000B
-                    bne       L3B96
-                    leax      L43AA,pcr
+                    bne       L3B93
+                    leax      L43A7,pcr
                     pshs      x
-                    lbsr      L024E
-                    bra       L3B9F
+                    lbsr      L024B
+                    bra       L3B9C
 
-L3B96               ldd       ,u
-                    beq       L3BA1
+L3B93               ldd       ,u
+                    beq       L3B9E
                     pshs      u
-                    lbsr      L0180
-L3B9F               leas      $02,s
-L3BA1               ldd       #$0001
+                    lbsr      L017D
+L3B9C               leas      $02,s
+L3B9E               ldd       #$0001
                     std       ,u
                     ldd       #$000B
                     std       $08,u
@@ -6528,70 +6544,70 @@ L3BA1               ldd       #$0001
                     ldd       #$0002
                     std       $02,u
                     ldd       [$06,s]
-                    beq       L3BC1
+                    beq       L3BBE
                     ldx       ,s
                     stu       $10,x
-                    bra       L3BC4
+                    bra       L3BC1
 
-L3BC1               stu       [$06,s]
-L3BC4               clra
+L3BBE               stu       [$06,s]
+L3BC1               clra
                     clrb
                     std       $10,u
                     stu       ,s
-                    lbsr      L552E
-                    bra       L3BD3
+                    lbsr      L552B
+                    bra       L3BD0
 
-L3BD0               lbsr      L42E2
-L3BD3               ldd       $005F
+L3BCD               lbsr      L42DF
+L3BD0               ldd       $005F
                     cmpd      #$0030
-                    lbeq      L3B6C
-L3BDD               ldd       #$002E
+                    lbeq      L3B69
+L3BDA               ldd       #$002E
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-                    bra       L3C34
+                    bra       L3C31
 
-L3BE9               pshs      u
+L3BE6               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$02,s
-                    lbsr      L043F
+                    lbsr      L043C
                     std       -$02,s
-                    beq       L3C32
+                    beq       L3C2F
                     ldd       $0061
                     std       ,s
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       $005F
                     cmpd      #$0033
-                    bne       L3C2E
+                    bne       L3C2B
                     ldd       $0061
                     cmpd      #$0021
-                    bne       L3C2E
+                    bne       L3C2B
                     ldx       ,s
-                    bra       L3C21
+                    bra       L3C1E
 
-L3C15               ldd       #$0023
-                    bra       L3C1D
+L3C12               ldd       #$0023
+                    bra       L3C1A
 
-L3C1A               ldd       #$0022
-L3C1D               std       ,s
-                    bra       L3C2B
+L3C17               ldd       #$0022
+L3C1A               std       ,s
+                    bra       L3C28
 
-L3C21               cmpx      #$000F
-                    beq       L3C15
+L3C1E               cmpx      #$000F
+                    beq       L3C12
                     cmpx      #$000E
-                    beq       L3C1A
-L3C2B               lbsr      L552E
-L3C2E               ldd       ,s
-                    bra       L3C34
+                    beq       L3C17
+L3C28               lbsr      L552B
+L3C2B               ldd       ,s
+                    bra       L3C31
 
-L3C32               clra
+L3C2F               clra
                     clrb
-L3C34               leas      $02,s
-L3C36               puls      pc,u
-L3C38               pshs      u
+L3C31               leas      $02,s
+                    puls      pc,u
+L3C35               pshs      u
                     ldd       #$FF98
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$1a,s
                     clra
                     clrb
@@ -6603,54 +6619,54 @@ L3C38               pshs      u
                     std       [$22,s]
                     ldd       $005F
                     cmpd      #$0033
-                    lbne      L3F54
+                    lbne      L3F51
                     ldd       $0061
                     std       $02,s
                     tfr       d,x
-                    lbra      L3F12
+                    lbra      L3F0F
 
-L3C64               ldd       #$0001
+L3C61               ldd       #$0001
                     std       $02,s
-L3C69               lbsr      L552E
+L3C66               lbsr      L552B
                     ldd       $005F
                     cmpd      #$0033
-                    lbne      L3F7C
+                    lbne      L3F79
                     ldd       $0061
                     cmpd      #$0001
-                    lbne      L3F7C
-                    bra       L3CBA
+                    lbne      L3F79
+                    bra       L3CB7
 
-L3C82               ldd       #$0001
-                    bra       L3CB8
+L3C7F               ldd       #$0001
+                    bra       L3CB5
 
-L3C87               lbsr      L552E
+L3C84               lbsr      L552B
                     ldd       #$0004
                     std       ,s
                     ldd       $005F
                     cmpd      #$0033
-                    lbne      L3F7C
+                    lbne      L3F79
                     ldd       $0061
                     cmpd      #$0001
-                    beq       L3CBA
+                    beq       L3CB7
                     ldd       $0061
                     cmpd      #$0005
-                    lbne      L3F7C
-L3CAB               ldd       #$0006
+                    lbne      L3F79
+L3CA8               ldd       #$0006
                     std       $02,s
                     ldd       #$0008
-                    bra       L3CB8
+                    bra       L3CB5
 
-L3CB5               ldd       #$0004
-L3CB8               std       ,s
-L3CBA               lbsr      L552E
-                    lbra      L3F7C
+L3CB2               ldd       #$0004
+L3CB5               std       ,s
+L3CB7               lbsr      L552B
+                    lbra      L3F79
 
-L3CC0               clra
+L3CBD               clra
                     clrb
                     std       $02,s
-                    lbra      L3F7C
+                    lbra      L3F79
 
-L3CC7               clra
+L3CC4               clra
                     clrb
                     std       $16,s
                     std       ,s
@@ -6660,39 +6676,39 @@ L3CC7               clra
                     clra
                     clrb
                     std       $18,s
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       $0041
                     addd      #$FFFF
                     std       $0041
                     ldd       $005F
                     cmpd      #$0034
-                    lbne      L3D60
+                    lbne      L3D5D
                     ldd       $0061
                     std       $18,s
                     ldd       [$18,s]
-                    bne       L3D08
+                    bne       L3D05
                     ldd       #$000A
                     std       [$18,s]
                     ldd       #$0008
                     ldx       $18,s
                     std       $08,x
-                    bra       L3D1E
+                    bra       L3D1B
 
-L3D08               ldx       $18,s
+L3D05               ldx       $18,s
                     ldd       $08,x
                     cmpd      #$0008
-                    beq       L3D1E
-                    leax      L43B6,pcr
+                    beq       L3D1B
+                    leax      L43B3,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L3D1E               lbsr      L552E
+L3D1B               lbsr      L552B
                     ldd       $005F
                     cmpd      #$0029
-                    beq       L3D54
+                    beq       L3D51
                     ldd       [$18,s]
                     cmpd      #$0004
-                    bne       L3D48
+                    bne       L3D45
                     ldx       $18,s
                     ldd       $02,x
                     std       [$1e,s]
@@ -6700,57 +6716,57 @@ L3D1E               lbsr      L552E
                     ldd       $0a,x
                     std       [$22,s]
                     ldd       #$0004
-                    lbra      L3F88
+                    lbra      L3F85
 
-L3D48               ldd       $18,s
+L3D45               ldd       $18,s
                     std       [$1e,s]
                     ldd       #$000A
-                    lbra      L3F88
+                    lbra      L3F85
 
-L3D54               ldd       [$18,s]
+L3D51               ldd       [$18,s]
                     cmpd      #$0004
-                    bne       L3D60
-                    lbsr      L0241
-L3D60               ldd       $005F
+                    bne       L3D5D
+                    lbsr      L023E
+L3D5D               ldd       $005F
                     cmpd      #$0029
-                    beq       L3D76
-                    leax      L43C1,pcr
+                    beq       L3D73
+                    leax      L43BE,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbra      L3F7C
+                    lbra      L3F79
 
-L3D76               ldd       $0041
+L3D73               ldd       $0041
                     addd      #$0001
                     std       $0041
-L3D7D               ldd       $0041
+L3D7A               ldd       $0041
                     std       $10,s
                     clra
                     clrb
                     std       $0041
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       $10,s
                     std       $0041
                     ldd       $005F
                     cmpd      #$002A
-                    lbeq      L3EE5
+                    lbeq      L3EE2
                     leax      $04,s
                     pshs      x
                     leax      $0e,s
                     pshs      x
                     leax      $18,s
                     pshs      x
-                    lbsr      L3C38
+                    lbsr      L3C35
                     leas      $06,s
                     std       $12,s
-                    bra       L3DAF
+                    bra       L3DAC
 
-L3DAF               leas      -$04,s
+L3DAC               leas      -$04,s
                     ldd       $10,s
                     std       $02,s
                     ldd       $005F
                     cmpd      #$0028
-                    lbeq      L3ECF
+                    lbeq      L3ECC
                     ldd       L0051
                     addd      #$0001
                     std       L0051
@@ -6760,7 +6776,7 @@ L3DAF               leas      -$04,s
                     pshs      x
                     leax      $04,s
                     pshs      x
-                    lbsr      L3F8D
+                    lbsr      L3F8A
                     leas      $06,s
                     std       $12,s
                     ldu       ,s
@@ -6768,41 +6784,41 @@ L3DAF               leas      -$04,s
                     addd      #$FFFF
                     std       L0051
                     cmpu      #$0000
-                    bne       L3DF4
-                    lbsr      L42E2
+                    bne       L3DF1
+                    lbsr      L42DF
                     leax      $1e,s
-                    lbra      L3EC4
+                    lbra      L3EC1
 
-L3DF4               ldd       ,u
-                    beq       L3E29
+L3DF1               ldd       ,u
+                    beq       L3E26
                     ldd       $0C,u
                     cmpd      L0051
-                    bne       L3E22
+                    bne       L3E1F
                     ldd       ,u
                     cmpd      $12,s
-                    bne       L3E17
+                    bne       L3E14
                     ldd       $08,u
                     cmpd      #$0011
-                    bne       L3E17
+                    bne       L3E14
                     ldd       $06,u
                     cmpd      $1a,s
-                    beq       L3E29
-L3E17               leax      L43CF,pcr
+                    beq       L3E26
+L3E14               leax      L43CC,pcr
                     pshs      x
-                    lbsr      L024E
-                    bra       L3E27
+                    lbsr      L024B
+                    bra       L3E24
 
-L3E22               pshs      u
-                    lbsr      L0180
-L3E27               leas      $02,s
-L3E29               ldd       $12,s
+L3E1F               pshs      u
+                    lbsr      L017D
+L3E24               leas      $02,s
+L3E26               ldd       $12,s
                     cmpd      #$000A
-                    bne       L3E3D
-                    leax      L43E6,pcr
+                    bne       L3E3A
+                    leax      L43E3,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L3E3D               ldd       $12,s
+L3E3A               ldd       $12,s
                     std       ,u
                     ldd       #$0011
                     std       $08,u
@@ -6815,75 +6831,75 @@ L3E3D               ldd       $12,s
                     ldd       $04,s
                     pshs      d
                     pshs      u
-                    lbsr      L4103
+                    lbsr      L4100
                     leas      $06,s
                     std       $0e,s
-                    beq       L3E87
+                    beq       L3E84
                     ldd       $06,s
                     cmpd      #$0004
-                    bne       L3E76
+                    bne       L3E73
                     ldd       $1a,s
                     addd      $0e,s
                     std       $1a,s
-                    bra       L3E83
+                    bra       L3E80
 
-L3E76               ldd       $0e,s
+L3E73               ldd       $0e,s
                     cmpd      $04,s
-                    ble       L3E81
+                    ble       L3E7E
                     ldd       $0e,s
-                    bra       L3E83
+                    bra       L3E80
 
-L3E81               ldd       $04,s
-L3E83               std       $04,s
-                    bra       L3E8A
+L3E7E               ldd       $04,s
+L3E80               std       $04,s
+                    bra       L3E87
 
-L3E87               lbsr      L42D4
-L3E8A               ldd       L0051
+L3E84               lbsr      L42D1
+L3E87               ldd       L0051
                     std       $0C,u
                     ldd       $004B
                     std       $10,u
                     stu       $004B
                     ldd       $06,s
                     cmpd      #$0004
-                    bne       L3EC7
+                    bne       L3EC4
                     ldd       #$0004
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     std       $0C,s
                     ldx       $0C,s
                     stu       $02,x
                     ldd       [$26,s]
-                    beq       L3EB9
+                    beq       L3EB6
                     ldd       $0C,s
                     std       [$0a,s]
-                    bra       L3EBE
+                    bra       L3EBB
 
-L3EB9               ldd       $0C,s
+L3EB6               ldd       $0C,s
                     std       [$26,s]
-L3EBE               ldd       $0C,s
+L3EBB               ldd       $0C,s
                     std       $0a,s
-                    bra       L3EC7
+                    bra       L3EC4
 
-L3EC4               leas      -$1e,x
-L3EC7               ldd       $005F
+L3EC1               leas      -$1e,x
+L3EC4               ldd       $005F
                     cmpd      #$0030
-                    beq       L3ED3
-L3ECF               leas      $04,s
-                    bra       L3EDB
+                    beq       L3ED0
+L3ECC               leas      $04,s
+                    bra       L3ED8
 
-L3ED3               lbsr      L552E
+L3ED0               lbsr      L552B
                     leas      $04,s
-                    lbra      L3DAF
+                    lbra      L3DAC
 
-L3EDB               ldd       $005F
+L3ED8               ldd       $005F
                     cmpd      #$0028
-                    lbeq      L3D7D
-L3EE5               ldd       $0041
+                    lbeq      L3D7A
+L3EE2               ldd       $0041
                     addd      #$FFFF
                     std       $0041
                     ldd       $18,s
-                    beq       L3F06
+                    beq       L3F03
                     ldd       ,s
                     ldx       $18,s
                     std       $02,x
@@ -6892,88 +6908,88 @@ L3EE5               ldd       $0041
                     ldd       [$22,s]
                     ldx       $18,s
                     std       $0a,x
-L3F06               ldd       #$002A
+L3F03               ldd       #$002A
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-                    bra       L3F7C
+                    bra       L3F79
 
-L3F12               cmpx      #$000A
-                    lbeq      L3C64
+L3F0F               cmpx      #$000A
+                    lbeq      L3C61
                     cmpx      #$0007
-                    lbeq      L3C69
+                    lbeq      L3C66
                     cmpx      #$0002
-                    lbeq      L3C82
+                    lbeq      L3C7F
                     cmpx      #$0001
-                    lbeq      L3CBA
+                    lbeq      L3CB7
                     cmpx      #$0008
-                    lbeq      L3C87
+                    lbeq      L3C84
                     cmpx      #$0006
-                    lbeq      L3CAB
+                    lbeq      L3CA8
                     cmpx      #$0005
-                    lbeq      L3CB5
+                    lbeq      L3CB2
                     cmpx      #$0003
-                    lbeq      L3CC7
+                    lbeq      L3CC4
                     cmpx      #$0004
-                    lbeq      L3CC7
-                    lbra      L3CC0
+                    lbeq      L3CC4
+                    lbra      L3CBD
 
-L3F54               ldd       $005F
+L3F51               ldd       $005F
                     cmpd      #$0034
-                    bne       L3F7C
+                    bne       L3F79
                     ldu       $0061
                     ldd       $08,u
-                    cmpd      #_start
-                    bne       L3F7C
+                    cmpd      #start
+                    bne       L3F79
                     ldd       $02,u
                     std       [$1e,s]
                     ldd       $04,u
                     std       [$20,s]
                     ldd       $0a,u
                     std       [$22,s]
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       ,u
-                    bra       L3F88
+                    bra       L3F85
 
-L3F7C               ldd       ,s
+L3F79               ldd       ,s
                     std       [$1e,s]
                     clra
                     clrb
                     std       [$20,s]
                     ldd       $02,s
-L3F88               leas      $1a,s
-L3F8B               puls      pc,u
-L3F8D               pshs      u
+L3F85               leas      $1a,s
+                    puls      pc,u
+L3F8A               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$0C,s
                     clra
                     clrb
                     std       [$10,s]
                     std       $0a,s
-                    bra       L3FAE
+                    bra       L3FAB
 
-L3FA0               ldd       $0a,s
+L3F9D               ldd       $0a,s
                     pshs      d
-                    lbsr      L0486
+                    lbsr      L0483
                     leas      $02,s
                     std       $0a,s
-                    lbsr      L552E
-L3FAE               ldd       $005F
+                    lbsr      L552B
+L3FAB               ldd       $005F
                     cmpd      #$0042
-                    beq       L3FA0
+                    beq       L3F9D
                     ldd       $005F
                     cmpd      #$0034
-                    bne       L3FC8
+                    bne       L3FC5
                     ldd       $0061
                     std       [$10,s]
-                    lbsr      L552E
-                    bra       L4002
+                    lbsr      L552B
+                    bra       L3FFF
 
-L3FC8               ldd       $005F
+L3FC5               ldd       $005F
                     cmpd      #$002D
-                    bne       L4002
-                    lbsr      L552E
+                    bne       L3FFF
+                    lbsr      L552B
                     ldd       L0051
                     addd      #$0001
                     std       L0051
@@ -6983,7 +6999,7 @@ L3FC8               ldd       $005F
                     pshs      d
                     ldd       $14,s
                     pshs      d
-                    lbsr      L3F8D
+                    lbsr      L3F8A
                     leas      $06,s
                     std       $14,s
                     ldd       L0051
@@ -6991,11 +7007,11 @@ L3FC8               ldd       $005F
                     std       L0051
                     ldd       #$002E
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-L4002               ldd       $005F
+L3FFF               ldd       $005F
                     cmpd      #$002D
-                    bne       L4039
+                    bne       L4036
                     ldd       $0a,s
                     aslb
                     rola
@@ -7004,23 +7020,23 @@ L4002               ldd       $005F
                     addd      #$0030
                     std       $0a,s
                     ldd       L0051
-                    bne       L4024
+                    bne       L4021
                     leax      >$0047,y
                     pshs      x
-                    lbsr      L3B5D
-                    bra       L4034
+                    lbsr      L3B5A
+                    bra       L4031
 
-L4024               leax      ,s
+L4021               leax      ,s
                     pshs      x
-                    lbsr      L3B5D
+                    lbsr      L3B5A
                     leas      $02,s
                     leax      ,s
                     pshs      x
-                    lbsr      L4207
-L4034               leas      $02,s
-                    lbra      L40BC
+                    lbsr      L4204
+L4031               leas      $02,s
+                    lbra      L40B9
 
-L4039               clra
+L4036               clra
                     clrb
                     std       $06,s
                     std       $04,s
@@ -7030,99 +7046,99 @@ L4039               clra
                     clra
                     clrb
                     std       $0041
-                    lbra      L40A0
+                    lbra      L409D
 
-L404C               ldd       $0a,s
+L4049               ldd       $0a,s
                     aslb
                     rola
                     aslb
                     rola
                     addd      #$0020
                     std       $0a,s
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       #$0004
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     tfr       d,u
                     ldd       $04,s
-                    bne       L4076
+                    bne       L4073
                     ldd       $005F
                     cmpd      #$002C
-                    bne       L4076
+                    bne       L4073
                     clra
                     clrb
-                    bra       L407F
+                    bra       L407C
 
-L4076               clra
+L4073               clra
                     clrb
                     pshs      d
-                    lbsr      L0A52
+                    lbsr      L0A4F
                     leas      $02,s
-L407F               std       ,u
+L407C               std       ,u
                     ldd       $06,s
-                    beq       L408B
+                    beq       L4088
                     ldx       $06,s
                     stu       $02,x
-                    bra       L408D
+                    bra       L408A
 
-L408B               stu       $02,s
-L408D               stu       $06,s
+L4088               stu       $02,s
+L408A               stu       $06,s
                     ldd       #$002C
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
                     ldd       $04,s
                     addd      #$0001
                     std       $04,s
-L40A0               ldd       $005F
+L409D               ldd       $005F
                     cmpd      #$002B
-                    lbeq      L404C
+                    lbeq      L4049
                     ldd       $08,s
                     std       $0041
                     ldd       $02,s
-                    beq       L40BC
+                    beq       L40B9
                     ldd       [$12,s]
                     std       $02,u
                     ldd       $02,s
                     std       [$12,s]
-L40BC               ldd       $0a,s
+L40B9               ldd       $0a,s
                     pshs      d
                     ldd       $16,s
                     pshs      d
-                    bsr       L40CD
+                    bsr       L40CA
                     leas      $04,s
                     leas      $0C,s
                     puls      pc,u
-L40CD               pshs      u
+L40CA               pshs      u
                     ldd       #$FFBC
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-                    bra       L40F5
+                    bra       L40F2
 
-L40DD               ldd       ,s
+L40DA               ldd       ,s
                     pshs      d
                     ldd       #$0002
-                    lbsr      L7660
+                    lbsr      L765D
                     std       ,s
                     ldd       $08,s
                     pshs      d
                     ldd       #$0002
-                    lbsr      L7683
+                    lbsr      L7680
                     std       $08,s
-L40F5               ldd       ,s
+L40F2               ldd       ,s
                     clra
                     andb      #$30
-                    bne       L40DD
+                    bne       L40DA
                     ldd       $06,s
                     addd      $08,s
-                    lbra      L42F3
+                    lbra      L42F0
 
-L4103               pshs      u
+L4100               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     ldd       ,u
@@ -7130,53 +7146,53 @@ L4103               pshs      u
                     clra
                     andb      #$0f
                     tfr       d,x
-                    bra       L4138
+                    bra       L4135
 
-L411A               ldd       #$0001
-                    bra       L4134
+L4117               ldd       #$0001
+                    bra       L4131
 
-L411F               ldd       #$0002
-                    bra       L4134
+L411C               ldd       #$0002
+                    bra       L4131
 
-L4124               ldd       #$0004
-                    bra       L4134
+L4121               ldd       #$0004
+                    bra       L4131
 
-L4129               ldd       #$0008
-                    bra       L4134
+L4126               ldd       #$0008
+                    bra       L4131
 
-L412E               ldd       $0C,s
-                    bra       L4134
+L412B               ldd       $0C,s
+                    bra       L4131
 
-L4132               clra
+L412F               clra
                     clrb
-L4134               std       ,s
-                    bra       L416B
+L4131               std       ,s
+                    bra       L4168
 
-L4138               cmpx      #$0002
-                    beq       L411A
+L4135               cmpx      #$0002
+                    beq       L4117
                     cmpx      #$0001
-                    beq       L411F
+                    beq       L411C
                     cmpx      #$0007
-                    lbeq      L411F
+                    lbeq      L411C
                     cmpx      #$0008
-                    beq       L4124
+                    beq       L4121
                     cmpx      #$0005
-                    lbeq      L4124
+                    lbeq      L4121
                     cmpx      #$0006
-                    beq       L4129
+                    beq       L4126
                     cmpx      #$0003
-                    beq       L412E
+                    beq       L412B
                     cmpx      #$0004
-                    lbeq      L412E
+                    lbeq      L412B
                     cmpx      #$000A
-                    beq       L4132
-L416B               ldd       ,s
-                    beq       L4173
+                    beq       L412F
+L4168               ldd       ,s
+                    beq       L4170
                     ldd       ,s
-                    bra       L4175
+                    bra       L4172
 
-L4173               ldd       $0C,s
-L4175               std       $02,u
+L4170               ldd       $0C,s
+L4172               std       $02,u
                     ldd       $0a,s
                     std       $04,u
                     pshs      d
@@ -7184,408 +7200,408 @@ L4175               std       $02,u
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    bsr       L418D
+                    bsr       L418A
                     leas      $06,s
                     leas      $04,s
-L418B               puls      pc,u
-L418D               pshs      u
+                    puls      pc,u
+L418A               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $08,s
                     leas      -$02,s
                     ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    beq       L41AF
+                    beq       L41AC
                     ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    bne       L41B5
-L41AF               ldd       #$0002
-                    lbra      L42F3
+                    bne       L41B2
+L41AC               ldd       #$0002
+                    lbra      L42F0
 
-L41B5               ldd       $06,s
+L41B2               ldd       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L4202
+                    bne       L41FF
                     ldd       #$0001
                     std       ,s
-L41C5               ldd       ,s
+L41C2               ldd       ,s
                     pshs      d
                     ldd       ,u
-                    lbsr      L7542
+                    lbsr      L753F
                     std       ,s
                     ldu       $02,u
                     ldd       $06,s
                     pshs      d
-                    lbsr      L047A
+                    lbsr      L0477
                     leas      $02,s
                     std       $06,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    beq       L41C5
+                    beq       L41C2
                     ldd       ,s
                     pshs      d
                     ldd       $08,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L41FA
+                    bne       L41F7
                     ldd       #$0002
-                    bra       L41FC
+                    bra       L41F9
 
-L41FA               ldd       $0a,s
-L41FC               lbsr      L7542
-                    lbra      L42F3
+L41F7               ldd       $0a,s
+L41F9               lbsr      L753F
+                    lbra      L42F0
 
-L4202               ldd       $08,s
-                    lbra      L42F3
+L41FF               ldd       $08,s
+                    lbra      L42F0
 
-L4207               pshs      u
+L4204               pshs      u
                     ldd       #$FF74
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$40,s
                     ldu       [$44,s]
-                    lbra      L42C4
+                    lbra      L42C1
 
-L4218               ldd       $10,u
+L4215               ldd       $10,u
                     std       $3C,s
                     ldd       ,u
                     cmpd      #$0009
-                    bne       L4258
+                    bne       L4255
                     ldd       $0a,u
                     clra
                     andb      #$01
-                    bne       L4258
+                    bne       L4255
                     ldd       #$0008
                     pshs      d
                     pshs      u
                     ldd       #$0014
                     addd      ,s++
                     pshs      d
-                    leax      L43FA,pcr
+                    leax      L43F7,pcr
                     pshs      x
                     leax      $06,s
                     pshs      x
-                    lbsr      $7314
+                    lbsr      L7311
                     leas      $04,s
                     pshs      d
-                    lbsr      $740C
+                    lbsr      L7409
                     leas      $06,s
                     pshs      d
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-L4258               ldx       $08,u
-                    bra       L4265
+L4255               ldx       $08,u
+                    bra       L4262
 
-L425C               ldd       $0003
+L4259               ldd       $0003
                     addd      #$FFFF
                     std       $0003
-                    bra       L4271
+                    bra       L426E
 
-L4265               cmpx      #$006F
-                    beq       L425C
+L4262               cmpx      #$006F
+                    beq       L4259
                     cmpx      #$0076
-                    lbeq      L425C
-L4271               ldd       $0e,u
+                    lbeq      L4259
+L426E               ldd       $0e,u
                     std       $3e,s
                     cmpd      L0066
-                    bls       L428C
+                    bls       L4289
                     ldd       $3e,s
                     cmpd      $0068
-                    bcc       L428C
+                    bcc       L4289
                     pshs      u
-                    lbsr      L01D2
+                    lbsr      L01CF
                     leas      $02,s
-                    bra       L42C1
+                    bra       L42BE
 
-L428C               cmpu      [$3e,s]
-                    bne       L429A
+L4289               cmpu      [$3e,s]
+                    bne       L4297
                     ldd       $12,u
                     std       [$3e,s]
-                    bra       L42BA
+                    bra       L42B7
 
-L429A               ldd       [$3e,s]
-                    bra       L42A5
+L4297               ldd       [$3e,s]
+                    bra       L42A2
 
-L429F               ldx       $3e,s
+L429C               ldx       $3e,s
                     ldd       $12,x
-L42A5               std       $3e,s
+L42A2               std       $3e,s
                     ldx       $3e,s
                     cmpu      $12,x
-                    bne       L429F
+                    bne       L429C
                     ldd       $12,u
                     ldx       $3e,s
                     std       $12,x
-L42BA               ldd       L0019
+L42B7               ldd       L0019
                     std       $12,u
                     stu       L0019
-L42C1               ldu       $3C,s
-L42C4               stu       -$02,s
-                    lbne      L4218
+L42BE               ldu       $3C,s
+L42C1               stu       -$02,s
+                    lbne      L4215
                     clra
                     clrb
                     std       [$44,s]
                     leas      $40,s
                     puls      pc,u
-L42D4               pshs      u
+L42D1               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    leax      L440D,pcr
-L42E0               bra       L42EE
+                    lbsr      L0110
+                    leax      L440A,pcr
+                    bra       L42EB
 
-L42E2               pshs      u
+L42DF               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    leax      L4422,pcr
-L42EE               pshs      x
-                    lbsr      L024E
-L42F3               leas      $02,s
+                    lbsr      L0110
+                    leax      L441F,pcr
+L42EB               pshs      x
+                    lbsr      L024B
+L42F0               leas      $02,s
                     puls      pc,u
-L42F7               fcc       /too many brackets/
+L42F4               fcc       /too many brackets/
                     fcb       $00
-L4309               fcc       /function header missing/
+L4306               fcc       /function header missing/
                     fcb       $00
-L4321               fcc       /storage error/
+L431E               fcc       /storage error/
                     fcb       $00
-L432F               fcc       /function type error/
+L432C               fcc       /function type error/
                     fcb       $00
-L4343               fcc       /argument storage/
+L4340               fcc       /argument storage/
                     fcb       $00
-L4354               fcc       /argument error/
+L4351               fcc       /argument error/
                     fcb       $00
-L4363               fcc       /not an argument/
+L4360               fcc       /not an argument/
                     fcb       $00
-L4373               fcc       /storage error/
+L4370               fcc       /storage error/
                     fcb       $00
-L4381               fcc       /declaration mismatch/
+L437E               fcc       /declaration mismatch/
                     fcb       $00
-L4396               fcc       /function unfinished/
+L4393               fcc       /function unfinished/
                     fcb       $00
-L43AA               fcc       /named twice/
+L43A7               fcc       /named twice/
                     fcb       $00
-L43B6               fcc       /name clash/
+L43B3               fcc       /name clash/
                     fcb       $00
-L43C1               fcc       /struct syntax/
+L43BE               fcc       /struct syntax/
                     fcb       $00
-L43CF               fcc       /struct member mismatch/
+L43CC               fcc       /struct member mismatch/
                     fcb       $00
-L43E6               fcc       /undefined structure/
+L43E3               fcc       /undefined structure/
                     fcb       $00
-L43FA               fcc       /label undefined : /
+L43F7               fcc       /label undefined : /
                     fcb       $00
-L440D               fcc       /cannot evaluate size/
+L440A               fcc       /cannot evaluate size/
                     fcb       $00
-L4422               fcc       /identifier missing/
+L441F               fcc       /identifier missing/
                     fcb       $00
-L4435               pshs      u
+L4432               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     ldx       $0a,s
-                    bra       L445B
+                    bra       L4458
 
-L4445               lbsr      L4980
-                    lbra      L456F
+L4442               lbsr      L497D
+                    lbra      L456C
 
-L444B               ldd       #$0001
-                    bra       L4452
+L4448               ldd       #$0001
+                    bra       L444F
 
-L4450               clra
+L444D               clra
                     clrb
-L4452               pshs      d
-                    lbsr      $6814
+L444F               pshs      d
+                    lbsr      L6811
                     leas      $02,s
-                    bra       L447C
+                    bra       L4479
 
-L445B               cmpx      #_start
-                    beq       L4445
+L4458               cmpx      #start
+                    beq       L4442
                     cmpx      #$000E
-                    lbeq      L4445
+                    lbeq      L4442
                     cmpx      #$0022
-                    lbeq      L4445
+                    lbeq      L4442
                     cmpx      #$0021
-                    beq       L444B
+                    beq       L4448
                     cmpx      #$0023
-                    lbeq      L444B
-                    bra       L4450
+                    lbeq      L4448
+                    bra       L444D
 
-L447C               ldd       L0051
-                    bne       L44AE
+L4479               ldd       L0051
+                    bne       L44AB
                     leax      $14,u
                     stx       $02,s
                     ldd       $0a,s
                     cmpd      #$000F
-                    beq       L449A
+                    beq       L4497
                     ldd       $0a,s
                     cmpd      #$0023
-                    beq       L449A
+                    beq       L4497
                     ldd       #$0001
-                    bra       L44A1
+                    bra       L449E
 
-L449A               ldd       #$000C
+L4497               ldd       #$000C
                     std       $08,u
                     clra
                     clrb
-L44A1               pshs      d
+L449E               pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4A23
+                    lbsr      L4A20
                     leas      $04,s
-                    bra       L44BD
+                    bra       L44BA
 
-L44AE               lbsr      L4BEF
+L44AB               lbsr      L4BEC
                     ldd       $06,u
                     pshs      d
-                    lbsr      L4B04
+                    lbsr      L4B01
                     leas      $02,s
-                    lbsr      L4A77
-L44BD               ldd       $0C,s
+                    lbsr      L4A74
+L44BA               ldd       $0C,s
                     cmpd      #$0022
-                    bne       L4511
+                    bne       L450E
                     ldd       #$0001
                     std       $000B
-                    lbsr      L552E
+                    lbsr      L552B
                     ldd       $005F
                     cmpd      #$0037
-                    bne       L450A
+                    bne       L4507
                     ldd       $04,u
                     std       $02,s
                     ldd       [$02,s]
-                    bne       L44E5
+                    bne       L44E2
                     ldd       L0017
                     std       [$02,s]
-                    bra       L4502
+                    bra       L44FF
 
-L44E5               ldd       [$02,s]
+L44E2               ldd       [$02,s]
                     subd      L0017
                     std       ,s
-                    blt       L44F7
+                    blt       L44F4
                     ldd       ,s
                     pshs      d
-                    lbsr      $603F
-                    bra       L4500
+                    lbsr      L603C
+                    bra       L44FD
 
-L44F7               leax      L49C1,pcr
+L44F4               leax      L49BE,pcr
                     pshs      x
-                    lbsr      L024E
-L4500               leas      $02,s
-L4502               lbsr      L552E
+                    lbsr      L024B
+L44FD               leas      $02,s
+L44FF               lbsr      L552B
                     leax      $04,s
-                    lbra      L4566
+                    lbra      L4563
 
-L450A               ldd       #$0002
+L4507               ldd       #$0002
                     std       $000B
-                    bra       L4519
+                    bra       L4516
 
-L4511               ldd       #$0002
+L450E               ldd       #$0002
                     std       $000B
-                    lbsr      L552E
-L4519               ldd       $0C,s
+                    lbsr      L552B
+L4516               ldd       $0C,s
                     cmpd      #$0004
-                    bne       L4536
+                    bne       L4533
                     clra
                     clrb
                     pshs      d
                     ldd       $0a,u
-L4527               pshs      d
+L4524               pshs      d
                     pshs      u
                     ldd       $12,s
                     pshs      d
-                    bsr       L4573
+                    bsr       L4570
                     leas      $08,s
-                    bra       L4568
+                    bra       L4565
 
-L4536               ldd       $0C,s
+L4533               ldd       $0C,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    bne       L4549
+                    bne       L4546
                     clra
                     clrb
                     pshs      d
                     ldd       $04,u
-                    bra       L4527
+                    bra       L4524
 
-L4549               ldd       #$0001
+L4546               ldd       #$0001
                     pshs      d
                     ldd       $04,u
                     pshs      d
                     pshs      u
                     ldd       $12,s
                     pshs      d
-                    bsr       L4573
+                    bsr       L4570
                     leas      $08,s
                     std       -$02,s
-                    bne       L4568
-                    lbsr      L4997
-                    bra       L4568
+                    bne       L4565
+                    lbsr      L4994
+                    bra       L4565
 
-L4566               leas      -$04,x
-L4568               lbsr      $6824
+L4563               leas      -$04,x
+L4565               lbsr      L6821
                     clra
                     clrb
                     std       $000B
-L456F               leas      $04,s
+L456C               leas      $04,s
                     puls      pc,u
-L4573               pshs      u
+L4570               pshs      u
                     ldd       #$FFA8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $06,s
                     leas      -$0C,s
                     ldd       $16,s
-                    bne       L4590
+                    bne       L458D
                     ldd       #$0029
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-                    bra       L45A6
+                    bra       L45A3
 
-L4590               ldd       $005F
+L458D               ldd       $005F
                     cmpd      #$0029
-                    bne       L45A2
+                    bne       L459F
                     ldd       #$0001
                     std       $0a,s
-                    lbsr      L552E
-                    bra       L45A6
+                    lbsr      L552B
+                    bra       L45A3
 
-L45A2               clra
+L459F               clra
                     clrb
                     std       $0a,s
-L45A6               ldd       $10,s
+L45A3               ldd       $10,s
                     clra
                     andb      #$30
                     cmpd      #$0020
-                    lbne      L4694
+                    lbne      L4691
                     ldd       [$14,s]
                     std       $02,s
-                    bne       L45C0
+                    bne       L45BD
                     ldd       #$FFFF
                     std       $02,s
-L45C0               ldd       $10,s
+L45BD               ldd       $10,s
                     pshs      d
-                    lbsr      L047A
+                    lbsr      L0477
                     leas      $02,s
                     std       $08,s
                     cmpd      #$0004
-                    bne       L45D6
+                    bne       L45D3
                     ldd       $0a,u
-                    bra       L45DB
+                    bra       L45D8
 
-L45D6               ldx       $14,s
+L45D3               ldx       $14,s
                     ldd       $02,x
-L45DB               std       $04,s
+L45D8               std       $04,s
                     clra
                     clrb
                     std       $06,s
-                    bra       L4619
+                    bra       L4616
 
-L45E3               ldd       $16,s
+L45E0               ldd       $16,s
                     addd      #$0001
                     pshs      d
                     ldd       $06,s
@@ -7593,34 +7609,34 @@ L45E3               ldd       $16,s
                     pshs      u
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L4573
+                    lbsr      L4570
                     leas      $08,s
                     std       -$02,s
-                    lbeq      L474B
+                    lbeq      L4748
                     ldd       $06,s
                     addd      #$0001
                     std       $06,s
                     cmpd      $02,s
-                    bcc       L4621
+                    bcc       L461E
                     ldd       $005F
                     cmpd      #$0030
-                    bne       L4621
-                    lbsr      L552E
-                    bra       L4619
+                    bne       L461E
+                    lbsr      L552B
+                    bra       L4616
 
-L4619               ldd       $005F
+L4616               ldd       $005F
                     cmpd      #$002A
-                    bne       L45E3
-L4621               ldd       $02,s
+                    bne       L45E0
+L461E               ldd       $02,s
                     cmpd      #$FFFF
-                    bne       L4630
+                    bne       L462D
                     ldd       $06,s
                     std       [$14,s]
-                    bra       L465F
+                    bra       L465C
 
-L4630               ldd       $06,s
+L462D               ldd       $06,s
                     cmpd      $02,s
-                    bcc       L465F
+                    bcc       L465C
                     ldx       $14,s
                     ldd       $02,x
                     pshs      d
@@ -7628,83 +7644,83 @@ L4630               ldd       $06,s
                     pshs      d
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L418D
+                    lbsr      L418A
                     leas      $06,s
                     pshs      d
                     ldd       $04,s
                     subd      $08,s
-                    lbsr      L7542
+                    lbsr      L753F
                     pshs      d
-                    lbsr      L4751
+                    lbsr      L474E
                     leas      $02,s
-                    bra       L465F
+                    bra       L465C
 
-L465D               leas      -$0C,x
-L465F               ldd       $16,s
-                    beq       L466A
+L465A               leas      -$0C,x
+L465C               ldd       $16,s
+                    beq       L4667
                     ldd       $0a,s
-                    lbeq      L4738
-L466A               ldd       $005F
+                    lbeq      L4735
+L4667               ldd       $005F
                     cmpd      #$0030
-                    bne       L4675
-                    lbsr      L552E
-L4675               ldd       $005F
+                    bne       L4672
+                    lbsr      L552B
+L4672               ldd       $005F
                     cmpd      #$002A
-                    bne       L4683
-                    lbsr      L552E
-                    lbra      L4738
+                    bne       L4680
+                    lbsr      L552B
+                    lbra      L4735
 
-L4683               leax      L49CA,pcr
+L4680               leax      L49C7,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbsr      L4997
-                    lbra      L4738
+                    lbsr      L4994
+                    lbra      L4735
 
-L4694               ldd       $10,s
+L4691               ldd       $10,s
                     cmpd      #$0004
-                    lbne      L471F
+                    lbne      L471C
                     ldd       $14,s
                     std       ,s
-                    bne       L46ED
-                    leax      L49DC,pcr
-                    lbra      L4741
+                    bne       L46EA
+                    leax      L49D9,pcr
+                    lbra      L473E
 
-L46AD               ldx       ,s
+L46AA               ldx       ,s
                     ldu       $02,x
                     ldd       $16,s
                     addd      #$0001
                     pshs      d
                     ldd       ,u
                     cmpd      #$0004
-                    bne       L46C5
+                    bne       L46C2
                     ldd       $0a,u
-                    bra       L46C7
+                    bra       L46C4
 
-L46C5               ldd       $04,u
-L46C7               pshs      d
+L46C2               ldd       $04,u
+L46C4               pshs      d
                     pshs      u
                     ldd       ,u
                     pshs      d
-                    lbsr      L4573
+                    lbsr      L4570
                     leas      $08,s
                     std       -$02,s
-                    lbeq      L474B
+                    lbeq      L4748
                     ldd       [,s]
                     std       ,s
-                    beq       L4716
+                    beq       L4713
                     ldd       $005F
                     cmpd      #$0030
-                    bne       L4716
-                    lbsr      L552E
-                    bra       L46ED
+                    bne       L4713
+                    lbsr      L552B
+                    bra       L46EA
 
-L46ED               ldd       $005F
+L46EA               ldd       $005F
                     cmpd      #$002A
-                    bne       L46AD
-                    bra       L4716
+                    bne       L46AA
+                    bra       L4713
 
-L46F7               ldx       ,s
+L46F4               ldx       ,s
                     ldu       $02,x
                     ldd       $04,u
                     pshs      d
@@ -7712,73 +7728,73 @@ L46F7               ldx       ,s
                     pshs      d
                     ldd       ,u
                     pshs      d
-                    lbsr      L418D
+                    lbsr      L418A
                     leas      $06,s
                     pshs      d
-                    bsr       L4751
+                    bsr       L474E
                     leas      $02,s
                     ldd       [,s]
                     std       ,s
-L4716               ldd       ,s
-                    bne       L46F7
+L4713               ldd       ,s
+                    bne       L46F4
                     leax      $0C,s
-                    lbra      L465D
+                    lbra      L465A
 
-L471F               ldd       $10,s
+L471C               ldd       $10,s
                     pshs      d
-                    bsr       L4775
+                    bsr       L4772
                     std       ,s++
-                    beq       L473D
+                    beq       L473A
                     ldd       $0a,s
-                    beq       L4738
+                    beq       L4735
                     ldd       #$002A
                     pshs      d
-                    lbsr      L04BF
+                    lbsr      L04BC
                     leas      $02,s
-L4738               ldd       #$0001
-                    bra       L474D
+L4735               ldd       #$0001
+                    bra       L474A
 
-L473D               leax      L49EF,pcr
-L4741               pshs      x
-                    lbsr      L024E
+L473A               leax      L49EC,pcr
+L473E               pshs      x
+                    lbsr      L024B
                     leas      $02,s
-                    lbsr      L4997
-L474B               clra
+                    lbsr      L4994
+L4748               clra
                     clrb
-L474D               leas      $0C,s
+L474A               leas      $0C,s
                     puls      pc,u
-L4751               pshs      u
+L474E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    lbsr      L4BEF
-                    leax      L4A0C,pcr
+                    lbsr      L0110
+                    lbsr      L4BEC
+                    leax      L4A09,pcr
                     pshs      x
-                    lbsr      L4A47
+                    lbsr      L4A44
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4AB4
+                    lbsr      L4AB1
                     leas      $02,s
-                    lbsr      L4A77
+                    lbsr      L4A74
                     puls      pc,u
-L4775               pshs      u
+L4772               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$08,s
                     ldd       #$0002
                     pshs      d
-                    lbsr      L0583
+                    lbsr      L0580
                     std       ,s
-                    lbsr      L0F1B
+                    lbsr      L0F18
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    bne       L4799
+                    bne       L4796
                     clra
                     clrb
-                    lbra      L4912
+                    lbra      L490F
 
-L4799               clra
+L4796               clra
                     clrb
                     std       $04,s
                     ldd       #$0001
@@ -7789,504 +7805,505 @@ L4799               clra
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L47D8
+                    bne       L47D5
                     ldx       ,s
-                    bra       L47C7
+                    bra       L47C4
 
-L47B5               ldd       #$0001
-                    bra       L4801
+L47B2               ldd       #$0001
+                    bra       L47FE
 
-L47BA               ldd       ,s
+L47B7               ldd       ,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    beq       L480A
-                    bra       L47EE
+                    beq       L4807
+                    bra       L47EB
 
-L47C7               cmpx      #$0008
-                    beq       L47B5
+L47C4               cmpx      #$0008
+                    beq       L47B2
                     cmpx      #$0001
-                    beq       L480A
+                    beq       L4807
                     cmpx      #$0007
-                    beq       L480A
-                    bra       L47BA
+                    beq       L4807
+                    bra       L47B7
 
-L47D8               ldd       ,s
+L47D5               ldd       ,s
                     clra
                     andb      #$30
                     cmpd      #$0010
-                    bne       L47F2
+                    bne       L47EF
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L2630
+                    lbsr      L262D
                     std       ,s++
-                    bne       L480A
-L47EE               leax      $08,s
-                    bra       L482A
+                    bne       L4807
+L47EB               leax      $08,s
+                    bra       L4827
 
-L47F2               ldd       $0C,s
+L47EF               ldd       $0C,s
                     cmpd      #$0005
-                    bne       L47FF
+                    bne       L47FC
                     ldd       #$0006
-                    bra       L4801
+                    bra       L47FE
 
-L47FF               ldd       $0C,s
-L4801               pshs      d
+L47FC               ldd       $0C,s
+L47FE               pshs      d
                     pshs      u
-                    lbsr      L202A
+                    lbsr      L2027
                     leas      $04,s
-L480A               ldd       $06,u
+L4807               ldd       $06,u
                     cmpd      #$0050
-                    beq       L481A
+                    beq       L4817
                     ldd       $06,u
                     cmpd      #$0051
-                    bne       L4863
-L481A               ldd       $0C,u
+                    bne       L4860
+L4817               ldd       $0C,u
                     std       $06,s
                     tfr       d,x
                     ldd       $06,x
                     cmpd      #$0036
-                    beq       L4835
-                    bra       L482C
+                    beq       L4832
+                    bra       L4829
 
-L482A               leas      -$08,x
-L482C               clra
+L4827               leas      -$08,x
+L4829               clra
                     clrb
                     std       $02,s
                     leax      $08,s
-                    lbra      L4907
+                    lbra      L4904
 
-L4835               ldd       $06,u
+L4832               ldd       $06,u
                     cmpd      #$0051
-                    bne       L4847
+                    bne       L4844
                     ldx       $06,s
                     ldd       $08,x
                     nega
                     negb
                     sbca      #$00
-                    bra       L484B
+                    bra       L4848
 
-L4847               ldx       $06,s
+L4844               ldx       $06,s
                     ldd       $08,x
-L484B               std       $04,s
+L4848               std       $04,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      L0396
+                    lbsr      L0393
                     leas      $02,s
                     stu       $06,s
                     ldu       $0a,u
                     ldd       $06,s
                     pshs      d
-                    lbsr      L03B7
+                    lbsr      L03B4
                     leas      $02,s
-L4863               ldd       $06,u
+L4860               ldd       $06,u
                     cmpd      #$0041
-                    bne       L48BA
+                    bne       L48B7
                     ldd       $0a,u
                     std       $06,s
                     tfr       d,x
                     ldx       $08,x
                     ldx       $08,x
-                    bra       L4897
+                    bra       L4894
 
-L4877               clra
+L4874               clra
                     clrb
                     std       $02,s
-                    lbra      L4909
+                    lbra      L4906
 
-L487E               ldd       #$0001
+L487B               ldd       #$0001
                     std       $000D
                     ldd       $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L50A1
+                    lbsr      L509E
                     leas      $04,s
                     clra
                     clrb
                     std       $000D
-                    lbra      L4909
+                    lbra      L4906
 
-L4897               cmpx      #$000F
-                    beq       L487E
+L4894               cmpx      #$000F
+                    beq       L487B
                     cmpx      #$000E
-                    lbeq      L487E
+                    lbeq      L487B
                     cmpx      #$000C
-                    lbeq      L487E
+                    lbeq      L487B
                     cmpx      #$0021
-                    lbeq      L487E
+                    lbeq      L487B
                     cmpx      #$0022
-                    lbeq      L487E
-                    bra       L4877
+                    lbeq      L487B
+                    bra       L4874
 
-L48BA               ldx       $06,u
-                    bra       L48EE
+L48B7               ldx       $06,u
+                    bra       L48EB
 
-L48BE               ldd       $0C,s
+L48BB               ldd       $0C,s
                     cmpd      #$0005
-                    bne       L48D2
+                    bne       L48CF
                     ldx       $08,u
                     pshs      x
                     ldx       $08,u
-                    lbsr      L695C
-                    lbsr      $6A02
-L48D2               ldd       $0C,s
+                    lbsr      L6959
+                    lbsr      L69FF
+L48CF               ldd       $0C,s
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    bsr       L4916
+                    bsr       L4913
                     leas      $04,s
-                    bra       L4909
+                    bra       L4906
 
-L48E0               lbsr      $67F2
+L48DD               lbsr      L67EF
                     ldd       $08,u
                     pshs      d
-                    lbsr      L4AEB
+                    lbsr      L4AE8
                     leas      $02,s
-                    bra       L4909
+                    bra       L4906
 
-L48EE               cmpx      #$004B
-                    beq       L48BE
+L48EB               cmpx      #$004B
+                    beq       L48BB
                     cmpx      #$0036
-                    beq       L48D2
+                    beq       L48CF
                     cmpx      #$004A
-                    lbeq      L48D2
+                    lbeq      L48CF
                     cmpx      #$0037
-                    beq       L48E0
-                    lbra      L4877
+                    beq       L48DD
+                    lbra      L4874
 
-L4907               leas      -$08,x
-L4909               pshs      u
-                    lbsr      L0396
+L4904               leas      -$08,x
+L4906               pshs      u
+                    lbsr      L0393
                     leas      $02,s
                     ldd       $02,s
-L4912               leas      $08,s
+L490F               leas      $08,s
                     puls      pc,u
-L4916               pshs      u
+L4913               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $08,s
-                    bra       L494C
+                    bra       L4949
 
-L4926               lbsr      $67E7
+L4923               lbsr      L67E4
                     pshs      u
-                    lbsr      L4AB4
+                    lbsr      L4AB1
                     leas      $02,s
-                    lbsr      L4A77
-                    bra       L497C
+                    lbsr      L4A74
+                    bra       L4979
 
-L4935               ldd       #$0001
-                    bra       L493D
+L4932               ldd       #$0001
+                    bra       L493A
 
-L493A               ldd       #$0002
-L493D               std       ,s
-                    bra       L4971
+L4937               ldd       #$0002
+L493A               std       ,s
+                    bra       L496E
 
-L4941               ldd       $08,s
+L493E               ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      L5069
-                    bra       L497A
+                    lbsr      L5066
+                    bra       L4977
 
-L494C               cmpx      #$0002
-                    beq       L4926
+L4949               cmpx      #$0002
+                    beq       L4923
                     cmpx      #$0001
-                    beq       L4935
+                    beq       L4932
                     cmpx      #$0007
-                    lbeq      L4935
+                    lbeq      L4932
                     cmpx      #$0008
-                    beq       L493A
+                    beq       L4937
                     cmpx      #$0005
-                    beq       L4941
+                    beq       L493E
                     cmpx      #$0006
-                    lbeq      L4941
-                    lbra      L4935
+                    lbeq      L493E
+                    lbra      L4932
 
-L4971               ldd       ,s
+L496E               ldd       ,s
                     pshs      d
                     pshs      u
-                    lbsr      L4FE1
-L497A               leas      $04,s
-L497C               leas      $02,s
+                    lbsr      L4FDE
+L4977               leas      $04,s
+L4979               leas      $02,s
                     puls      pc,u
-L4980               pshs      u
+L497D               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    leax      L4A11,pcr
+                    lbsr      L0110
+                    leax      L4A0E,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    bsr       L4997
+                    bsr       L4994
                     puls      pc,u
-L4997               pshs      u
+L4994               pshs      u
                     ldd       #$FFBC
-                    lbsr      L0113
-L499F               ldx       $005F
-                    bra       L49AA
+                    lbsr      L0110
+L499C               ldx       $005F
+                    bra       L49A7
 
-L49A3               puls      pc,u
-L49A5               lbsr      L552E
-                    bra       L499F
+L49A0               puls      pc,u
+L49A2               lbsr      L552B
+                    bra       L499C
 
-L49AA               cmpx      #$0030
-                    beq       L49A3
+L49A7               cmpx      #$0030
+                    beq       L49A0
                     cmpx      #$0028
-                    lbeq      L49A3
+                    lbeq      L49A0
                     cmpx      #$FFFF
-                    lbeq      L49A3
-                    bra       L49A5
+                    lbeq      L49A0
+                    bra       L49A2
                     puls      pc,u
-L49C1               fcc       /too long/
+L49BE               fcc       /too long/
                     fcb       $00
-L49CA               fcc       /too many elements/
+L49C7               fcc       /too many elements/
                     fcb       $00
-L49DC               fcc       /unions not allowed/
+L49D9               fcc       /unions not allowed/
                     fcb       $00
-L49EF               fcc       /constant expression required/
+L49EC               fcc       /constant expression required/
                     fcb       $00
-L4A0C               fcc       /rzb /
+L4A09               fcc       /rzb /
                     fcb       $00
-L4A11               fcc       /cannot initialize/
+L4A0E               fcc       /cannot initialize/
                     fcb       $00
-L4A23               pshs      u
+L4A20               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
-                    lbsr      L4BEF
+                    lbsr      L0110
+                    lbsr      L4BEC
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4B20
+                    lbsr      L4B1D
                     leas      $02,s
                     ldd       $06,s
-                    lbeq      L4AFF
+                    lbeq      L4AFC
                     ldd       #$003A
                     pshs      d
-                    bsr       L4A88
-                    lbra      L4AFD
+                    bsr       L4A85
+                    lbra      L4AFA
 
-L4A47               pshs      u
+L4A44               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $0025
                     pshs      d
                     ldd       #$0020
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $04,s
                     pshs      d
-                    bsr       L4A9E
-                    lbra      L5065
+                    bsr       L4A9B
+                    lbra      L5062
                     pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    bsr       L4A47
-                    lbra      L4AFD
+                    bsr       L4A44
+                    lbra      L4AFA
 
-L4A77               pshs      u
+L4A74               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $0025
                     pshs      d
                     ldd       #$000D
-                    bra       L4A96
+                    bra       L4A93
 
-L4A88               pshs      u
+L4A85               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $0025
                     pshs      d
                     ldd       $06,s
-L4A96               pshs      d
-                    lbsr      $6F04
-                    lbra      L4BC4
+L4A93               pshs      d
+                    lbsr      L6F01
+                    lbra      L4BC1
 
-L4A9E               pshs      u
+L4A9B               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E6
-                    lbra      L4BC4
+                    lbsr      L50E3
+                    lbra      L4BC1
 
-L4AB4               pshs      u
+L4AB1               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    leax      L50C1,pcr
-                    lbra      L4C12
+                    leax      L50BE,pcr
+                    lbra      L4C0F
 
-L4AC7               pshs      u
+L4AC4               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       #$006C
                     pshs      d
-                    bsr       L4A88
+                    bsr       L4A85
                     leas      $02,s
                     ldd       $0025
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     clra
                     clrb
                     std       L004F
                     puls      pc,u
-L4AEB               pshs      u
+L4AE8               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     clra
                     clrb
                     std       L004F
                     ldd       $04,s
                     pshs      d
-                    bsr       L4B04
-L4AFD               leas      $02,s
-L4AFF               lbsr      L4A77
+                    bsr       L4B01
+L4AFA               leas      $02,s
+L4AFC               lbsr      L4A74
                     puls      pc,u
-L4B04               pshs      u
+L4B01               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       #$005F
                     pshs      d
-                    lbsr      L4A88
+                    lbsr      L4A85
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4AB4
-                    lbra      L5065
+                    lbsr      L4AB1
+                    lbra      L5062
 
-L4B20               pshs      u
+L4B1D               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    leax      $50C4,pcr
-                    lbra      L4C12
+                    leax      $50C1,pcr
+                    lbra      L4C0F
 
-L4B33               pshs      u
+L4B30               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     leas      -$02,s
                     ldd       $06,s
                     subd      $002F
                     std       ,s
-                    beq       L4B5C
+                    beq       L4B59
                     ldd       #$004D
                     pshs      d
-                    lbsr      L4A88
+                    lbsr      L4A85
                     leas      $02,s
                     ldd       $0025
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
-L4B5C               ldd       $06,s
-                    lbra      L5065
+L4B59               ldd       $06,s
+                    lbra      L5062
 
-L4B61               pshs      u
+L4B5E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $0025
                     ldx       $04,s
-                    lbra      L4BC8
+                    lbra      L4BC5
 
-L4B70               ldd       #$004A
+L4B6D               ldd       #$004A
                     pshs      d
-                    lbsr      L4A88
+                    lbsr      L4A85
                     leas      $02,s
                     pshs      u
                     ldd       $0a,s
-                    bra       L4BA3
+                    bra       L4BA0
 
-L4B80               ldd       #$0072
-                    lbra      L4BFA
+L4B7D               ldd       #$0072
+                    lbra      L4BF7
 
-L4B86               ldd       #$0047
-                    bra       L4BB4
+L4B83               ldd       #$0047
+                    bra       L4BB1
 
-L4B8B               ldd       #$006A
-                    bra       L4BB4
+L4B88               ldd       #$006A
+                    bra       L4BB1
 
-L4B90               ldd       #$0044
+L4B8D               ldd       #$0044
                     pshs      d
-                    lbsr      L4A88
+                    lbsr      L4A85
                     leas      $02,s
                     pshs      u
                     ldd       L002B
                     addd      #$0001
                     std       L002B
-L4BA3               pshs      d
-                    lbsr      $6FA9
+L4BA0               pshs      d
+                    lbsr      L6FA6
                     leas      $04,s
-                    bra       L4BBB
+                    bra       L4BB8
 
-L4BAC               ldd       #$0059
-                    bra       L4BB4
+L4BA9               ldd       #$0059
+                    bra       L4BB1
 
-L4BB1               ldd       #$0055
-L4BB4               pshs      d
-                    lbsr      L4A88
+L4BAE               ldd       #$0055
+L4BB1               pshs      d
+                    lbsr      L4A85
                     leas      $02,s
-L4BBB               pshs      u
+L4BB8               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      $6FA9
-L4BC4               leas      $04,s
+                    lbsr      L6FA6
+L4BC1               leas      $04,s
                     puls      pc,u
-L4BC8               cmpx      #$007D
-                    lbeq      L4B70
+L4BC5               cmpx      #$007D
+                    lbeq      L4B6D
                     cmpx      #$0012
-                    beq       L4B80
+                    beq       L4B7D
                     cmpx      #$001D
-                    beq       L4B86
+                    beq       L4B83
                     cmpx      #$007C
-                    beq       L4B8B
+                    beq       L4B88
                     cmpx      #$0009
-                    beq       L4B90
+                    beq       L4B8D
                     cmpx      #$0076
-                    beq       L4BAC
+                    beq       L4BA9
                     cmpx      #$006F
-                    beq       L4BB1
+                    beq       L4BAE
                     puls      pc,u
-L4BEF               pshs      u
+L4BEC               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       #$002A
-L4BFA               pshs      d
-                    lbsr      L4A88
-                    lbra      L5065
-                    pshs      u
+L4BF7               pshs      d
+                    lbsr      L4A85
+                    lbra      L5062
+
+L4BFF               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    leax      $50C9,pcr
-L4C12               pshs      x
+                    leax      $50C6,pcr
+L4C0F               pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      L50E6
-                    lbra      L4E18
+                    lbsr      L50E3
+                    lbra      L4E15
 
-L4C1E               pshs      u
+L4C1B               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
                     ldd       #$0001
-                    bra       L4C61
+                    bra       L4C5E
 
-L4C2F               pshs      u
+L4C2C               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $0a,s
                     pshs      d
                     ldd       $0a,s
@@ -8297,203 +8314,203 @@ L4C2F               pshs      u
                     pshs      d
                     ldd       #$0002
                     pshs      d
-                    bsr       L4C6B
+                    bsr       L4C68
                     leas      $0a,s
-                    bra       L4C67
+                    bra       L4C64
 
-L4C52               pshs      u
+L4C4F               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
                     ldd       #$0004
-L4C61               pshs      d
-                    bsr       L4C6B
+L4C5E               pshs      d
+                    bsr       L4C68
                     leas      $04,s
-L4C67               ldd       $04,s
+L4C64               ldd       $04,s
                     puls      pc,u
-L4C6B               pshs      u
+L4C68               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $0025
                     pshs      u
                     ldd       #$0054
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     pshs      u
                     ldd       $06,s
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     pshs      u
                     ldd       L002B
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     pshs      u
                     ldd       $002F
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldx       $04,s
-                    bra       L4CDA
+                    bra       L4CD7
 
-L4CA6               pshs      u
+L4CA3               pshs      u
                     ldd       $0a,s
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     pshs      u
                     ldd       $0C,s
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     pshs      u
                     ldd       $0e,s
                     pshs      d
-                    lbsr      $6F04
-                    bra       L4CD6
+                    lbsr      L6F01
+                    bra       L4CD3
 
-L4CC7               pshs      u
+L4CC4               pshs      u
                     ldd       $000D
-                    bra       L4CD1
+                    bra       L4CCE
 
-L4CCD               pshs      u
+L4CCA               pshs      u
                     ldd       $0a,s
-L4CD1               pshs      d
-                    lbsr      $6FA9
-L4CD6               leas      $04,s
-                    bra       L4CE9
+L4CCE               pshs      d
+                    lbsr      L6FA6
+L4CD3               leas      $04,s
+                    bra       L4CE6
 
-L4CDA               cmpx      #$0002
-                    beq       L4CA6
+L4CD7               cmpx      #$0002
+                    beq       L4CA3
                     cmpx      #$0005
-                    beq       L4CC7
+                    beq       L4CC4
                     cmpx      #$0012
-                    beq       L4CCD
-L4CE9               ldd       L002B
+                    beq       L4CCA
+L4CE6               ldd       L002B
                     pshs      d
                     ldd       $06,s
                     cmpd      #$0002
-                    bne       L4CFA
+                    bne       L4CF7
                     ldd       #$0001
-                    bra       L4CFC
+                    bra       L4CF9
 
-L4CFA               clra
+L4CF7               clra
                     clrb
-L4CFC               pshs      d
+L4CF9               pshs      d
                     ldd       $0a,s
                     pshs      d
-                    bsr       L4D0F
+                    bsr       L4D0C
                     leas      $04,s
                     addd      ,s++
                     std       L002B
                     ldd       $06,s
-                    lbra      L4E3C
+                    lbra      L4E39
 
-L4D0F               pshs      u
+L4D0C               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$06,s
                     stu       -$02,s
-                    lbeq      L4E16
+                    lbeq      L4E13
                     ldx       $06,u
-                    lbra      L4D81
+                    lbra      L4D7E
 
-L4D26               ldd       $0C,s
-                    beq       L4D2F
+L4D23               ldd       $0C,s
+                    beq       L4D2C
                     ldd       #$0001
-                    bra       L4D32
+                    bra       L4D2F
 
-L4D2F               ldd       #$0004
-L4D32               std       $04,s
+L4D2C               ldd       #$0004
+L4D2F               std       $04,s
                     ldd       #$0001
-                    bra       L4D6E
+                    bra       L4D6B
 
-L4D39               ldd       #$0003
+L4D36               ldd       #$0003
                     std       $04,s
                     ldd       #$0001
-                    bra       L4D70
+                    bra       L4D6D
 
-L4D43               ldd       $0C,s
-                    beq       L4D4B
+L4D40               ldd       $0C,s
+                    beq       L4D48
                     clra
                     clrb
-                    bra       L4D4E
+                    bra       L4D4B
 
-L4D4B               ldd       #$0003
-L4D4E               std       $04,s
+L4D48               ldd       #$0003
+L4D4B               std       $04,s
                     clra
                     clrb
-                    bra       L4D6E
+                    bra       L4D6B
 
-L4D54               ldd       #$0003
+L4D51               ldd       #$0003
                     std       $04,s
                     ldd       #$0001
                     std       $02,s
                     clra
                     clrb
                     std       ,s
-                    lbra      L4DF4
+                    lbra      L4DF1
 
-L4D65               ldd       #$0001
+L4D62               ldd       #$0001
                     std       $04,s
                     clra
                     clrb
                     std       $0C,s
-L4D6E               std       ,s
-L4D70               std       $02,s
-                    lbra      L4DF4
+L4D6B               std       ,s
+L4D6D               std       $02,s
+                    lbra      L4DF1
 
-L4D75               clra
+L4D72               clra
                     clrb
                     std       $0C,s
                     std       ,s
                     std       $02,s
                     std       $04,s
-                    bra       L4DF4
+                    bra       L4DF1
 
-L4D81               cmpx      #$0047
-                    lbeq      L4D26
+L4D7E               cmpx      #$0047
+                    lbeq      L4D23
                     cmpx      #$0048
-                    lbeq      L4D26
+                    lbeq      L4D23
                     cmpx      #$0040
-                    lbeq      L4D39
+                    lbeq      L4D36
                     cmpx      #$005A
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$005B
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$005C
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$005D
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$005E
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$005F
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$0060
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$0061
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$0062
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$0063
-                    lbeq      L4D43
+                    lbeq      L4D40
                     cmpx      #$0064
-                    lbeq      L4D54
+                    lbeq      L4D51
                     cmpx      #$004B
-                    lbeq      L4D65
+                    lbeq      L4D62
                     cmpx      #$004A
-                    lbeq      L4D65
-                    lbra      L4D75
+                    lbeq      L4D62
+                    lbra      L4D72
 
-L4DF4               ldd       $02,s
+L4DF1               ldd       $02,s
                     pshs      d
                     ldd       $0a,u
                     pshs      d
-                    lbsr      L4D0F
+                    lbsr      L4D0C
                     leas      $04,s
                     addd      $04,s
                     pshs      d
@@ -8501,86 +8518,86 @@ L4DF4               ldd       $02,s
                     pshs      d
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L4D0F
+                    lbsr      L4D0C
                     leas      $04,s
                     addd      ,s++
-                    bra       L4E18
+                    bra       L4E15
 
-L4E16               clra
+L4E13               clra
                     clrb
-L4E18               leas      $06,s
+L4E15               leas      $06,s
                     puls      pc,u
-L4E1C               pshs      u
+L4E19               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     stu       -$02,s
-                    lbeq      L5067
+                    lbeq      L5064
                     pshs      u
-                    bsr       L4E44
+                    bsr       L4E41
                     leas      $02,s
                     ldd       $0a,u
                     pshs      d
-                    bsr       L4E1C
+                    bsr       L4E19
                     leas      $02,s
                     ldd       $0C,u
-L4E3C               pshs      d
-                    lbsr      L4E1C
-                    lbra      L5065
+L4E39               pshs      d
+                    lbsr      L4E19
+                    lbra      L5062
 
-L4E44               pshs      u
+L4E41               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $0a,u
-                    beq       L4E5D
+                    beq       L4E5A
                     ldd       $0C,u
-                    beq       L4E5D
+                    beq       L4E5A
                     ldd       #$0042
-                    bra       L4E72
+                    bra       L4E6F
 
-L4E5D               ldd       $0a,u
-                    beq       L4E66
+L4E5A               ldd       $0a,u
+                    beq       L4E63
                     ldd       #$004C
-                    bra       L4E72
+                    bra       L4E6F
 
-L4E66               ldd       $0C,u
-                    beq       L4E6F
+L4E63               ldd       $0C,u
+                    beq       L4E6C
                     ldd       #$0052
-                    bra       L4E72
+                    bra       L4E6F
 
-L4E6F               ldd       #$004E
-L4E72               std       ,s
+L4E6C               ldd       #$004E
+L4E6F               std       ,s
                     ldd       $0025
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       ,u
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $02,u
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $06,u
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $0e,u
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldd       $0025
                     pshs      d
@@ -8589,79 +8606,79 @@ L4E72               std       ,s
                     ldd       $10,u
                     subd      ,s++
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $12,u
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $14,u
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldd       $06,u
                     cmpd      #$0034
-                    lbne      L4F52
+                    lbne      L4F4F
                     ldu       $08,u
                     ldd       $0025
                     pshs      d
                     ldd       ,u
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      $6F04
+                    lbsr      L6F01
                     leas      $04,s
                     ldx       $08,u
-                    bra       L4F36
+                    bra       L4F33
 
-L4F11               pshs      u
+L4F0E               pshs      u
                     ldd       #$0014
                     addd      ,s++
                     pshs      d
-                    lbsr      L4B20
+                    lbsr      L4B1D
                     leas      $02,s
                     ldd       $0025
                     pshs      d
                     clra
                     clrb
                     pshs      d
-                    lbsr      $6F04
-                    lbra      L4FDC
+                    lbsr      L6F01
+                    lbra      L4FD9
 
-L4F2D               ldd       $0025
+L4F2A               ldd       $0025
                     pshs      d
                     ldd       $06,u
-                    lbra      L4FD7
+                    lbra      L4FD4
 
-L4F36               cmpx      #$000E
-                    beq       L4F11
+L4F33               cmpx      #$000E
+                    beq       L4F0E
                     cmpx      #$000C
-                    lbeq      L4F11
+                    lbeq      L4F0E
                     cmpx      #$0021
-                    lbeq      L4F11
+                    lbeq      L4F0E
                     cmpx      #$0022
-                    lbeq      L4F11
-                    bra       L4F2D
+                    lbeq      L4F0E
+                    bra       L4F2A
 
-L4F52               ldd       $06,u
+L4F4F               ldd       $06,u
                     cmpd      #$004A
-                    bne       L4F8E
+                    bne       L4F8B
                     leas      -$04,s
                     leax      ,s
                     pshs      x
-                    bsr       L4F66
+                    bsr       L4F63
                     neg       $0000
                     neg       $0000
-L4F66               puls      x
-                    lbsr      L74D6
+L4F63               puls      x
+                    lbsr      L74D3
                     ldd       $0025
                     pshs      d
                     ldd       #$0001
@@ -8669,30 +8686,30 @@ L4F66               puls      x
                     ldd       #$0004
                     pshs      d
                     ldu       $08,u
-                    beq       L4F81
+                    beq       L4F7E
                     tfr       u,d
-                    bra       L4F85
+                    bra       L4F82
 
-L4F81               leax      $06,s
+L4F7E               leax      $06,s
                     tfr       x,d
-L4F85               pshs      d
-                    lbsr      L6EBA
+L4F82               pshs      d
+                    lbsr      $6EB7
                     leas      $08,s
-                    bra       L4FDC
+                    bra       L4FD9
 
-L4F8E               ldd       $06,u
+L4F8B               ldd       $06,u
                     cmpd      #$004B
-                    bne       L4FD1
+                    bne       L4FCE
                     leas      -$08,s
                     leax      ,s
                     pshs      x
-                    bsr       L4FA6
+                    bsr       L4FA3
                     neg       $0000
                     neg       $0000
                     neg       $0000
                     neg       $0000
-L4FA6               puls      x
-                    lbsr      $6A02
+L4FA3               puls      x
+                    lbsr      L69FF
                     ldd       $0025
                     pshs      d
                     ldd       #$0001
@@ -8700,99 +8717,99 @@ L4FA6               puls      x
                     ldd       #$0008
                     pshs      d
                     ldu       $08,u
-                    beq       L4FC1
+                    beq       L4FBE
                     tfr       u,d
-                    bra       L4FC5
+                    bra       L4FC2
 
-L4FC1               leax      $06,s
+L4FBE               leax      $06,s
                     tfr       x,d
-L4FC5               pshs      d
-                    lbsr      L6EBA
+L4FC2               pshs      d
+                    lbsr      $6EB7
                     leas      $08,s
                     leas      $08,s
-                    lbra      L5065
-
-L4FD1               ldd       $0025
-                    pshs      d
-                    ldd       $08,u
-L4FD7               pshs      d
-                    lbsr      $6FA9
-L4FDC               leas      $04,s
-                    lbra      L5065
-
-L4FE1               pshs      u
-                    ldd       #$FFB8
-                    lbsr      L0113
-                    ldu       $04,s
-                    leas      -$02,s
-                    lbsr      $67F2
-                    ldd       $08,s
-                    cmpd      #$0001
-                    bne       L5002
-                    pshs      u
-                    lbsr      L4AB4
-L4FFD               leas      $02,s
                     lbra      L5062
 
-L5002               cmpu      #$0000
-                    bne       L5033
+L4FCE               ldd       $0025
+                    pshs      d
+                    ldd       $08,u
+L4FD4               pshs      d
+                    lbsr      L6FA6
+L4FD9               leas      $04,s
+                    lbra      L5062
+
+L4FDE               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0110
+                    ldu       $04,s
+                    leas      -$02,s
+                    lbsr      L67EF
+                    ldd       $08,s
+                    cmpd      #$0001
+                    bne       L4FFF
+                    pshs      u
+                    lbsr      L4AB1
+L4FFA               leas      $02,s
+                    lbra      L505F
+
+L4FFF               cmpu      #$0000
+                    bne       L5030
                     ldd       #$0001
                     std       ,s
-                    bra       L501A
+                    bra       L5017
 
-L500F               leax      L50CE,pcr
+L500C               leax      L50CB,pcr
                     pshs      x
-                    lbsr      L4A9E
+                    lbsr      L4A9B
                     leas      $02,s
-L501A               ldd       ,s
+L5017               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      $08,s
-                    blt       L500F
+                    blt       L500C
                     ldd       #$0030
                     pshs      d
-                    lbsr      L4A88
-                    bra       L4FFD
+                    lbsr      L4A85
+                    bra       L4FFA
 
-L5033               clra
+L5030               clra
                     clrb
-                    bra       L5059
+                    bra       L5056
 
-L5037               ldd       ,u++
+L5034               ldd       ,u++
                     pshs      d
-                    lbsr      L4AB4
+                    lbsr      L4AB1
                     leas      $02,s
                     ldd       $08,s
                     addd      #$FFFF
                     cmpd      ,s
-                    beq       L5054
+                    beq       L5051
                     ldd       #$002C
                     pshs      d
-                    lbsr      L4A88
+                    lbsr      L4A85
                     leas      $02,s
-L5054               ldd       ,s
+L5051               ldd       ,s
                     addd      #$0001
-L5059               std       ,s
+L5056               std       ,s
                     ldd       ,s
                     cmpd      $08,s
-                    blt       L5037
-L5062               lbsr      L4A77
-L5065               leas      $02,s
-L5067               puls      pc,u
-L5069               pshs      u
+                    blt       L5034
+L505F               lbsr      L4A74
+L5062               leas      $02,s
+L5064               puls      pc,u
+L5066               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       #$0066
                     pshs      d
-                    lbsr      L4A88
+                    lbsr      L4A85
                     leas      $02,s
                     ldd       $0025
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      $6FA9
+                    lbsr      L6FA6
                     leas      $04,s
                     ldd       $0025
                     pshs      d
@@ -8801,12 +8818,12 @@ L5069               pshs      u
                     ldd       #$0008
                     pshs      d
                     pshs      u
-                    lbsr      L6EBA
+                    lbsr      $6EB7
                     leas      $08,s
                     puls      pc,u
-L50A1               pshs      u
+L509E               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0113
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       $14,u
                     addd      $06,s
@@ -8814,70 +8831,70 @@ L50A1               pshs      u
                     pshs      u
                     ldd       #$0005
                     pshs      d
-                    lbsr      L4C6B
+                    lbsr      L4C68
                     leas      $04,s
                     puls      pc,u
-L50C1               bcs       $5127
+L50BE               bcs       $5124
                     neg       $0025
-                    bgt       L50FF
+                    bgt       L50FC
                     com       >$0046
-                    bcs       $513F
+                    bcs       $513C
                     tst       $0000
-L50CE               leax      $0C,y
+L50CB               leax      $0C,y
                     neg       $0034
-L50D2               nega
+                    nega
                     leax      $01C1,y
                     stx       $000F
                     ldd       #$0001
-                    std       copybytes
+                    std       L0015
                     leax      $06,s
                     pshs      x
                     ldd       $06,s
-L50E4               bra       L50F7
+                    bra       L50F4
 
-L50E6               pshs      u
+L50E3               pshs      u
                     ldd       $04,s
                     std       $000F
                     ldd       #$0001
-                    std       copybytes
+                    std       L0015
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
-L50F7               pshs      d
-                    bsr       doprnt
+L50F4               pshs      d
+                    bsr       L511B
                     leas      $04,s
                     puls      pc,u
-L50FF               pshs      u
+L50FC               pshs      u
                     ldd       $04,s
                     std       $000F
                     ldd       #$0002
-                    std       copybytes
+                    std       L0015
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       doprnt
+                    bsr       L511B
                     leas      $04,s
                     clra
                     clrb
                     stb       [$000F,y]
                     puls      pc,u
-doprnt              pshs      u
+L511B               pshs      u
                     ldu       $04,s
                     leas      -$0b,s
-                    bra       L5136
+                    bra       L5133
 
-L5126               ldb       $08,s
-                    lbeq      L5294
+L5123               ldb       $08,s
+                    lbeq      L5291
                     ldb       $08,s
                     sex
                     pshs      d
-                    lbsr      L5473
+                    lbsr      L5470
                     leas      $02,s
-L5136               ldb       ,u+
+L5133               ldb       ,u+
                     stb       $08,s
                     cmpb      #$25
-                    bne       L5126
+                    bne       L5123
                     ldb       ,u+
                     stb       $08,s
                     clra
@@ -8886,30 +8903,30 @@ L5136               ldb       ,u+
                     std       $06,s
                     ldb       $08,s
                     cmpb      #$2d
-                    bne       L5159
+                    bne       L5156
                     ldd       #$0001
                     std       $0011
                     ldb       ,u+
                     stb       $08,s
-                    bra       L515D
+                    bra       L515A
 
-L5159               clra
+L5156               clra
                     clrb
                     std       $0011
-L515D               ldb       $08,s
+L515A               ldb       $08,s
                     cmpb      #$30
-                    bne       L5168
+                    bne       L5165
                     ldd       #$0030
-                    bra       L516B
+                    bra       L5168
 
-L5168               ldd       #$0020
-L516B               std       $0013
-                    bra       L5189
+L5165               ldd       #$0020
+L5168               std       $0013
+                    bra       L5186
 
-L516F               ldd       $06,s
+L516C               ldd       $06,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L7542
+                    lbsr      L753F
                     pshs      d
                     ldb       $0a,s
                     sex
@@ -8918,31 +8935,31 @@ L516F               ldd       $06,s
                     std       $06,s
                     ldb       ,u+
                     stb       $08,s
-L5189               ldb       $08,s
+L5186               ldb       $08,s
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L516F
+                    beq       L516C
                     ldb       $08,s
                     cmpb      #$2e
-                    bne       L51D0
+                    bne       L51CD
                     ldd       #$0001
                     std       $04,s
-                    bra       L51BB
+                    bra       L51B8
 
-L51A5               ldd       $02,s
+L51A2               ldd       $02,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L7542
+                    lbsr      L753F
                     pshs      d
                     ldb       $0a,s
                     sex
                     addd      #$FFD0
                     addd      ,s++
                     std       $02,s
-L51BB               ldb       ,u+
+L51B8               ldb       ,u+
                     stb       $08,s
                     ldb       $08,s
                     sex
@@ -8950,138 +8967,138 @@ L51BB               ldb       ,u+
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L51A5
-                    bra       L51D4
+                    beq       L51A2
+                    bra       L51D1
 
-L51D0               clra
+L51CD               clra
                     clrb
                     std       $04,s
-L51D4               ldb       $08,s
+L51D1               ldb       $08,s
                     sex
                     tfr       d,x
-                    lbra      L5276
+                    lbra      L5273
 
-L51DC               ldd       $06,s
+L51D9               ldd       $06,s
                     pshs      d
                     ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L5298
-                    bra       L5204
+                    lbsr      L5295
+                    bra       L5201
 
-L51F1               ldd       $06,s
+L51EE               ldd       $06,s
                     pshs      d
                     ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L5359
-L5204               std       ,s
-                    lbra      L5261
+                    lbsr      L5356
+L5201               std       ,s
+                    lbra      L525E
 
-L5209               ldx       $11,s
+L5206               ldx       $11,s
                     leax      $02,x
                     stx       $11,s
                     ldd       -$02,x
-                    lbra      L526C
+                    lbra      L5269
 
-L5216               ldx       $11,s
+L5213               ldx       $11,s
                     leax      $02,x
                     stx       $11,s
                     ldd       -$02,x
                     std       $09,s
                     ldd       $04,s
-                    beq       L5259
+                    beq       L5256
                     ldd       $09,s
                     std       $04,s
-                    bra       L5238
+                    bra       L5235
 
-L522C               ldb       [$09,s]
-                    beq       L5244
+L5229               ldb       [$09,s]
+                    beq       L5241
                     ldd       $09,s
                     addd      #$0001
                     std       $09,s
-L5238               ldd       $02,s
+L5235               ldd       $02,s
                     addd      #$FFFF
                     std       $02,s
                     subd      #$FFFF
-                    bne       L522C
-L5244               ldd       $06,s
+                    bne       L5229
+L5241               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
                     subd      $06,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L5418
+                    lbsr      L5415
                     leas      $06,s
-                    bra       L5266
+                    bra       L5263
 
-L5259               ldd       $06,s
+L5256               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
                     pshs      d
-L5261               lbsr      L53B8
+L525E               lbsr      L53B5
                     leas      $04,s
-L5266               lbra      L5136
+L5263               lbra      L5133
 
-L5269               ldb       $08,s
+L5266               ldb       $08,s
                     sex
-L526C               pshs      d
-                    lbsr      L5473
+L5269               pshs      d
+                    lbsr      L5470
                     leas      $02,s
-                    lbra      L5136
+                    lbra      L5133
 
-L5276               cmpx      #$0064
-                    lbeq      L51DC
+L5273               cmpx      #$0064
+                    lbeq      L51D9
                     cmpx      #$0078
-                    lbeq      L51F1
+                    lbeq      L51EE
                     cmpx      #$0063
-                    lbeq      L5209
+                    lbeq      L5206
                     cmpx      #$0073
-                    lbeq      L5216
-                    bra       L5269
+                    lbeq      L5213
+                    bra       L5266
 
-L5294               leas      $0b,s
+L5291               leas      $0b,s
                     puls      pc,u
-L5298               pshs      u,d
+L5295               pshs      u,d
                     leax      $02DA,y
                     stx       ,s
                     ldd       $06,s
-                    bge       L52CD
+                    bge       L52CA
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-                    bge       L52C2
-                    leax      L5498,pcr
+                    bge       L52BF
+                    leax      L5495,pcr
                     pshs      x
                     leax      $02DA,y
                     pshs      x
-                    lbsr      $7314
+                    lbsr      L7311
                     leas      $04,s
-                    lbra      L546F
+                    lbra      L546C
 
-L52C2               ldd       #$002D
+L52BF               ldd       #$002D
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L52CD               ldd       $06,s
+L52CA               ldd       $06,s
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    bsr       L52E2
+                    bsr       L52DF
                     leas      $04,s
                     leax      $02DA,y
                     tfr       x,d
-                    lbra      L546F
+                    lbra      L546C
 
-L52E2               pshs      u,y,x,d
+L52DF               pshs      u,y,x,d
                     ldu       $0a,s
                     clra
                     clrb
@@ -9089,48 +9106,48 @@ L52E2               pshs      u,y,x,d
                     clra
                     clrb
                     std       ,s
-                    bra       L52FF
+                    bra       L52FC
 
-L52F0               ldd       ,s
+L52ED               ldd       ,s
                     addd      #$0001
                     std       ,s
                     ldd       $0C,s
                     subd      $0081,y
                     std       $0C,s
-L52FF               ldd       $0C,s
-                    blt       L52F0
+L52FC               ldd       $0C,s
+                    blt       L52ED
                     leax      $0081,y
                     stx       $04,s
-                    bra       L5341
+                    bra       L533E
 
-L530B               ldd       ,s
+L5308               ldd       ,s
                     addd      #$0001
                     std       ,s
-L5312               ldd       $0C,s
+L530F               ldd       $0C,s
                     subd      [$04,s]
                     std       $0C,s
-                    bge       L530B
+                    bge       L5308
                     ldd       $0C,s
                     addd      [$04,s]
                     std       $0C,s
                     ldd       ,s
-                    beq       L532B
+                    beq       L5328
                     ldd       #$0001
                     std       $02,s
-L532B               ldd       $02,s
-                    beq       L5336
+L5328               ldd       $02,s
+                    beq       L5333
                     ldd       ,s
                     addd      #$0030
                     stb       ,u+
-L5336               clra
+L5333               clra
                     clrb
                     std       ,s
                     ldd       $04,s
                     addd      #$0002
                     std       $04,s
-L5341               ldd       $04,s
+L533E               ldd       $04,s
                     cmpd      $0001
-                    bne       L5312
+                    bne       L530F
                     ldd       $0C,s
                     addd      #$0030
                     stb       ,u+
@@ -9140,23 +9157,23 @@ L5341               ldd       $04,s
                     ldd       $0a,s
                     leas      $06,s
                     puls      pc,u
-L5359               pshs      u,x,d
+L5356               pshs      u,x,d
                     leax      $02DA,y
                     stx       $02,s
                     leau      $02E4,y
-L5365               ldd       $08,s
+L5362               ldd       $08,s
                     clra
                     andb      #$0f
                     std       ,s
                     pshs      d
                     ldd       $02,s
                     cmpd      #$0009
-                    ble       L537B
+                    ble       L5378
                     ldd       #$0057
-                    bra       L537E
+                    bra       L537B
 
-L537B               ldd       #$0030
-L537E               addd      ,s++
+L5378               ldd       #$0030
+L537B               addd      ,s++
                     stb       ,u+
                     ldd       $08,s
                     lsra
@@ -9169,141 +9186,141 @@ L537E               addd      ,s++
                     rorb
                     anda      #$0f
                     std       $08,s
-                    bne       L5365
-                    bra       L539E
+                    bne       L5362
+                    bra       L539B
 
-L5394               ldb       ,u
+L5391               ldb       ,u
                     ldx       $02,s
                     leax      $01,x
                     stx       $02,s
                     stb       -$01,x
-L539E               leau      -$01,u
+L539B               leau      -$01,u
                     pshs      u
                     leax      $02E4,y
                     cmpx      ,s++
-                    bls       L5394
+                    bls       L5391
                     clra
                     clrb
                     stb       [$02,s]
                     leax      $02DA,y
                     tfr       x,d
-                    lbra      L5494
+                    lbra      L5491
 
-L53B8               pshs      u
+L53B5               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      $7303
+                    lbsr      L7300
                     leas      $02,s
                     nega
                     negb
                     sbca      #$00
                     leau      d,u
                     ldd       $0011
-                    bne       L53EF
-                    bra       L53DC
+                    bne       L53EC
+                    bra       L53D9
 
-L53D3               ldd       $0013
+L53D0               ldd       $0013
                     pshs      d
-                    lbsr      L5473
+                    lbsr      L5470
                     leas      $02,s
-L53DC               tfr       u,d
+L53D9               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    bgt       L53D3
-                    bra       L53EF
+                    bgt       L53D0
+                    bra       L53EC
 
-L53E6               ldd       ,s
+L53E3               ldd       ,s
                     pshs      d
-                    lbsr      L5473
+                    lbsr      L5470
                     leas      $02,s
-L53EF               ldx       $06,s
+L53EC               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
                     sex
                     std       ,s
-                    bne       L53E6
+                    bne       L53E3
                     ldd       $0011
-                    lbeq      L546F
-                    bra       L540D
+                    lbeq      L546C
+                    bra       L540A
 
-L5404               ldd       $0013
+L5401               ldd       $0013
                     pshs      d
-                    lbsr      L5473
+                    lbsr      L5470
                     leas      $02,s
-L540D               tfr       u,d
+L540A               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    bgt       L5404
-                    lbra      L546F
+                    bgt       L5401
+                    lbra      L546C
 
-L5418               pshs      u
+L5415               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $0a,s
                     subd      $08,s
                     std       ,s
                     ldd       $0011
-                    bne       L5449
-                    bra       L5432
+                    bne       L5446
+                    bra       L542F
 
-L542A               ldd       $0013
+L5427               ldd       $0013
                     pshs      d
-                    bsr       L5473
+                    bsr       L5470
                     leas      $02,s
-L5432               ldd       ,s
+L542F               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bgt       L542A
-                    bra       L5449
+                    bgt       L5427
+                    bra       L5446
 
-L5440               ldb       ,u+
+L543D               ldb       ,u+
                     sex
                     pshs      d
-                    bsr       L5473
+                    bsr       L5470
                     leas      $02,s
-L5449               ldd       $08,s
+L5446               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L5440
+                    bne       L543D
                     ldd       $0011
-                    beq       L546F
-                    bra       L5463
+                    beq       L546C
+                    bra       L5460
 
-L545B               ldd       $0013
+L5458               ldd       $0013
                     pshs      d
-                    bsr       L5473
+                    bsr       L5470
                     leas      $02,s
-L5463               ldd       ,s
+L5460               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bgt       L545B
-L546F               leas      $02,s
+                    bgt       L5458
+L546C               leas      $02,s
                     puls      pc,u
-L5473               pshs      u
-                    ldd       copybytes
+L5470               pshs      u
+                    ldd       L0015
                     cmpd      #$0002
-                    bne       L5489
+                    bne       L5486
                     ldd       $04,s
                     ldx       $000F
                     leax      $01,x
                     stx       $000F
                     stb       -$01,x
-                    bra       L5496
+                    bra       L5493
 
-L5489               ldd       $000F
+L5486               ldd       $000F
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $6F04
-L5494               leas      $04,s
-L5496               puls      pc,u
-L5498               blt       $54CD
+                    lbsr      L6F01
+L5491               leas      $04,s
+L5493               puls      pc,u
+L5495               blt       $54CA
                     leas      -$09,y
                     pshu      y,x,dp
                     neg       $00AE
@@ -9335,7 +9352,7 @@ L5498               blt       $54CD
                     rol       $02,x
                     rol       $01,x
                     rol       ,x
-                    bcs       L5528
+                    bcs       L5525
                     asl       $06,x
                     rol       $05,x
                     rol       $04,x
@@ -9343,7 +9360,7 @@ L5498               blt       $54CD
                     rol       $02,x
                     rol       $01,x
                     rol       ,x
-                    bcs       L5528
+                    bcs       L5525
                     ldd       $05,x
                     addd      $05,s
                     std       $05,x
@@ -9358,7 +9375,7 @@ L5498               blt       $54CD
                     ldb       ,x
                     adcb      ,s
                     stb       ,x
-                    bcs       L5528
+                    bcs       L5525
                     ldb       $0d,s
                     andb      #$0f
                     clra
@@ -9375,49 +9392,49 @@ L5498               blt       $54CD
                     lda       #$00
                     adca      ,x
                     sta       ,x
-                    bcs       L5528
+                    bcs       L5525
                     leas      $08,s
                     clra
                     clrb
                     rts
 
-L5528               ldd       #$0001
+L5525               ldd       #$0001
                     leas      $08,s
                     rts
 
-L552E               pshs      u
+L552B               pshs      u
                     leas      -$15,s
-                    lbsr      $6348
+                    lbsr      L6345
                     ldb       $0065
                     sex
                     cmpd      #$FFFF
-                    bne       L5549
+                    bne       L5546
                     ldd       #$FFFF
                     std       $005F
                     leas      $15,s
                     puls      pc,u
-L5549               ldd       $006A
+L5546               ldd       $006A
                     addd      #$FFFF
                     std       $0063
                     ldd       L0027
                     std       L003F
-                    bra       L5568
+                    bra       L5565
 
-L5556               leax      $61EC,pcr
+L5553               leax      L61E9,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbsr      $635E
+                    lbsr      L635B
                     ldd       $006A
                     std       $0063
-L5568               ldb       $0065
+L5565               ldb       $0065
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     sex
                     std       $005F
-                    beq       L5556
+                    beq       L5553
                     ldb       $0065
                     sex
                     leax      $0109,y
@@ -9426,542 +9443,542 @@ L5568               ldb       $0065
                     sex
                     std       $0061
                     ldx       $005F
-                    lbra      L5876
+                    lbra      L5873
 
-L558B               leax      $0a,s
+L5588               leax      $0a,s
                     pshs      x
-                    lbsr      L5ABF
+                    lbsr      L5ABC
                     leas      $02,s
                     leax      $0a,s
                     pshs      x
-                    lbsr      L5B36
+                    lbsr      L5B33
                     leas      $02,s
                     tfr       d,u
                     ldd       ,u
                     std       $005F
                     cmpd      #$0033
-                    bne       L55C2
+                    bne       L55BF
                     ldd       $08,u
                     std       $0061
                     cmpd      #$003B
-                    lbne      L5895
+                    lbne      L5892
                     ldd       #$003B
                     std       $005F
                     ldd       #$000E
                     std       $0061
-                    lbra      L5895
+                    lbra      L5892
 
-L55C2               ldd       #$0034
+L55BF               ldd       #$0034
                     std       $005F
                     stu       $0061
-                    lbra      L5895
+                    lbra      L5892
 
-L55CC               leax      ,s
+L55C9               leax      ,s
                     pshs      x
                     ldd       #$0001
                     pshs      d
-                    lbsr      L5C5C
+                    lbsr      L5C59
                     leas      $04,s
                     std       $13,s
-                    bra       L55E2
+                    bra       L55DF
 
-L55DF               leas      -$15,x
-L55E2               leax      ,s
+L55DC               leas      -$15,x
+L55DF               leax      ,s
                     stx       $08,s
                     ldx       $13,s
-                    bra       L5640
+                    bra       L563D
 
-L55EB               ldd       [$08,s]
-                    bra       L5636
+L55E8               ldd       [$08,s]
+                    bra       L5633
 
-L55F0               ldd       #$0004
+L55ED               ldd       #$0004
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     tfr       d,u
                     leax      ,u
                     pshs      x
                     ldx       $0a,s
-                    lbsr      L74D6
+                    lbsr      L74D3
                     stu       $0061
                     ldd       #$004A
-                    bra       L563B
+                    bra       L5638
 
-L560C               ldd       #$0008
+L5609               ldd       #$0008
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     tfr       d,u
                     leax      ,u
                     pshs      x
                     ldx       $0a,s
-                    lbsr      $6A02
+                    lbsr      L69FF
                     stu       $0061
                     ldd       #$004B
-                    bra       L563B
+                    bra       L5638
 
-L5628               leax      L61FA,pcr
+L5625               leax      L61F7,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
                     ldd       #$0001
-L5636               std       $0061
+L5633               std       $0061
                     ldd       #$0036
-L563B               std       $005F
-                    lbra      L5895
+L5638               std       $005F
+                    lbra      L5892
 
-L5640               cmpx      #$0001
-                    beq       L55EB
+L563D               cmpx      #$0001
+                    beq       L55E8
                     cmpx      #$0008
-                    beq       L55F0
+                    beq       L55ED
                     cmpx      #$0006
-                    beq       L560C
-                    bra       L5628
+                    beq       L5609
+                    bra       L5625
 
-L5651               lbsr      L5F03
+L564E               lbsr      L5F00
                     ldd       #$0036
-                    bra       L565F
+                    bra       L565C
 
-L5659               lbsr      L5F33
+L5656               lbsr      L5F30
                     ldd       #$0037
-L565F               std       $005F
-                    lbra      L5895
+L565C               std       $005F
+                    lbra      L5892
 
-L5664               lbsr      $635E
+L5661               lbsr      L635B
                     ldx       $005F
-                    lbra      L5819
+                    lbra      L5816
 
-L566C               ldb       $0065
+L5669               ldb       $0065
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    lbne      L5895
+                    lbne      L5892
                     leax      ,s
                     pshs      x
                     ldd       #$0006
                     pshs      d
-                    lbsr      L5C5C
+                    lbsr      L5C59
                     leas      $04,s
                     std       $13,s
                     leax      $15,s
-                    lbra      L55DF
+                    lbra      L55DC
 
-L5694               ldb       $0065
+L5691               ldb       $0065
                     sex
                     tfr       d,x
-                    bra       L56B3
+                    bra       L56B0
 
-L569B               ldd       #$0047
+L5698               ldd       #$0047
                     std       $005F
-                    lbsr      $635E
+                    lbsr      L635B
                     ldd       #$0005
-                    bra       L56F2
+                    bra       L56EF
 
-L56A8               ldd       #$00A7
+L56A5               ldd       #$00A7
                     std       $005F
                     ldd       #$0002
-                    lbra      L57FF
+                    lbra      L57FC
 
-L56B3               cmpx      #$0026
-                    beq       L569B
+L56B0               cmpx      #$0026
+                    beq       L5698
                     cmpx      #$003D
-                    beq       L56A8
-                    lbra      L5895
+                    beq       L56A5
+                    lbra      L5892
 
-L56C0               ldb       $0065
+L56BD               ldb       $0065
                     cmpb      #$3d
-                    lbne      L5895
+                    lbne      L5892
                     ldd       #$005A
                     std       $005F
                     ldd       #$0009
-                    lbra      L57FF
+                    lbra      L57FC
 
-L56D3               ldb       $0065
+L56D0               ldb       $0065
                     sex
                     tfr       d,x
-                    bra       L56F7
+                    bra       L56F4
 
-L56DA               ldd       #$0048
+L56D7               ldd       #$0048
                     std       $005F
-                    lbsr      $635E
+                    lbsr      L635B
                     ldd       #$0004
-                    bra       L56F2
+                    bra       L56EF
 
-L56E7               ldd       #$00A8
-L56EA               std       $005F
-                    lbsr      $635E
+L56E4               ldd       #$00A8
+L56E7               std       $005F
+                    lbsr      L635B
                     ldd       #$0002
-L56F2               std       $0061
-                    lbra      L5895
+L56EF               std       $0061
+                    lbra      L5892
 
-L56F7               cmpx      #$007C
-                    beq       L56DA
+L56F4               cmpx      #$007C
+                    beq       L56D7
                     cmpx      #$003D
-                    beq       L56E7
-                    lbra      L5895
+                    beq       L56E4
+                    lbra      L5892
 
-L5704               ldb       $0065
+L5701               ldb       $0065
                     cmpb      #$3d
-                    lbne      L5895
+                    lbne      L5892
                     ldd       #$005B
                     std       $005F
-                    lbsr      $635E
+                    lbsr      L635B
                     ldd       #$0009
-                    bra       L56F2
+                    bra       L56EF
 
-L5719               ldb       $0065
+L5716               ldb       $0065
                     cmpb      #$3d
-                    lbne      L5895
+                    lbne      L5892
                     ldd       #$00A2
-                    bra       L56EA
+                    bra       L56E7
 
-L5726               ldb       $0065
+L5723               ldb       $0065
                     cmpb      #$3d
-                    lbne      L5895
+                    lbne      L5892
                     ldd       $005F
                     addd      #$0050
-                    lbra      L56EA
+                    lbra      L56E7
 
-L5736               ldb       $0065
+L5733               ldb       $0065
                     sex
                     tfr       d,x
-                    bra       L5768
+                    bra       L5765
 
-L573D               ldd       #$0056
+L573A               ldd       #$0056
                     std       $005F
                     ldd       #$000B
                     std       $0061
-                    lbsr      $635E
+                    lbsr      L635B
                     ldb       $0065
                     cmpb      #$3d
-                    lbne      L5895
+                    lbne      L5892
                     ldd       #$00A6
                     std       $005F
                     ldd       #$0002
-                    lbra      L57FF
+                    lbra      L57FC
 
-L575D               ldd       #$005C
+L575A               ldd       #$005C
                     std       $005F
                     ldd       #$000A
-                    lbra      L57FF
+                    lbra      L57FC
 
-L5768               cmpx      #$003C
-                    beq       L573D
+L5765               cmpx      #$003C
+                    beq       L573A
                     cmpx      #$003D
-                    beq       L575D
-                    lbra      L5895
+                    beq       L575A
+                    lbra      L5892
 
-L5775               ldb       $0065
+L5772               ldb       $0065
                     sex
                     tfr       d,x
-                    bra       L57A7
+                    bra       L57A4
 
-L577C               ldd       #$0055
+L5779               ldd       #$0055
                     std       $005F
                     ldd       #$000B
                     std       $0061
-                    lbsr      $635E
+                    lbsr      L635B
                     ldb       $0065
                     cmpb      #$3d
-                    lbne      L5895
+                    lbne      L5892
                     ldd       #$00A5
                     std       $005F
                     ldd       #$0002
-                    lbra      L57FF
+                    lbra      L57FC
 
-L579C               ldd       #$005E
+L5799               ldd       #$005E
                     std       $005F
                     ldd       #$000A
-                    lbra      L57FF
+                    lbra      L57FC
 
-L57A7               cmpx      #$003E
-                    beq       L577C
+L57A4               cmpx      #$003E
+                    beq       L5779
                     cmpx      #$003D
-                    beq       L579C
-                    lbra      L5895
+                    beq       L5799
+                    lbra      L5892
 
-L57B4               ldb       $0065
+L57B1               ldb       $0065
                     sex
                     tfr       d,x
-                    bra       L57CF
+                    bra       L57CC
 
-L57BB               ldd       #$003C
+L57B8               ldd       #$003C
                     std       $005F
                     ldd       #$000E
-                    bra       L57FF
+                    bra       L57FC
 
-L57C5               ldd       #$00A0
+L57C2               ldd       #$00A0
                     std       $005F
                     ldd       #$0002
-                    bra       L57FF
+                    bra       L57FC
 
-L57CF               cmpx      #$002B
-                    beq       L57BB
+L57CC               cmpx      #$002B
+                    beq       L57B8
                     cmpx      #$003D
-                    beq       L57C5
-                    lbra      L5895
+                    beq       L57C2
+                    lbra      L5892
 
-L57DC               ldb       $0065
+L57D9               ldb       $0065
                     sex
                     tfr       d,x
-                    bra       L5807
+                    bra       L5804
 
-L57E3               ldd       #$003D
+L57E0               ldd       #$003D
                     std       $005F
                     ldd       #$000E
-                    bra       L57FF
+                    bra       L57FC
 
-L57ED               ldd       #$00A1
+L57EA               ldd       #$00A1
                     std       $005F
                     ldd       #$0002
-                    bra       L57FF
+                    bra       L57FC
 
-L57F7               ldd       #$0046
+L57F4               ldd       #$0046
                     std       $005F
                     ldd       #$000F
-L57FF               std       $0061
-                    lbsr      $635E
-                    lbra      L5895
+L57FC               std       $0061
+                    lbsr      L635B
+                    lbra      L5892
 
-L5807               cmpx      #$002D
-                    beq       L57E3
+L5804               cmpx      #$002D
+                    beq       L57E0
                     cmpx      #$003D
-                    beq       L57ED
+                    beq       L57EA
                     cmpx      #$003E
-                    beq       L57F7
-                    lbra      L5895
+                    beq       L57F4
+                    lbra      L5892
 
-L5819               cmpx      #$0045
-                    lbeq      L566C
+L5816               cmpx      #$0045
+                    lbeq      L5669
                     cmpx      #$0041
-                    lbeq      L5694
+                    lbeq      L5691
                     cmpx      #$0078
-                    lbeq      L56C0
+                    lbeq      L56BD
                     cmpx      #$0058
-                    lbeq      L56D3
+                    lbeq      L56D0
                     cmpx      #$0040
-                    lbeq      L5704
+                    lbeq      L5701
                     cmpx      #$0042
-                    lbeq      L5719
+                    lbeq      L5716
                     cmpx      #$0053
-                    lbeq      L5726
+                    lbeq      L5723
                     cmpx      #$0054
-                    lbeq      L5726
+                    lbeq      L5723
                     cmpx      #$0059
-                    lbeq      L5726
+                    lbeq      L5723
                     cmpx      #$005D
-                    lbeq      L5736
+                    lbeq      L5733
                     cmpx      #$005F
-                    lbeq      L5775
+                    lbeq      L5772
                     cmpx      #$0050
-                    lbeq      L57B4
+                    lbeq      L57B1
                     cmpx      #$0043
-                    lbeq      L57DC
-                    bra       L5895
+                    lbeq      L57D9
+                    bra       L5892
 
-L5876               cmpx      #$006A
-                    lbeq      L558B
+L5873               cmpx      #$006A
+                    lbeq      L5588
                     cmpx      #$006B
-                    lbeq      L55CC
+                    lbeq      L55C9
                     cmpx      #$0068
-                    lbeq      L5651
+                    lbeq      L564E
                     cmpx      #$0069
-                    lbeq      L5659
-                    lbra      L5664
+                    lbeq      L5656
+                    lbra      L5661
 
-L5895               leas      $15,s
+L5892               leas      $15,s
                     puls      pc,u
-                    pshs      u
+L5897               pshs      u
                     ldd       #$0006
                     pshs      d
-                    leax      L620C,pcr
+                    leax      L6209,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0005
                     pshs      d
-                    leax      L6213,pcr
+                    leax      L6210,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
-                    ldd       #_start
+                    ldd       #start
                     pshs      d
-                    leax      L6219,pcr
+                    leax      L6216,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$000F
                     pshs      d
-                    leax      L6221,pcr
+                    leax      L621E,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$003B
                     pshs      d
-                    leax      L6228,pcr
+                    leax      L6225,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    leax      L622F,pcr
+                    leax      L622C,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0001
                     std       $0041
                     ldd       #$0001
                     pshs      d
-                    leax      $6233,pcr
+                    leax      $6230,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0005
                     pshs      d
-                    leax      L6237,pcr
+                    leax      $6234,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     clra
                     clrb
                     std       $0041
                     ldd       #$0002
                     pshs      d
-                    leax      L623D,pcr
+                    leax      L623A,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$000A
                     pshs      d
-                    leax      L6242,pcr
+                    leax      L623F,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$000D
                     pshs      d
-                    leax      L6248,pcr
+                    leax      L6245,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$000E
                     pshs      d
-                    leax      L624D,pcr
+                    leax      L624A,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0021
                     pshs      d
-                    leax      L6254,pcr
+                    leax      L6251,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0010
                     pshs      d
-                    leax      L625B,pcr
+                    leax      L6258,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$001D
                     pshs      d
-                    leax      L6264,pcr
+                    leax      L6261,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0012
                     pshs      d
-                    leax      L6269,pcr
+                    leax      L6266,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0013
                     pshs      d
-                    leax      L6270,pcr
+                    leax      L626D,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0014
                     pshs      d
-                    leax      L6273,pcr
+                    leax      $6270,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0015
                     pshs      d
-                    leax      L6279,pcr
+                    leax      L6276,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0016
                     pshs      d
-                    leax      L627E,pcr
+                    leax      L627B,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0017
                     pshs      d
-                    leax      L6285,pcr
+                    leax      L6282,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0018
                     pshs      d
-                    leax      L628A,pcr
+                    leax      L6287,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0019
                     pshs      d
-                    leax      L6290,pcr
+                    leax      L628D,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$001A
                     pshs      d
-                    leax      L6299,pcr
+                    leax      L6296,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$001B
                     pshs      d
-                    leax      L629C,pcr
+                    leax      $6299,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$001C
                     pshs      d
-                    leax      L62A4,pcr
+                    leax      L62A1,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0004
                     pshs      d
-                    leax      L62A8,pcr
+                    leax      $62A5,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0003
                     pshs      d
-                    leax      L62AF,pcr
+                    leax      L62AC,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0007
                     pshs      d
-                    leax      L62B5,pcr
+                    leax      L62B2,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
                     ldd       #$0008
                     pshs      d
-                    leax      L62BE,pcr
+                    leax      L62BB,pcr
                     pshs      x
-                    lbsr      L5BD8
+                    lbsr      L5BD5
                     leas      $04,s
-                    leax      L62C3,pcr
+                    leax      L62C0,pcr
                     pshs      x
-                    lbsr      L5B36
+                    lbsr      L5B33
                     leas      $02,s
                     tfr       d,u
                     ldd       #$0001
@@ -9970,9 +9987,9 @@ L5895               leas      $15,s
                     std       $08,u
                     ldd       #$0002
                     std       $02,u
-                    leax      L62C9,pcr
+                    leax      L62C6,pcr
                     pshs      x
-                    lbsr      L5B36
+                    lbsr      L5B33
                     leas      $02,s
                     tfr       d,u
                     ldd       #$0038
@@ -9982,92 +9999,92 @@ L5895               leas      $15,s
                     ldd       #$0004
                     std       $02,u
                     puls      pc,u
-L5ABF               pshs      u
+L5ABC               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       #$0001
-                    bra       L5AD6
+                    bra       L5AD3
 
-L5ACA               ldb       $0065
+L5AC7               ldb       $0065
                     stb       ,u+
-                    lbsr      $635E
+                    lbsr      L635B
                     ldd       ,s
                     addd      #$0001
-L5AD6               std       ,s
+L5AD3               std       ,s
                     ldb       $0065
                     sex
                     pshs      d
-                    bsr       L5B0F
+                    bsr       L5B0C
                     std       ,s++
-                    beq       L5AEB
+                    beq       L5AE8
                     ldd       ,s
                     cmpd      #$0008
-                    ble       L5ACA
-L5AEB               ldd       ,s
+                    ble       L5AC7
+L5AE8               ldd       ,s
                     cmpd      #$0002
-                    bne       L5AF8
+                    bne       L5AF5
                     ldd       #$005F
                     stb       ,u+
-L5AF8               clra
+L5AF5               clra
                     clrb
                     stb       ,u
-                    bra       L5B01
+                    bra       L5AFE
 
-L5AFE               lbsr      $635E
-L5B01               ldb       $0065
+L5AFB               lbsr      L635B
+L5AFE               ldb       $0065
                     sex
                     pshs      d
-                    bsr       L5B0F
+                    bsr       L5B0C
                     std       ,s++
-                    bne       L5AFE
-                    lbra      L5C58
+                    bne       L5AFB
+                    lbra      L5C55
 
-L5B0F               pshs      u
+L5B0C               pshs      u
                     ldd       $04,s
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6a
-                    beq       L5B2D
+                    beq       L5B2A
                     ldd       $04,s
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    bne       L5B32
-L5B2D               ldd       #$0001
-                    bra       L5B34
+                    bne       L5B2F
+L5B2A               ldd       #$0001
+                    bra       L5B31
 
-L5B32               clra
+L5B2F               clra
                     clrb
-L5B34               puls      pc,u
-L5B36               pshs      u,y,x,d
+L5B31               puls      pc,u
+L5B33               pshs      u,y,x,d
                     ldd       $0041
-                    beq       L5B42
+                    beq       L5B3F
                     leax      $050C,y
-                    bra       L5B46
+                    bra       L5B43
 
-L5B42               leax      $040C,y
-L5B46               tfr       x,d
+L5B3F               leax      $040C,y
+L5B43               tfr       x,d
                     std       $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L5C0A
+                    lbsr      L5C07
                     leas      $02,s
                     aslb
                     rola
                     addd      $02,s
                     std       $04,s
                     ldu       [$04,s]
-                    bra       L5B8B
+                    bra       L5B88
 
-L5B5E               ldb       $14,u
+L5B5B               ldb       $14,u
                     sex
                     pshs      d
                     ldb       [$0C,s]
                     sex
                     cmpd      ,s++
-                    bne       L5B88
+                    bne       L5B85
                     ldd       #$0008
                     pshs      d
                     pshs      u
@@ -10076,25 +10093,25 @@ L5B5E               ldb       $14,u
                     pshs      d
                     ldd       $0e,s
                     pshs      d
-                    lbsr      $73C7
+                    lbsr      L73C4
                     leas      $06,s
                     std       -$02,s
-                    beq       L5BD2
-L5B88               ldu       $12,u
-L5B8B               stu       -$02,s
-                    bne       L5B5E
+                    beq       L5BCF
+L5B85               ldu       $12,u
+L5B88               stu       -$02,s
+                    bne       L5B5B
                     ldu       L0019
-                    beq       L5B9A
+                    beq       L5B97
                     ldd       $12,u
                     std       L0019
-                    bra       L5BA6
+                    bra       L5BA3
 
-L5B9A               ldd       #$001C
+L5B97               ldd       #$001C
                     pshs      d
-                    lbsr      L5C2A
+                    lbsr      L5C27
                     leas      $02,s
                     tfr       d,u
-L5BA6               ldd       #$0008
+L5BA3               ldd       #$0008
                     pshs      d
                     ldd       $0C,s
                     pshs      d
@@ -10102,7 +10119,7 @@ L5BA6               ldd       #$0008
                     ldd       #$0014
                     addd      ,s++
                     pshs      d
-                    lbsr      $738A
+                    lbsr      L7387
                     leas      $06,s
                     clra
                     clrb
@@ -10115,10 +10132,10 @@ L5BA6               ldd       #$0008
                     stu       [$04,s]
                     ldd       $04,s
                     std       $0e,u
-L5BD2               tfr       u,d
+L5BCF               tfr       u,d
                     leas      $06,s
                     puls      pc,u
-L5BD8               pshs      u
+L5BD5               pshs      u
                     leas      -$09,s
                     ldd       #$0008
                     pshs      d
@@ -10126,14 +10143,14 @@ L5BD8               pshs      u
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    lbsr      $738A
+                    lbsr      L7387
                     leas      $06,s
                     clra
                     clrb
                     stb       $08,s
                     leax      ,s
                     pshs      x
-                    lbsr      L5B36
+                    lbsr      L5B33
                     leas      $02,s
                     tfr       d,u
                     ldd       #$0033
@@ -10142,48 +10159,48 @@ L5BD8               pshs      u
                     std       $08,u
                     leas      $09,s
                     puls      pc,u
-L5C0A               pshs      u
+L5C07               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
-                    bra       L5C18
+                    bra       L5C15
 
-L5C14               ldd       $02,s
+L5C11               ldd       $02,s
                     addd      ,s
-L5C18               std       $02,s
+L5C15               std       $02,s
                     ldb       ,u+
                     sex
                     std       ,s
-                    bne       L5C14
+                    bne       L5C11
                     ldd       $02,s
                     clra
                     andb      #$7f
                     leas      $04,s
-L5C28               puls      pc,u
-L5C2A               pshs      u,d
+                    puls      pc,u
+L5C27               pshs      u,d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $784A
+                    lbsr      L7847
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L5C48
-                    leax      L62CF,pcr
+                    bne       L5C45
+                    leax      L62CC,pcr
                     pshs      x
-                    lbsr      L022B
+                    lbsr      L0228
                     leas      $02,s
-L5C48               ldd       L0066
-                    bne       L5C50
+L5C45               ldd       L0066
+                    bne       L5C4D
                     ldd       ,s
                     std       L0066
-L5C50               ldd       ,s
+L5C4D               ldd       ,s
                     addd      $06,s
                     std       $0068
                     ldd       ,s
-L5C58               leas      $02,s
+L5C55               leas      $02,s
                     puls      pc,u
-L5C5C               pshs      u
+L5C59               pshs      u
                     ldu       $06,s
                     leas      -$10,s
                     clra
@@ -10191,89 +10208,89 @@ L5C5C               pshs      u
                     std       $02,s
                     leax      $08,s
                     pshs      x
-                    bsr       L5C74
+                    bsr       L5C71
                     neg       $0000
                     neg       $0000
                     neg       $0000
                     neg       $0000
-L5C74               puls      x
-                    lbsr      $6A02
+L5C71               puls      x
+                    lbsr      L69FF
                     leax      $08,s
                     stx       ,s
                     ldd       $14,s
                     cmpd      #$0006
-                    bne       L5C8C
+                    bne       L5C89
                     leax      $10,s
-                    lbra      L5DC7
+                    lbra      L5DC4
 
-L5C8C               ldb       $0065
+L5C89               ldb       $0065
                     cmpb      #$30
-                    lbne      L5D99
+                    lbne      L5D96
                     leas      -$06,s
-                    lbsr      $635E
+                    lbsr      L635B
                     ldb       $0065
                     cmpb      #$2e
-                    bne       L5CA8
-                    lbsr      $635E
+                    bne       L5CA5
+                    lbsr      L635B
                     leax      $16,s
-                    lbra      L5DC7
+                    lbra      L5DC4
 
-L5CA8               leax      $02,s
+L5CA5               leax      $02,s
                     pshs      x
-                    bsr       L5CB2
+                    bsr       L5CAF
                     neg       $0000
                     neg       $0000
-L5CB2               puls      x
-                    lbsr      L74D6
+L5CAF               puls      x
+                    lbsr      L74D3
                     ldb       $0065
                     cmpb      #$78
-                    beq       L5CC5
+                    beq       L5CC2
                     ldb       $0065
                     cmpb      #$58
-                    lbne      L5D3B
-L5CC5               leas      -$02,s
-                    bra       L5CFE
+                    lbne      L5D38
+L5CC2               leas      -$02,s
+                    bra       L5CFB
 
-L5CC9               leax      $04,s
+L5CC6               leax      $04,s
                     pshs      x
                     leax      $06,s
                     pshs      x
                     ldd       #$0004
-                    lbsr      L74EC
+                    lbsr      L74E9
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
                     ldd       $06,s
                     cmpd      #$0041
-                    blt       L5CEC
+                    blt       L5CE9
                     ldd       #$0037
-                    bra       L5CEF
+                    bra       L5CEC
 
-L5CEC               ldd       #$0030
-L5CEF               pshs      d
+L5CE9               ldd       #$0030
+L5CEC               pshs      d
                     ldd       $08,s
                     subd      ,s++
-                    lbsr      L74BD
-                    lbsr      $746C
-                    lbsr      L74D6
-L5CFE               lbsr      $635E
+                    lbsr      L74BA
+                    lbsr      L7469
+                    lbsr      L74D3
+L5CFB               lbsr      L635B
                     ldb       $0065
                     sex
                     pshs      d
-                    lbsr      $61BF
+                    lbsr      L61BC
                     leas      $02,s
                     std       ,s
-                    bne       L5CC9
+                    bne       L5CC6
                     leas      $02,s
-                    bra       L5D47
+                    bra       L5D44
 
-L5D13               leax      $02,s
+L5D10               leax      $02,s
                     pshs      x
                     leax      $04,s
                     pshs      x
                     ldd       #$0003
-                    lbsr      L74EC
+                    lbsr      L74E9
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
@@ -10281,166 +10298,166 @@ L5D13               leax      $02,s
                     ldb       $0065
                     sex
                     addd      #$FFD0
-                    lbsr      L74BD
-                    lbsr      $746C
-                    lbsr      L74D6
-                    lbsr      $635E
-L5D3B               ldb       $0065
+                    lbsr      L74BA
+                    lbsr      L7469
+                    lbsr      L74D3
+                    lbsr      L635B
+L5D38               ldb       $0065
                     sex
                     pshs      d
-                    lbsr      $61AC
+                    lbsr      L61A9
                     std       ,s++
-                    bne       L5D13
-L5D47               leax      $02,s
+                    bne       L5D10
+L5D44               leax      $02,s
                     stx       ,s
                     ldb       $0065
                     cmpb      #$4C
-                    beq       L5D57
+                    beq       L5D54
                     ldb       $0065
                     cmpb      #$6C
-                    bne       L5D5F
-L5D57               lbsr      $635E
+                    bne       L5D5C
+L5D54               lbsr      L635B
                     leax      $16,s
-                    bra       L5D6E
+                    bra       L5D6B
 
-L5D5F               ldd       [,s]
-                    bne       L5D71
+L5D5C               ldd       [,s]
+                    bne       L5D6E
                     ldd       $04,s
                     std       ,u
                     ldd       #$0001
-                    bra       L5D7D
-                    bra       L5D71
+                    bra       L5D7A
+                    bra       L5D6E
 
-L5D6E               leas      -$16,x
-L5D71               leax      ,u
+L5D6B               leas      -$16,x
+L5D6E               leax      ,u
                     pshs      x
                     leax      $04,s
-                    lbsr      L74D6
+                    lbsr      L74D3
                     ldd       #$0008
-L5D7D               leas      $16,s
+L5D7A               leas      $16,s
                     puls      pc,u
-                    bra       L5D99
+                    bra       L5D96
 
-L5D84               ldb       $0065
+L5D81               ldb       $0065
                     sex
                     pshs      d
                     leax      $0a,s
                     pshs      x
-                    lbsr      $549F
+                    lbsr      $549C
                     leas      $04,s
                     std       -$02,s
-                    bne       L5DDD
-                    lbsr      $635E
-L5D99               ldb       $0065
+                    bne       L5DDA
+                    lbsr      L635B
+L5D96               ldb       $0065
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L5D84
+                    beq       L5D81
                     ldb       $0065
                     cmpb      #$2e
-                    beq       L5DBC
+                    beq       L5DB9
                     ldb       $0065
                     cmpb      #$65
-                    beq       L5DBC
+                    beq       L5DB9
                     ldb       $0065
                     cmpb      #$45
-                    lbne      L5E98
-L5DBC               ldb       $0065
+                    lbne      L5E95
+L5DB9               ldb       $0065
                     cmpb      #$2e
-                    bne       L5DFC
-                    lbsr      $635E
-                    bra       L5DED
+                    bne       L5DF9
+                    lbsr      L635B
+                    bra       L5DEA
 
-L5DC7               leas      -$10,x
-                    bra       L5DED
+L5DC4               leas      -$10,x
+                    bra       L5DEA
 
-L5DCB               ldb       $0065
+L5DC8               ldb       $0065
                     sex
                     pshs      d
                     leax      $0a,s
                     pshs      x
-                    lbsr      $549F
+                    lbsr      $549C
                     leas      $04,s
                     std       -$02,s
-                    beq       L5DE3
-L5DDD               lbsr      $635E
-                    lbra      L5EA8
+                    beq       L5DE0
+L5DDA               lbsr      L635B
+                    lbra      L5EA5
 
-L5DE3               lbsr      $635E
+L5DE0               lbsr      L635B
                     ldd       $02,s
                     addd      #$0001
                     std       $02,s
-L5DED               ldb       $0065
+L5DEA               ldb       $0065
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L5DCB
-L5DFC               ldb       $0065
+                    beq       L5DC8
+L5DF9               ldb       $0065
                     cmpb      #$45
-                    beq       L5E0A
+                    beq       L5E07
                     ldb       $0065
                     cmpb      #$65
-                    lbne      L5E78
-L5E0A               ldd       #$0001
+                    lbne      L5E75
+L5E07               ldd       #$0001
                     std       $04,s
-                    lbsr      $635E
+                    lbsr      L635B
                     ldb       $0065
                     cmpb      #$2b
-                    bne       L5E1D
-                    lbsr      $635E
-                    bra       L5E2A
+                    bne       L5E1A
+                    lbsr      L635B
+                    bra       L5E27
 
-L5E1D               ldb       $0065
+L5E1A               ldb       $0065
                     cmpb      #$2d
-                    bne       L5E2A
-                    lbsr      $635E
+                    bne       L5E27
+                    lbsr      L635B
                     clra
                     clrb
                     std       $04,s
-L5E2A               clra
+L5E27               clra
                     clrb
                     std       $06,s
-                    bra       L5E49
+                    bra       L5E46
 
-L5E30               ldd       $06,s
+L5E2D               ldd       $06,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L7542
+                    lbsr      L753F
                     pshs      d
                     ldb       $0065
                     sex
                     addd      #$FFD0
                     addd      ,s++
                     std       $06,s
-                    lbsr      $635E
-L5E49               ldb       $0065
+                    lbsr      L635B
+L5E46               ldb       $0065
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L5E30
+                    beq       L5E2D
                     ldd       $06,s
                     cmpd      #$0028
-                    lbge      L5EA8
+                    lbge      L5EA5
                     ldd       $02,s
                     pshs      d
                     ldd       $06,s
-                    beq       L5E72
+                    beq       L5E6F
                     ldd       $08,s
                     nega
                     negb
                     sbca      #$00
-                    bra       L5E74
+                    bra       L5E71
 
-L5E72               ldd       $08,s
-L5E74               addd      ,s++
+L5E6F               ldd       $08,s
+L5E71               addd      ,s++
                     std       $02,s
-L5E78               ldd       $02,s
+L5E75               ldd       $02,s
                     nega
                     negb
                     sbca      #$00
@@ -10453,127 +10470,127 @@ L5E78               ldd       $02,s
                     leax      ,u
                     pshs      x
                     leax      $0a,s
-                    lbsr      $6A02
+                    lbsr      L69FF
                     ldd       #$0006
-                    lbra      L5EFE
+                    lbra      L5EFB
 
-L5E98               ldb       [,s]
-                    bne       L5EA8
+L5E95               ldb       [,s]
+                    bne       L5EA5
                     ldx       ,s
                     ldb       $01,x
-                    bne       L5EA8
+                    bne       L5EA5
                     ldx       ,s
                     ldb       $02,x
-                    beq       L5EAD
-L5EA8               clra
+                    beq       L5EAA
+L5EA5               clra
                     clrb
-                    lbra      L5EFE
+                    lbra      L5EFB
 
-L5EAD               ldb       $0065
+L5EAA               ldb       $0065
                     cmpb      #$6C
-                    beq       L5EB9
+                    beq       L5EB6
                     ldb       $0065
                     cmpb      #$4C
-                    bne       L5ED8
-L5EB9               leas      -$02,s
-                    lbsr      $635E
-                    bra       L5EC3
+                    bne       L5ED5
+L5EB6               leas      -$02,s
+                    lbsr      L635B
+                    bra       L5EC0
 
-L5EC0               leas      -$12,x
-L5EC3               ldd       $02,s
+L5EBD               leas      -$12,x
+L5EC0               ldd       $02,s
                     addd      #$0003
                     std       ,s
                     leax      ,u
                     pshs      x
                     ldx       $02,s
-                    lbsr      L74D6
+                    lbsr      L74D3
                     ldd       #$0008
-                    bra       L5EF9
+                    bra       L5EF6
 
-L5ED8               ldx       ,s
+L5ED5               ldx       ,s
                     ldb       $03,x
-                    bne       L5EE4
+                    bne       L5EE1
                     ldx       ,s
                     ldb       $04,x
-                    beq       L5EE9
-L5EE4               leax      $10,s
-                    bra       L5EC0
+                    beq       L5EE6
+L5EE1               leax      $10,s
+                    bra       L5EBD
 
-L5EE9               leas      -$02,s
+L5EE6               leas      -$02,s
                     ldd       $02,s
                     addd      #$0005
                     std       ,s
                     ldd       [,s]
                     std       ,u
                     ldd       #$0001
-L5EF9               leas      $12,s
+L5EF6               leas      $12,s
                     puls      pc,u
-L5EFE               leas      $10,s
+L5EFB               leas      $10,s
                     puls      pc,u
-L5F03               pshs      u
-                    lbsr      $635E
+L5F00               pshs      u
+                    lbsr      L635B
                     ldb       $0065
                     cmpb      #$5C
-                    bne       L5F15
-                    lbsr      $6059
+                    bne       L5F12
+                    lbsr      L6056
                     std       $0061
-                    bra       L5F1D
+                    bra       L5F1A
 
-L5F15               ldb       $0065
+L5F12               ldb       $0065
                     sex
                     std       $0061
-                    lbsr      $635E
-L5F1D               ldb       $0065
+                    lbsr      L635B
+L5F1A               ldb       $0065
                     cmpb      #$27
-                    lbeq      $6008
-                    leax      L62DD,pcr
+                    lbeq      L6005
+                    leax      L62DA,pcr
                     pshs      x
-                    lbsr      L024E
+                    lbsr      L024B
                     leas      $02,s
-                    lbra      $600B
+                    lbra      L6008
 
-L5F33               pshs      u
+L5F30               pshs      u
                     ldx       $000B
-                    bra       $5F67
-                    ldd       $006C
-                    bne       $5F5D
-                    leax      L62FD,pcr
+                    bra       L5F64
+
+L5F36               ldd       $006C
+                    bne       L5F5A
+                    leax      L62FA,pcr
                     pshs      x
                     leax      $01A9,y
                     pshs      x
-                    lbsr      $6DF0
+                    lbsr      L6DED
                     leas      $04,s
                     std       $006C
-                    bne       $5F5D
-                    leax      $0d,y
-                    bsr       L5F59
-                    ora       -$0C,y
-                    fcb       $10
-L5F59               lbsr      $022C
+                    bne       L5F5A
+                    leax      L62FD,pcr
+                    pshs      x
+                    lbsr      L0228
                     leas      $02,s
-                    ldd       $006C
-                    bra       L5F64
+L5F5A               ldd       $006C
+                    bra       L5F60
 
-L5F62               ldd       $0025
-L5F64               std       L001B
-                    bra       L5F78
-                    stx       -$02,s
-                    beq       $5F3A
+L5F5E               ldd       $0025
+L5F60               std       L001B
+                    bra       L5F74
+
+L5F64               stx       -$02,s
+                    beq       L5F36
                     cmpx      #$0002
-                    lbeq      $5F3A
+                    lbeq      L5F36
                     cmpx      #$0001
-                    beq       L5F62
-L5F78               clra
+                    beq       L5F5E
+L5F74               clra
                     clrb
                     std       L0017
                     ldd       $000B
                     cmpd      #$0001
-                    beq       L5FA6
+                    beq       L5FA2
                     ldd       L001B
                     pshs      d
                     ldd       #$006C
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       L001B
                     pshs      d
@@ -10582,147 +10599,147 @@ L5F78               clra
                     std       L002B
                     std       $0061
                     pshs      d
-                    lbsr      L6FAA
+                    lbsr      L6FA6
                     leas      $04,s
-L5FA6               lbsr      L635F
+L5FA2               lbsr      L635B
                     ldd       L001B
                     pshs      d
                     ldd       #$0073
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
-                    bra       L5FEF
+                    bra       L5FEB
 
-L5FB9               leax      $060C,y
+L5FB5               leax      $060C,y
                     pshs      x
                     ldd       $006A
                     subd      ,s++
-                    bne       L5FD2
-                    leax      L6319,pcr
+                    bne       L5FCE
+                    leax      L6315,pcr
                     pshs      x
-                    lbsr      $024F
+                    lbsr      L024B
                     leas      $02,s
-                    bra       L5FF5
+                    bra       L5FF1
 
-L5FD2               ldb       $0065
+L5FCE               ldb       $0065
                     cmpb      #$5C
-                    bne       L5FE3
-                    lbsr      L605A
+                    bne       L5FDF
+                    lbsr      L6056
                     pshs      d
-                    bsr       L600E
+                    bsr       L600A
                     leas      $02,s
-                    bra       L5FEF
+                    bra       L5FEB
 
-L5FE3               ldb       $0065
+L5FDF               ldb       $0065
                     sex
                     pshs      d
-                    bsr       L600E
+                    bsr       L600A
                     leas      $02,s
-                    lbsr      L635F
-L5FEF               ldb       $0065
+                    lbsr      L635B
+L5FEB               ldb       $0065
                     cmpb      #$22
-                    bne       L5FB9
-L5FF5               ldd       L001B
+                    bne       L5FB5
+L5FF1               ldd       L001B
                     pshs      d
                     clra
                     clrb
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       L0017
                     addd      #$0001
                     std       L0017
-                    lbsr      L635F
-                    puls      pc,u
-L600E               pshs      u
+L6005               lbsr      L635B
+L6008               puls      pc,u
+L600A               pshs      u
                     ldd       $04,s
-                    beq       L601C
+                    beq       L6018
                     ldd       $04,s
                     cmpd      #$005C
-                    bne       L602A
-L601C               ldd       L001B
+                    bne       L6026
+L6018               ldd       L001B
                     pshs      d
                     ldd       #$005C
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
-L602A               ldd       L001B
+L6026               ldd       L001B
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       L0017
                     addd      #$0001
                     std       L0017
                     puls      pc,u
-                    pshs      u
-                    lbsr      $4BF0
+L603C               pshs      u
+                    lbsr      L4BEC
                     ldd       $04,s
                     pshs      d
-                    leax      L632D,pcr
+                    leax      L6329,pcr
                     pshs      x
                     ldd       L001B
                     pshs      d
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $06,s
                     puls      pc,u
-L605A               pshs      u,d
-                    lbsr      L635F
+L6056               pshs      u,d
+                    lbsr      L635B
                     ldb       $0065
                     sex
                     tfr       d,u
-                    lbsr      L635F
+                    lbsr      L635B
                     leax      ,u
-                    bra       L6095
+                    bra       L6091
 
-L606B               ldd       #$000A
-                    lbra      L61A9
+L6067               ldd       #$000A
+                    lbra      L61A5
 
-L6071               ldd       #$0009
-                    lbra      L61A9
+L606D               ldd       #$0009
+                    lbra      L61A5
 
-L6077               ldd       #$0008
-                    lbra      L61A9
+L6073               ldd       #$0008
+                    lbra      L61A5
 
-L607D               ldd       #$000B
-                    lbra      L61A9
+L6079               ldd       #$000B
+                    lbra      L61A5
 
-L6083               ldd       #$000D
-                    lbra      L61A9
+L607F               ldd       #$000D
+                    lbra      L61A5
 
-L6089               ldd       #$000C
-                    lbra      L61A9
+L6085               ldd       #$000C
+                    lbra      L61A5
 
-L608F               ldd       #$0020
-                    lbra      L61A9
+L608B               ldd       #$0020
+                    lbra      L61A5
 
-L6095               cmpx      #$006E
-                    beq       L6083
+L6091               cmpx      #$006E
+                    beq       L607F
                     cmpx      #$006C
-                    beq       L606B
+                    beq       L6067
                     cmpx      #$0074
-                    beq       L6071
+                    beq       L606D
                     cmpx      #$0062
-                    beq       L6077
+                    beq       L6073
                     cmpx      #$0076
-                    beq       L607D
+                    beq       L6079
                     cmpx      #$0072
-                    lbeq      L6083
+                    lbeq      L607F
                     cmpx      #$0066
-                    beq       L6089
+                    beq       L6085
                     cmpx      #$000D
-                    beq       L608F
+                    beq       L608B
                     cmpu      #$0078
-                    lbne      L611B
+                    lbne      L6117
                     leas      -$02,s
                     clra
                     clrb
                     std       $02,s
                     tfr       d,u
-                    bra       L60F8
+                    bra       L60F4
 
-L60D1               tfr       u,d
+L60CD               tfr       u,d
                     aslb
                     rola
                     aslb
@@ -10734,76 +10751,76 @@ L60D1               tfr       u,d
                     pshs      d
                     ldd       $02,s
                     cmpd      #$0041
-                    bge       L60EC
+                    bge       L60E8
                     ldd       $02,s
                     addd      #$FFD0
-                    bra       L60F1
+                    bra       L60ED
 
-L60EC               ldd       $02,s
+L60E8               ldd       $02,s
                     addd      #$FFC9
-L60F1               addd      ,s++
+L60ED               addd      ,s++
                     tfr       d,u
-                    lbsr      L635F
-L60F8               ldb       $0065
+                    lbsr      L635B
+L60F4               ldb       $0065
                     sex
                     pshs      d
-                    lbsr      L61C0
+                    lbsr      L61BC
                     leas      $02,s
                     std       ,s
-                    beq       L6116
+                    beq       L6112
                     ldd       $02,s
                     addd      #$0001
                     std       $02,s
                     subd      #$0001
                     cmpd      #$0002
-                    blt       L60D1
-L6116               leas      $02,s
-                    lbra      L61A7
+                    blt       L60CD
+L6112               leas      $02,s
+                    lbra      L61A3
 
-L611B               cmpu      #$0064
-                    bne       L6163
+L6117               cmpu      #$0064
+                    bne       L615F
                     clra
                     clrb
                     std       ,s
                     tfr       d,u
-                    bra       L6140
+                    bra       L613C
 
-L6129               pshs      u
+L6125               pshs      u
                     ldd       #$000A
-                    lbsr      L7543
+                    lbsr      L753F
                     pshs      d
                     ldb       $0065
                     sex
                     addd      ,s++
                     addd      #$FFD0
                     tfr       d,u
-                    lbsr      L635F
-L6140               ldb       $0065
+                    lbsr      L635B
+L613C               ldb       $0065
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    lbne      L61A7
+                    lbne      L61A3
                     ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0003
-                    blt       L6129
-                    bra       L61A7
+                    blt       L6125
+                    bra       L61A3
 
-L6163               pshs      u
-                    lbsr      L61AD
+L615F               pshs      u
+                    lbsr      L61A9
                     std       ,s++
-                    beq       L61A7
+                    beq       L61A3
                     leau      -$30,u
                     clra
                     clrb
                     std       ,s
-                    bra       L618C
+                    bra       L6188
 
-L6175               tfr       u,d
+L6171               tfr       u,d
                     aslb
                     rola
                     aslb
@@ -10816,383 +10833,383 @@ L6175               tfr       u,d
                     addd      #$FFD0
                     addd      ,s++
                     tfr       d,u
-                    lbsr      L635F
-L618C               ldb       $0065
+                    lbsr      L635B
+L6188               ldb       $0065
                     sex
                     pshs      d
-                    bsr       L61AD
+                    bsr       L61A9
                     std       ,s++
-                    beq       L61A7
+                    beq       L61A3
                     ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0003
-                    blt       L6175
-L61A7               tfr       u,d
-L61A9               leas      $02,s
+                    blt       L6171
+L61A3               tfr       u,d
+L61A5               leas      $02,s
                     puls      pc,u
-L61AD               pshs      u
+L61A9               pshs      u
                     ldb       $05,s
                     cmpb      #$37
-                    bgt       L61E9
+                    bgt       L61E5
                     ldb       $05,s
                     cmpb      #$30
-                    blt       L61E9
+                    blt       L61E5
                     ldd       #$0001
-                    bra       L61EB
+                    bra       L61E7
 
-L61C0               pshs      u
+L61BC               pshs      u
                     ldb       $05,s
                     sex
                     leax      $0089,y
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L61E4
+                    beq       L61E0
                     ldb       $05,s
                     clra
                     andb      #$5f
                     stb       $05,s
                     cmpd      #$0041
-                    blt       L61E9
+                    blt       L61E5
                     ldb       $05,s
                     cmpb      #$46
-                    bgt       L61E9
-L61E4               ldb       $05,s
+                    bgt       L61E5
+L61E0               ldb       $05,s
                     sex
-                    bra       L61EB
+                    bra       L61E7
 
-L61E9               clra
+L61E5               clra
                     clrb
-L61EB               puls      pc,u
-                    fcc       /bad character/
-L61FA               fcb       $00
-                    fcc       /constant overflow/
-L620C               fcb       $00
-                    fcc       /double/
-L6213               fcb       $00
-                    fcc       /float/
-L6219               fcb       $00
-                    fcc       /typede/
-L6220               fcb       $66
-L6221               fcb       $00
-                    fcc       /static/
-L6228               fcb       $00
-                    fcc       /sizeof/
-L622F               fcb       $00
-                    rol       $0e,s
+L61E7               puls      pc,u
+L61E9               fcc       /bad character/
+                    fcb       $00
+L61F7               fcc       /constant overflow/
+                    fcb       $00
+L6209               fcc       /double/
+                    fcb       $00
+L6210               fcc       /float/
+                    fcb       $00
+L6216               fcc       /typedef/
+                    fcb       $00
+L621E               fcb       $73,$74
+L6220               fcc       /atic/
+                    fcb       $00
+L6225               fcc       /sizeof/
+                    fcb       $00
+L622C               rol       $0e,s
                     lsr       >L0069
                     jmp       -$0C,s
-
-L6237               neg       L0066
+                    neg       L0066
                     fcc       /loat/
-L623D               fcb       $00
-                    fcc       /char/
-L6242               fcb       $00
-                    fcc       /short/
-L6248               fcb       $00
-                    fcc       /auto/
-L624D               fcb       $00
-                    fcc       /extern/
-L6254               fcb       $00
-                    fcc       /direct/
-L625B               fcb       $00
-                    fcc       /register/
-L6264               fcb       $00
-                    fcc       /goto/
-L6269               fcb       $00
-                    fcc       /return/
-L6270               fcb       $00
-                    rol       $06,s
-L6273               neg       $0077
+                    fcb       $00
+L623A               fcc       /char/
+                    fcb       $00
+L623F               fcc       /short/
+                    fcb       $00
+L6245               fcc       /auto/
+                    fcb       $00
+L624A               fcc       /extern/
+                    fcb       $00
+L6251               fcc       /direct/
+                    fcb       $00
+L6258               fcc       /register/
+                    fcb       $00
+L6261               fcc       /goto/
+                    fcb       $00
+L6266               fcc       /return/
+                    fcb       $00
+L626D               rol       $06,s
+                    neg       $0077
                     fcc       /hile/
-L6279               fcb       $00
-                    fcc       /else/
-L627E               fcb       $00
-                    fcc       /switch/
-L6285               fcb       $00
-                    fcc       /case/
-L628A               fcb       $00
-                    fcc       /break/
-L6290               fcb       $00
-                    fcc       /continue/
-L6299               fcb       $00
-                    lsr       $0f,s
-L629C               neg       L0064
+                    fcb       $00
+L6276               fcc       /else/
+                    fcb       $00
+L627B               fcc       /switch/
+                    fcb       $00
+L6282               fcc       /case/
+                    fcb       $00
+L6287               fcc       /break/
+                    fcb       $00
+L628D               fcc       /continue/
+                    fcb       $00
+L6296               lsr       $0f,s
+                    neg       L0064
                     fcc       /efault/
-L62A4               fcb       $00
-                    ror       $0f,s
+                    fcb       $00
+L62A1               ror       $0f,s
                     fcb       $72
-L62A8               neg       $0073
+                    neg       $0073
                     fcc       /truct/
-L62AF               fcb       $00
-                    fcc       /union/
-L62B5               fcb       $00
-                    fcc       /unsigned/
-L62BE               fcb       $00
-                    fcc       /long/
-L62C3               fcb       $00
-                    fcc       /errno/
-L62C9               fcb       $00
-                    fcc       /lseek/
-L62CF               fcb       $00
-                    fcc       /out of memory/
-L62DD               fcb       $00
-                    fcc       /unterminated character constant/
-L62FD               fcb       $00
-                    asr       L2B00
-                    fcc       /can't open strings file/
                     fcb       $00
-L6319               fcc       /unterminated string/
+L62AC               fcc       /union/
                     fcb       $00
-L632D               bra       L63A1
+L62B2               fcc       /unsigned/
+                    fcb       $00
+L62BB               fcc       /long/
+                    fcb       $00
+L62C0               fcc       /errno/
+                    fcb       $00
+L62C6               fcc       /lseek/
+                    fcb       $00
+L62CC               fcc       /out of memory/
+                    fcb       $00
+L62DA               fcc       /unterminated character constant/
+                    fcb       $00
+L62FA               asr       $2B00
+L62FD               fcc       /can't open strings file/
+                    fcb       $00
+L6315               fcc       /unterminated string/
+                    fcb       $00
+L6329               bra       L639D
                     dec       L6220
-                    bcs       $6398
+                    bcs       $6394
                     tst       $0000
-L6336               pshs      u
+L6332               pshs      u
                     leax      $060C,y
                     stx       $006A
                     clra
                     clrb
                     stb       $060C,y
                     ldd       #$0020
-                    bra       L636F
-                    pshs      u
-                    bra       L634F
+                    bra       L636B
 
-L634D               bsr       L635F
-L634F               ldb       $0065
+L6345               pshs      u
+                    bra       L634B
+
+L6349               bsr       L635B
+L634B               ldb       $0065
                     cmpb      #$20
-                    beq       L634D
+                    beq       L6349
                     ldb       $0065
                     cmpb      #$09
-                    lbeq      L634D
+                    lbeq      L6349
                     puls      pc,u
-L635F               pshs      u
+L635B               pshs      u
                     ldx       $006A
                     leax      $01,x
                     stx       $006A
                     ldb       -$01,x
                     stb       $0065
-                    bne       L6371
-                    bsr       L6373
-L636F               stb       $0065
-L6371               puls      pc,u
-L6373               pshs      u
+                    bne       L636D
+                    bsr       L636F
+L636B               stb       $0065
+L636D               puls      pc,u
+L636F               pshs      u
                     leas      -$08,s
                     ldd       L001D
-                    bne       L6389
+                    bne       L6385
                     ldd       #$0001
                     std       L001D
-                    leax      L6635,pcr
+                    leax      L6631,pcr
                     stx       $006A
-                    lbra      L656A
+                    lbra      L6566
 
-L6389               clra
+L6385               clra
                     clrb
                     std       L001D
                     leax      $060C,y
                     pshs      x
                     leax      $070C,y
                     pshs      x
-                    lbsr      L7315
+                    lbsr      L7311
                     leas      $04,s
-L639E               lbsr      L65A7
-L63A1               std       $006A
-                    lbeq      L64A8
+L639A               lbsr      L65A3
+L639D               std       $006A
+                    lbeq      L64A4
                     ldb       [$006A,y]
                     cmpb      #$23
-                    lbne      L6563
+                    lbne      L655F
                     ldx       $006A
                     ldb       $01,x
                     sex
                     std       $04,s
-                    lbsr      L65A7
+                    lbsr      L65A3
                     std       -$02,s
-                    lbeq      L64A8
+                    lbeq      L64A4
                     ldx       $04,s
-                    lbra      L652F
+                    lbra      L652B
 
-L63C6               leax      $060C,y
+L63C2               leax      $060C,y
                     pshs      x
-                    lbsr      L6571
+                    lbsr      L656D
                     leas      $02,s
                     std       L0027
-                    bra       L639E
+                    bra       L639A
 
-L63D5               lbsr      L6804
-L63D8               lbsr      $4BF0
+L63D1               lbsr      L6800
+L63D4               lbsr      L4BEC
                     leax      $060C,y
                     pshs      x
-                    leax      $6636,pcr
-                    lbra      L645A
+                    leax      $6632,pcr
+                    lbra      L6456
 
-L63E8               leax      $060C,y
+L63E4               leax      $060C,y
                     pshs      x
                     leax      $03EE,y
                     pshs      x
-                    lbsr      L7315
+                    lbsr      L7311
                     leas      $04,s
                     leax      $03EE,y
                     pshs      x
-                    lbsr      $4C03
+                    lbsr      L4BFF
                     leas      $02,s
-                    lbsr      L65A7
+                    lbsr      L65A3
                     std       -$02,s
-                    lbne      L639E
-                    lbra      L64A8
+                    lbne      L639A
+                    lbra      L64A4
 
-L6410               leax      $060C,y
+L640C               leax      $060C,y
                     pshs      x
                     leax      $02EE,y
                     pshs      x
-                    lbsr      L7315
+                    lbsr      L7311
                     leas      $04,s
-                    lbsr      L65A7
+                    lbsr      L65A3
                     std       -$02,s
-                    lbeq      L64A8
-                    lbsr      $4BF0
+                    lbeq      L64A4
+                    lbsr      L4BEC
                     leax      $060C,y
                     pshs      x
-                    lbsr      L6571
+                    lbsr      L656D
                     std       ,s
                     leax      $02EE,y
                     pshs      x
-                    leax      L663A,pcr
+                    leax      L6636,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $08,s
-                    lbsr      $4BF0
+                    lbsr      L4BEC
                     leax      $02EE,y
                     pshs      x
-                    leax      L6650,pcr
-L645A               pshs      x
+                    leax      L664C,pcr
+L6456               pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $06,s
-                    lbra      L639E
+                    lbra      L639A
 
-L6468               leax      $060C,y
+L6464               leax      $060C,y
                     pshs      x
                     leax      $02EE,y
                     pshs      x
-                    lbsr      L7315
+                    lbsr      L7311
                     leas      $04,s
-                    lbsr      L65A7
+                    lbsr      L65A3
                     std       -$02,s
-                    beq       L64A8
+                    beq       L64A4
                     leax      $060C,y
                     pshs      x
-                    lbsr      L6571
+                    lbsr      L656D
                     leas      $02,s
                     std       $06,s
-                    lbsr      L65A7
+                    lbsr      L65A3
                     std       -$02,s
-                    beq       L64A8
+                    beq       L64A4
                     leax      $060C,y
                     pshs      x
-                    lbsr      L6571
+                    lbsr      L656D
                     leas      $02,s
                     std       $02,s
-                    lbsr      L65A7
+                    lbsr      L65A3
                     std       -$02,s
-                    bne       L64AE
-L64A8               ldd       #$FFFF
-                    lbra      L656D
+                    bne       L64AA
+L64A4               ldd       #$FFFF
+                    lbra      L6569
 
-L64AE               ldd       $06,s
-                    beq       L64C9
+L64AA               ldd       $06,s
+                    beq       L64C5
                     ldd       $06,s
                     pshs      d
                     leax      $03EE,y
                     pshs      x
-                    leax      L6659,pcr
+                    leax      L6655,pcr
                     pshs      x
-                    lbsr      L50D2
+                    lbsr      $50CE
                     leas      $06,s
-                    bra       L64D4
+                    bra       L64D0
 
-L64C9               leax      L6667,pcr
+L64C5               leax      L6663,pcr
                     pshs      x
-                    lbsr      L50D2
+                    lbsr      $50CE
                     leas      $02,s
-L64D4               leax      $060C,y
+L64D0               leax      $060C,y
                     pshs      x
-                    leax      L6673,pcr
+                    leax      L666F,pcr
                     pshs      x
-                    lbsr      L50D2
+                    lbsr      $50CE
                     leas      $04,s
                     ldb       $02EE,y
-                    beq       L651F
+                    beq       L651B
                     leax      $02EE,y
                     pshs      x
-                    lbsr      L6E43
+                    lbsr      L6E3F
                     leas      $02,s
-                    bra       L6508
+                    bra       L6504
 
-L64F8               leax      $01C1,y
+L64F4               leax      $01C1,y
                     pshs      x
                     ldd       #$0020
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
-L6508               ldd       $02,s
+L6504               ldd       $02,s
                     addd      #$FFFF
                     std       $02,s
                     subd      #$FFFF
-                    bne       L64F8
-                    leax      $6681,pcr
+                    bne       L64F4
+                    leax      $667D,pcr
                     pshs      x
-                    lbsr      L6E43
+                    lbsr      L6E3F
                     leas      $02,s
-L651F               ldd       $04,s
+L651B               ldd       $04,s
                     cmpd      #$0031
-                    lbne      L639E
-                    lbsr      L68C5
-                    lbra      L639E
+                    lbne      L639A
+                    lbsr      L68C1
+                    lbra      L639A
 
-L652F               cmpx      #$0035
-                    lbeq      L63C6
+L652B               cmpx      #$0035
+                    lbeq      L63C2
                     cmpx      #$0036
-                    lbeq      L63D5
+                    lbeq      L63D1
                     cmpx      #$0032
-                    lbeq      L63D8
+                    lbeq      L63D4
                     cmpx      #$0037
-                    lbeq      L63E8
+                    lbeq      L63E4
                     cmpx      #$0050
-                    lbeq      L6410
+                    lbeq      L640C
                     cmpx      #$0030
-                    lbeq      L6468
+                    lbeq      L6464
                     cmpx      #$0031
-                    lbeq      L6468
-                    lbra      L639E
+                    lbeq      L6464
+                    lbra      L639A
 
-L6563               ldd       L0027
+L655F               ldd       L0027
                     addd      #$0001
                     std       L0027
-L656A               ldd       #$0020
-L656D               leas      $08,s
+L6566               ldd       #$0020
+L6569               leas      $08,s
                     puls      pc,u
-L6571               pshs      u
+L656D               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
-                    bra       L658E
+                    bra       L658A
 
-L657B               ldd       ,s
+L6577               ldd       ,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L7543
+                    lbsr      L753F
                     pshs      d
                     ldd       $04,s
                     addd      #$FFD0
                     addd      ,s++
-L658E               std       ,s
+L658A               std       ,s
                     ldb       ,u+
                     sex
                     std       $02,s
@@ -11200,151 +11217,154 @@ L658E               std       ,s
                     leax      d,x
                     ldb       ,x
                     cmpb      #$6b
-                    beq       L657B
+                    beq       L6577
                     ldd       ,s
                     leas      $04,s
                     puls      pc,u
-L65A7               pshs      u,d
+L65A3               pshs      u,d
                     leau      $060C,y
                     ldd       L0023
                     pshs      d
-                    lbsr      L7120
+                    lbsr      L711C
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    lbne      L6610
+                    lbne      L660C
                     ldx       L0023
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L65DD
+                    beq       L65D9
                     leax      $01CE,y
                     pshs      x
-                    leax      $6683,pcr
+                    leax      $667F,pcr
                     pshs      x
-                    lbsr      L6E65
+                    lbsr      L6E61
                     leas      $04,s
-                    lbsr      L68C5
-L65DD               clra
+                    lbsr      L68C1
+L65D9               clra
                     clrb
-                    bra       L6631
+                    bra       L662D
 
-L65E1               ldx       ,s
-                    bra       L6602
+L65DD               ldx       ,s
+                    bra       L65FE
 
-L65E5               clra
+L65E1               clra
                     clrb
                     stb       ,u
                     leax      $060C,y
                     tfr       x,d
-                    bra       L6631
+                    bra       L662D
 
-L65F1               ldd       ,s
+L65ED               ldd       ,s
                     stb       ,u+
                     ldd       L0023
                     pshs      d
-                    lbsr      L7120
+                    lbsr      L711C
                     leas      $02,s
                     std       ,s
-                    bra       L6610
+                    bra       L660C
 
-L6602               cmpx      #$000D
-                    beq       L65E5
+L65FE               cmpx      #$000D
+                    beq       L65E1
                     cmpx      #$FFFF
-                    lbeq      L65E5
-                    bra       L65F1
+                    lbeq      L65E1
+                    bra       L65ED
 
-L6610               cmpu      $0189,y
-                    bne       L65E1
+L660C               cmpu      $0189,y
+                    bne       L65DD
                     ldd       L0027
                     addd      #$0001
                     std       L0027
                     std       L003F
                     leax      $060C,y
                     stx       $0063
-                    leax      >L66A6,pcr
+                    leax      >L66A2,pcr
                     pshs      x
-                    lbsr      $022C
+                    lbsr      L0228
                     leas      $02,s
-L6631               leas      $02,s
+L662D               leas      $02,s
                     puls      pc,u
-L6635               neg       $0025
-                    com       L0D00
-L663A               bra       L66AC
+L6631               neg       $0025
+                    com       $0D00
+L6636               bra       L66A8
                     fcc       /sect %s,0,0,%d,0,0/
                     fcb       $0D,$00
-L6650               bra       $66C0
+L664C               bra       $66BC
                     fcb       $61
                     tst       0,y
-                    bcs       $66CA
+                    bcs       $66C6
                     tst       $0000
-L6659               fcc       /%s : line %d /
+L6655               fcc       /%s : line %d /
                     fcb       $00
-L6667               fcc       /argument : /
+L6663               fcc       /argument : /
                     fcb       $00
-L6673               bpl       L669F
-                    bpl       L66A1
-                    bra       L669E
-                    com       L202A
-                    bpl       L66A8
-                    bpl       L668D
+L666F               bpl       L669B
+                    bpl       L669D
+                    bra       L669A
+                    com       $202A
+                    bpl       L66A4
+                    bpl       L6689
                     neg       $005E
                     neg       L0049
                     fcc       /NPUT FILE/
-L668D               fcc       / ERROR : TEMPORAR/
-L669E               fcb       $59
-L669F               fcb       $20,$46
-L66A1               fcb       $49,$4C,$45
+L6689               fcc       / ERROR : TEMPORAR/
+L669A               fcb       $59
+L669B               fcb       $20,$46
+L669D               fcb       $49,$4C,$45
                     fcb       $0D,$00
-L66A6               fcb       $69,$6E
-L66A8               fcc       /put /
-L66AC               fcc       /line too long/
+L66A2               fcb       $69,$6E
+L66A4               fcc       /put /
+L66A8               fcc       /line too long/
                     fcb       $00
-L66BA               pshs      u
-                    lbsr      L6871
-                    lbra      L6718
-                    pshs      u
+L66B6               pshs      u
+                    lbsr      L686D
+                    lbra      L6714
+
+L66BE               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6815
+                    lbsr      L6811
                     leas      $02,s
-                    lbsr      $4BF0
+                    lbsr      L4BEC
                     ldd       $04,s
                     pshs      d
-                    lbsr      $4B05
+                    lbsr      L4B01
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
-                    leax      L691E,pcr
+                    leax      L691A,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      $50E7
-                    bra       L6716
-                    pshs      u
+                    lbsr      L50E3
+                    bra       L6712
+
+L66E8               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6815
+                    lbsr      L6811
                     leas      $02,s
                     ldd       #$003A
-                    bra       L670A
-                    pshs      u
+                    bra       L6706
+
+L66F8               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6815
+                    lbsr      L6811
                     leas      $02,s
                     ldd       #$0020
-L670A               pshs      d
+L6706               pshs      d
                     ldd       $08,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    bsr       L671D
-L6716               leas      $06,s
-L6718               lbsr      L6825
+                    bsr       L6719
+L6712               leas      $06,s
+L6714               lbsr      L6821
                     puls      pc,u
-L671D               pshs      u
-                    lbsr      $4BF0
+L6719               pshs      u
+                    lbsr      L4BEC
                     ldd       $06,s
                     pshs      d
                     ldb       $0b,s
@@ -11353,125 +11373,127 @@ L671D               pshs      u
                     ldd       $08,s
                     addd      #$0014
                     pshs      d
-                    leax      $6927,pcr
+                    leax      $6923,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $0a,s
                     puls      pc,u
-                    pshs      u
+L673F               pshs      u
                     ldd       $0025
                     pshs      d
                     ldd       #$0053
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $0025
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $0035
-                    bne       L6776
+                    bne       L6772
                     ldd       $0025
                     pshs      d
                     ldd       L002B
                     addd      #$0001
                     std       L002B
                     pshs      d
-                    lbsr      L6FAA
+                    lbsr      L6FA6
                     leas      $04,s
-L6776               clra
+L6772               clra
                     clrb
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      $6936,pcr
+                    leax      $6932,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $08,s
                     ldd       L0037
-                    lbeq      L67E6
+                    lbeq      L67E2
                     ldd       $0025
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L6FAA
-                    bra       L67E4
-                    pshs      u
+                    lbsr      L6FA6
+                    bra       L67E0
+
+L679C               pshs      u
                     ldd       #$0070
                     pshs      d
-                    lbsr      $4A89
+                    lbsr      L4A85
                     leas      $02,s
                     ldd       $0025
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6FAA
+                    lbsr      L6FA6
                     leas      $04,s
                     clra
                     clrb
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      L693D,pcr
+                    leax      L6939,pcr
                     pshs      x
                     ldd       $0025
                     pshs      d
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $08,s
                     puls      pc,u
-                    pshs      u
+L67CE               pshs      u
                     ldd       $0035
-                    bne       L67E6
+                    bne       L67E2
                     ldd       $0025
                     pshs      d
                     ldd       #$0045
                     pshs      d
-                    lbsr      L6F05
-L67E4               leas      $04,s
-L67E6               puls      pc,u
-                    pshs      u
-                    lbsr      $4BF0
-                    leax      L6944,pcr
-                    bra       L67FC
-                    pshs      u
-                    lbsr      $4BF0
-                    leax      L6949,pcr
-L67FC               pshs      x
-                    lbsr      $4A48
-                    lbra      L691A
+                    lbsr      L6F01
+L67E0               leas      $04,s
+L67E2               puls      pc,u
+L67E4               pshs      u
+                    lbsr      L4BEC
+                    leax      L6940,pcr
+                    bra       L67F8
 
-L6804               pshs      u
-                    lbsr      $4BF0
-                    leax      L694E,pcr
+L67EF               pshs      u
+                    lbsr      L4BEC
+                    leax      L6945,pcr
+L67F8               pshs      x
+                    lbsr      L4A44
+                    lbra      L6916
+
+L6800               pshs      u
+                    lbsr      L4BEC
+                    leax      L694A,pcr
                     pshs      x
-                    lbsr      $4A9F
-                    lbra      L691A
+                    lbsr      L4A9B
+                    lbra      L6916
 
-L6815               pshs      u
+L6811               pshs      u
                     ldd       $04,s
-                    beq       L6820
+                    beq       L681C
                     ldd       #$0064
-                    bra       L682A
+                    bra       L6826
 
-L6820               ldd       #$0076
-                    bra       L682A
+L681C               ldd       #$0076
+                    bra       L6826
 
-L6825               pshs      u
+L6821               pshs      u
                     ldd       #$0065
-L682A               pshs      d
-                    lbsr      $4A89
-                    lbra      L691A
+L6826               pshs      d
+                    lbsr      L4A85
+                    lbra      L6916
 
-L6832               pshs      u
+L682E               pshs      u
                     ldd       $04,s
                     pshs      d
-                    lbsr      L7030
+                    lbsr      L702C
                     leas      $02,s
                     ldx       $04,s
                     ldd       $02,x
@@ -11495,113 +11517,113 @@ L6832               pshs      u
                     ldx       $0a,s
                     ldd       $08,x
                     pshs      d
-                    lbsr      L77E4
+                    lbsr      L77E0
                     leas      $08,s
                     ldd       $02C8,y
                     puls      pc,u
-L6871               pshs      u
+L686D               pshs      u
                     ldd       $006C
-                    lbeq      L691C
+                    lbeq      L6918
                     ldd       $006C
                     pshs      d
-                    bsr       L6832
+                    bsr       L682E
                     leas      $02,s
-                    bra       L688E
+                    bra       L688A
 
-L6883               ldd       $0025
+L687F               ldd       $0025
                     pshs      d
                     pshs      u
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
-L688E               ldd       $006C
+L688A               ldd       $006C
                     pshs      d
-                    lbsr      L7120
+                    lbsr      L711C
                     leas      $02,s
                     tfr       d,u
                     cmpu      #$FFFF
-                    bne       L6883
+                    bne       L687F
                     ldx       $006C
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L68B1
-                    leax      $6951,pcr
+                    beq       L68AD
+                    leax      $694D,pcr
                     ldd       $06,x
                     clra
                     andb      #$20
-L68B1               ldd       $006C
+L68AD               ldd       $006C
                     pshs      d
-                    lbsr      L6FF6
+                    lbsr      L6FF2
                     leas      $02,s
                     leax      $01A9,y
                     pshs      x
-                    lbsr      L7775
-                    bra       L691A
+                    lbsr      L7771
+                    bra       L6916
 
-L68C5               pshs      u,d
+L68C1               pshs      u,d
                     ldd       $02D2,y
-                    beq       L68D3
+                    beq       L68CF
                     ldd       $02D2,y
-                    bra       L68D6
+                    bra       L68D2
 
-L68D3               ldd       #$0001
-L68D6               std       ,s
+L68CF               ldd       #$0001
+L68D2               std       ,s
                     leax      $01C1,y
                     pshs      x
-                    lbsr      L7030
+                    lbsr      L702C
                     leas      $02,s
                     ldd       $006C
-                    beq       L68FB
+                    beq       L68F7
                     ldd       $006C
                     pshs      d
-                    lbsr      L6FF6
+                    lbsr      L6FF2
                     leas      $02,s
                     leax      $01A9,y
                     pshs      x
-                    lbsr      L7775
+                    lbsr      L7771
                     leas      $02,s
-L68FB               ldd       $001F
-                    beq       L6911
+L68F7               ldd       $001F
+                    beq       L690D
                     ldd       L0023
                     pshs      d
-                    lbsr      L6FF6
+                    lbsr      L6FF2
                     leas      $02,s
                     ldd       $001F
                     pshs      d
-                    lbsr      L7775
+                    lbsr      L7771
                     leas      $02,s
-L6911               ldd       ,s
+L690D               ldd       ,s
                     pshs      d
-                    lbsr      L794A
+                    lbsr      L7946
                     leas      $02,s
-L691A               leas      $02,s
-L691C               puls      pc,u
-L691E               bra       $6992
+L6916               leas      $02,s
+L6918               puls      pc,u
+L691A               bra       $698E
                     tst       $02,s
-                    bra       L6949
+                    bra       L6945
                     lsr       $0d,x
                     neg       $0025
-                    bgt       $6962
-                    com       $2563
-                    bra       L69A1
+                    bgt       $695E
+                    com       L2563
+                    bra       L699D
                     tst       $02,s
-                    bra       L6958
+                    bra       L6954
                     lsr       $0d,x
                     neg       $0025
                     fcc       /.8s%c/
                     fcb       $00
-L693D               fcc       /%.8s%c/
+L6939               fcc       /%.8s%c/
                     fcb       $00
-L6944               fcc       /fcb /
+L6940               fcc       /fcb /
                     fcb       $00
-L6949               fcc       /fdb /
+L6945               fcc       /fdb /
                     fcb       $00
-L694E               bpl       $6970
+L694A               bpl       $696C
                     neg       L0064
                     fcc       /umpstr/
-L6958               fcc       /ings/
-L695C               fcb       $00
-L695D               pshs      u
+L6954               fcc       /ings/
+                    fcb       $00
+L6959               pshs      u
                     leau      $02C6,y
                     ldd       ,x
                     std       ,u
@@ -11613,38 +11635,39 @@ L695D               pshs      u
                     std       $06,u
                     tfr       u,x
                     puls      pc,u
-                    bsr       L695D
+L6973               bsr       L6959
                     lda       ,x
                     eora      #$80
                     sta       ,x
-L697F               rts
-                    bsr       L6985
-                    ldd       $02,x
-L6984               rts
+                    rts
 
-L6985               lda       ,x
+L697C               bsr       L6981
+                    ldd       $02,x
+                    rts
+
+L6981               lda       ,x
                     pshs      a
-                    bsr       L695D
-                    bsr       L6997
+                    bsr       L6959
+                    bsr       L6993
                     leax      $03,x
                     lda       ,s+
-                    bpl       L6996
-                    lbra      L749A
+                    bpl       L6992
+                    lbra      L7496
 
-L6996               rts
+L6992               rts
 
-L6997               lda       $07,x
-                    blt       L69C5
+L6993               lda       $07,x
+                    blt       L69C1
                     pshs      x
                     leax      $07,x
                     pshs      x,a
-L69A1               bra       L69BD
+L699D               bra       L69B9
 
-L69A3               ldx       $01,s
+L699F               ldx       $01,s
                     ldb       #$06
                     pshs      b
                     clra
-L69AA               pshs      a
+L69A6               pshs      a
                     lda       #$0a
                     ldb       ,-x
                     mul
@@ -11652,19 +11675,19 @@ L69AA               pshs      a
                     adca      #$00
                     stb       ,x
                     dec       ,s
-                    bpl       L69AA
+                    bpl       L69A6
                     leas      $01,s
-L69BD               dec       ,s
-                    bge       L69A3
+L69B9               dec       ,s
+                    bge       L699F
                     leas      $03,s
                     puls      pc,x
-L69C5               pshs      u,x,a
+L69C1               pshs      u,x,a
                     leau      $07,x
                     pshs      u
-L69CB               cmpx      ,s
-                    bcc       L69FF
+L69C7               cmpx      ,s
+                    bcc       L69FB
                     lda       ,x+
-                    beq       L69CB
+                    beq       L69C7
                     leax      -$01,x
                     pshs      x
                     clrb
@@ -11675,24 +11698,24 @@ L69CB               cmpx      ,s
                     asl       ,x
                     rolb
                     lda       #$05
-L69E3               asl       ,x
+L69DF               asl       ,x
                     rolb
                     cmpb      #$0a
-                    bcs       L69EE
+                    bcs       L69EA
                     subb      #$0a
                     inc       ,x
-L69EE               deca
-                    bne       L69E3
+L69EA               deca
+                    bne       L69DF
                     lda       #$08
                     leax      $01,x
                     cmpx      $02,s
-                    bcs       L69E3
+                    bcs       L69DF
                     puls      x
                     inc       $02,s
-                    bne       L69CB
-L69FF               leas      $03,s
+                    bne       L69C7
+L69FB               leas      $03,s
                     puls      pc,u,x
-                    pshs      u
+L69FF               pshs      u
                     ldu       $04,s
                     exg       x,u
                     ldd       ,u
@@ -11706,16 +11729,17 @@ L69FF               leas      $03,s
                     puls      u
                     puls      d
                     std       ,s
-L6A1F               rts
-                    leax      $02C6,y
+                    rts
+
+L6A1C               leax      $02C6,y
                     std       -$02,s
-                    bpl       L6A3B
+                    bpl       L6A37
                     nega
                     negb
                     sbca      #$00
                     std       $05,x
                     lda       #$80
-L6A30               sta       ,x
+L6A2C               sta       ,x
                     clra
                     clrb
                     std       $01,x
@@ -11723,10 +11747,11 @@ L6A30               sta       ,x
                     sta       $07,x
                     rts
 
-L6A3B               std       $05,x
+L6A37               std       $05,x
                     clra
-                    bra       L6A30
-                    pshs      u
+                    bra       L6A2C
+
+L6A3C               pshs      u
                     leau      $02C6,y
                     clra
                     clrb
@@ -11739,7 +11764,7 @@ L6A3B               std       $05,x
                     std       $05,u
                     clr       $07,u
                     ldd       ,s++
-                    bpl       L6A70
+                    bpl       L6A6C
                     lda       #$80
                     sta       ,u
                     ldd       #$0000
@@ -11749,269 +11774,269 @@ L6A3B               std       $05,x
                     sbcb      $04,u
                     sbca      $03,u
                     std       $03,u
-L6A70               tfr       u,x
+L6A6C               tfr       u,x
                     puls      pc,u
-                    pshs      u
-                    leax      L68C5,pcr
+L6A70               pshs      u
+                    leax      L68C1,pcr
                     pshs      x
-                    lbsr      L7914
+                    lbsr      L7910
                     leas      $02,s
                     leax      $01A9,y
                     pshs      x
-                    lbsr      L6E85
+                    lbsr      L6E81
                     leas      $02,s
-                    leax      L6C19,pcr
+                    leax      L6C15,pcr
                     pshs      x
                     ldd       $01A7,y
                     pshs      d
-                    lbsr      L7315
+                    lbsr      L7311
                     leas      $04,s
-                    lbsr      $589B
+                    lbsr      L5897
                     leax      $01B4,y
                     stx       L0023
                     leax      $01C1,y
                     stx       $0025
-                    lbra      L6BA1
+                    lbra      L6B9D
 
-L6AAF               ldx       $06,s
+L6AAB               ldx       $06,s
                     leax      $02,x
                     stx       $06,s
                     ldu       ,x
                     ldb       ,u
                     cmpb      #$2d
-                    lbne      L6B6C
-                    lbra      L6B5E
+                    lbne      L6B68
+                    lbra      L6B5A
 
-L6AC2               ldb       ,u
+L6ABE               ldb       ,u
                     sex
                     tfr       d,x
-                    lbra      L6B3B
+                    lbra      L6B37
 
-L6ACA               ldd       #$0001
+L6AC6               ldd       #$0001
                     std       $0021
-                    lbra      L6B5E
+                    lbra      L6B5A
 
-L6AD2               ldd       #$0001
+L6ACE               ldd       #$0001
                     std       $0035
-                    lbra      L6B5E
+                    lbra      L6B5A
 
-L6ADA               ldd       L0039
+L6AD6               ldd       L0039
                     addd      #$0001
                     std       L0039
-                    lbra      L6B5E
+                    lbra      L6B5A
 
-L6AE4               leau      $01,u
+L6AE0               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    bne       L6B15
-                    leax      L6C21,pcr
+                    bne       L6B11
+                    leax      L6C1D,pcr
                     pshs      x
                     leau      $01,u
                     pshs      u
-                    lbsr      L6DF1
+                    lbsr      L6DED
                     leas      $04,s
                     std       $0025
-                    bne       L6B15
+                    bne       L6B11
                     pshs      u
-                    leax      $6C23,pcr
+                    leax      $6C1F,pcr
                     pshs      x
                     leax      $01CE,y
                     pshs      x
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $06,s
-                    lbsr      L6BFE
-L6B15               leax      ,s
-                    bra       L6B68
+                    lbsr      L6BFA
+L6B11               leax      ,s
+                    bra       L6B64
 
-L6B19               ldd       #$0001
+L6B15               ldd       #$0001
                     std       L0037
-                    bra       L6B5E
+                    bra       L6B5A
 
-L6B20               ldb       ,u
+L6B1C               ldb       ,u
                     sex
                     pshs      d
-                    leax      L6C32,pcr
+                    leax      L6C2E,pcr
                     pshs      x
                     leax      $01CE,y
                     pshs      x
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $06,s
-                    lbsr      L6BFE
-                    bra       L6B5E
+                    lbsr      L6BFA
+                    bra       L6B5A
 
-L6B3B               cmpx      #$0065
-                    lbeq      L6ACA
+L6B37               cmpx      #$0065
+                    lbeq      L6AC6
                     cmpx      #$0073
-                    lbeq      L6AD2
+                    lbeq      L6ACE
                     cmpx      #$006E
-                    lbeq      L6ADA
+                    lbeq      L6AD6
                     cmpx      #$006F
-                    lbeq      L6AE4
+                    lbeq      L6AE0
                     cmpx      #$0070
-                    beq       L6B19
-                    bra       L6B20
+                    beq       L6B15
+                    bra       L6B1C
 
-L6B5E               leau      $01,u
+L6B5A               leau      $01,u
                     ldb       ,u
-                    lbne      L6AC2
-                    bra       L6BA1
+                    lbne      L6ABE
+                    bra       L6B9D
 
-L6B68               leas      ,x
-                    bra       L6BA1
+L6B64               leas      ,x
+                    bra       L6B9D
 
-L6B6C               ldd       $0072
-                    bne       L6BA1
+L6B68               ldd       $0072
+                    bne       L6B9D
                     ldd       $0072
                     addd      #$0001
                     std       $0072
                     leax      $01B4,y
                     pshs      x
-                    leax      L6C46,pcr
+                    leax      L6C42,pcr
                     pshs      x
                     ldd       [$0a,s]
                     pshs      d
-                    lbsr      L6E10
+                    lbsr      L6E0C
                     leas      $06,s
                     std       L0023
-                    bne       L6B9C
-                    leax      $6C48,pcr
+                    bne       L6B98
+                    leax      $6C44,pcr
                     pshs      x
-                    lbsr      $022C
+                    lbsr      L0228
                     leas      $02,s
-L6B9C               ldd       [$06,s]
+L6B98               ldd       [$06,s]
                     std       $001F
-L6BA1               ldd       $04,s
+L6B9D               ldd       $04,s
                     addd      #$FFFF
                     std       $04,s
-                    lbgt      L6AAF
-                    lbsr      L6336
-                    lbsr      $552F
-                    bra       L6BB7
+                    lbgt      L6AAB
+                    lbsr      L6332
+                    lbsr      L552B
+                    bra       L6BB3
 
-L6BB4               lbsr      $322B
-L6BB7               ldd       $005F
+L6BB0               lbsr      L3227
+L6BB3               ldd       $005F
                     cmpd      #$FFFF
-                    bne       L6BB4
-                    lbsr      L66BA
+                    bne       L6BB0
+                    lbsr      L66B6
                     ldx       $0025
                     ldd       $06,x
                     clra
                     andb      #$20
-                    beq       L6BD6
-                    leax      L6C5E,pcr
+                    beq       L6BD2
+                    leax      L6C5A,pcr
                     pshs      x
-                    lbsr      $022C
+                    lbsr      L0228
                     leas      $02,s
-L6BD6               leax      $01C1,y
+L6BD2               leax      $01C1,y
                     pshs      x
-                    lbsr      L7030
+                    lbsr      L702C
                     leas      $02,s
                     ldd       L0029
-                    beq       L6BFC
+                    beq       L6BF8
                     ldd       L0029
                     pshs      d
-                    leax      L6C7F,pcr
+                    leax      L6C7B,pcr
                     pshs      x
                     leax      $01CE,y
                     pshs      x
-                    lbsr      $50E7
+                    lbsr      L50E3
                     leas      $06,s
-                    bsr       L6BFE
-L6BFC               puls      pc,u
-L6BFE               pshs      u
+                    bsr       L6BFA
+L6BF8               puls      pc,u
+L6BFA               pshs      u
                     ldd       $001F
-                    beq       L6C0D
+                    beq       L6C09
                     ldd       $001F
                     pshs      d
-                    lbsr      L7775
+                    lbsr      L7771
                     leas      $02,s
-L6C0D               ldd       #$0001
+L6C09               ldd       #$0001
                     pshs      d
-                    lbsr      L7944
+                    lbsr      L7940
                     leas      $02,s
                     puls      pc,u
-L6C19               clrb
+L6C15               clrb
                     fcc       /dummy_/
                     fcb       $00
-L6C21               asr       >$0063
+L6C1D               asr       >$0063
                     fcb       $61
                     jmp       $07,y
-                    lsr       $206F
+                    lsr       L206F
                     neg       $656E
-                    bra       L6C54
-                    com       L0D00
-L6C32               fcc       /unknown flag : -%c/
+                    bra       L6C50
+                    com       $0D00
+L6C2E               fcc       /unknown flag : -%c/
                     fcb       $0D,$00
-L6C46               fcb       $72
+L6C42               fcb       $72
                     neg       $0063
                     fcc       /an't open i/
-L6C54               fcc       /nput file/
+L6C50               fcc       /nput file/
                     fcb       $00
-L6C5E               fcc       /error writing assembly code file/
+L6C5A               fcc       /error writing assembly code file/
                     fcb       $00
-L6C7F               fcc       /errors in compilation : %d/
+L6C7B               fcc       /errors in compilation : %d/
                     fcb       $0D,$00
-L6C9B               pshs      u
+L6C97               pshs      u
                     leau      $01B4,y
-L6CA1               ldd       $06,u
+L6C9D               ldd       $06,u
                     clra
                     andb      #$03
-                    lbeq      L6D12
+                    lbeq      L6D0E
                     leau      $0d,u
                     pshs      u
                     leax      $0284,y
                     cmpx      ,s++
-                    bhi       L6CA1
+                    bhi       L6C9D
                     ldd       #$00C8
                     std       $02D2,y
-                    lbra      L6D16
+                    lbra      L6D12
                     puls      pc,u
-L6CC2               pshs      u
+L6CBE               pshs      u
                     ldu       $08,s
-                    bne       L6CCC
-                    bsr       L6C9B
+                    bne       L6CC8
+                    bsr       L6C97
                     tfr       d,u
-L6CCC               stu       -$02,s
-                    beq       L6D16
+L6CC8               stu       -$02,s
+                    beq       L6D12
                     ldd       $04,s
                     std       $08,u
                     ldx       $06,s
                     ldb       $01,x
                     cmpb      #$2b
-                    beq       L6CE4
+                    beq       L6CE0
                     ldx       $06,s
                     ldb       $02,x
                     cmpb      #$2b
-                    bne       L6CEA
-L6CE4               ldd       $06,u
+                    bne       L6CE6
+L6CE0               ldd       $06,u
                     orb       #$03
-                    bra       L6D08
+                    bra       L6D04
 
-L6CEA               ldd       $06,u
+L6CE6               ldd       $06,u
                     pshs      d
                     ldb       [$08,s]
                     cmpb      #$72
-                    beq       L6CFC
+                    beq       L6CF8
                     ldb       [$08,s]
                     cmpb      #$64
-                    bne       L6D01
-L6CFC               ldd       #$0001
-                    bra       L6D04
+                    bne       L6CFD
+L6CF8               ldd       #$0001
+                    bra       L6D00
 
-L6D01               ldd       #$0002
-L6D04               ora       ,s+
+L6CFD               ldd       #$0002
+L6D00               ora       ,s+
                     orb       ,s+
-L6D08               std       $06,u
+L6D04               std       $06,u
                     ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
-L6D12               tfr       u,d
+L6D0E               tfr       u,d
                     puls      pc,u
-L6D16               clra
+L6D12               clra
                     clrb
                     puls      pc,u
-L6D1A               pshs      u
+L6D16               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -12021,51 +12046,51 @@ L6D1A               pshs      u
                     ldb       $01,x
                     sex
                     tfr       d,x
-                    bra       L6D4B
+                    bra       L6D47
 
-L6D2D               ldx       $0a,s
+L6D29               ldx       $0a,s
                     ldb       $02,x
                     cmpb      #$2b
-                    bne       L6D3A
+                    bne       L6D36
                     ldd       #$0007
-                    bra       L6D42
+                    bra       L6D3E
 
-L6D3A               ldd       #$0004
-                    bra       L6D42
+L6D36               ldd       #$0004
+                    bra       L6D3E
 
-L6D3F               ldd       #$0003
-L6D42               std       ,s
-                    bra       L6D5B
+L6D3B               ldd       #$0003
+L6D3E               std       ,s
+                    bra       L6D57
 
-L6D46               leax      $04,s
-                    lbra      L6DB3
+L6D42               leax      $04,s
+                    lbra      L6DAF
 
-L6D4B               stx       -$02,s
-                    beq       L6D5B
+L6D47               stx       -$02,s
+                    beq       L6D57
                     cmpx      #$0078
-                    beq       L6D2D
+                    beq       L6D29
                     cmpx      #$002B
-                    beq       L6D3F
-                    bra       L6D46
+                    beq       L6D3B
+                    bra       L6D42
 
-L6D5B               ldb       [$0a,s]
+L6D57               ldb       [$0a,s]
                     sex
                     tfr       d,x
-                    lbra      L6DC0
+                    lbra      L6DBC
 
-L6D64               ldd       ,s
+L6D60               ldd       ,s
                     orb       #$01
-                    bra       L6DA6
+                    bra       L6DA2
 
-L6D6A               ldd       ,s
+L6D66               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      L770E
+                    lbsr      L770A
                     leas      $04,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L6D95
+                    beq       L6D91
                     ldd       #$0002
                     pshs      d
                     clra
@@ -12074,45 +12099,45 @@ L6D6A               ldd       ,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L77E4
+                    lbsr      L77E0
                     leas      $08,s
-                    bra       L6DDA
+                    bra       L6DD6
 
-L6D95               ldd       ,s
+L6D91               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      L772F
-                    bra       L6DAD
+                    lbsr      L772B
+                    bra       L6DA9
 
-L6DA2               ldd       ,s
+L6D9E               ldd       ,s
                     orb       #$81
-L6DA6               pshs      d
+L6DA2               pshs      d
                     pshs      u
-                    lbsr      L770E
-L6DAD               leas      $04,s
+                    lbsr      L770A
+L6DA9               leas      $04,s
                     std       $02,s
-                    bra       L6DDA
+                    bra       L6DD6
 
-L6DB3               leas      -$04,x
-L6DB5               ldd       #$00CB
+L6DAF               leas      -$04,x
+L6DB1               ldd       #$00CB
                     std       $02D2,y
                     clra
                     clrb
-                    bra       L6DDC
+                    bra       L6DD8
 
-L6DC0               cmpx      #$0072
-                    lbeq      L6D64
+L6DBC               cmpx      #$0072
+                    lbeq      L6D60
                     cmpx      #$0061
-                    lbeq      L6D6A
+                    lbeq      L6D66
                     cmpx      #$0077
-                    beq       L6D95
+                    beq       L6D91
                     cmpx      #$0064
-                    beq       L6DA2
-                    bra       L6DB5
+                    beq       L6D9E
+                    bra       L6DB1
 
-L6DDA               ldd       $02,s
-L6DDC               leas      $04,s
+L6DD6               ldd       $02,s
+L6DD8               leas      $04,s
                     puls      pc,u
                     pshs      u
                     clra
@@ -12122,167 +12147,167 @@ L6DDC               leas      $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbra      L6E3C
+                    lbra      L6E38
 
-L6DF1               pshs      u
+L6DED               pshs      u
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L6D1A
+                    lbsr      L6D16
                     leas      $04,s
                     tfr       d,u
                     cmpu      #$FFFF
-                    bne       L6E0C
+                    bne       L6E08
                     clra
                     clrb
-                    bra       L6E41
+                    bra       L6E3D
 
-L6E0C               clra
+L6E08               clra
                     clrb
-                    bra       L6E34
+                    bra       L6E30
 
-L6E10               pshs      u
+L6E0C               pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6FF6
+                    lbsr      L6FF2
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L6D1A
+                    lbsr      L6D16
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    bge       L6E32
+                    bge       L6E2E
                     clra
                     clrb
-                    bra       L6E41
+                    bra       L6E3D
 
-L6E32               ldd       $08,s
-L6E34               pshs      d
+L6E2E               ldd       $08,s
+L6E30               pshs      d
                     ldd       $08,s
                     pshs      d
                     pshs      u
-L6E3C               lbsr      L6CC2
+L6E38               lbsr      L6CBE
                     leas      $06,s
-L6E41               puls      pc,u
-L6E43               pshs      u
+L6E3D               puls      pc,u
+L6E3F               pshs      u
                     leax      $01C1,y
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    bsr       L6E65
+                    bsr       L6E61
                     leas      $04,s
                     leax      $01C1,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     puls      pc,u
-L6E65               pshs      u
+L6E61               pshs      u
                     ldu       $04,s
                     leas      -$01,s
-                    bra       L6E7B
+                    bra       L6E77
 
-L6E6D               ldd       $07,s
+L6E69               ldd       $07,s
                     pshs      d
                     ldb       $02,s
                     sex
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
-L6E7B               ldb       ,u+
+L6E77               ldb       ,u+
                     stb       ,s
-                    bne       L6E6D
+                    bne       L6E69
                     leas      $01,s
                     puls      pc,u
-L6E85               pshs      u,d
+L6E81               pshs      u,d
                     ldu       $06,s
-                    bra       L6E8D
+                    bra       L6E89
 
-L6E8B               leau      $01,u
-L6E8D               ldb       ,u
+L6E87               leau      $01,u
+L6E89               ldb       ,u
                     sex
                     std       ,s
-                    beq       L6E9C
+                    beq       L6E98
                     ldd       ,s
                     cmpd      #$0058
-                    bne       L6E8B
-L6E9C               ldd       ,s
-                    beq       L6EB2
-                    lbsr      L78CF
+                    bne       L6E87
+L6E98               ldd       ,s
+                    beq       L6EAE
+                    lbsr      L78CB
                     pshs      d
-                    leax      >L6EB8,pcr
+                    leax      >L6EB4,pcr
                     pshs      x
                     pshs      u
-                    lbsr      $5100
+                    lbsr      L50FC
                     leas      $06,s
-L6EB2               ldd       $06,s
+L6EAE               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
-L6EB8               bcs       L6F1E
-L6EBA               neg       $0034
+L6EB4               bcs       L6F1A
+                    neg       $0034
                     nega
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
-                    bra       L6EF6
+                    bra       L6EF2
 
-L6EC5               clra
+L6EC1               clra
                     clrb
                     std       ,s
-                    bra       L6EE2
+                    bra       L6EDE
 
-L6ECB               ldd       $0e,s
+L6EC7               ldd       $0e,s
                     pshs      d
                     ldb       ,u+
                     sex
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldx       $0e,s
                     ldd       $06,x
                     clra
                     andb      #$20
-                    bne       L6EFF
-L6EE2               ldd       ,s
+                    bne       L6EFB
+L6EDE               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      $0a,s
-                    blt       L6ECB
+                    blt       L6EC7
                     ldd       $02,s
                     addd      #$0001
-L6EF6               std       $02,s
+L6EF2               std       $02,s
                     ldd       $02,s
                     cmpd      $0C,s
-                    blt       L6EC5
-L6EFF               ldd       $02,s
+                    blt       L6EC1
+L6EFB               ldd       $02,s
                     leas      $04,s
                     puls      pc,u
-L6F05               pshs      u
+L6F01               pshs      u
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$22
                     cmpd      #$8002
-                    beq       L6F29
+                    beq       L6F25
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-L6F1E               lbne      L7041
+L6F1A               lbne      L703D
                     pshs      u
-                    lbsr      L7274
+                    lbsr      L7270
                     leas      $02,s
-L6F29               ldd       $06,u
+L6F25               ldd       $06,u
                     clra
                     andb      #$04
-                    beq       L6F65
+                    beq       L6F61
                     ldd       #$0001
                     pshs      d
                     leax      $07,s
@@ -12292,31 +12317,31 @@ L6F29               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L6F4A
-                    leax      L77D4,pcr
-                    bra       L6F4E
+                    beq       L6F46
+                    leax      L77D0,pcr
+                    bra       L6F4A
 
-L6F4A               leax      L77BB,pcr
-L6F4E               tfr       x,d
+L6F46               leax      L77B7,pcr
+L6F4A               tfr       x,d
                     tfr       d,x
                     jsr       ,x
                     leas      $06,s
                     cmpd      #$FFFF
-                    bne       L6FA6
+                    bne       L6FA2
                     ldd       $06,u
                     orb       #$20
                     std       $06,u
-                    lbra      L7041
+                    lbra      L703D
 
-L6F65               ldd       $06,u
+L6F61               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L6F75
+                    bne       L6F71
                     pshs      u
-                    lbsr      L705E
+                    lbsr      L705A
                     leas      $02,s
-L6F75               ldd       ,u
+L6F71               ldd       ,u
                     addd      #$0001
                     std       ,u
                     subd      #$0001
@@ -12325,126 +12350,126 @@ L6F75               ldd       ,u
                     stb       ,x
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L6F9B
+                    bcc       L6F97
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L6FA6
+                    beq       L6FA2
                     ldd       $04,s
                     cmpd      #$000D
-                    bne       L6FA6
-L6F9B               pshs      u
-                    lbsr      L705E
+                    bne       L6FA2
+L6F97               pshs      u
+                    lbsr      L705A
                     std       ,s++
-                    lbne      L7041
-L6FA6               ldd       $04,s
+                    lbne      L703D
+L6FA2               ldd       $04,s
                     puls      pc,u
-L6FAA               pshs      u
+L6FA6               pshs      u
                     ldu       $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
                     ldd       #$0008
-                    lbsr      L766D
+                    lbsr      L7669
                     pshs      d
-                    lbsr      L6F05
+                    lbsr      L6F01
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      L6F05
-                    lbra      L7118
+                    lbsr      L6F01
+                    lbra      L7114
 
-L6FCD               pshs      u,d
+L6FC9               pshs      u,d
                     leau      $01B4,y
                     clra
                     clrb
                     std       ,s
-                    bra       L6FE3
+                    bra       L6FDF
 
-L6FD9               tfr       u,d
+L6FD5               tfr       u,d
                     leau      $0d,u
                     pshs      d
-                    bsr       L6FF6
+                    bsr       L6FF2
                     leas      $02,s
-L6FE3               ldd       ,s
+L6FDF               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0010
-                    blt       L6FD9
-                    lbra      L705A
+                    blt       L6FD5
+                    lbra      L7056
 
-L6FF6               pshs      u
+L6FF2               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     cmpu      #$0000
-                    beq       L7006
+                    beq       L7002
                     ldd       $06,u
-                    bne       L700C
-L7006               ldd       #$FFFF
-                    lbra      L705A
+                    bne       L7008
+L7002               ldd       #$FFFF
+                    lbra      L7056
 
-L700C               ldd       $06,u
+L7008               ldd       $06,u
                     clra
                     andb      #$02
-                    beq       L701B
+                    beq       L7017
                     pshs      u
-                    bsr       L7030
+                    bsr       L702C
                     leas      $02,s
-                    bra       L701D
+                    bra       L7019
 
-L701B               clra
+L7017               clra
                     clrb
-L701D               std       ,s
+L7019               std       ,s
                     ldd       $08,u
                     pshs      d
-                    lbsr      L771D
+                    lbsr      L7719
                     leas      $02,s
                     clra
                     clrb
                     std       $06,u
                     ldd       ,s
-                    bra       L705A
+                    bra       L7056
 
-L7030               pshs      u
+L702C               pshs      u
                     ldu       $04,s
-                    beq       L7041
+                    beq       L703D
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    beq       L7046
-L7041               ldd       #$FFFF
+                    beq       L7042
+L703D               ldd       #$FFFF
                     puls      pc,u
-L7046               ldd       $06,u
+L7042               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L7056
+                    bne       L7052
                     pshs      u
-                    lbsr      L7274
+                    lbsr      L7270
                     leas      $02,s
-L7056               pshs      u
-                    bsr       L705E
-L705A               leas      $02,s
+L7052               pshs      u
+                    bsr       L705A
+L7056               leas      $02,s
                     puls      pc,u
-L705E               pshs      u
+L705A               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L7090
+                    bne       L708C
                     ldd       ,u
                     cmpd      $04,u
-                    beq       L7090
+                    beq       L708C
                     clra
                     clrb
                     pshs      d
                     pshs      u
-                    lbsr      L711C
+                    lbsr      L7118
                     leas      $02,s
                     ldd       $02,x
                     pshs      d
@@ -12452,70 +12477,70 @@ L705E               pshs      u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L77E4
+                    lbsr      L77E0
                     leas      $08,s
-L7090               ldd       ,u
+L708C               ldd       ,u
                     subd      $02,u
                     std       $02,s
-                    lbeq      L7108
+                    lbeq      L7104
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      L7108
+                    lbeq      L7104
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L70DF
+                    beq       L70DB
                     ldd       $02,u
-                    bra       L70D7
+                    bra       L70D3
 
-L70B0               ldd       $02,s
+L70AC               ldd       $02,s
                     pshs      d
                     ldd       ,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L77D4
+                    lbsr      L77D0
                     leas      $06,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L70CD
+                    bne       L70C9
                     leax      $04,s
-                    bra       L70F7
+                    bra       L70F3
 
-L70CD               ldd       $02,s
+L70C9               ldd       $02,s
                     subd      ,s
                     std       $02,s
                     ldd       ,u
                     addd      ,s
-L70D7               std       ,u
+L70D3               std       ,u
                     ldd       $02,s
-                    bne       L70B0
-                    bra       L7108
+                    bne       L70AC
+                    bra       L7104
 
-L70DF               ldd       $02,s
+L70DB               ldd       $02,s
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L77BB
+                    lbsr      L77B7
                     leas      $06,s
                     cmpd      $02,s
-                    beq       L7108
-                    bra       L70F9
+                    beq       L7104
+                    bra       L70F5
 
-L70F7               leas      -$04,x
-L70F9               ldd       $06,u
+L70F3               leas      -$04,x
+L70F5               ldd       $06,u
                     orb       #$20
                     std       $06,u
                     ldd       $04,u
                     std       ,u
                     ldd       #$FFFF
-                    bra       L7118
+                    bra       L7114
 
-L7108               ldd       $06,u
+L7104               ldd       $06,u
                     ora       #$01
                     std       $06,u
                     ldd       $02,u
@@ -12524,21 +12549,21 @@ L7108               ldd       $06,u
                     std       $04,u
                     clra
                     clrb
-L7118               leas      $04,s
+L7114               leas      $04,s
+                    puls      pc,u
+L7118               pshs      u
                     puls      pc,u
 L711C               pshs      u
-                    puls      pc,u
-L7120               pshs      u
                     ldu       $04,s
-                    beq       L716C
+                    beq       L7168
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L716C
+                    bne       L7168
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L7148
+                    bcc       L7144
                     ldd       ,u
                     addd      #$0001
                     std       ,u
@@ -12546,27 +12571,27 @@ L7120               pshs      u
                     tfr       d,x
                     ldb       ,x
                     clra
-                    lbra      L7272
+                    lbra      L726E
 
-L7148               pshs      u
-                    lbsr      L71BB
-                    lbra      L7270
+L7144               pshs      u
+                    lbsr      L71B7
+                    lbra      L726C
                     pshs      u
                     ldu       $06,s
-                    beq       L716C
+                    beq       L7168
                     ldd       $06,u
                     clra
                     andb      #$01
-                    beq       L716C
+                    beq       L7168
                     ldd       $04,s
                     cmpd      #$FFFF
-                    beq       L716C
+                    beq       L7168
                     ldd       ,u
                     cmpd      $02,u
-                    bhi       L7171
-L716C               ldd       #$FFFF
+                    bhi       L716D
+L7168               ldd       #$FFFF
                     puls      pc,u
-L7171               ldd       ,u
+L716D               ldd       ,u
                     addd      #$FFFF
                     std       ,u
                     tfr       d,x
@@ -12578,59 +12603,59 @@ L7171               ldd       ,u
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
-                    lbsr      L7120
+                    lbsr      L711C
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L71A6
+                    beq       L71A2
                     pshs      u
-                    lbsr      L7120
+                    lbsr      L711C
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L71AB
-L71A6               ldd       #$FFFF
-                    bra       L71B7
+                    bne       L71A7
+L71A2               ldd       #$FFFF
+                    bra       L71B3
 
-L71AB               ldd       $02,s
+L71A7               ldd       $02,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      L7684
+                    lbsr      L7680
                     addd      ,s
-L71B7               leas      $04,s
+L71B3               leas      $04,s
                     puls      pc,u
-L71BB               pshs      u
+L71B7               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$31
                     cmpd      #$8001
-                    beq       L71E1
+                    beq       L71DD
                     ldd       $06,u
                     clra
                     andb      #$31
                     cmpd      #$0001
-                    lbne      L725A
+                    lbne      L7256
                     pshs      u
-                    lbsr      L7274
+                    lbsr      L7270
                     leas      $02,s
-L71E1               leax      $01B4,y
+L71DD               leax      $01B4,y
                     pshs      x
                     cmpu      ,s++
-                    bne       L71FE
+                    bne       L71FA
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L71FE
+                    beq       L71FA
                     leax      $01C1,y
                     pshs      x
-                    lbsr      L7030
+                    lbsr      L702C
                     leas      $02,s
-L71FE               ldd       $06,u
+L71FA               ldd       $06,u
                     clra
                     andb      #$08
-                    beq       L722A
+                    beq       L7226
                     ldd       $0b,u
                     pshs      d
                     ldd       $02,u
@@ -12640,43 +12665,43 @@ L71FE               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L721E
-                    leax      L77AB,pcr
-                    bra       L7222
+                    beq       L721A
+                    leax      L77A7,pcr
+                    bra       L721E
 
-L721E               leax      L778A,pcr
-L7222               tfr       x,d
+L721A               leax      L7786,pcr
+L721E               tfr       x,d
                     tfr       d,x
                     jsr       ,x
-                    bra       L723C
+                    bra       L7238
 
-L722A               ldd       #$0001
+L7226               ldd       #$0001
                     pshs      d
                     leax      $0a,u
                     stx       $02,u
                     pshs      x
                     ldd       $08,u
                     pshs      d
-                    lbsr      L778A
-L723C               leas      $06,s
+                    lbsr      L7786
+L7238               leas      $06,s
                     std       ,s
                     ldd       ,s
-                    bgt       L725F
+                    bgt       L725B
                     ldd       $06,u
                     pshs      d
                     ldd       $02,s
-                    beq       L7251
+                    beq       L724D
                     ldd       #$0020
-                    bra       L7254
+                    bra       L7250
 
-L7251               ldd       #$0010
-L7254               ora       ,s+
+L724D               ldd       #$0010
+L7250               ora       ,s+
                     orb       ,s+
                     std       $06,u
-L725A               ldd       #$FFFF
-                    bra       L7270
+L7256               ldd       #$FFFF
+                    bra       L726C
 
-L725F               ldd       $02,u
+L725B               ldd       $02,u
                     addd      #$0001
                     std       ,u
                     ldd       $02,u
@@ -12684,14 +12709,14 @@ L725F               ldd       $02,u
                     std       $04,u
                     ldb       [$02,u]
                     clra
-L7270               leas      $02,s
-L7272               puls      pc,u
-L7274               pshs      u
+L726C               leas      $02,s
+L726E               puls      pc,u
+L7270               pshs      u
                     ldu       $04,s
                     ldd       $06,u
                     clra
                     andb      #$C0
-                    bne       L72AC
+                    bne       L72A8
                     leas      -$20,s
                     leax      ,s
                     pshs      x
@@ -12700,126 +12725,127 @@ L7274               pshs      u
                     clra
                     clrb
                     pshs      d
-                    lbsr      L769F
+                    lbsr      L769B
                     leas      $06,s
                     ldd       $06,u
                     pshs      d
                     ldb       $02,s
-                    bne       L72A0
+                    bne       L729C
                     ldd       #$0040
-                    bra       L72A3
+                    bra       L729F
 
-L72A0               ldd       #$0080
-L72A3               ora       ,s+
+L729C               ldd       #$0080
+L729F               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     leas      $20,s
-L72AC               ldd       $06,u
+L72A8               ldd       $06,u
                     ora       #$80
                     std       $06,u
                     clra
                     andb      #$0C
-                    beq       L72B9
+                    beq       L72B5
                     puls      pc,u
-L72B9               ldd       $0b,u
-                    bne       L72CE
+L72B5               ldd       $0b,u
+                    bne       L72CA
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L72C9
+                    beq       L72C5
                     ldd       #$0080
-                    bra       L72CC
+                    bra       L72C8
 
-L72C9               ldd       #$0100
-L72CC               std       $0b,u
-L72CE               ldd       $02,u
-                    bne       L72E3
+L72C5               ldd       #$0100
+L72C8               std       $0b,u
+L72CA               ldd       $02,u
+                    bne       L72DF
                     ldd       $0b,u
                     pshs      d
-                    lbsr      L78A2
+                    lbsr      L789E
                     leas      $02,s
                     std       $02,u
                     cmpd      #$FFFF
-                    beq       L72EB
-L72E3               ldd       $06,u
+                    beq       L72E7
+L72DF               ldd       $06,u
                     orb       #$08
                     std       $06,u
-                    bra       L72FA
+                    bra       L72F6
 
-L72EB               ldd       $06,u
+L72E7               ldd       $06,u
                     orb       #$04
                     std       $06,u
                     leax      $0a,u
                     stx       $02,u
                     ldd       #$0001
                     std       $0b,u
-L72FA               ldd       $02,u
+L72F6               ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
                     puls      pc,u
-                    pshs      u
+L7300               pshs      u
                     ldu       $04,s
-L7308               ldb       ,u+
-                    bne       L7308
+L7304               ldb       ,u+
+                    bne       L7304
                     tfr       u,d
                     subd      $04,s
                     addd      #$FFFF
                     puls      pc,u
-L7315               pshs      u
+L7311               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L731F               ldb       ,u+
+L731B               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L731F
-                    bra       L7354
-                    pshs      u
+                    bne       L731B
+                    bra       L7350
+
+L7329               pshs      u
                     ldu       $06,s
-L7331               leas      -$02,s
+                    leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L7337               ldx       ,s
+L7333               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L7337
+                    bne       L7333
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-L7348               ldb       ,u+
+L7344               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L7348
-L7354               ldd       $06,s
+                    bne       L7344
+L7350               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
-                    bra       L7370
+                    bra       L736C
 
-L7360               ldx       $06,s
+L735C               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       L736E
+                    bne       L736A
                     clra
                     clrb
                     puls      pc,u
-L736E               leau      $01,u
-L7370               ldb       ,u
+L736A               leau      $01,u
+L736C               ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       L7360
+                    beq       L735C
                     ldb       [$06,s]
                     sex
                     pshs      d
@@ -12827,114 +12853,115 @@ L7370               ldb       ,u
                     sex
                     subd      ,s++
                     puls      pc,u
-                    pshs      u
+L7387               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L7395               ldd       $0a,s
+L7391               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       L73B9
+                    ble       L73B5
                     ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L7395
-                    bra       L73B9
+                    bne       L7391
+                    bra       L73B5
 
-L73AF               clra
+L73AB               clra
                     clrb
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L73B9               ldd       $0a,s
+L73B5               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    bgt       L73AF
-                    lbra      L7448
-                    pshs      u
-                    ldu       $04,s
-                    bra       L73DE
+                    bgt       L73AB
+                    lbra      L7444
 
-L73CE               ldx       $06,s
+L73C4               pshs      u
+                    ldu       $04,s
+                    bra       L73DA
+
+L73CA               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       L73DC
+                    bne       L73D8
                     clra
                     clrb
                     puls      pc,u
-L73DC               leau      $01,u
-L73DE               ldd       $08,s
+L73D8               leau      $01,u
+L73DA               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    ble       L73F8
+                    ble       L73F4
                     ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       L73CE
-L73F8               ldd       $08,s
-                    bge       L7400
+                    beq       L73CA
+L73F4               ldd       $08,s
+                    bge       L73FC
                     clra
                     clrb
-                    bra       L740B
+                    bra       L7407
 
-L7400               ldb       [$06,s]
+L73FC               ldb       [$06,s]
                     sex
                     pshs      d
                     ldb       ,u
                     sex
                     subd      ,s++
-L740B               puls      pc,u
-                    pshs      u
+L7407               puls      pc,u
+L7409               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L7417               ldx       ,s
+L7413               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L7417
+                    bne       L7413
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-L7428               ldd       $0a,s
+L7424               ldd       $0a,s
                     addd      #$FFFF
                     std       $0a,s
                     subd      #$FFFF
-                    ble       L7440
+                    ble       L743C
                     ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L7428
-L7440               ldd       $0a,s
-                    bge       L7448
+                    bne       L7424
+L743C               ldd       $0a,s
+                    bge       L7444
                     clra
                     clrb
                     stb       [,s]
-L7448               ldd       $06,s
+L7444               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
-L7452               ldx       $06,s
+L744E               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
                     stb       ,u+
-                    bgt       L7452
+                    bgt       L744E
                     ldb       -$01,u
                     clra
                     andb      #$7f
@@ -12944,14 +12971,14 @@ L7452               ldx       $06,s
                     stb       ,u
                     ldd       $04,s
                     puls      pc,u
-                    ldd       $04,s
+L7469               ldd       $04,s
                     addd      $02,x
                     std       $02C8,y
                     ldd       $02,s
                     adcb      $01,x
                     adca      ,x
                     std       $02C6,y
-                    lbra      L7525
+                    lbra      L7521
                     ldd       $04,s
                     subd      $02,x
                     std       $02C8,y
@@ -12959,17 +12986,19 @@ L7452               ldx       $06,s
                     sbcb      $01,x
                     sbca      ,x
                     std       $02C6,y
-L7494               lbra      L7525
-                    lbsr      L7534
-L749A               ldd       #$0000
+                    lbra      L7521
+
+L7493               lbsr      L7530
+L7496               ldd       #$0000
                     subd      $02,x
                     std       $02,x
                     ldd       #$0000
                     sbcb      $01,x
                     sbca      ,x
-L74A8               std       ,x
+                    std       ,x
                     rts
-                    ldd       ,x
+
+L74A7               ldd       ,x
                     coma
                     comb
                     std       $02C6,y
@@ -12978,8 +13007,9 @@ L74A8               std       ,x
                     comb
                     leax      $02C6,y
                     std       $02,x
-L74BD               rts
-                    leax      $02C6,y
+                    rts
+
+L74BA               leax      $02C6,y
                     std       $02,x
                     tfr       a,b
                     sex
@@ -12989,9 +13019,10 @@ L74BD               rts
                     leax      $02C6,y
                     std       $02,x
                     clr       ,x
-L74D4               clr       $01,x
-L74D6               rts
-                    pshs      y
+                    clr       $01,x
+                    rts
+
+L74D3               pshs      y
                     ldy       $04,s
                     ldd       ,x
                     std       ,y
@@ -13001,39 +13032,40 @@ L74D6               rts
                     exg       y,x
                     puls      d
                     std       ,s
-L74EC               rts
-                    ldx       $02,s
+                    rts
+
+L74E9               ldx       $02,s
                     pshs      b
-                    lbsr      L7534
+                    lbsr      L7530
                     puls      b
                     tstb
-                    beq       L7504
-L74F9               asl       $03,x
+                    beq       L7500
+L74F5               asl       $03,x
                     rol       $02,x
                     rol       $01,x
                     rol       ,x
                     decb
-                    bne       L74F9
-L7504               puls      d
+                    bne       L74F5
+L7500               puls      d
                     std       ,s
                     rts
                     ldx       $02,s
                     pshs      b
-                    lbsr      L7534
+                    lbsr      L7530
                     puls      b
                     tstb
-                    beq       L7520
-L7515               asr       ,x
+                    beq       L751C
+L7511               asr       ,x
                     ror       $01,x
                     ror       $02,x
                     ror       $03,x
                     decb
-                    bne       L7515
-L7520               puls      d
+                    bne       L7511
+L751C               puls      d
                     std       ,s
                     rts
 
-L7525               tfr       cc,a
+L7521               tfr       cc,a
                     puls      x
                     stx       $02,s
                     leas      $02,s
@@ -13041,17 +13073,17 @@ L7525               tfr       cc,a
                     tfr       a,cc
                     rts
 
-L7534               ldd       ,x
+L7530               ldd       ,x
                     std       $02C6,y
                     ldd       $02,x
                     leax      $02C6,y
-L7540               std       $02,x
-L7542               rts
+                    std       $02,x
+                    rts
 
-L7543               tsta
-                    bne       L7558
+L753F               tsta
+                    bne       L7554
                     tst       $02,s
-                    bne       L7558
+                    bne       L7554
                     lda       $03,s
                     mul
                     ldx       ,s
@@ -13059,7 +13091,7 @@ L7543               tsta
                     ldx       #$0000
                     std       ,s
                     puls      pc,d
-L7558               pshs      d
+L7554               pshs      d
                     ldd       #$0000
                     pshs      d
                     pshs      d
@@ -13072,16 +13104,16 @@ L7558               pshs      d
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L7575
+                    bcc       L7571
                     inc       ,s
-L7575               lda       $04,s
+L7571               lda       $04,s
                     ldb       $09,s
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L7582
+                    bcc       L757E
                     inc       ,s
-L7582               lda       $04,s
+L757E               lda       $04,s
                     ldb       $08,s
                     mul
                     addd      ,s
@@ -13093,164 +13125,166 @@ L7582               lda       $04,s
                     leas      $08,s
                     rts
                     clr       $080C,y
-                    leax      >L75DE,pcr
+                    leax      >L75DA,pcr
                     stx       $080d,y
-                    bra       L75B8
-                    leax      >L75F7,pcr
+                    bra       L75B4
+
+L75A0               leax      >L75F3,pcr
                     stx       $080d,y
                     clr       $080C,y
                     tst       $02,s
-                    bpl       L75B8
+                    bpl       L75B4
                     inc       $080C,y
-L75B8               subd      #$0000
-                    bne       L75C3
+L75B4               subd      #$0000
+                    bne       L75BF
                     puls      x
                     ldd       ,s++
                     jmp       ,x
 
-L75C3               ldx       $02,s
+L75BF               ldx       $02,s
                     pshs      x
                     jsr       [$080d,y]
                     ldd       ,s
                     std       $02,s
                     tfr       x,d
                     tst       $080C,y
-                    beq       L75DB
+                    beq       L75D7
                     nega
                     negb
                     sbca      #$00
-L75DB               std       ,s++
+L75D7               std       ,s++
                     rts
 
-L75DE               subd      #$0000
-                    beq       L75ED
+L75DA               subd      #$0000
+                    beq       L75E9
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
-                    bra       L761B
+                    bra       L7617
 
-L75ED               puls      d
+L75E9               puls      d
                     std       ,s
                     ldd       #$002D
-L75F4               lbra      L7690
+                    lbra      L768C
 
-L75F7               subd      #$0000
-                    beq       L75ED
+L75F3               subd      #$0000
+                    beq       L75E9
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
                     tsta
-                    bpl       L760F
+                    bpl       L760B
                     nega
                     negb
                     sbca      #$00
                     inc       $01,s
                     std       $02,s
-L760F               ldd       $06,s
-                    bpl       L761B
+L760B               ldd       $06,s
+                    bpl       L7617
                     nega
                     negb
                     sbca      #$00
                     com       $01,s
                     std       $06,s
-L761B               lda       #$01
-L761D               inca
+L7617               lda       #$01
+L7619               inca
                     asl       $03,s
                     rol       $02,s
-                    bpl       L761D
+                    bpl       L7619
                     sta       ,s
                     ldd       $06,s
                     clr       $06,s
                     clr       $07,s
-L762C               subd      $02,s
-                    bcc       L7636
+L7628               subd      $02,s
+                    bcc       L7632
                     addd      $02,s
                     andcc     #$FE
-                    bra       L7638
+                    bra       L7634
 
-L7636               orcc      #$01
-L7638               rol       $07,s
+L7632               orcc      #$01
+L7634               rol       $07,s
                     rol       $06,s
                     lsr       $02,s
                     ror       $03,s
                     dec       ,s
-                    bne       L762C
+                    bne       L7628
                     std       $02,s
                     tst       $01,s
-                    beq       L7652
+                    beq       L764E
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-L7652               ldx       $04,s
+L764E               ldx       $04,s
                     ldd       $06,s
                     std       $04,s
                     stx       $06,s
                     ldx       $02,s
                     ldd       $04,s
-L765E               leas      $06,s
-L7660               rts
-                    tstb
-                    beq       L7677
-L7664               asr       $02,s
-                    ror       $03,s
-                    decb
-                    bne       L7664
-                    bra       L7677
+                    leas      $06,s
+                    rts
 
-L766D               tstb
-                    beq       L7677
-L7670               lsr       $02,s
+L765D               tstb
+                    beq       L7673
+L7660               asr       $02,s
                     ror       $03,s
                     decb
-                    bne       L7670
-L7677               ldd       $02,s
+                    bne       L7660
+                    bra       L7673
+
+L7669               tstb
+                    beq       L7673
+L766C               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L766C
+L7673               ldd       $02,s
                     pshs      d
                     ldd       $02,s
                     std       $04,s
                     ldd       ,s
-L7681               leas      $04,s
-L7683               rts
+                    leas      $04,s
+                    rts
 
-L7684               tstb
-                    beq       L7677
-L7687               asl       $03,s
+L7680               tstb
+                    beq       L7673
+L7683               asl       $03,s
                     rol       $02,s
                     decb
-                    bne       L7687
-                    bra       L7677
+                    bne       L7683
+                    bra       L7673
 
-L7690               std       $02D2,y
+L768C               std       $02D2,y
                     pshs      y,b
                     os9       F$ID
                     puls      y,b
                     os9       F$Send
                     rts
 
-L769F               lda       $05,s
+L769B               lda       $05,s
                     ldb       $03,s
-                    beq       L76D2
+                    beq       L76CE
                     cmpb      #$01
-                    beq       L76D4
+                    beq       L76D0
                     cmpb      #$06
-                    beq       L76D4
+                    beq       L76D0
                     cmpb      #$02
-                    beq       L76BA
+                    beq       L76B6
                     cmpb      #$05
-                    beq       L76BA
+                    beq       L76B6
                     ldb       #$D0
-                    lbra      L7936
+                    lbra      L7932
 
-L76BA               pshs      u
+L76B6               pshs      u
                     os9       I$GetStt
-                    bcc       L76C6
+                    bcc       L76C2
                     puls      u
-                    lbra      L7936
+                    lbra      L7932
 
-L76C6               stx       [$08,s]
+L76C2               stx       [$08,s]
                     ldx       $08,s
                     stu       $02,x
                     puls      u
@@ -13258,202 +13292,202 @@ L76C6               stx       [$08,s]
                     clrb
                     rts
 
-L76D2               ldx       $06,s
-L76D4               os9       I$GetStt
-                    lbra      L793F
+L76CE               ldx       $06,s
+L76D0               os9       I$GetStt
+                    lbra      L793B
                     lda       $05,s
                     ldb       $03,s
-                    beq       L76E9
+                    beq       L76E5
                     cmpb      #$02
-                    beq       L76F1
+                    beq       L76ED
                     ldb       #$D0
-                    lbra      L7936
+                    lbra      L7932
 
-L76E9               ldx       $06,s
+L76E5               ldx       $06,s
                     os9       I$SetStt
-                    lbra      L793F
+                    lbra      L793B
 
-L76F1               pshs      u
+L76ED               pshs      u
                     ldx       $08,s
                     ldu       $0a,s
                     os9       I$SetStt
                     puls      u
-                    lbra      L793F
+                    lbra      L793B
                     ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    bcs       L770B
+                    bcs       L7707
                     os9       I$Close
-L770B               lbra      L793F
+L7707               lbra      L793B
 
-L770E               ldx       $02,s
+L770A               ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    lbcs      L7936
+                    lbcs      L7932
                     tfr       a,b
                     clra
                     rts
 
-L771D               lda       $03,s
+L7719               lda       $03,s
                     os9       I$Close
-                    lbra      L793F
+                    lbra      L793B
                     ldx       $02,s
                     ldb       $05,s
                     os9       I$MakDir
-                    lbra      L793F
+                    lbra      L793B
 
-L772F               ldx       $02,s
+L772B               ldx       $02,s
                     lda       $05,s
                     tfr       a,b
                     andb      #$24
                     orb       #$0b
                     os9       I$Create
-                    bcs       L7742
-L773E               tfr       a,b
+                    bcs       L773E
+L773A               tfr       a,b
                     clra
                     rts
 
-L7742               cmpb      #$DA
-                    lbne      L7936
+L773E               cmpb      #$DA
+                    lbne      L7932
                     lda       $05,s
                     bita      #$80
-                    lbne      L7936
+                    lbne      L7932
                     anda      #$07
                     ldx       $02,s
                     os9       I$Open
-                    lbcs      L7936
+                    lbcs      L7932
                     pshs      u,a
                     ldx       #$0000
                     leau      ,x
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-                    bcc       L773E
+                    bcc       L773A
                     pshs      b
                     os9       I$Close
                     puls      b
-                    lbra      L7936
+                    lbra      L7932
 
-L7775               ldx       $02,s
+L7771               ldx       $02,s
                     os9       I$Delete
-                    lbra      L793F
+                    lbra      L793B
                     lda       $03,s
                     os9       I$Dup
-                    lbcs      L7936
+                    lbcs      L7932
                     tfr       a,b
                     clra
                     rts
 
-L778A               pshs      y
+L7786               pshs      y
                     ldx       $06,s
                     lda       $05,s
                     ldy       $08,s
                     pshs      y
                     os9       I$Read
-L7798               bcc       L77A7
+L7794               bcc       L77A3
                     cmpb      #$D3
-                    bne       L77A2
+                    bne       L779E
                     clra
                     clrb
                     puls      pc,y,x
-L77A2               puls      y,x
-                    lbra      L7936
+L779E               puls      y,x
+                    lbra      L7932
 
-L77A7               tfr       y,d
+L77A3               tfr       y,d
                     puls      pc,y,x
-L77AB               pshs      y
+L77A7               pshs      y
                     lda       $05,s
                     ldx       $06,s
                     ldy       $08,s
                     pshs      y
                     os9       I$ReadLn
-                    bra       L7798
+                    bra       L7794
 
-L77BB               pshs      y
+L77B7               pshs      y
                     ldy       $08,s
-                    beq       L77D0
+                    beq       L77CC
                     lda       $05,s
                     ldx       $06,s
                     os9       I$Write
-L77C9               bcc       L77D0
+L77C5               bcc       L77CC
                     puls      y
-                    lbra      L7936
+                    lbra      L7932
 
-L77D0               tfr       y,d
+L77CC               tfr       y,d
                     puls      pc,y
-L77D4               pshs      y
+L77D0               pshs      y
                     ldy       $08,s
-                    beq       L77D0
+                    beq       L77CC
                     lda       $05,s
                     ldx       $06,s
                     os9       I$WritLn
-                    bra       L77C9
+                    bra       L77C5
 
-L77E4               pshs      u
+L77E0               pshs      u
                     ldd       $0a,s
-                    bne       L77F2
+                    bne       L77EE
                     ldu       #$0000
                     ldx       #$0000
-                    bra       L7826
+                    bra       L7822
 
-L77F2               cmpd      #$0001
-                    beq       L781D
+L77EE               cmpd      #$0001
+                    beq       L7819
                     cmpd      #$0002
-                    beq       L7812
+                    beq       L780E
                     ldb       #$F7
-L7800               clra
+L77FC               clra
                     std       $02D2,y
                     ldd       #$FFFF
                     leax      $02C6,y
                     std       ,x
                     std       $02,x
                     puls      pc,u
-L7812               lda       $05,s
+L780E               lda       $05,s
                     ldb       #$02
                     os9       I$GetStt
-                    bcs       L7800
-                    bra       L7826
+                    bcs       L77FC
+                    bra       L7822
 
-L781D               lda       $05,s
+L7819               lda       $05,s
                     ldb       #$05
                     os9       I$GetStt
-                    bcs       L7800
-L7826               tfr       u,d
+                    bcs       L77FC
+L7822               tfr       u,d
                     addd      $08,s
                     std       $02C8,y
                     tfr       d,u
                     tfr       x,d
                     adcb      $07,s
                     adca      $06,s
-                    bmi       L7800
+                    bmi       L77FC
                     tfr       d,x
                     std       $02C6,y
                     lda       $05,s
                     os9       I$Seek
-                    bcs       L7800
+                    bcs       L77FC
                     leax      $02C6,y
                     puls      pc,u
-                    ldd       $02C4,y
+L7847               ldd       $02C4,y
                     pshs      d
                     ldd       $04,s
                     cmpd      $080f,y
-                    bcs       L787F
+                    bcs       L787B
                     addd      $02C4,y
                     pshs      y
                     subd      ,s
                     os9       F$Mem
                     tfr       y,d
                     puls      y
-                    bcc       L7871
+                    bcc       L786D
                     ldd       #$FFFF
                     leas      $02,s
                     rts
 
-L7871               std       $02C4,y
+L786D               std       $02C4,y
                     addd      $080f,y
                     subd      ,s
                     std       $080f,y
-L787F               leas      $02,s
+L787B               leas      $02,s
                     ldd       $080f,y
                     pshs      d
                     subd      $04,s
@@ -13463,171 +13497,328 @@ L787F               leas      $02,s
                     pshs      d
                     clra
                     ldx       ,s
-L7898               sta       ,x+
+L7894               sta       ,x+
                     cmpx      $02C4,y
-                    bcs       L7898
+                    bcs       L7894
                     puls      pc,d
-L78A2               ldd       $02,s
+L789E               ldd       $02,s
                     addd      $02CE,y
-                    bcs       L78CB
+                    bcs       L78C7
                     cmpd      $02D0,y
-                    bcc       L78CB
+                    bcc       L78C7
                     pshs      d
                     ldx       $02CE,y
                     clra
-L78B8               cmpx      ,s
-                    bcc       L78C0
+L78B4               cmpx      ,s
+                    bcc       L78BC
                     sta       ,x+
-                    bra       L78B8
+                    bra       L78B4
 
-L78C0               ldd       $02CE,y
+L78BC               ldd       $02CE,y
                     puls      x
                     stx       $02CE,y
                     rts
 
-L78CB               ldd       #$FFFF
+L78C7               ldd       #$FFFF
                     rts
 
-L78CF               pshs      y
+L78CB               pshs      y
                     os9       F$ID
                     puls      y
-                    bcc       L78DC
-                    lbcs      L7936
-L78DC               tfr       a,b
+                    bcc       L78D8
+                    lbcs      L7932
+L78D8               tfr       a,b
                     clra
                     rts
 
-L78E0               pshs      y
+L78DC               pshs      y
                     os9       F$ID
-                    bcc       L78EC
-L78E7               puls      y
-                    lbra      L7936
+                    bcc       L78E8
+L78E3               puls      y
+                    lbra      L7932
 
-L78EC               tfr       y,d
+L78E8               tfr       y,d
                     puls      pc,y
                     pshs      y
-                    bsr       L78E0
+                    bsr       L78DC
                     std       -$02,s
-                    beq       L78FC
+                    beq       L78F8
                     ldb       #$D6
-                    bra       L78E7
+                    bra       L78E3
 
-L78FC               ldy       $04,s
+L78F8               ldy       $04,s
                     os9       F$SUser
-                    bcc       L7910
+                    bcc       L790C
                     cmpb      #$D0
-                    bne       L78E7
+                    bne       L78E3
                     tfr       y,d
                     ldy       >$004B
                     std       $09,y
-L7910               clra
+L790C               clra
                     clrb
                     puls      pc,y
-L7914               pshs      u
+L7910               pshs      u
                     tfr       y,u
                     ldx       $04,s
                     stx       $0811,y
-                    leax      >L792A,pcr
+                    leax      >L7926,pcr
                     os9       F$Icpt
                     puls      u
-                    lbra      L793F
+                    lbra      L793B
 
-L792A               tfr       u,y
+L7926               tfr       u,y
                     clra
                     pshs      d
                     jsr       [$0811,y]
                     leas      $02,s
                     rti
 
-L7936               clra
+L7932               clra
                     std       $02D2,y
                     ldd       #$FFFF
                     rts
 
-L793F               bcs       L7936
-exit                clra
+L793B               bcs       L7932
+                    clra
                     clrb
                     rts
 
-L7944               lbsr      L794F
-L7947               lbsr      L6FCD
-L794A               ldd       $02,s
-L794C               os9       F$Exit
-* ------------------------------------------------------------------
-* L794F - cc1-style init image for the work block (see _start);
-* pure data: rts stub + count/block table + reloc dirs + module name.
-* ------------------------------------------------------------------
-L794F               fcb       $39       init table / work-block image
-                    fcb       $00,$03,$00,$00,$89,$02,$0E
-                    fcc       /x expected/
+L7940               lbsr      L794B
+                    lbsr      L6FC9
+L7946               ldd       $02,s
+                    os9       F$Exit
+L794B               rts
+
+L794C               neg       $0003
+                    neg       $0000
+                    adca      #$02
+                    jmp       $0078
+                    fcc       / expected/
                     fcb       $00
-                    fcb       $27
-                    fcb       $10,$03,$E8,$00
-                    fcb       $64
-                    fcb       $00,$0A,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00
-                    fcb       $6D,$40,$69
-                    fcb       $00,$00
-                    fcc       |TAh-.BP0CESkkkkkkkkkk/(]x_d|
+                    beq       L7970
+                    com       $00E8
+                    neg       L0064
+                    neg       $000A
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L7970               neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    tst       0,u
+                    rol       0,x
+                    neg       $0054
+                    fcc       |Ah-.BP0CESkkkkkkkkkk/(]x_d|
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj+f,Yj/
                     fcb       $00
                     fcc       /jjjjjjjjjjjjjjjjjjjjjjjjjj)X*D/
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$09,$00,$00,$00,$0D,$0E
-                    fcb       $00,$00,$00,$0E,$0C,$01,$0E,$0F
-                    fcb       $0D,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$03,$00,$0A,$02,$0A
-                    fcb       $03,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$07
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$06,$00,$0E
-                    fcb       $00,$07,$0B,$00,$01,$00,$02,$00
-                    fcb       $00,$00,$00,$00,$0C,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$01
-                    fcb       $9F
-                    fcc       /cstr.XXXXX/
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00
+                    fcb       $00,$00,$00
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0009
+                    neg       $0000
+                    neg       $000D
+                    jmp       $0000
+                    neg       $0000
+                    jmp       $000C
+                    fcb       $01
+                    jmp       $000F
+                    tst       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0003
+                    neg       $000A
+                    fcb       $02
+                    dec       $0003
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    asr       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    ror       $0000
+                    jmp       $0000
+                    asr       $000B
+                    neg       $0001
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $000C
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    stx       $0063
+                    fcc       /str.XXXXX/
+                    fcb       $00,$00,$00,$00,$00
+                    neg       $0000
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
                     fcb       $42
-                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$03,$00,$01,$01,$89,$01,$A7
-                    fcc       /c.pa/
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0003
+                    neg       $0001
+                    fcb       $01
+                    adca      #$01
+                    sta       $03,s
+                    fcc       /.pass1/
+                    fcb       $00
+
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -5465,11 +5465,9 @@ L30F9               ldd       L001B
                     lbsr      L515E
 L3104               leas      $04,s
 L3106               puls      pc,u
-L3108               blt       $313D
-                    leas      -$09,y
-                    pshu      y,x,dp
-                    neg       $0034
-                    rorb
+L3108               fcc       /-32768/
+                    fcb       $00
+L310F               pshs      u,x,d
                     ldd       $08,s
                     pshs      d
                     lbsr      L31AE
@@ -10225,10 +10223,7 @@ L5C6D               andb      #$80
                     sta       $22,u
 L5C76               rts
 
-L5C77               neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       L0081
+L5C77               fcb       $00,$00,$00,$00,$00,$00,$00,$81
                     leax      >L5C77,pcr
 L5C83               pshs      a
                     ldd       ,x

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -7990,9 +7990,9 @@ L4919               std       ,s
 L491B               ldd       ,s
                     cmpd      $02DC,y
                     bne       L48F0
-                    bsr       $492A
-                    stu       $FFFF
-                    stu       $3510
+                    bsr       L492A
+                    fcb       $FF,$FF,$FF,$FF
+L492A               puls      x
 L492C               leau      $0254,y
                     pshs      u
                     lbsr      L5E23
@@ -8041,9 +8041,9 @@ L498C               leax      $01,s
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $49AA
-                    stu       $FFFF
-                    stu       $3510
+                    bsr       L49AA
+                    fcb       $FF,$FF,$FF,$FF
+L49AA               puls      x
                     lbsr      L5DBF
                     bne       L49B6
 L49B1               leax      $05,s
@@ -8767,8 +8767,7 @@ L501A               ldd       $0b,u
                     ldd       ,x
                     pshs      d
                     bsr       L5037
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00
 L5037               puls      x
                     lbsr      L5DBF
                     bge       L5045
@@ -8833,9 +8832,9 @@ L50A0               ldd       $06,u
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $50CC
-                    stu       $FFFF
-                    stu       $3510
+                    bsr       L50CC
+                    fcb       $FF,$FF,$FF,$FF
+L50CC               puls      x
                     lbsr      L5DBF
                     bne       L50D8
                     ldd       #$FFFF
@@ -8865,9 +8864,9 @@ L50F5               pshs      u
                     clra
                     andb      #$03
                     bne       L5115
-L5102               bsr       $5108
-                    stu       $FFFF
-                    stu       $3510
+L5102               bsr       L5108
+                    fcb       $FF,$FF,$FF,$FF
+L5108               puls      x
                     leau      $0254,y
                     pshs      u
                     lbsr      L5E23

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -114,6 +114,14 @@ L00CD               cmpa      #$0d
 L00DD               clr       -$01,x
                     bra       L0085
 
+* ------------------------------------------------------------------
+* SPURIOUS $00 below (defect in the c.pass2 FCB source, same as c.pass1).
+* cstart.a's real crt0 loads 'ldd argc,u' (EC C9 02 4E); the stray $00
+* makes it 'ldd 0,x' + 'adcb #2' (EC 00 C9 02 ..).  Here the trailing $4E
+* is an undefined 1-byte opcode, so the decode re-syncs at 'pshs d' and
+* 'lbsr main' survives.  Bytes below are byte-faithful to the defective
+* FCB; the genuine binary uses the clean 'ldd argc,u' form.
+* ------------------------------------------------------------------
 L00E1               leax      $0212,u
                     pshs      x
                     ldd       0,x

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -1,0 +1,11547 @@
+                    nam       c.pass2
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $05
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       3431
+size                equ       .
+
+name                equ       *
+                    fcs       /c.pass2/
+                    fcb       edition
+
+L0015               lda       ,y+
+L0017               sta       ,u+
+L0019               leax      -$01,x
+L001B               bne       L0015
+L001D               rts
+
+start               pshs      y
+L0020               pshs      u
+L0022               clra
+L0023               clrb
+L0024               sta       ,u+
+                    decb
+L0027               bne       L0024
+L0029               ldx       ,s
+L002B               leau      ,x
+L002D               leax      $02E7,x
+                    pshs      x
+L0033               leay      $6235,pcr
+L0037               ldx       ,y++
+                    beq       L003F
+                    bsr       L0015
+L003D               ldu       $02,s
+L003F               leau      >$0027,u
+L0043               ldx       ,y++
+L0045               beq       L004A
+L0047               bsr       L0015
+                    clra
+L004A               cmpu      ,s
+L004D               beq       L0053
+L004F               sta       ,u+
+L0051               bra       L004A
+
+L0053               ldu       $02,s
+L0055               ldd       ,y++
+L0057               beq       L0060
+L0059               leax      >$0000,pcr
+L005D               lbsr      L0163
+L0060               ldd       ,y++
+L0062               beq       L0069
+L0064               leax      ,u
+L0066               lbsr      L0163
+L0069               leas      $04,s
+                    puls      x
+                    stx       $0252,u
+L0071               sty       $0212,u
+L0076               ldd       #$0001
+L0079               std       $024e,u
+L007D               leay      $0214,u
+L0081               leax      ,s
+L0083               lda       ,x+
+L0085               ldb       $024f,u
+L0089               cmpb      #$1d
+L008B               beq       L00E1
+L008D               cmpa      #$0d
+L008F               beq       L00E1
+L0091               cmpa      #$20
+L0093               beq       L0099
+L0095               cmpa      #$2C
+L0097               bne       L009D
+L0099               lda       ,x+
+L009B               bra       L008D
+
+L009D               cmpa      #$22
+                    beq       L00A5
+L00A1               cmpa      #$27
+                    bne       L00C3
+L00A5               stx       ,y++
+L00A7               inc       $024f,u
+                    pshs      a
+L00AD               lda       ,x+
+                    cmpa      #$0d
+                    beq       L00B7
+                    cmpa      ,s
+                    bne       L00AD
+L00B7               puls      b
+                    clr       -$01,x
+L00BB               cmpa      #$0d
+                    beq       L00E1
+                    lda       ,x+
+                    bra       L0085
+
+L00C3               leax      -$01,x
+                    stx       ,y++
+                    leax      $01,x
+                    inc       $024f,u
+L00CD               cmpa      #$0d
+                    beq       L00DD
+                    cmpa      #$20
+                    beq       L00DD
+                    cmpa      #$2C
+                    beq       L00DD
+                    lda       ,x+
+                    bra       L00CD
+
+L00DD               clr       -$01,x
+                    bra       L0085
+
+L00E1               leax      $0212,u
+                    pshs      x
+                    ldd       0,x
+                    adcb      #$02
+                    fcb       $4e
+                    pshs      d
+                    leay      ,u
+                    bsr       L00FC
+                    lbsr      L017E
+                    clr       ,-s
+                    clr       ,-s
+                    lbsr      L622A
+L00FC               leax      $02E7,y
+L0100               stx       $025C,y
+                    sts       $0250,y
+                    sts       $025e,y
+                    ldd       #$FF82
+L0111               leax      d,s
+                    cmpx      $025e,y
+                    bcc       L0123
+                    cmpx      $025C,y
+                    bcs       L013D
+                    stx       $025e,y
+L0123               rts
+L0124               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L013D               leax      L0124,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clr       ,-s
+                    lbsr      $6230
+                    ldd       $0250,y
+                    subd      $025e,y
+                    rts
+                    ldd       $025e,y
+                    subd      $025C,y
+L0163               rts
+                    pshs      x
+                    leax      d,y
+                    leax      d,x
+                    pshs      x
+L016C               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+                    std       ,x
+                    cmpy      ,s
+                    bne       L016C
+                    leas      $04,s
+                    rts
+
+L017E               pshs      u
+                    ldd       #$FF86
+                    lbsr      L0111
+                    leas      -$24,s
+                    lbra      L028F
+
+L018C               ldx       $2a,s
+                    leax      $02,x
+                    stx       $2a,s
+                    ldu       ,x
+                    ldb       ,u
+                    cmpb      #$2d
+                    lbne      L023B
+                    lbra      L0231
+
+L01A1               ldb       ,u
+                    sex
+                    tfr       d,x
+                    lbra      L0215
+
+L01A9               ldd       #$0001
+                    std       $0011
+                    lbra      L0231
+
+L01B1               ldd       #$0001
+                    std       L0015
+                    leax      L0B05,pcr
+                    pshs      x
+                    lbsr      L09DC
+                    leas      $02,s
+                    lbra      L0231
+
+L01C4               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$3d
+                    bne       L01DB
+                    leau      $01,u
+                    pshs      u
+                    lbsr      L09DC
+                    leas      $02,s
+                    leax      $24,s
+                    lbra      L028C
+
+L01DB               leau      -$01,u
+                    pshs      u
+                    leax      $0B0F,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+L01F3               ldd       #$0001
+                    std       $0013
+                    bra       L0231
+
+L01FA               ldb       ,u
+                    sex
+                    pshs      d
+                    leax      L0B21,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+                    bra       L0231
+
+L0215               cmpx      #$0073
+                    lbeq      L01A9
+                    cmpx      #$006E
+                    lbeq      L01B1
+                    cmpx      #$006F
+                    lbeq      L01C4
+                    cmpx      #$0070
+                    beq       L01F3
+                    bra       L01FA
+
+L0231               leau      $01,u
+                    ldb       ,u
+                    lbne      L01A1
+                    bra       L028F
+
+L023B               ldd       $0003
+                    beq       L025F
+                    ldd       $0280,y
+                    beq       L0259
+                    leax      L0B37,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $04,s
+                    lbsr      L0AE0
+L0259               stu       $0280,y
+                    bra       L028F
+
+L025F               leax      $0B46,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L4F07
+                    leas      $04,s
+                    std       $0003
+                    bne       L0286
+                    pshs      u
+                    leax      $0B48,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+L0286               stu       $0284,y
+                    bra       L028F
+
+L028C               leas      -$24,x
+L028F               ldd       $28,s
+                    addd      #$FFFF
+                    std       $28,s
+                    lbne      L018C
+                    ldd       $0005
+                    bne       L02A6
+                    leax      $00CE,y
+                    stx       $0005
+L02A6               ldd       $0003
+                    bne       L02B0
+                    leax      $00C1,y
+                    stx       $0003
+L02B0               ldd       $0280,y
+                    bne       L02BE
+                    leax      L0B57,pcr
+                    stx       $0280,y
+L02BE               lbra      L076F
+
+L02C1               ldx       $1a,s
+                    lbra      L06D4
+
+L02C7               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1a,s
+                    cmpd      #$FFFF
+                    beq       L02F0
+                    ldd       $0005
+                    pshs      d
+                    ldd       $1C,s
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    ldd       $1a,s
+                    cmpd      #$000D
+                    bne       L02C7
+L02F0               lbra      L076F
+
+L02F3               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $0007
+                    leax      $14,s
+                    pshs      x
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    clra
+                    lbsr      $5E0B
+                    pshs      x
+                    ldd       #$0010
+                    lbsr      $5E3A
+                    lbsr      $5E24
+                    leax      $14,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    lbsr      $5E0B
+                    lbsr      $5D96
+                    lbsr      $5E24
+                    leax      $14,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $0007
+                    pshs      d
+                    lbsr      L4897
+                    leas      $06,s
+                    lbra      L076F
+
+L0351               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $22,s
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $000B
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $000D
+                    ldd       L0017
+                    cmpd      $000D
+                    ble       L037E
+                    ldd       $000D
+                    std       L0017
+L037E               ldx       $22,s
+                    bra       L03C4
+
+L0383               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $1e,s
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $20,s
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1C,s
+                    bra       L03D3
+
+L03A9               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       L0023
+                    bra       L03D3
+
+L03B6               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $18,s
+                    bra       L03D3
+
+L03C4               cmpx      #$0002
+                    beq       L0383
+                    cmpx      #$0005
+                    beq       L03A9
+                    cmpx      #$0012
+                    beq       L03B6
+L03D3               lbsr      L0788
+                    std       $0282,y
+                    ldx       $22,s
+                    lbra      L046B
+
+L03E0               ldd       $1C,s
+                    pshs      d
+                    ldd       $22,s
+                    pshs      d
+                    ldd       $22,s
+                    pshs      d
+                    ldd       $0282,y
+                    pshs      d
+                    lbsr      L1F14
+                    leas      $08,s
+                    lbra      L048E
+
+L03FD               ldd       $18,s
+                    pshs      d
+                    ldd       $0282,y
+                    pshs      d
+                    lbsr      L0A17
+                    leas      $04,s
+                    lbra      L048E
+
+L0410               ldd       $0282,y
+                    pshs      d
+                    lbsr      L0D05
+                    leas      $02,s
+                    std       $0282,y
+                    lbra      L048E
+
+L0422               ldd       $0282,y
+                    pshs      d
+                    lbsr      L0BF8
+                    leas      $02,s
+                    lbra      L048E
+
+L0430               lbsr      $4B89
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0282,y
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    lbsr      L40D1
+                    leas      $06,s
+                    lbsr      L43DD
+                    clra
+                    clrb
+                    std       L0023
+                    bra       L048E
+
+L0450               ldd       $22,s
+                    pshs      d
+                    leax      $0B58,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+                    bra       L048E
+
+L046B               cmpx      #$0002
+                    lbeq      L03E0
+                    cmpx      #$0012
+                    lbeq      L03FD
+                    cmpx      #$0004
+                    lbeq      L0410
+                    cmpx      #$0001
+                    lbeq      L0422
+                    cmpx      #$0005
+                    beq       L0430
+                    bra       L0450
+
+L048E               ldd       $0282,y
+                    pshs      d
+                    lbsr      L4A6A
+                    lbra      L0511
+
+L049A               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    lbsr      L4415
+                    lbra      L0511
+
+L04A9               ldd       $1a,s
+                    cmpd      #$0064
+                    bne       L04B7
+                    ldd       #$0001
+                    bra       L04B9
+
+L04B7               clra
+                    clrb
+L04B9               pshs      d
+                    lbsr      L4C3F
+                    bra       L0511
+
+L04C0               lbsr      L4C55
+                    lbra      L076F
+
+L04C6               ldd       $1a,s
+                    cmpd      #$FFFF
+                    beq       L04FC
+                    ldd       $1a,s
+                    cmpd      #$005C
+                    bne       L04E4
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1a,s
+L04E4               ldd       $1a,s
+                    pshs      d
+                    lbsr      L4C93
+                    leas      $02,s
+L04EE               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1a,s
+                    bne       L04C6
+L04FC               clra
+                    clrb
+                    pshs      d
+                    lbsr      L4C93
+                    bra       L0511
+
+L0505               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    lbsr      L0AC3
+L0511               leas      $02,s
+                    lbra      L076F
+
+L0516               clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0012
+                    lbra      L057E
+
+L0524               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $18,s
+                    pshs      d
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    ldd       #$007D
+                    bra       L057E
+
+L0540               clra
+                    clrb
+                    pshs      d
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    ldd       #$001D
+                    bra       L057E
+
+L0552               clra
+                    clrb
+                    pshs      d
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    ldd       #$007C
+                    bra       L057E
+
+L0564               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $18,s
+                    pshs      d
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    ldd       #$0009
+L057E               pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    lbra      L076F
+
+L0588               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    ldd       #$0076
+                    bra       L05A2
+
+L0596               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    ldd       #$006F
+L05A2               pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    lbra      L076F
+
+L05AC               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $18,s
+                    ldd       $0011
+                    bne       L05C7
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $000B
+L05C7               leau      ,s
+                    bra       L05D0
+
+L05CB               ldd       $1a,s
+                    stb       ,u+
+L05D0               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1a,s
+                    bne       L05CB
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0013
+                    beq       L05F2
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $1a,s
+L05F2               ldd       $1a,s
+                    pshs      d
+                    ldd       $000B
+                    pshs      d
+                    ldd       $1C,s
+                    pshs      d
+                    leax      $06,s
+                    pshs      x
+                    lbsr      L4B97
+                    leas      $08,s
+                    lbra      L076F
+
+L060C               lbsr      L4C1B
+                    lbra      L076F
+
+L0612               leas      -$0a,s
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       ,s
+                    ldd       $0003
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0008
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    lbsr      L4F59
+                    leas      $08,s
+                    leax      $02,s
+                    pshs      x
+                    lbsr      L095D
+                    leas      $02,s
+                    ldd       ,s
+                    cmpd      #$0006
+                    bne       L0655
+                    ldd       #$0004
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    lbsr      L3DD1
+                    bra       L0671
+
+L0655               leas      -$04,s
+                    leax      ,s
+                    pshs      x
+                    leax      $08,s
+                    lbsr      L56F3
+                    lbsr      $5D69
+                    ldd       #$0002
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    lbsr      L3DD1
+                    leas      $04,s
+L0671               leas      $04,s
+                    leas      $0a,s
+                    lbra      L076F
+                    leas      $0a,s
+L067A               lbsr      L4C62
+                    lbra      L076F
+
+L0680               leau      $0262,y
+                    bra       L069F
+
+L0686               ldd       $1a,s
+                    cmpd      #$FFFF
+                    beq       L06B1
+                    leax      $027f,y
+                    pshs      x
+                    cmpu      ,s++
+                    beq       L069F
+                    ldd       $1a,s
+                    stb       ,u+
+L069F               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1a,s
+                    cmpd      #$000D
+                    bne       L0686
+L06B1               clra
+                    clrb
+                    stb       ,u
+                    lbra      L076F
+
+L06B8               ldd       $1a,s
+                    pshs      d
+                    leax      L0B6D,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+                    lbra      L076F
+
+L06D4               cmpx      #$002A
+                    lbeq      L02C7
+                    cmpx      #$004F
+                    lbeq      L02F3
+                    cmpx      #$0054
+                    lbeq      L0351
+                    cmpx      #$006C
+                    lbeq      L049A
+                    cmpx      #$0076
+                    lbeq      L04A9
+                    cmpx      #$0064
+                    lbeq      L04A9
+                    cmpx      #$0065
+                    lbeq      L04C0
+                    cmpx      #$0073
+                    lbeq      L04EE
+                    cmpx      #$004D
+                    lbeq      L0505
+                    cmpx      #$0072
+                    lbeq      L0516
+                    cmpx      #$004A
+                    lbeq      L0524
+                    cmpx      #$0047
+                    lbeq      L0540
+                    cmpx      #$006A
+                    lbeq      L0552
+                    cmpx      #$0044
+                    lbeq      L0564
+                    cmpx      #$0059
+                    lbeq      L0588
+                    cmpx      #$0055
+                    lbeq      L0596
+                    cmpx      #$0053
+                    lbeq      L05AC
+                    cmpx      #$0045
+                    lbeq      L060C
+                    cmpx      #$0066
+                    lbeq      L0612
+                    cmpx      #$0070
+                    lbeq      L067A
+                    cmpx      #$0046
+                    lbeq      L0680
+                    cmpx      #$000D
+                    beq       L076F
+                    lbra      L06B8
+
+L076F               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $1a,s
+                    cmpd      #$FFFF
+                    lbne      L02C1
+                    leas      $24,s
+                    puls      pc,u
+L0788               pshs      u
+                    ldd       #$FFAA
+                    lbsr      L0111
+                    leas      -$0a,s
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $06,s
+                    ldd       #$0016
+                    pshs      d
+                    lbsr      $3110
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L07B0
+                    lbsr      L4835
+L07B0               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       ,u
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $02,u
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $06,u
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $0e,u
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    clra
+                    std       $10,u
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $12,u
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    std       $14,u
+                    ldx       $06,u
+                    lbra      L08F5
+
+L0806               ldd       #$000D
+                    pshs      d
+                    lbsr      $3110
+                    leas      $02,s
+                    std       $08,s
+                    std       $08,u
+                    ldd       $08,s
+                    bne       L081B
+                    lbsr      L4835
+L081B               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    ldx       $08,s
+                    std       $02,x
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       [$08,s]
+                    ldx       [$08,s]
+                    bra       L086B
+
+L0839               ldd       $08,s
+                    addd      #$0004
+                    std       $04,s
+L0840               ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    stb       -$01,x
+                    bne       L0840
+                    clra
+                    clrb
+                    stb       [$04,s]
+                    lbra      L090A
+
+L085B               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+                    ldx       $08,s
+                    std       $04,x
+                    lbra      L090A
+
+L086B               cmpx      #$000E
+                    beq       L0839
+                    cmpx      #$000C
+                    lbeq      L0839
+                    cmpx      #$0021
+                    lbeq      L0839
+                    cmpx      #$0022
+                    lbeq      L0839
+                    bra       L085B
+
+L0887               ldd       #$0004
+                    pshs      d
+                    lbsr      $3110
+                    leas      $02,s
+                    std       $02,s
+                    bne       L0898
+                    lbsr      L4835
+L0898               ldd       $0003
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0004
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L4F59
+                    leas      $08,s
+                    ldd       $02,s
+                    bra       L08F1
+
+L08B3               ldd       #$0008
+                    pshs      d
+                    lbsr      $3110
+                    leas      $02,s
+                    std       ,s
+                    bne       L08C4
+                    lbsr      L4835
+L08C4               ldd       $0003
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0008
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L4F59
+                    leas      $08,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L095D
+                    leas      $02,s
+                    ldd       ,s
+                    bra       L08F1
+
+L08E8               ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    leas      $02,s
+L08F1               std       $08,u
+                    bra       L090A
+
+L08F5               cmpx      #$0034
+                    lbeq      L0806
+                    cmpx      #$004A
+                    lbeq      L0887
+                    cmpx      #$004B
+                    beq       L08B3
+                    bra       L08E8
+
+L090A               clra
+                    clrb
+                    std       $0a,u
+                    ldx       $06,s
+                    bra       L0941
+
+L0912               lbsr      L0788
+                    std       $0a,u
+L0917               lbsr      L0788
+                    bra       L0923
+
+L091C               lbsr      L0788
+                    std       $0a,u
+L0921               clra
+                    clrb
+L0923               std       $0C,u
+                    bra       L0957
+
+L0927               ldd       $06,s
+                    pshs      d
+                    leax      L0B92,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+                    bra       L0957
+
+L0941               cmpx      #$0042
+                    beq       L0912
+                    cmpx      #$0052
+                    beq       L0917
+                    cmpx      #$004C
+                    beq       L091C
+                    cmpx      #$004E
+                    beq       L0921
+                    bra       L0927
+
+L0957               tfr       u,d
+                    leas      $0a,s
+                    puls      pc,u
+L095D               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$08,s
+                    stu       $06,s
+                    ldx       $06,s
+                    ldb       $07,x
+                    sex
+                    std       $02,s
+                    ldd       #$00B8
+                    ldx       $06,s
+                    stb       $07,x
+                    ldb       [$06,s]
+                    clra
+                    andb      #$80
+                    std       ,s
+                    beq       L098C
+                    ldb       [$06,s]
+                    clra
+                    andb      #$7f
+                    stb       [$06,s]
+L098C               leax      ,u
+                    pshs      x
+                    pshs      u
+                    lbsr      L5676
+                    leas      $02,s
+                    lbsr      L5D79
+                    ldd       $02,s
+                    bge       L09AA
+                    ldd       $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $02,s
+                    clra
+                    clrb
+                    bra       L09AD
+
+L09AA               ldd       #$0001
+L09AD               std       $04,s
+                    leax      ,u
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      ,u
+                    lbsr      $5D52
+                    lbsr      L55A3
+                    leas      $0C,s
+                    lbsr      L5D79
+                    ldd       ,s
+                    beq       L09D8
+                    leax      ,u
+                    pshs      x
+                    leax      ,u
+                    lbsr      L5691
+                    lbsr      L5D79
+L09D8               leas      $08,s
+                    puls      pc,u
+L09DC               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0111
+                    ldd       $0005
+                    beq       L09EA
+                    puls      pc,u
+L09EA               leax      L0BA7,pcr
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L4F07
+                    leas      $04,s
+                    std       $0005
+                    bne       L0A15
+                    ldd       $04,s
+                    pshs      d
+                    leax      $0BA9,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbsr      L0AE0
+L0A15               puls      pc,u
+L0A17               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldx       $06,s
+                    lbra      L0AAA
+
+L0A26               pshs      u
+                    lbsr      L2506
+                    leas      $02,s
+                    leax      ,s
+                    bra       L0A3A
+
+L0A31               pshs      u
+                    lbsr      $29FD
+                    leas      $02,s
+                    bra       L0A3C
+
+L0A3A               leas      ,x
+L0A3C               ldd       $06,u
+                    cmpd      #$0080
+                    lbeq      L0AC1
+                    ldd       #$0080
+                    pshs      d
+                    ldd       #$006F
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       #$006F
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldx       $06,s
+                    bra       L0A93
+
+L0A6D               ldd       $06,s
+                    pshs      d
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L0AC1
+
+L0A82               ldd       #$0089
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    bra       L0AC1
+
+L0A93               cmpx      #$0005
+                    beq       L0A6D
+                    cmpx      #$0006
+                    lbeq      L0A6D
+                    bra       L0A82
+
+L0AA1               pshs      u
+                    lbsr      L0BC4
+                    leas      $02,s
+                    bra       L0AC1
+
+L0AAA               cmpx      #$0008
+                    lbeq      L0A26
+                    cmpx      #$0005
+                    lbeq      L0A31
+                    cmpx      #$0006
+                    lbeq      L0A31
+                    bra       L0AA1
+
+L0AC1               puls      pc,u
+L0AC3               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L0111
+                    ldd       $04,s
+                    pshs      d
+                    leax      L0BB8,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+                    puls      pc,u
+L0AE0               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    ldd       $0284,y
+                    beq       L0AF9
+                    ldd       $0284,y
+                    pshs      d
+                    lbsr      $60C2
+                    leas      $02,s
+L0AF9               ldd       #$0001
+                    pshs      d
+                    lbsr      L622A
+                    leas      $02,s
+                    puls      pc,u
+L0B05               ble       L0B6B
+                    fcb       $65
+                    ror       L2F6E
+                    fcb       $75
+                    inc       $0C,s
+                    neg       L0062
+                    fcb       $61,$64,$20,$61,$72,$67,$75,$6d
+                    fcb       $65,$6e,$74,$3a,$20,$25,$73
+                    fcb       $0d,$00
+L0B21               fcb       $62,$61,$64,$20,$6f,$70,$74,$69
+                    fcb       $6f,$6e,$20,$66,$6C,$61,$67,$3a
+                    fcb       $20,$2b,$25,$63,$0d,$00
+L0B37               lsr       $6F6F
+                    bra       $0BA9
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       L0BA7
+                    rol       $0C,s
+                    fcb       $65
+                    com       >$0072
+                    neg       $0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L0B79
+                    com       $0D00
+L0B57               neg       L0062
+                    fcb       $61,$64,$20,$61,$63,$74,$69,$6f
+                    fcb       $6e,$20,$63,$6f,$64,$65,$3a,$20
+                    fcb       $25,$64
+L0B6B               fcb       $0d,$00
+L0B6D               fcb       $62,$61,$64,$20,$63,$6f,$64,$65
+                    fcb       $20,$69,$6e,$20
+L0B79               fcb       $69,$6e,$74,$65,$72,$6d,$65,$64
+                    fcb       $69,$61,$74,$65,$20,$66,$69,$6C
+                    fcb       $65,$3a,$20,$25,$30,$32,$78
+                    fcb       $0d,$00
+L0B92               fcb       $62,$61,$64,$20,$6e,$6f,$64,$65
+                    fcb       $20,$74,$79,$70,$65,$3a,$20,$25
+                    fcb       $30,$32,$78,$0d,$00
+L0BA7               asr       >$0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       $0BDA
+                    com       $0D00
+L0BB8               bra       $0C26
+                    fcb       $65
+                    fcb       $61
+                    com       L2025
+                    lsr       $0C,y
+                    com       $0D00
+L0BC4               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    pshs      u
+                    lbsr      L0C2E
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0070
+                    beq       L0C2C
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    bra       L0C2A
+
+L0BF8               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    pshs      u
+                    lbsr      L1C1E
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0071
+                    beq       L0C2C
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0071
+L0C2A               std       $06,u
+L0C2C               puls      pc,u
+L0C2E               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldx       ,u
+                    bra       L0C59
+
+L0C3C               pshs      u
+                    lbsr      L2506
+                    bra       L0C55
+
+L0C43               pshs      u
+                    lbsr      $29FD
+                    bra       L0C55
+
+L0C4A               pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    pshs      u
+                    bsr       L0C6E
+L0C55               leas      $02,s
+                    bra       L0C6C
+
+L0C59               cmpx      #$0008
+                    beq       L0C3C
+                    cmpx      #$0005
+                    beq       L0C43
+                    cmpx      #$0006
+                    lbeq      L0C43
+                    bra       L0C4A
+
+L0C6C               puls      pc,u
+L0C6E               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldx       $06,u
+                    lbra      L0CE1
+
+L0C7D               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0071
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L0D03
+
+L0C9F               ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    clra
+                    clrb
+                    std       $08,u
+                    ldd       #$0071
+                    bra       L0CDD
+
+L0CC0               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L0CDA
+                    leas      ,x
+L0CDA               ldd       #$0070
+L0CDD               std       $06,u
+                    bra       L0D03
+
+L0CE1               cmpx      #$0037
+                    lbeq      L0C7D
+                    cmpx      #$0041
+                    beq       L0C9F
+                    cmpx      #$0071
+                    beq       L0D03
+                    cmpx      #$0070
+                    beq       L0D03
+                    cmpx      #$006F
+                    beq       L0D03
+                    cmpx      #$0076
+                    beq       L0D03
+                    bra       L0CC0
+
+L0D03               puls      pc,u
+L0D05               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    std       ,s
+                    cmpd      #$0030
+                    bne       L0D4E
+                    leas      -$02,s
+                    ldd       $0C,u
+                    std       ,s
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L0D05
+                    std       ,s
+                    lbsr      L4A6A
+                    leas      $02,s
+                    pshs      u
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L4ACE
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4A8B
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    leas      $02,s
+                    lbra      L0EF8
+
+L0D4E               ldd       ,u
+                    cmpd      #$0008
+                    bne       L0D60
+                    pshs      u
+                    lbsr      L2521
+                    leas      $02,s
+                    lbra      L0EF8
+
+L0D60               ldd       ,u
+                    cmpd      #$0005
+                    beq       L0D70
+                    ldd       ,u
+                    cmpd      #$0006
+                    bne       L0D7A
+L0D70               pshs      u
+                    lbsr      L2A18
+                    leas      $02,s
+                    lbra      L0EF8
+
+L0D7A               ldd       ,s
+                    pshs      d
+                    lbsr      L4AF8
+                    std       ,s++
+                    beq       L0D93
+                    pshs      u
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L0EFE
+                    leas      $04,s
+                    lbra      L0EF8
+
+L0D93               ldx       ,s
+                    lbra      L0E5F
+
+L0D98               pshs      u
+                    lbsr      L1568
+                    lbra      L0E28
+
+L0DA0               ldd       $0a,u
+                    pshs      d
+                    lbsr      L0D05
+                    lbra      L0E28
+
+L0DAA               ldd       $0a,u
+                    pshs      d
+                    lbsr      L2521
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0084
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L0E0F
+
+L0DC8               ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       #$008F
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    bra       L0E0D
+
+L0DE0               pshs      u
+                    lbsr      L1954
+                    bra       L0E28
+
+L0DE7               pshs      u
+                    lbsr      L124D
+                    bra       L0E28
+
+L0DEE               ldd       $0a,u
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L3293
+                    leas      $02,s
+                    bra       L0E0F
+
+L0E02               leax      L0BC4,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L12E9
+L0E0D               leas      $04,s
+L0E0F               ldd       #$0070
+                    std       $06,u
+                    lbra      L0EF8
+
+L0E17               ldd       #$0070
+                    pshs      d
+                    pshs      u
+                    lbsr      L1A9B
+                    bra       L0E5A
+
+L0E23               pshs      u
+                    lbsr      L1365
+L0E28               leas      $02,s
+                    lbra      L0EF8
+
+L0E2D               ldd       ,s
+                    cmpd      #$00A0
+                    blt       L0E40
+                    ldd       ,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L16CC
+                    bra       L0E5A
+
+L0E40               leax      L1ED5,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L484C
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    leax      L1EE1,pcr
+                    pshs      x
+                    lbsr      L2D40
+L0E5A               leas      $04,s
+                    lbra      L0EF8
+
+L0E5F               cmpx      #$0037
+                    lbeq      L0EF8
+                    cmpx      #$0034
+                    lbeq      L0EF8
+                    cmpx      #$0076
+                    lbeq      L0EF8
+                    cmpx      #$006F
+                    lbeq      L0EF8
+                    cmpx      #$0041
+                    beq       L0EF8
+                    cmpx      #$0036
+                    beq       L0EF8
+                    cmpx      #$0078
+                    lbeq      L0D98
+                    cmpx      #$0085
+                    lbeq      L0DA0
+                    cmpx      #$0084
+                    lbeq      L0DAA
+                    cmpx      #$008F
+                    lbeq      L0DC8
+                    cmpx      #$0042
+                    lbeq      L0DE0
+                    cmpx      #$0040
+                    lbeq      L0DE7
+                    cmpx      #$0047
+                    lbeq      L0DE7
+                    cmpx      #$0048
+                    lbeq      L0DE7
+                    cmpx      #$0044
+                    lbeq      L0DEE
+                    cmpx      #$0043
+                    lbeq      L0DEE
+                    cmpx      #$0064
+                    lbeq      L0E02
+                    cmpx      #$003C
+                    lbeq      L0E17
+                    cmpx      #$003E
+                    lbeq      L0E17
+                    cmpx      #$003D
+                    lbeq      L0E17
+                    cmpx      #$003F
+                    lbeq      L0E17
+                    cmpx      #$0065
+                    lbeq      L0E23
+                    lbra      L0E2D
+
+L0EF8               tfr       u,d
+                    leas      $02,s
+                    puls      pc,u
+L0EFE               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    leas      -$06,s
+                    ldx       $0C,s
+                    ldu       $0a,x
+                    ldx       $0C,s
+                    ldd       $0C,x
+                    std       $04,s
+                    ldd       ,u
+                    cmpd      #$0007
+                    bne       L0F40
+                    ldx       $0a,s
+                    bra       L0F2F
+
+L0F1E               ldd       #$004E
+                    bra       L0F2B
+
+L0F23               ldd       #$004C
+                    bra       L0F2B
+
+L0F28               ldd       #$004D
+L0F2B               std       $0a,s
+                    bra       L0F74
+
+L0F2F               cmpx      #$0053
+                    beq       L0F1E
+                    cmpx      #$0054
+                    beq       L0F23
+                    cmpx      #$0055
+                    beq       L0F28
+                    bra       L0F74
+
+L0F40               ldx       $0a,s
+                    bra       L0F68
+
+L0F44               ldd       $06,u
+                    cmpd      #$0041
+                    bne       L0F74
+                    ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    beq       L0F74
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L1C1E
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       L0019
+                    lbra      L1361
+                    bra       L0F74
+
+L0F68               cmpx      #$0050
+                    beq       L0F44
+                    cmpx      #$0051
+                    lbeq      L0F44
+L0F74               ldx       $0a,s
+                    lbra      L1168
+
+L0F79               ldd       $04,s
+                    pshs      d
+                    lbsr      L22CB
+                    std       ,s++
+                    bne       L0FAB
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0C2E
+                    leas      $02,s
+                    ldx       $04,s
+                    ldd       $06,x
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$006E
+                    ldx       $04,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L0BC4
+                    bra       L0FB9
+
+L0FAB               pshs      u
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0D05
+L0FB9               leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0051
+                    lbra      L1064
+
+L0FCF               pshs      u
+                    lbsr      L22CB
+                    std       ,s++
+                    beq       L0FE3
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L22CB
+                    std       ,s++
+                    beq       L0FEB
+L0FE3               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L0FF7
+L0FEB               leas      -$02,s
+                    stu       ,s
+                    ldu       $06,s
+                    ldd       ,s
+                    std       $06,s
+                    leas      $02,s
+L0FF7               ldd       $06,u
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    beq       L1022
+                    ldd       $06,u
+L1004               pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       #$006E
+                    ldx       $04,s
+                    std       $06,x
+                    bra       L1053
+
+L1022               pshs      u
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L22CB
+                    std       ,s++
+                    bne       L1039
+                    ldd       #$0070
+                    bra       L1004
+
+L1039               ldd       $04,s
+                    pshs      d
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldd       $0a,s
+                    cmpd      #$0050
+                    beq       L1053
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L152E
+                    leas      $02,s
+L1053               ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $10,s
+L1064               pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    lbra      L120E
+
+L106E               ldd       $0C,s
+                    pshs      d
+                    lbsr      L124D
+                    lbra      L1151
+
+L1078               ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L10DC
+                    ldx       $04,s
+                    ldd       $08,x
+                    std       ,s
+                    bra       L108E
+
+L108C               leas      -$06,x
+L108E               ldd       ,s
+                    cmpd      #$0004
+                    bhi       L10DC
+                    pshs      u
+                    lbsr      L0BC4
+L109B               leas      $02,s
+                    bra       L10C6
+
+L109F               ldx       $0a,s
+                    bra       L10B7
+
+L10A3               ldd       #$0098
+                    bra       L10B0
+
+L10A8               ldd       #$0096
+                    bra       L10B0
+
+L10AD               ldd       #$0097
+L10B0               pshs      d
+                    lbsr      L3293
+                    bra       L109B
+
+L10B7               cmpx      #$0056
+                    beq       L10A3
+                    cmpx      #$0055
+                    beq       L10A8
+                    cmpx      #$004D
+                    beq       L10AD
+L10C6               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bne       L109F
+                    ldd       #$0001
+                    std       L0019
+                    leax      $06,s
+                    lbra      L1214
+
+L10DC               leax      $06,s
+                    bra       L112A
+
+L10E0               ldd       $06,u
+                    cmpd      #$0036
+                    bne       L10F4
+                    leas      -$02,s
+                    stu       ,s
+                    ldu       $06,s
+                    ldd       ,s
+                    std       $06,s
+                    leas      $02,s
+L10F4               ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L112C
+                    ldx       $04,s
+                    ldd       $08,x
+                    pshs      d
+                    lbsr      L1220
+                    leas      $02,s
+                    std       ,s
+                    beq       L112C
+                    ldd       ,s
+                    ldx       $04,s
+                    std       $08,x
+                    ldd       $0a,s
+                    cmpd      #$0052
+                    bne       L1120
+                    ldd       #$0056
+                    bra       L1123
+
+L1120               ldd       #$004D
+L1123               std       $0a,s
+                    leax      $06,s
+                    lbra      L108C
+
+L112A               leas      -$06,x
+L112C               pshs      u
+                    lbsr      L0C2E
+                    leas      $02,s
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L3293
+L1151               leas      $02,s
+                    lbra      L120E
+
+L1156               leax      L1EE5,pcr
+                    pshs      x
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L484C
+                    leas      $04,s
+                    lbra      L120E
+
+L1168               cmpx      #$0051
+                    lbeq      L0F79
+                    cmpx      #$0057
+                    lbeq      L0FCF
+                    cmpx      #$0058
+                    lbeq      L0FCF
+                    cmpx      #$0059
+                    lbeq      L0FCF
+                    cmpx      #$0050
+                    lbeq      L0FCF
+                    cmpx      #$005A
+                    lbeq      L106E
+                    cmpx      #$005B
+                    lbeq      L106E
+                    cmpx      #$005F
+                    lbeq      L106E
+                    cmpx      #$005D
+                    lbeq      L106E
+                    cmpx      #$005C
+                    lbeq      L106E
+                    cmpx      #$005E
+                    lbeq      L106E
+                    cmpx      #$0063
+                    lbeq      L106E
+                    cmpx      #$0061
+                    lbeq      L106E
+                    cmpx      #$0060
+                    lbeq      L106E
+                    cmpx      #$0062
+                    lbeq      L106E
+                    cmpx      #$004D
+                    lbeq      L1078
+                    cmpx      #$0055
+                    lbeq      L1078
+                    cmpx      #$0056
+                    lbeq      L1078
+                    cmpx      #$0052
+                    lbeq      L10E0
+                    cmpx      #$004E
+                    lbeq      L10F4
+                    cmpx      #$0053
+                    lbeq      L112C
+                    cmpx      #$004C
+                    lbeq      L112C
+                    cmpx      #$0054
+                    lbeq      L112C
+                    lbra      L1156
+                    leas      -$06,x
+L120E               clra
+                    clrb
+                    std       L0019
+                    bra       L1216
+
+L1214               leas      -$06,x
+L1216               ldd       #$0070
+                    ldx       $0C,s
+                    std       $06,x
+                    lbra      L1361
+
+L1220               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldu       #$0000
+                    bra       L1244
+
+L122D               tfr       u,d
+                    leau      $01,u
+                    aslb
+                    rola
+                    leax      >$0027,y
+                    leax      d,x
+                    ldd       ,x
+                    cmpd      $04,s
+                    bne       L1244
+                    tfr       u,d
+                    puls      pc,u
+L1244               cmpu      #$000E
+                    blt       L122D
+                    lbra      L152A
+
+L124D               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $02,s
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L1F14
+                    leas      $08,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    ldd       #$0070
+                    std       $06,u
+                    lbra      L1A97
+
+L12E9               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$06,s
+                    ldd       #$0001
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $02,s
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $08,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L1F14
+                    leas      $08,s
+                    ldu       $0C,u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    jsr       [$0e,s]
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       #$007C
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    jsr       [$0e,s]
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+L1361               leas      $06,s
+                    puls      pc,u
+L1365               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L0111
+                    leas      -$04,s
+                    ldd       $000D
+                    std       ,s
+                    ldd       $08,s
+                    std       $02,s
+                    lbra      L1402
+
+L137A               ldx       $02,s
+                    ldu       $0a,x
+                    ldd       ,u
+                    cmpd      #$0008
+                    bne       L13A9
+                    ldd       $06,u
+                    cmpd      #$004A
+                    bne       L1398
+                    pshs      u
+                    lbsr      L294C
+                    leas      $02,s
+                    lbra      L1402
+
+L1398               pshs      u
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0088
+                    bra       L13FB
+
+L13A9               ldd       ,u
+                    cmpd      #$0005
+                    beq       L13B9
+                    ldd       ,u
+                    cmpd      #$0006
+                    bne       L13CA
+L13B9               pshs      u
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0087
+                    bra       L13FB
+
+L13CA               pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L13DE
+
+L13D5               pshs      u
+                    lbsr      L0C6E
+                    leas      $02,s
+                    bra       L13F4
+
+L13DE               cmpx      #$0070
+                    beq       L13F4
+                    cmpx      #$0071
+                    beq       L13F4
+                    cmpx      #$006F
+                    beq       L13F4
+                    cmpx      #$0076
+                    beq       L13F4
+                    bra       L13D5
+
+L13F4               ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+L13FB               pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+L1402               ldx       $02,s
+                    ldd       $0C,x
+                    std       $02,s
+                    lbne      L137A
+                    ldx       $08,s
+                    ldd       $0a,x
+                    pshs      d
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldx       $08,s
+                    ldd       $0a,x
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0065
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4440
+                    leas      $02,s
+                    std       $000D
+                    ldd       #$0070
+                    ldx       $08,s
+                    std       $06,x
+                    lbra      L1A97
+
+L1441               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldx       $06,u
+                    bra       L1486
+
+L1451               ldd       $0a,u
+                    std       ,s
+                    tfr       d,x
+                    ldx       $06,x
+                    bra       L146A
+
+L145B               ldd       #$0001
+                    bra       L149B
+
+L1460               ldd       ,s
+                    pshs      d
+                    bsr       L149F
+                    leas      $02,s
+                    bra       L149B
+
+L146A               cmpx      #$0036
+                    beq       L145B
+                    cmpx      #$0034
+                    lbeq      L145B
+                    cmpx      #$0076
+                    lbeq      L145B
+                    cmpx      #$006F
+                    lbeq      L145B
+                    bra       L1460
+
+L1486               cmpx      #$0034
+                    lbeq      L145B
+                    cmpx      #$0036
+                    lbeq      L145B
+                    cmpx      #$0042
+                    beq       L1451
+                    clra
+                    clrb
+L149B               leas      $02,s
+                    puls      pc,u
+L149F               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldx       $06,u
+                    bra       L14CD
+
+L14AD               ldx       $0a,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    lbeq      L152A
+                    ldx       $0C,u
+                    ldd       $06,x
+                    cmpd      #$0036
+                    lbne      L152A
+                    bra       L150B
+                    lbra      L152A
+
+L14CD               cmpx      #$0050
+                    beq       L14AD
+                    cmpx      #$0051
+                    lbeq      L14AD
+                    bra       L152A
+
+L14DB               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldx       $04,s
+                    ldd       $12,x
+                    cmpd      #$0002
+                    bge       L152A
+                    ldd       #$0001
+                    bra       L152C
+
+L14F3               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldx       $06,u
+                    bra       L1512
+
+L1501               ldx       $0a,u
+                    ldd       $06,x
+                    cmpd      #$0041
+                    bne       L152A
+L150B               ldd       #$0001
+                    puls      pc,u
+                    bra       L152A
+
+L1512               cmpx      #$0050
+                    beq       L1501
+                    cmpx      #$0051
+                    lbeq      L1501
+                    cmpx      #$0037
+                    beq       L150B
+                    cmpx      #$0041
+                    lbeq      L150B
+L152A               clra
+                    clrb
+L152C               puls      pc,u
+L152E               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L1566
+                    ldd       $06,u
+                    anda      #$7f
+                    std       $06,u
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0093
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+L1566               puls      pc,u
+L1568               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0111
+                    leas      -$04,s
+                    ldx       $08,s
+                    ldd       $0C,x
+                    std       ,s
+                    ldx       $08,s
+                    ldu       $0a,x
+                    ldd       $06,u
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    lbeq      L15FE
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L149F
+                    std       ,s++
+                    beq       L159D
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L1C1E
+                    bra       L15A4
+
+L159D               ldd       ,s
+                    pshs      d
+                    lbsr      L0D05
+L15A4               leas      $02,s
+                    ldx       ,s
+                    ldx       $06,x
+                    bra       L15F2
+
+L15AC               ldx       ,s
+                    ldd       $0a,x
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$007F
+                    bra       L15E8
+
+L15C0               ldd       ,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+L15D8               ldd       ,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$0075
+L15E8               pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    lbra      L1795
+
+L15F2               cmpx      #$0041
+                    beq       L15AC
+                    cmpx      #$0085
+                    beq       L15C0
+                    bra       L15D8
+
+L15FE               pshs      u
+                    lbsr      L1441
+                    std       ,s++
+                    beq       L1636
+                    ldd       ,u
+                    cmpd      #$0002
+                    beq       L1636
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L149F
+                    std       ,s++
+                    bne       L1625
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L14F3
+                    std       ,s++
+                    beq       L1636
+L1625               pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L1BE5
+                    lbra      L16AC
+
+L1636               ldx       ,s
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    beq       L165D
+                    pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldd       ,u
+                    cmpd      #$0002
+                    lbne      L16AE
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L0BC4
+                    bra       L16AC
+
+L165D               pshs      u
+                    lbsr      L14DB
+                    std       ,s++
+                    beq       L1676
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L0D05
+                    bra       L16AC
+
+L1676               pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L1441
+                    std       ,s++
+                    bne       L16A5
+                    ldd       $06,u
+                    anda      #$7f
+                    tfr       d,x
+                    bra       L1699
+
+L1690               pshs      u
+                    lbsr      L1905
+                    leas      $02,s
+                    bra       L16A5
+
+L1699               cmpx      #$0095
+                    beq       L16A5
+                    cmpx      #$0094
+                    beq       L16A5
+                    bra       L1690
+
+L16A5               ldd       ,s
+                    pshs      d
+                    lbsr      L0C2E
+L16AC               leas      $02,s
+L16AE               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldx       $04,s
+                    ldd       $06,x
+                    pshs      d
+                    ldd       #$0079
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldx       ,s
+                    ldd       $06,x
+                    lbra      L1797
+
+L16CC               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0111
+                    leas      -$04,s
+                    ldx       $08,s
+                    ldd       $0C,x
+                    std       $02,s
+                    ldx       $08,s
+                    ldu       $0a,x
+                    pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldd       $0a,s
+                    addd      #$FFB0
+                    std       $0a,s
+                    ldd       ,u
+                    cmpd      #$0007
+                    bne       L171A
+                    ldx       $0a,s
+                    bra       L170B
+
+L16FA               ldd       #$004E
+                    bra       L1707
+
+L16FF               ldd       #$004D
+                    bra       L1707
+
+L1704               ldd       #$004C
+L1707               std       $0a,s
+                    bra       L171A
+
+L170B               cmpx      #$0053
+                    beq       L16FA
+                    cmpx      #$0055
+                    beq       L16FF
+                    cmpx      #$0054
+                    beq       L1704
+L171A               ldd       $06,u
+                    anda      #$7f
+                    std       ,s
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    lbeq      L17F0
+                    ldx       $0a,s
+                    lbra      L17CB
+
+L1730               ldx       $02,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1767
+                    ldd       $0a,s
+                    cmpd      #$0050
+                    bne       L1748
+                    ldx       $02,s
+                    ldd       $08,x
+                    bra       L1750
+
+L1748               ldx       $02,s
+                    ldd       $08,x
+                    nega
+                    negb
+                    sbca      #$00
+L1750               pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0074
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L1795
+
+L1767               ldd       $02,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $0a,s
+                    cmpd      #$0051
+                    bne       L1782
+                    ldd       #$0043
+                    pshs      d
+                    lbsr      L3293
+                    leas      $02,s
+L1782               ldd       #$0070
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0074
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+L1795               ldd       $06,u
+L1797               ldx       $08,s
+                    std       $06,x
+                    clra
+                    clrb
+                    ldx       $08,s
+                    std       $08,x
+                    lbra      L1A97
+
+L17A4               leax      $04,s
+                    bra       L17EE
+
+L17A8               ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L3293
+                    leas      $02,s
+                    lbra      L18E5
+
+L17CB               cmpx      #$0050
+                    lbeq      L1730
+                    cmpx      #$0051
+                    lbeq      L1730
+                    cmpx      #$0057
+                    beq       L17A4
+                    cmpx      #$0058
+                    lbeq      L17A4
+                    cmpx      #$0059
+                    lbeq      L17A4
+                    bra       L17A8
+
+L17EE               leas      -$04,x
+L17F0               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       ,u
+                    cmpd      #$0002
+                    bne       L1818
+                    ldd       #$0085
+                    pshs      d
+                    lbsr      L3293
+                    leas      $02,s
+L1818               ldx       $0a,s
+                    lbra      L18BF
+
+L181D               ldd       $02,s
+                    pshs      d
+                    lbsr      L1441
+                    std       ,s++
+                    beq       L186E
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldx       $0a,s
+                    bra       L1840
+
+L1835               ldd       $02,s
+                    pshs      d
+                    lbsr      L152E
+                    leas      $02,s
+                    bra       L1853
+
+L1840               cmpx      #$0057
+                    beq       L1835
+                    cmpx      #$0058
+                    lbeq      L1835
+                    cmpx      #$0059
+                    lbeq      L1835
+L1853               ldd       $02,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    lbra      L18E5
+
+L186E               ldd       ,s
+                    cmpd      #$0094
+                    beq       L1885
+                    ldd       ,s
+                    cmpd      #$0095
+                    beq       L1885
+                    pshs      u
+                    lbsr      L1905
+                    leas      $02,s
+L1885               ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $0a,s
+                    cmpd      #$0051
+                    bne       L18AA
+                    ldd       #$004F
+                    std       $0a,s
+L18AA               ldd       #$006E
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L18E5
+
+L18BF               cmpx      #$0057
+                    lbeq      L181D
+                    cmpx      #$0058
+                    lbeq      L181D
+                    cmpx      #$0059
+                    lbeq      L181D
+                    cmpx      #$0050
+                    lbeq      L181D
+                    cmpx      #$0051
+                    lbeq      L181D
+                    lbra      L186E
+
+L18E5               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0079
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    ldx       $08,s
+                    std       $06,x
+                    lbra      L1A97
+
+L1905               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldd       $06,u
+                    anda      #$7f
+                    cmpd      #$0034
+                    bne       L191B
+                    puls      pc,u
+L191B               pshs      u
+                    lbsr      L152E
+                    leas      $02,s
+                    ldd       $08,u
+                    beq       L193E
+                    ldd       $08,u
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0074
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+L193E               ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$806E
+                    std       $06,u
+                    puls      pc,u
+L1954               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $0a,u
+                    std       $02,s
+                    pshs      d
+                    lbsr      L1C1E
+                    leas      $02,s
+                    ldx       $02,s
+                    ldd       $06,x
+                    std       ,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    lbeq      L19D8
+                    ldd       ,s
+                    anda      #$7f
+                    std       ,s
+                    tfr       d,x
+                    bra       L19B0
+
+L1984               ldx       $02,s
+                    ldd       $08,x
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L19CC
+
+L199F               leax      L1EF0,pcr
+                    pshs      x
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L484C
+                    leas      $04,s
+                    bra       L19CC
+
+L19B0               cmpx      #$0034
+                    beq       L1984
+                    cmpx      #$0093
+                    lbeq      L1984
+                    cmpx      #$0094
+                    lbeq      L1984
+                    cmpx      #$0095
+                    lbeq      L1984
+                    bra       L199F
+
+L19CC               ldd       #$8093
+                    std       ,s
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L1A93
+
+L19D8               ldx       ,s
+                    lbra      L1A54
+
+L19DD               ldd       #$0095
+                    bra       L19F0
+
+L19E2               ldd       #$0094
+                    bra       L19F0
+
+L19E7               ldd       #$0093
+                    bra       L19F0
+
+L19EC               ldd       ,s
+                    ora       #$80
+L19F0               std       ,s
+                    leax      $04,s
+                    bra       L1A05
+
+L19F6               ldd       #$8034
+                    std       ,s
+                    ldx       $02,s
+                    ldd       $14,x
+                    std       $14,u
+                    bra       L1A07
+
+L1A05               leas      -$04,x
+L1A07               ldx       $02,s
+                    ldd       $08,x
+                    bra       L1A2C
+
+L1A0D               ldd       $02,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0093
+                    std       ,s
+                    clra
+                    clrb
+L1A2C               std       $08,u
+                    bra       L1A93
+
+L1A30               clra
+                    clrb
+                    std       $08,u
+                    ldx       $02,s
+                    ldd       $08,x
+                    std       $14,u
+                    ldd       #$0034
+                    bra       L1A50
+
+L1A40               leax      L1EFC,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L484C
+                    leas      $04,s
+                    ldd       #$0093
+L1A50               std       ,s
+                    bra       L1A93
+
+L1A54               cmpx      #$006F
+                    lbeq      L19DD
+                    cmpx      #$0076
+                    lbeq      L19E2
+                    cmpx      #$0071
+                    lbeq      L19E7
+                    cmpx      #$0093
+                    lbeq      L19EC
+                    cmpx      #$0094
+                    lbeq      L19EC
+                    cmpx      #$0095
+                    lbeq      L19EC
+                    cmpx      #$0034
+                    lbeq      L19F6
+                    cmpx      #$0070
+                    lbeq      L1A0D
+                    cmpx      #$0036
+                    beq       L1A30
+                    bra       L1A40
+
+L1A93               ldd       ,s
+                    std       $06,u
+L1A97               leas      $04,s
+                    puls      pc,u
+L1A9B               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L0111
+                    leas      -$08,s
+                    ldx       $0C,s
+                    ldu       $0a,x
+                    pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldx       $0C,s
+                    ldd       $06,x
+                    std       $02,s
+                    ldd       $06,u
+                    std       ,s
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    beq       L1AFB
+                    ldx       $02,s
+                    bra       L1AED
+
+L1AC7               ldd       $0e,s
+                    cmpd      #$0070
+                    bne       L1AE7
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L1B2C
+
+L1AE7               ldd       ,s
+                    std       $0e,s
+                    bra       L1B2C
+
+L1AED               cmpx      #$003E
+                    beq       L1AC7
+                    cmpx      #$003F
+                    lbeq      L1AC7
+                    bra       L1AE7
+
+L1AFB               ldd       $0e,s
+                    cmpd      #$0071
+                    bne       L1B12
+                    ldd       ,s
+                    anda      #$7f
+                    cmpd      #$0034
+                    beq       L1B12
+                    ldd       #$0070
+                    std       $0e,s
+L1B12               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       $0e,s
+                    std       ,s
+L1B2C               ldx       $0C,s
+                    ldd       $08,x
+                    std       $06,s
+                    ldx       $02,s
+                    bra       L1B71
+
+L1B36               ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+L1B3E               ldd       ,s
+                    cmpd      #$0070
+                    bne       L1B58
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0050
+                    bra       L1B68
+
+L1B58               ldd       $06,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0074
+L1B68               pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L1B7F
+
+L1B71               cmpx      #$003D
+                    beq       L1B36
+                    cmpx      #$003F
+                    lbeq      L1B36
+                    bra       L1B3E
+
+L1B7F               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       #$0079
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldx       $02,s
+                    bra       L1BCA
+
+L1B98               clra
+                    clrb
+                    bra       L1BC4
+
+L1B9C               ldd       ,s
+                    cmpd      #$0070
+                    bne       L1BBE
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0051
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L1BD8
+
+L1BBE               ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+L1BC4               ldx       $0C,s
+                    std       $08,x
+                    bra       L1BD8
+
+L1BCA               cmpx      #$003E
+                    beq       L1B9C
+                    cmpx      #$003F
+                    lbeq      L1B9C
+                    bra       L1B98
+
+L1BD8               ldd       $0e,s
+                    ldx       $0C,s
+                    std       $06,x
+                    clra
+                    clrb
+                    std       L0019
+                    lbra      L1EB0
+
+L1BE5               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldu       $04,s
+                    pshs      u
+                    bsr       L1C1E
+                    leas      $02,s
+                    ldd       $06,u
+                    cmpd      #$0071
+                    bne       L1C01
+                    ldd       $08,u
+                    beq       L1C17
+L1C01               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+L1C17               ldd       #$0071
+                    std       $06,u
+                    puls      pc,u
+L1C1E               pshs      u
+                    ldd       #$FFAC
+                    lbsr      L0111
+                    leas      -$08,s
+                    ldx       $0C,s
+                    ldu       $0a,x
+                    ldx       $0C,s
+                    ldd       $0C,x
+                    std       $06,s
+                    ldd       #$0071
+                    std       ,s
+                    ldx       $0C,s
+                    ldd       $06,x
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L1E50
+
+L1C42               ldd       $0C,s
+                    pshs      d
+                    lbsr      L1954
+                    lbra      L1E4C
+
+L1C4C               ldd       #$0071
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L1A9B
+                    leas      $04,s
+                    lbra      L1EB0
+
+L1C5D               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    clra
+                    clrb
+                    lbra      L1E3D
+
+L1C78               ldd       $0C,s
+                    pshs      d
+                    lbsr      L0BC4
+                    lbra      L1E4C
+
+L1C82               ldd       $06,u
+                    cmpd      #$0041
+                    beq       L1C93
+                    ldx       $06,s
+                    ldd       $12,x
+                    lbne      L1D31
+L1C93               ldd       $06,u
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    bne       L1CA6
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L1CFA
+L1CA6               ldx       $06,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1CC2
+                    pshs      u
+                    lbsr      L1C1E
+                    leas      $02,s
+                    ldd       $06,u
+                    std       ,s
+                    ldx       $06,s
+                    ldd       $08,x
+                    lbra      L1E27
+
+L1CC2               ldd       $06,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L1C1E
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0051
+                    bne       L1CE4
+                    ldd       #$0043
+                    pshs      d
+                    lbsr      L3293
+                    leas      $02,s
+L1CE4               ldd       $06,u
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    lbra      L1E25
+
+L1CFA               ldd       $02,s
+                    cmpd      #$0050
+                    bne       L1D19
+                    ldd       $12,u
+                    ldx       $06,s
+                    cmpd      $12,x
+                    bge       L1D19
+                    leas      -$02,s
+                    stu       ,s
+                    ldu       $08,s
+                    ldd       ,s
+                    std       $08,s
+                    leas      $02,s
+L1D19               ldd       $06,s
+                    pshs      d
+                    lbsr      L1441
+                    std       ,s++
+                    bne       L1D36
+                    ldx       $06,s
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    bne       L1D36
+L1D31               leax      $08,s
+                    lbra      L1E43
+
+L1D36               pshs      u
+                    lbsr      L1C1E
+                    leas      $02,s
+                    ldd       $06,u
+                    anda      #$7f
+                    tfr       d,x
+                    lbra      L1D9B
+
+L1D46               ldd       $02,s
+                    cmpd      #$0050
+                    bne       L1D6A
+                    ldx       $06,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    beq       L1D6A
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L0BF8
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $08,u
+                    leax      $08,s
+                    lbra      L1E0B
+
+L1D6A               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    clra
+                    clrb
+                    std       $08,u
+                    bra       L1DD6
+
+L1D86               ldd       $06,u
+                    std       ,s
+                    bra       L1DD6
+
+L1D8C               leax      L1F08,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L484C
+                    leas      $04,s
+                    bra       L1DD6
+
+L1D9B               cmpx      #$0070
+                    lbeq      L1D46
+                    cmpx      #$0034
+                    beq       L1D6A
+                    cmpx      #$0037
+                    lbeq      L1D6A
+                    cmpx      #$0093
+                    lbeq      L1D6A
+                    cmpx      #$0094
+                    lbeq      L1D6A
+                    cmpx      #$0095
+                    lbeq      L1D6A
+                    cmpx      #$0071
+                    beq       L1DD6
+                    cmpx      #$0076
+                    beq       L1D86
+                    cmpx      #$006F
+                    lbeq      L1D86
+                    bra       L1D8C
+
+L1DD6               ldx       $06,s
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L1DE6
+                    ldx       $06,s
+                    ldd       $08,x
+                    bra       L1E27
+
+L1DE6               ldd       $06,s
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0051
+                    bne       L1E0D
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0043
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L1E0D
+
+L1E0B               leas      -$08,x
+L1E0D               ldd       ,s
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       #$0071
+                    std       ,s
+L1E25               clra
+                    clrb
+L1E27               std       $04,s
+                    ldd       $02,s
+                    cmpd      #$0050
+                    bne       L1E35
+                    ldd       $04,s
+                    bra       L1E3B
+
+L1E35               ldd       $04,s
+                    nega
+                    negb
+                    sbca      #$00
+L1E3B               addd      $08,u
+L1E3D               ldx       $0C,s
+                    std       $08,x
+                    bra       L1EAA
+
+L1E43               leas      -$08,x
+L1E45               ldd       $0C,s
+                    pshs      d
+                    lbsr      L0D05
+L1E4C               leas      $02,s
+                    bra       L1EB0
+
+L1E50               cmpx      #$0042
+                    lbeq      L1C42
+                    cmpx      #$0034
+                    beq       L1EB0
+                    cmpx      #$0076
+                    beq       L1EB0
+                    cmpx      #$006F
+                    beq       L1EB0
+                    cmpx      #$0036
+                    beq       L1EB0
+                    cmpx      #$0037
+                    beq       L1EB0
+                    cmpx      #$003E
+                    lbeq      L1C4C
+                    cmpx      #$003C
+                    lbeq      L1C4C
+                    cmpx      #$003D
+                    lbeq      L1C4C
+                    cmpx      #$003F
+                    lbeq      L1C4C
+                    cmpx      #$0041
+                    lbeq      L1C5D
+                    cmpx      #$0085
+                    lbeq      L1C78
+                    cmpx      #$0051
+                    lbeq      L1C82
+                    cmpx      #$0050
+                    lbeq      L1C93
+                    bra       L1E45
+
+L1EAA               ldd       ,s
+                    ldx       $0C,s
+                    std       $06,x
+L1EB0               leas      $08,s
+                    puls      pc,u
+L1EB4               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldd       $04,s
+                    cmpd      #$006F
+                    beq       L1ECC
+                    ldd       $04,s
+                    cmpd      #$0076
+                    bne       L1ED1
+L1ECC               ldd       #$0001
+                    bra       L1ED3
+
+L1ED1               clra
+                    clrb
+L1ED3               puls      pc,u
+L1ED5               lsr       $7261
+                    jmp       -$0d,s
+                    inc       $01,s
+                    lsr       $696F
+                    jmp       0,x
+
+L1EE1               bcs       $1F5B
+                    tst       $0000
+L1EE5               fcb       $62
+                    rol       $0e,s
+                    fcb       $61
+                    fcb       $72
+                    rol       $206F
+                    neg       $2E00
+L1EF0               rol       $0e,s
+                    lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+                    rol       $0f,s
+                    jmp       0,x
+
+L1EFC               rol       $0e,s
+                    lsr       $09,s
+                    fcb       $72
+                    fcb       $65
+                    com       -$0C,s
+                    rol       $0f,s
+                    jmp       0,x
+
+L1F08               asl       $2074
+                    fcb       $72
+                    fcb       $61
+                    jmp       -$0d,s
+                    inc       $01,s
+                    lsr       $6500
+L1F14               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L2070
+
+L1F29               ldd       #$0001
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $04,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L1F14
+                    leas      $08,s
+                    leax      $04,s
+                    bra       L1F67
+
+L1F49               clra
+                    clrb
+                    pshs      d
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       $02,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L1F14
+                    leas      $08,s
+                    bra       L1F69
+
+L1F67               leas      -$04,x
+L1F69               ldd       ,s
+                    pshs      d
+                    lbsr      L4415
+                    lbra      L1FD3
+
+L1F73               ldd       #$0001
+                    subd      $0e,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $0a,u
+                    lbra      L1FE3
+
+L1F88               ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    pshs      u
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L20EE
+                    leas      $0a,s
+                    lbra      L20EA
+
+L1FA2               ldd       $08,u
+                    beq       L1FB2
+                    ldd       $0e,s
+                    bne       L1FB2
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0C,s
+                    bra       L1FC4
+
+L1FB2               ldd       $0e,s
+                    lbeq      L20EA
+                    ldd       $08,u
+                    lbne      L20EA
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $0e,s
+L1FC4               pshs      d
+                    ldd       #$007C
+                    lbra      L2067
+
+L1FCC               ldd       $0a,u
+                    pshs      d
+                    lbsr      L0D05
+L1FD3               leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0C,u
+L1FE3               pshs      d
+                    lbsr      L1F14
+                    leas      $08,s
+                    lbra      L20EA
+
+L1FED               ldd       ,u
+                    cmpd      #$0008
+                    bne       L200D
+                    pshs      u
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       #$008B
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    bra       L204E
+
+L200D               ldd       ,u
+                    cmpd      #$0005
+                    beq       L201D
+                    ldd       ,u
+                    cmpd      #$0006
+                    bne       L2043
+L201D               ldd       $06,u
+                    cmpd      #$008C
+                    bne       L2027
+L2025               ldu       $0a,u
+L2027               pshs      u
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       ,u
+                    pshs      d
+                    ldd       #$008B
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L204E
+
+L2043               pshs      u
+                    lbsr      L2324
+                    leas      $02,s
+                    bra       L204E
+                    leas      -$04,x
+L204E               ldd       $0e,s
+                    beq       L205B
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       #$005A
+                    bra       L2062
+
+L205B               ldd       $0a,s
+                    pshs      d
+                    ldd       #$005B
+L2062               pshs      d
+                    ldd       #$0082
+L2067               pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L20EA
+
+L2070               cmpx      #$0047
+                    lbeq      L1F29
+                    cmpx      #$0048
+                    lbeq      L1F49
+                    cmpx      #$0040
+                    lbeq      L1F73
+                    cmpx      #$005A
+                    lbeq      L1F88
+                    cmpx      #$005B
+                    lbeq      L1F88
+                    cmpx      #$005C
+                    lbeq      L1F88
+                    cmpx      #$005D
+                    lbeq      L1F88
+                    cmpx      #$005E
+                    lbeq      L1F88
+                    cmpx      #$005F
+                    lbeq      L1F88
+                    cmpx      #$0060
+                    lbeq      L1F88
+                    cmpx      #$0061
+                    lbeq      L1F88
+                    cmpx      #$0062
+                    lbeq      L1F88
+                    cmpx      #$0063
+                    lbeq      L1F88
+                    cmpx      #$0036
+                    lbeq      L1FA2
+                    cmpx      #$004B
+                    lbeq      L1FA2
+                    cmpx      #$004A
+                    lbeq      L1FA2
+                    cmpx      #$0030
+                    lbeq      L1FCC
+                    lbra      L1FED
+
+L20EA               leas      $04,s
+                    puls      pc,u
+L20EE               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    leas      -$06,s
+                    ldx       $0C,s
+                    ldd       $0a,x
+                    std       ,s
+                    ldx       $0C,s
+                    ldu       $0C,x
+                    ldd       $12,s
+                    beq       L210C
+                    ldd       $10,s
+                    bra       L210E
+
+L210C               ldd       $0e,s
+L210E               std       $02,s
+                    ldd       $12,s
+                    beq       L2120
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L2467
+                    leas      $02,s
+                    bra       L2122
+
+L2120               ldd       $0a,s
+L2122               std       $0a,s
+                    ldd       [,s]
+                    cmpd      #$0008
+                    bne       L2135
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L2521
+                    bra       L214C
+
+L2135               ldd       [,s]
+                    cmpd      #$0005
+                    beq       L2145
+                    ldd       [,s]
+                    cmpd      #$0006
+                    bne       L2153
+L2145               ldd       $0C,s
+                    pshs      d
+                    lbsr      L2A18
+L214C               leas      $02,s
+                    leax      $06,s
+                    lbra      L22B3
+
+L2153               ldd       ,s
+                    pshs      d
+                    lbsr      L24E7
+                    std       ,s++
+                    bne       L218A
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L22CB
+                    std       ,s++
+                    beq       L2172
+                    pshs      u
+                    lbsr      L22CB
+                    std       ,s++
+                    beq       L218A
+L2172               ldd       $06,u
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    beq       L219D
+                    ldx       ,s
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    bne       L219D
+L218A               ldd       ,s
+                    std       $04,s
+                    stu       ,s
+                    ldu       $04,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L249F
+                    leas      $02,s
+                    std       $0a,s
+L219D               ldx       ,s
+                    ldd       $06,x
+                    std       $04,s
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    lbeq      L2220
+                    pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L21F9
+
+L21B9               pshs      u
+                    lbsr      L0C2E
+                    leas      $02,s
+                    leax      $06,s
+                    bra       L21E1
+
+L21C4               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    std       $06,u
+                    bra       L21E3
+
+L21E1               leas      -$06,x
+L21E3               ldd       $06,u
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$006E
+                    std       $06,u
+                    lbra      L229C
+
+L21F9               cmpx      #$0041
+                    beq       L21B9
+                    cmpx      #$0085
+                    beq       L21C4
+                    cmpx      #$0071
+                    beq       L21E3
+                    cmpx      #$0076
+                    lbeq      L21E3
+                    cmpx      #$006F
+                    lbeq      L21E3
+                    cmpx      #$0070
+                    lbeq      L21E3
+                    lbra      L229C
+
+L2220               pshs      u
+                    lbsr      L24E7
+                    std       ,s++
+                    beq       L223D
+                    ldd       $0a,s
+                    cmpd      #$0060
+                    bge       L223D
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L2324
+                    leas      $02,s
+                    lbra      L22B5
+
+L223D               ldd       ,s
+                    pshs      d
+                    lbsr      L0C2E
+                    leas      $02,s
+                    ldx       ,s
+                    ldd       $06,x
+                    std       $04,s
+                    pshs      u
+                    lbsr      L1441
+                    std       ,s++
+                    bne       L2266
+                    ldd       $04,s
+                    cmpd      #$0070
+                    bne       L226F
+                    pshs      u
+                    lbsr      L22CB
+                    std       ,s++
+                    beq       L226F
+L2266               pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    bra       L229C
+
+L226F               ldd       $04,s
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$006E
+                    ldx       ,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L0C2E
+                    leas      $02,s
+                    ldd       $06,u
+                    std       $04,s
+                    ldu       ,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L249F
+                    leas      $02,s
+                    std       $0a,s
+L229C               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0081
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L22B5
+
+L22B3               leas      -$06,x
+L22B5               ldd       $02,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       #$0082
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    leas      $06,s
+                    puls      pc,u
+L22CB               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    ldx       $04,s
+                    ldx       $06,x
+                    bra       L22E9
+
+L22D9               ldd       #$0001
+                    puls      pc,u
+L22DE               ldd       $04,s
+                    pshs      d
+                    lbsr      L14DB
+                    leas      $02,s
+                    puls      pc,u
+L22E9               cmpx      #$0034
+                    beq       L22D9
+                    cmpx      #$0036
+                    lbeq      L22D9
+                    cmpx      #$0042
+                    beq       L22DE
+                    lbra      L2502
+                    pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$0034
+                    lbne      L2502
+                    ldx       $04,s
+                    ldd       [$08,x]
+                    cmpd      #$000D
+                    lbne      L2502
+                    ldd       #$0001
+                    lbra      L2504
+
+L2324               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $06,u
+                    bra       L2389
+
+L2338               ldd       $0C,u
+                    std       $02,s
+                    tfr       d,x
+                    ldd       $06,x
+                    cmpd      #$0036
+                    bne       L2381
+                    ldx       $02,s
+                    ldd       $08,x
+                    cmpd      #$00FF
+                    lbls      L23FF
+                    bra       L2381
+
+L2354               ldx       $0a,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    lbeq      L23FF
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L22CB
+                    std       ,s++
+                    lbne      L23FF
+                    bra       L2381
+
+L2372               ldx       $0a,u
+                    ldd       $06,x
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    lbeq      L23FF
+L2381               ldd       #$0001
+                    std       ,s
+                    lbra      L23FF
+
+L2389               cmpx      #$0057
+                    beq       L2338
+                    cmpx      #$0078
+                    beq       L2354
+                    cmpx      #$003E
+                    beq       L2372
+                    cmpx      #$003F
+                    lbeq      L2372
+                    cmpx      #$003D
+                    lbeq      L2372
+                    cmpx      #$003C
+                    lbeq      L2372
+                    cmpx      #$00A0
+                    lbeq      L2372
+                    cmpx      #$00A1
+                    lbeq      L2372
+                    cmpx      #$00A7
+                    lbeq      L2372
+                    cmpx      #$00A8
+                    lbeq      L2372
+                    cmpx      #$00A9
+                    lbeq      L2372
+                    cmpx      #$0076
+                    beq       L2381
+                    cmpx      #$006F
+                    lbeq      L2381
+                    cmpx      #$0058
+                    lbeq      L2381
+                    cmpx      #$0059
+                    lbeq      L2381
+                    cmpx      #$0044
+                    lbeq      L2381
+                    cmpx      #$0043
+                    lbeq      L2381
+                    cmpx      #$0065
+                    lbeq      L2381
+L23FF               clra
+L2400               clrb
+                    std       L0019
+                    pshs      u
+                    lbsr      L0D05
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L2442
+
+L240E               ldd       ,s
+                    bne       L2416
+                    ldd       L0019
+                    beq       L2463
+L2416               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       $06,u
+                    pshs      d
+                    ldd       #$0081
+                    bra       L2439
+
+L2428               ldu       $0a,u
+L242A               pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+L2439               pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L2463
+
+L2442               cmpx      #$0071
+                    beq       L240E
+                    cmpx      #$0070
+                    lbeq      L240E
+                    cmpx      #$0076
+                    lbeq      L240E
+                    cmpx      #$006F
+                    lbeq      L240E
+                    cmpx      #$0085
+                    beq       L2428
+                    bra       L242A
+
+L2463               leas      $04,s
+                    puls      pc,u
+L2467               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldx       $04,s
+                    bra       L2491
+
+L2473               ldd       #$005B
+                    puls      pc,u
+L2478               ldd       #$005A
+                    puls      pc,u
+L247D               ldd       $04,s
+                    cmpd      #$005F
+                    ble       L248A
+                    ldd       #$00C3
+                    bra       L248D
+
+L248A               ldd       #$00BB
+L248D               subd      $04,s
+                    puls      pc,u
+L2491               cmpx      #$005A
+                    beq       L2473
+                    cmpx      #$005B
+                    beq       L2478
+                    bra       L247D
+                    puls      pc,u
+L249F               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldx       $04,s
+                    bra       L24BD
+
+L24AB               ldd       $04,s
+                    puls      pc,u
+L24AF               ldd       $04,s
+                    addd      #$0002
+                    puls      pc,u
+L24B6               ldd       $04,s
+                    addd      #$FFFE
+                    puls      pc,u
+L24BD               cmpx      #$005A
+                    beq       L24AB
+                    cmpx      #$005B
+                    lbeq      L24AB
+                    cmpx      #$005C
+                    beq       L24AF
+                    cmpx      #$005D
+                    lbeq      L24AF
+                    cmpx      #$0060
+                    lbeq      L24AF
+                    cmpx      #$0061
+                    lbeq      L24AF
+                    bra       L24B6
+                    puls      pc,u
+L24E7               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L0111
+                    ldu       $04,s
+                    ldd       $06,u
+                    cmpd      #$0036
+                    bne       L2502
+                    ldd       $08,u
+                    bne       L2502
+                    ldd       #$0001
+                    bra       L2504
+
+L2502               clra
+                    clrb
+L2504               puls      pc,u
+L2506               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L2521
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L28FC
+                    leas      $02,s
+                    puls      pc,u
+L2521               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$06,s
+                    ldd       $06,u
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L2800
+
+L2536               pshs      u
+                    lbsr      L1954
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L152E
+                    leas      $02,s
+                    ldx       $06,u
+                    bra       L2562
+
+L2548               ldd       $08,u
+                    lbeq      L28F8
+                    pshs      u
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    lbra      L27D7
+
+L2562               cmpx      #$0093
+                    beq       L2548
+                    cmpx      #$0094
+                    lbeq      L2548
+                    cmpx      #$0095
+                    lbeq      L2548
+                    lbra      L28F8
+
+L2578               ldd       $0a,u
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       #$0086
+                    lbra      L2759
+
+L2587               ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0091
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    lbra      L2765
+
+L25A6               ldd       $0a,u
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    ldd       #$0083
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    bra       L25C2
+
+L25C0               leas      -$06,x
+L25C2               ldd       #$0080
+                    std       $06,u
+                    lbra      L28F8
+
+L25CA               ldd       $08,u
+                    pshs      d
+                    ldd       #$004A
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       #$0004
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3204
+                    bra       L260D
+
+L25EB               leax      L2506,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L12E9
+                    bra       L260D
+
+L25F8               ldd       $0a,u
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+L260D               leas      $04,s
+                    leax      $06,s
+                    lbra      L27D5
+
+L2614               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0080
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $02,s
+                    cmpd      #$003E
+                    bne       L266F
+                    ldd       #$003F
+                    lbra      L2759
+
+L266F               ldd       #$003E
+                    lbra      L2759
+
+L2675               pshs      u
+                    lbsr      L1365
+                    leas      $02,s
+                    lbra      L2765
+
+L267F               ldx       $0a,u
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L2699
+                    leas      -$02,s
+                    ldd       $0a,u
+                    std       ,s
+                    ldd       $0C,u
+                    std       $0a,u
+                    ldd       ,s
+                    std       $0C,u
+                    leas      $02,s
+L2699               ldx       $0C,u
+                    ldd       $06,x
+                    cmpd      #$004A
+                    lbne      L26FA
+                    ldx       $0C,u
+                    ldd       $08,x
+                    std       $04,s
+                    ldd       [$04,s]
+                    bne       L26FA
+                    ldx       $04,s
+                    ldd       $02,x
+                    pshs      d
+                    lbsr      L1220
+                    leas      $02,s
+                    std       ,s
+                    beq       L26FA
+                    ldd       #$0004
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L3204
+                    leas      $04,s
+                    ldd       $0C,u
+                    std       $04,s
+                    ldd       ,s
+                    ldx       $04,s
+                    std       $08,x
+                    ldd       #$0036
+                    ldx       $04,s
+                    std       $06,x
+                    ldd       #$0001
+                    std       [$04,s]
+                    ldd       $02,s
+                    cmpd      #$0052
+                    bne       L26F1
+                    ldd       #$0056
+                    bra       L26F4
+
+L26F1               ldd       #$0055
+L26F4               std       $02,s
+                    leax      $06,s
+                    bra       L2734
+
+L26FA               ldd       $0a,u
+                    std       $04,s
+                    ldx       $04,s
+                    ldd       $06,x
+                    cmpd      #$004A
+                    bne       L2713
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L294C
+                    leas      $02,s
+                    bra       L272B
+
+L2713               ldd       $04,s
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+L272B               ldd       $0C,u
+                    pshs      d
+                    lbsr      L2506
+                    bra       L2755
+
+L2734               leas      -$06,x
+L2736               ldd       $0a,u
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L0BC4
+L2755               leas      $02,s
+                    ldd       $02,s
+L2759               pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+L2765               leax      $06,s
+                    lbra      L25C0
+
+L276A               ldd       $0a,u
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    leax      $06,s
+                    bra       L27C2
+
+L278F               leas      -$06,x
+                    ldd       $0a,u
+                    std       $04,s
+                    pshs      d
+                    lbsr      L2506
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $02,s
+                    addd      #$FFB0
+                    std       $06,u
+                    ldd       #$0093
+                    ldx       $04,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L2521
+                    leas      $02,s
+                    bra       L27C4
+
+L27C2               leas      -$06,x
+L27C4               ldd       #$0089
+                    pshs      d
+                    ldd       #$0088
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    bra       L27D7
+
+L27D5               leas      -$06,x
+L27D7               ldd       #$0093
+                    std       $06,u
+                    clra
+                    clrb
+                    std       $08,u
+                    lbra      L28F8
+
+L27E3               ldd       $02,s
+                    cmpd      #$00A0
+                    blt       L27F0
+                    leax      $06,s
+                    lbra      L278F
+
+L27F0               leax      L29F7,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L484C
+                    leas      $04,s
+                    lbra      L28F8
+
+L2800               cmpx      #$0080
+                    lbeq      L28F8
+                    cmpx      #$0093
+                    lbeq      L28F8
+                    cmpx      #$0094
+                    lbeq      L28F8
+                    cmpx      #$0095
+                    lbeq      L28F8
+                    cmpx      #$0034
+                    lbeq      L28F8
+                    cmpx      #$0042
+                    lbeq      L2536
+                    cmpx      #$0086
+                    lbeq      L2578
+                    cmpx      #$0091
+                    lbeq      L2587
+                    cmpx      #$0083
+                    lbeq      L25A6
+                    cmpx      #$004A
+                    lbeq      L25CA
+                    cmpx      #$0064
+                    lbeq      L25EB
+                    cmpx      #$003C
+                    lbeq      L25F8
+                    cmpx      #$003D
+                    lbeq      L25F8
+                    cmpx      #$0044
+                    lbeq      L25F8
+                    cmpx      #$0043
+                    lbeq      L25F8
+                    cmpx      #$003E
+                    lbeq      L2614
+                    cmpx      #$003F
+                    lbeq      L2614
+                    cmpx      #$0065
+                    lbeq      L2675
+                    cmpx      #$0052
+                    lbeq      L267F
+                    cmpx      #$0053
+                    lbeq      L26FA
+                    cmpx      #$005A
+                    lbeq      L26FA
+                    cmpx      #$005B
+                    lbeq      L26FA
+                    cmpx      #$005E
+                    lbeq      L26FA
+                    cmpx      #$005C
+                    lbeq      L26FA
+                    cmpx      #$005F
+                    lbeq      L26FA
+                    cmpx      #$005D
+                    lbeq      L26FA
+                    cmpx      #$0050
+                    lbeq      L26FA
+                    cmpx      #$0051
+                    lbeq      L26FA
+                    cmpx      #$0054
+                    lbeq      L26FA
+                    cmpx      #$0057
+                    lbeq      L26FA
+                    cmpx      #$0058
+                    lbeq      L26FA
+                    cmpx      #$0059
+                    lbeq      L26FA
+                    cmpx      #$0056
+                    lbeq      L2736
+                    cmpx      #$0055
+                    lbeq      L2736
+                    cmpx      #$0078
+                    lbeq      L276A
+                    lbra      L27E3
+
+L28F8               leas      $06,s
+                    puls      pc,u
+L28FC               pshs      u
+                    ldd       #$FFB4
+                    lbsr      L0111
+                    ldx       $04,s
+                    ldx       $06,x
+                    bra       L2939
+
+L290A               ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L294A
+
+L2924               ldd       $04,s
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$007B
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L294A
+
+L2939               cmpx      #$0034
+                    beq       L290A
+                    cmpx      #$0094
+                    beq       L2924
+                    cmpx      #$0095
+                    lbeq      L2924
+L294A               puls      pc,u
+L294C               pshs      u
+                    ldd       #$FFB2
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $08,u
+                    std       ,s
+                    ldx       ,s
+                    lda       ,x
+                    ora       $01,x
+                    ora       $02,x
+                    ora       $03,x
+                    beq       L29AB
+                    ldx       ,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       [,s]
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    bra       L29D2
+
+L29AB               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+L29D2               ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$0004
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L3204
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $08,u
+                    leas      $02,s
+                    puls      pc,u
+L29F7               inc       $0f,s
+                    jmp       $07,s
+                    com       >$0034
+                    nega
+                    ldd       #$FFBA
+                    lbsr      L0111
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L2A18
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L28FC
+                    leas      $02,s
+                    puls      pc,u
+L2A18               pshs      u
+                    ldd       #$FFAE
+                    lbsr      L0111
+                    ldu       $04,s
+                    leas      -$08,s
+                    ldd       ,u
+                    std       $02,s
+                    ldd       $06,u
+                    std       $06,s
+                    tfr       d,x
+                    lbra      L2C60
+
+L2A31               pshs      u
+                    lbsr      L2521
+                    leas      $02,s
+                    lbra      L2D35
+
+L2A3B               ldd       $0a,u
+                    pshs      d
+                    lbsr      L0BC4
+                    leas      $02,s
+                    bra       L2A48
+
+L2A46               leas      -$08,x
+L2A48               ldd       $06,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    bra       L2A5A
+
+L2A58               leas      -$08,x
+L2A5A               ldd       #$0080
+                    std       $06,u
+                    lbra      L2D35
+
+L2A62               ldd       $0a,u
+                    pshs      d
+                    lbsr      L2506
+                    bra       L2A72
+
+L2A6B               ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+L2A72               leas      $02,s
+                    leax      $08,s
+                    bra       L2A46
+
+L2A78               ldd       $08,u
+                    pshs      d
+                    ldd       #$004B
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       #$0093
+                    std       $06,u
+                    ldd       #$0008
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3204
+                    leas      $04,s
+                    lbra      L2C3C
+
+L2AA1               leax      $29FD,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L12E9
+                    leas      $04,s
+                    bra       L2ACB
+
+L2AB0               ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+L2ACB               leax      $08,s
+                    lbra      L2C35
+
+L2AD0               ldd       #$0080
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007F
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    ldd       $02,s
+                    pshs      d
+                    ldd       $08,s
+                    cmpd      #$003E
+                    bne       L2B32
+                    ldd       #$003F
+                    bra       L2B35
+
+L2B32               ldd       #$003E
+L2B35               pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L2B7B
+
+L2B43               pshs      u
+                    lbsr      L1365
+                    leas      $02,s
+                    bra       L2B7B
+
+L2B4C               ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       #$006E
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+L2B7B               leax      $08,s
+                    lbra      L2A58
+
+L2B80               ldd       $0a,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    leax      $08,s
+                    lbra      L2C1E
+
+L2BA6               leas      -$08,x
+                    ldd       $0a,u
+                    std       $04,s
+                    ldd       $02,s
+                    cmpd      #$0005
+                    bne       L2BD8
+                    ldx       $04,s
+                    ldd       $0a,x
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       #$008C
+                    pshs      d
+                    ldd       #$0087
+                    bra       L2BE9
+
+L2BD8               ldd       $04,s
+                    pshs      d
+                    lbsr      $29FD
+                    leas      $02,s
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$007A
+L2BE9               pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    ldd       $06,s
+                    addd      #$FFB0
+                    std       $06,u
+                    ldd       #$0093
+                    ldx       $04,s
+                    std       $06,x
+                    pshs      u
+                    lbsr      L2A18
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0005
+                    bne       L2C20
+                    ldd       #$008D
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    bra       L2C20
+
+L2C1E               leas      -$08,x
+L2C20               ldd       $02,s
+                    pshs      d
+                    ldd       #$0089
+                    pshs      d
+                    ldd       #$0087
+                    pshs      d
+                    lbsr      L3293
+                    leas      $06,s
+                    bra       L2C37
+
+L2C35               leas      -$08,x
+L2C37               ldd       #$0093
+                    std       $06,u
+L2C3C               clra
+                    clrb
+                    std       $08,u
+                    lbra      L2D35
+
+L2C43               ldd       $06,s
+                    cmpd      #$00A0
+                    blt       L2C50
+                    leax      $08,s
+                    lbra      L2BA6
+
+L2C50               leax      L2D39,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L484C
+                    leas      $04,s
+                    lbra      L2D35
+
+L2C60               cmpx      #$0080
+                    lbeq      L2D35
+                    cmpx      #$0093
+                    lbeq      L2D35
+                    cmpx      #$0094
+                    lbeq      L2D35
+                    cmpx      #$0095
+                    lbeq      L2D35
+                    cmpx      #$0034
+                    lbeq      L2D35
+                    cmpx      #$0042
+                    lbeq      L2A31
+                    cmpx      #$0092
+                    lbeq      L2A3B
+                    cmpx      #$008E
+                    lbeq      L2A3B
+                    cmpx      #$0090
+                    lbeq      L2A62
+                    cmpx      #$008D
+                    lbeq      L2A6B
+                    cmpx      #$008C
+                    lbeq      L2A6B
+                    cmpx      #$004B
+                    lbeq      L2A78
+                    cmpx      #$0064
+                    lbeq      L2AA1
+                    cmpx      #$003C
+                    lbeq      L2AB0
+                    cmpx      #$003D
+                    lbeq      L2AB0
+                    cmpx      #$0043
+                    lbeq      L2AB0
+                    cmpx      #$003E
+                    lbeq      L2AD0
+                    cmpx      #$003F
+                    lbeq      L2AD0
+                    cmpx      #$0065
+                    lbeq      L2B43
+                    cmpx      #$005A
+                    lbeq      L2B4C
+                    cmpx      #$005B
+                    lbeq      L2B4C
+                    cmpx      #$005E
+                    lbeq      L2B4C
+                    cmpx      #$005C
+                    lbeq      L2B4C
+                    cmpx      #$005F
+                    lbeq      L2B4C
+                    cmpx      #$005D
+                    lbeq      L2B4C
+                    cmpx      #$0050
+                    lbeq      L2B4C
+                    cmpx      #$0051
+                    lbeq      L2B4C
+                    cmpx      #$0052
+                    lbeq      L2B4C
+                    cmpx      #$0053
+                    lbeq      L2B4C
+                    cmpx      #$0078
+                    lbeq      L2B80
+                    lbra      L2C43
+
+L2D35               leas      $08,s
+                    puls      pc,u
+L2D39               ror       $0C,s
+                    clr       $01,s
+                    lsr       $7300
+L2D40               pshs      u
+                    leax      $00CE,y
+                    stx       L001B
+                    ldd       #$0001
+                    std       $0021
+                    leax      $06,s
+                    pshs      x
+                    ldd       $06,s
+                    bra       L2D66
+
+L2D55               pshs      u
+                    ldd       $04,s
+                    std       L001B
+                    ldd       #$0001
+                    std       $0021
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L2D66               pshs      d
+                    bsr       L2D8D
+                    leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $04,s
+                    std       L001B
+                    ldd       #$0002
+                    std       $0021
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L2D8D
+                    leas      $04,s
+                    clra
+                    clrb
+                    stb       [L001B,y]
+                    puls      pc,u
+L2D8D               pshs      u
+                    ldu       $04,s
+                    leas      -$0b,s
+                    bra       L2DA5
+
+L2D95               ldb       $08,s
+                    lbeq      L2F05
+                    ldb       $08,s
+                    sex
+                    pshs      d
+                    lbsr      L30E4
+                    leas      $02,s
+L2DA5               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    bne       L2D95
+                    ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L2DC8
+                    ldd       #$0001
+                    std       L001D
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L2DCC
+
+L2DC8               clra
+                    clrb
+                    std       L001D
+L2DCC               ldb       $08,s
+                    cmpb      #$30
+                    bne       L2DD7
+                    ldd       #$0030
+                    bra       L2DDA
+
+L2DD7               ldd       #$0020
+L2DDA               std       $001F
+                    bra       L2DF8
+
+L2DDE               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $5E90
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+L2DF8               ldb       $08,s
+                    sex
+                    leax      $0192,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L2DDE
+                    ldb       $08,s
+                    cmpb      #$2e
+                    bne       L2E41
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L2E2B
+
+L2E15               ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $5E90
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+L2E2B               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $0192,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L2E15
+                    bra       L2E45
+
+L2E41               clra
+                    clrb
+                    std       $04,s
+L2E45               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L2EE7
+
+L2E4D               ldd       $06,s
+                    pshs      d
+                    ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L2F09
+                    bra       L2E75
+
+L2E62               ldd       $06,s
+                    pshs      d
+                    ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L2FCA
+L2E75               std       ,s
+                    lbra      L2ED2
+
+L2E7A               ldx       $11,s
+                    leax      $02,x
+                    stx       $11,s
+                    ldd       -$02,x
+                    lbra      L2EDD
+
+L2E87               ldx       $11,s
+                    leax      $02,x
+                    stx       $11,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L2ECA
+                    ldd       $09,s
+                    std       $04,s
+                    bra       L2EA9
+
+L2E9D               ldb       [$09,s]
+                    beq       L2EB5
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+L2EA9               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L2E9D
+L2EB5               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L3089
+                    leas      $06,s
+                    bra       L2ED7
+
+L2ECA               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    pshs      d
+L2ED2               lbsr      L3029
+                    leas      $04,s
+L2ED7               lbra      L2DA5
+
+L2EDA               ldb       $08,s
+                    sex
+L2EDD               pshs      d
+                    lbsr      L30E4
+                    leas      $02,s
+                    lbra      L2DA5
+
+L2EE7               cmpx      #$0064
+                    lbeq      L2E4D
+                    cmpx      #$0078
+                    lbeq      L2E62
+                    cmpx      #$0063
+                    lbeq      L2E7A
+                    cmpx      #$0073
+                    lbeq      L2E87
+                    bra       L2EDA
+
+L2F05               leas      $0b,s
+                    puls      pc,u
+L2F09               pshs      u,d
+                    leax      $0286,y
+                    stx       ,s
+                    ldd       $06,s
+                    bge       L2F3E
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+                    bge       L2F33
+                    leax      L3109,pcr
+                    pshs      x
+                    leax      $0286,y
+                    pshs      x
+                    lbsr      L5600
+                    leas      $04,s
+                    lbra      L30E0
+
+L2F33               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L2F3E               ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L2F53
+                    leas      $04,s
+                    leax      $0286,y
+                    tfr       x,d
+                    lbra      L30E0
+
+L2F53               pshs      u,y,x,d
+                    ldu       $0a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L2F70
+
+L2F61               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      >$0043,y
+L2F6E               std       $0C,s
+L2F70               ldd       $0C,s
+                    blt       L2F61
+                    leax      >$0043,y
+                    stx       $04,s
+                    bra       L2FB2
+
+L2F7C               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L2F83               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    bge       L2F7C
+                    ldd       $0C,s
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L2F9C
+                    ldd       #$0001
+                    std       $02,s
+L2F9C               ldd       $02,s
+                    beq       L2FA7
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L2FA7               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+L2FB2               ldd       $04,s
+                    cmpd      $0001
+                    bne       L2F83
+                    ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $06,s
+                    puls      pc,u
+L2FCA               pshs      u,x,d
+                    leax      $0286,y
+                    stx       $02,s
+                    leau      $0290,y
+L2FD6               ldd       $08,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L2FEC
+                    ldd       #$0057
+                    bra       L2FEF
+
+L2FEC               ldd       #$0030
+L2FEF               addd      ,s++
+                    stb       ,u+
+                    ldd       $08,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $08,s
+                    bne       L2FD6
+                    bra       L300F
+
+L3005               ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+L300F               leau      -$01,u
+                    pshs      u
+                    leax      $0290,y
+                    cmpx      ,s++
+                    bls       L3005
+                    clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $0286,y
+                    tfr       x,d
+                    lbra      L3105
+
+L3029               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L55EF
+                    leas      $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    leau      d,u
+                    ldd       L001D
+                    bne       L3060
+                    bra       L304D
+
+L3044               ldd       $001F
+                    pshs      d
+                    lbsr      L30E4
+                    leas      $02,s
+L304D               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bgt       L3044
+                    bra       L3060
+
+L3057               ldd       ,s
+                    pshs      d
+                    lbsr      L30E4
+                    leas      $02,s
+L3060               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    sex
+                    std       ,s
+                    bne       L3057
+                    ldd       L001D
+                    lbeq      L30E0
+                    bra       L307E
+
+L3075               ldd       $001F
+                    pshs      d
+                    lbsr      L30E4
+                    leas      $02,s
+L307E               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    bgt       L3075
+                    lbra      L30E0
+
+L3089               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       ,s
+                    ldd       L001D
+                    bne       L30BA
+                    bra       L30A3
+
+L309B               ldd       $001F
+                    pshs      d
+                    bsr       L30E4
+                    leas      $02,s
+L30A3               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bgt       L309B
+                    bra       L30BA
+
+L30B1               ldb       ,u+
+                    sex
+                    pshs      d
+                    bsr       L30E4
+                    leas      $02,s
+L30BA               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L30B1
+                    ldd       L001D
+                    beq       L30E0
+                    bra       L30D4
+
+L30CC               ldd       $001F
+                    pshs      d
+                    bsr       L30E4
+                    leas      $02,s
+L30D4               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    subd      #$FFFF
+                    bgt       L30CC
+L30E0               leas      $02,s
+                    puls      pc,u
+L30E4               pshs      u
+                    ldd       $0021
+                    cmpd      #$0002
+                    bne       L30FA
+                    ldd       $04,s
+                    ldx       L001B
+                    leax      $01,x
+                    stx       L001B
+                    stb       -$01,x
+                    bra       L3107
+
+L30FA               ldd       L001B
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L515F
+L3105               leas      $04,s
+L3107               puls      pc,u
+L3109               blt       $313E
+                    leas      -$09,y
+                    pshu      y,x,dp
+                    neg       $0034
+                    rorb
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L31AF
+                    leas      $02,s
+                    std       ,s
+                    lbeq      L31A0
+                    ldd       >$004b,y
+                    std       $02,s
+                    bne       L313F
+                    leax      $029a,y
+                    stx       $02,s
+                    tfr       x,d
+                    std       >$004b,y
+                    std       $029a,y
+                    clra
+                    clrb
+                    std       $029C,y
+L313F               ldu       [$02,s]
+L3142               ldd       $02,u
+                    cmpd      ,s
+                    bcs       L318B
+                    ldd       $02,u
+                    cmpd      ,s
+                    bne       L3157
+                    ldd       ,u
+                    std       [$02,s]
+                    bra       L3167
+
+L3157               ldd       $02,u
+                    subd      ,s
+                    std       $02,u
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    leau      d,u
+                    ldd       ,s
+                    std       $02,u
+L3167               ldd       $02,s
+                    std       >$004b,y
+                    stu       $02,s
+                    bra       L317B
+
+L3171               ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    clra
+                    clrb
+                    stb       -$01,x
+L317B               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L3171
+                    tfr       u,d
+                    bra       L31AB
+
+L318B               cmpu      >$004b,y
+                    bne       L31A4
+                    ldd       ,s
+                    pshs      d
+                    bsr       L31BC
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L31A4
+L31A0               clra
+                    clrb
+                    bra       L31AB
+
+L31A4               stu       $02,s
+                    ldu       ,u
+                    lbra      L3142
+
+L31AB               leas      $04,s
+                    puls      pc,u
+L31AF               pshs      u
+                    ldd       $04,s
+                    addd      #$0003
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    puls      pc,u
+L31BC               pshs      u,d
+                    ldd       $06,s
+                    addd      #$007F
+                    pshs      d
+                    ldd       #$0007
+                    lbsr      L5FBA
+                    pshs      d
+                    ldd       #$0007
+                    lbsr      $5FD1
+                    std       ,s
+                    pshs      d
+                    ldd       #$0004
+                    lbsr      $5E90
+                    std       ,s
+                    pshs      d
+                    lbsr      L6198
+                    leas      $02,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L31F3
+                    clra
+                    clrb
+                    lbra      L328F
+
+L31F3               ldd       ,s
+                    pshs      d
+                    pshs      u
+                    bsr       L3204
+                    leas      $04,s
+                    ldd       >$004b,y
+                    lbra      L328F
+
+L3204               pshs      u,d
+                    ldu       $06,s
+                    lbeq      L328F
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L31AF
+                    leas      $02,s
+                    std       $08,s
+                    ldd       >$004b,y
+                    bra       L3230
+
+L321D               ldd       ,s
+                    cmpd      [,s]
+                    bcs       L322E
+                    cmpu      ,s
+                    bhi       L323E
+                    cmpu      [,s]
+                    bcs       L323E
+L322E               ldd       [,s]
+L3230               std       ,s
+                    cmpu      ,s
+                    bls       L321D
+                    cmpu      [,s]
+                    lbcc      L321D
+L323E               pshs      u
+                    ldd       $0a,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      ,s++
+                    cmpd      [,s]
+                    bne       L3260
+                    ldd       $08,s
+                    pshs      d
+                    ldx       [$02,s]
+                    ldd       $02,x
+                    addd      ,s++
+                    std       $08,s
+                    ldx       ,s
+                    ldd       [,x]
+                    bra       L3262
+
+L3260               ldd       [,s]
+L3262               std       ,u
+                    ldx       ,s
+                    ldd       $02,x
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      ,s
+                    pshs      d
+                    cmpu      ,s++
+                    bne       L3283
+                    ldx       ,s
+                    ldd       $02,x
+                    addd      $08,s
+                    std       $02,x
+                    ldd       ,u
+                    std       [,s]
+                    bra       L3285
+
+L3283               stu       [,s]
+L3285               ldd       $08,s
+                    std       $02,u
+                    ldd       ,s
+                    std       >$004b,y
+L328F               leas      $02,s
+                    puls      pc,u
+L3293               pshs      u
+                    ldu       $0a,s
+                    leas      -$08,s
+                    ldd       $0C,s
+                    cmpd      #$0088
+                    bne       L32B1
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L39DA
+                    lbra      L3800
+
+L32B1               ldd       $0C,s
+                    cmpd      #$0087
+                    bne       L32C9
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L3BC3
+                    lbra      L3800
+
+L32C9               ldx       $0C,s
+                    lbra      L3549
+
+L32CE               ldd       $0e,s
+                    pshs      d
+                    lbsr      L3988
+                    std       ,s
+                    leax      L44F5,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+                    ldd       $000D
+                    subd      #$0002
+                    std       $000D
+                    cmpd      L0017
+                    lbge      L39D6
+                    ldd       $000D
+                    std       L0017
+                    lbra      L39D6
+
+L32FB               ldd       $10,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0071
+                    pshs      d
+                    ldd       #$0081
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       $0e,s
+                    std       $10,s
+                    ldd       #$005A
+                    std       $0e,s
+L331E               leax      $44FF,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L4333
+                    std       ,s
+                    lbra      L3401
+
+L3335               leax      $4502,pcr
+                    lbra      L34A2
+
+L333C               pshs      u
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L3EA5
+                    leas      $06,s
+                    lbra      L39D6
+
+L3350               leax      $450D,pcr
+                    bra       L337E
+
+L3356               leax      $4514,pcr
+                    bra       L337E
+
+L335C               leax      $451B,pcr
+                    bra       L337E
+
+L3362               leax      $4521,pcr
+                    bra       L337E
+
+L3368               leax      L4527,pcr
+                    bra       L337E
+
+L336E               leax      L452D,pcr
+                    bra       L337E
+
+L3374               leax      $4533,pcr
+                    bra       L337E
+
+L337A               leax      L453A,pcr
+L337E               pshs      x
+                    lbsr      L3E52
+                    lbra      L3786
+
+L3386               leax      L4540,pcr
+                    lbra      L34A2
+
+L338D               leax      L4554,pcr
+                    lbra      L34A2
+
+L3394               leax      $455F,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $000D
+                    nega
+                    negb
+                    sbca      #$00
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       >$004f,y
+                    pshs      d
+                    lbsr      L43F7
+                    leas      $02,s
+                    lbsr      L43DD
+L33BA               ldd       >$0053,y
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $0e,s
+                    bra       L3409
+
+L33C9               ldd       >$0053,y
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $10,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    leax      L4565,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $000D
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    leax      L456B,pcr
+                    pshs      x
+L3401               lbsr      L43F7
+                    leas      $02,s
+                    ldd       $10,s
+L3409               pshs      d
+                    lbsr      L4415
+                    lbra      L3786
+
+L3411               ldd       #$0004
+                    std       $000F
+                    ldx       $10,s
+                    ldd       $06,x
+                    cmpd      #$0034
+                    bne       L3446
+                    ldx       $10,s
+                    ldd       $08,x
+                    std       $04,s
+                    beq       L3446
+                    ldd       >$0051,y
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    addd      #$0004
+                    pshs      d
+                    lbsr      L4472
+                    lbra      L3800
+
+L3446               leax      L456F,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L40D1
+                    leas      $06,s
+                    lbra      L34D9
+
+L3467               leax      L4574,pcr
+                    bra       L34A2
+
+L346D               leax      $4578,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       #$0002
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    ldd       #$0064
+                    pshs      d
+                    lbsr      L4086
+                    lbra      L38D9
+
+L3492               leax      L457B,pcr
+                    bra       L34A2
+
+L3498               leax      $4586,pcr
+                    bra       L34A2
+
+L349E               leax      $4591,pcr
+L34A2               pshs      x
+                    lbra      L3783
+
+L34A7               leax      $459C,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    leax      $08,s
+                    bra       L34C3
+
+L34B6               leax      L45A1,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    bra       L34C5
+
+L34C3               leas      -$08,x
+L34C5               ldd       $0e,s
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       >$004f,y
+                    pshs      d
+                    lbsr      L43F7
+                    leas      $02,s
+L34D9               lbsr      L43DD
+                    lbra      L39D6
+
+L34DF               leax      L45A6,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldx       $0e,s
+                    bra       L353C
+
+L34EE               ldx       $10,s
+                    ldd       $06,x
+                    std       $06,s
+                    cmpd      #$0094
+                    bne       L3500
+                    ldd       #$0079
+                    bra       L3510
+
+L3500               ldd       $06,s
+                    cmpd      #$0095
+                    bne       L350D
+                    ldd       #$0075
+                    bra       L3510
+
+L350D               ldd       #$0078
+L3510               std       $06,s
+                    pshs      d
+                    ldx       $12,s
+                    ldd       $08,x
+                    pshs      d
+                    leax      L45AC,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    lbra      L38D9
+
+L352B               ldd       $10,s
+                    pshs      d
+                    lbsr      L3988
+                    std       ,s
+                    leax      $45B3,pcr
+                    lbra      L37A9
+
+L353C               cmpx      #$0077
+                    beq       L34EE
+                    cmpx      #$0070
+                    beq       L352B
+                    lbra      L39D6
+
+L3549               cmpx      #$007A
+                    lbeq      L32CE
+                    cmpx      #$007D
+                    lbeq      L32FB
+                    cmpx      #$0082
+                    lbeq      L331E
+                    cmpx      #$0012
+                    lbeq      L3335
+                    cmpx      #$0057
+                    lbeq      L333C
+                    cmpx      #$0058
+                    lbeq      L333C
+                    cmpx      #$0059
+                    lbeq      L333C
+                    cmpx      #$0052
+                    lbeq      L3350
+                    cmpx      #$004E
+                    lbeq      L3356
+                    cmpx      #$0053
+                    lbeq      L335C
+                    cmpx      #$0056
+                    lbeq      L3362
+                    cmpx      #$0055
+                    lbeq      L3368
+                    cmpx      #$004D
+                    lbeq      L336E
+                    cmpx      #$004C
+                    lbeq      L3374
+                    cmpx      #$0054
+                    lbeq      L337A
+                    cmpx      #$0043
+                    lbeq      L3386
+                    cmpx      #$0044
+                    lbeq      L338D
+                    cmpx      #$001D
+                    lbeq      L3394
+                    cmpx      #$007C
+                    lbeq      L33BA
+                    cmpx      #$0009
+                    lbeq      L33C9
+                    cmpx      #$0065
+                    lbeq      L3411
+                    cmpx      #$0085
+                    lbeq      L3467
+                    cmpx      #$0084
+                    lbeq      L346D
+                    cmpx      #$0098
+                    lbeq      L3492
+                    cmpx      #$0096
+                    lbeq      L3498
+                    cmpx      #$0097
+                    lbeq      L349E
+                    cmpx      #$0076
+                    lbeq      L34A7
+                    cmpx      #$006F
+                    lbeq      L34B6
+                    cmpx      #$007B
+                    lbeq      L34DF
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L3988
+                    leas      $02,s
+                    std       $06,s
+                    ldd       $10,s
+                    cmpd      #$0077
+                    lbne      L36A2
+                    ldd       $06,u
+                    cmpd      #$0085
+                    bne       L3685
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       $12,s
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldx       $0C,s
+                    bra       L3667
+
+L364E               leax      $45B9,pcr
+                    bra       L365E
+
+L3654               leax      $45BD,pcr
+                    bra       L365E
+
+L365A               leax      L45C5,pcr
+L365E               pshs      x
+                    lbsr      L43D2
+                    leas      $02,s
+                    bra       L367D
+
+L3667               cmpx      #$0075
+                    beq       L364E
+                    cmpx      #$004F
+                    beq       L3654
+                    cmpx      #$0050
+                    lbeq      L3654
+                    cmpx      #$0051
+                    beq       L365A
+L367D               ldd       #$0070
+                    std       $06,u
+                    lbra      L39D6
+
+L3685               ldd       ,u
+                    cmpd      #$0002
+                    bne       L36A2
+                    ldd       $0C,s
+                    cmpd      #$007F
+                    beq       L36A2
+                    ldd       $06,s
+                    cmpd      #$0078
+                    beq       L36A2
+                    ldd       #$0062
+                    std       $06,s
+L36A2               ldx       $0C,s
+                    lbra      L3947
+
+L36A7               ldd       $10,s
+                    cmpd      #$0077
+                    lbne      L3766
+                    ldd       $08,u
+                    std       ,s
+                    ldd       $06,u
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L3742
+
+L36BF               ldd       $0e,s
+                    cmpd      #$0070
+                    beq       L36E4
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L448F
+                    leas      $02,s
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L3988
+                    std       ,s
+                    ldd       $02,s
+                    pshs      d
+                    leax      L45CD,pcr
+                    lbra      L38D0
+
+L36E4               ldd       #$0064
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L3988
+                    std       ,s
+                    lbsr      L39BF
+                    leas      $04,s
+                    ldd       ,s
+                    lbeq      L39D6
+                    ldd       ,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0050
+                    pshs      d
+                    lbsr      L3293
+                    lbra      L38D9
+
+L3716               ldd       $0e,s
+                    cmpd      #$0070
+                    lbeq      L39D6
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$0064
+                    lbra      L37FB
+
+L372A               ldd       $08,u
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L44A6
+                    lbra      L3800
+
+L3738               ldd       #$0036
+                    std       $10,s
+                    ldu       ,s
+                    bra       L3766
+
+L3742               cmpx      #$0071
+                    lbeq      L36BF
+                    cmpx      #$0076
+                    lbeq      L36BF
+                    cmpx      #$006F
+                    lbeq      L36BF
+                    cmpx      #$0070
+                    beq       L3716
+                    cmpx      #$0037
+                    beq       L372A
+                    cmpx      #$0036
+                    beq       L3738
+L3766               ldd       $0e,s
+                    cmpd      #$0070
+                    bne       L378B
+                    ldd       $10,s
+                    cmpd      #$0036
+                    bne       L378B
+                    cmpu      #$0000
+                    bne       L378B
+                    leax      $45D4,pcr
+                    pshs      x
+L3783               lbsr      L43D2
+L3786               leas      $02,s
+                    lbra      L39D6
+
+L378B               leax      $45DF,pcr
+                    lbra      L380F
+
+L3792               ldd       $10,s
+                    cmpd      #$0036
+                    bne       L37B7
+                    cmpu      #$0000
+                    bne       L37B7
+                    ldd       $06,s
+                    pshs      d
+                    leax      L45E2,pcr
+L37A9               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+                    lbra      L39D6
+
+L37B7               leax      L45EE,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $06,s
+                    cmpd      #$0062
+                    bne       L3816
+                    ldd       #$0064
+                    std       $06,s
+                    bra       L3816
+
+L37D1               ldd       $10,s
+                    cmpd      #$0077
+                    bne       L3805
+                    ldd       $06,u
+                    std       $02,s
+                    pshs      d
+                    lbsr      L1EB4
+                    std       ,s++
+                    beq       L3805
+                    ldd       $02,s
+                    cmpd      $0e,s
+                    lbeq      L39D6
+                    ldd       $02,s
+                    pshs      d
+                    lbsr      L3988
+                    std       ,s
+                    ldd       $08,s
+L37FB               pshs      d
+                    lbsr      L39BF
+L3800               leas      $04,s
+                    lbra      L39D6
+
+L3805               leax      $45F2,pcr
+                    bra       L380F
+
+L380B               leax      $45F5,pcr
+L380F               pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+L3816               leax      $08,s
+                    bra       L382B
+
+L381A               ldd       #$0043
+                    pshs      d
+                    lbsr      L3293
+                    leas      $02,s
+L3824               leax      $45F9,pcr
+                    lbra      L38A3
+
+L382B               leas      -$08,x
+                    lbra      L38AA
+
+L3830               ldd       $10,s
+                    cmpd      #$0077
+                    lbne      L389F
+                    ldd       [$08,u]
+                    std       $02,s
+                    tfr       d,x
+                    bra       L388C
+
+L3844               ldd       $06,s
+                    pshs      d
+                    lbsr      L448F
+                    leas      $02,s
+                    ldd       #$003E
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    ldd       $02,s
+                    cmpd      #$0023
+                    bne       L386A
+                    ldx       $08,u
+                    ldd       $04,x
+                    pshs      d
+                    lbsr      L4420
+                    bra       L3874
+
+L386A               ldd       $08,u
+                    addd      #$0004
+                    pshs      d
+                    lbsr      L4433
+L3874               leas      $02,s
+                    ldd       $14,u
+                    pshs      d
+                    lbsr      L40B0
+                    leas      $02,s
+                    ldd       >$004d,y
+                    pshs      d
+                    lbsr      L43F7
+                    lbra      L3917
+
+L388C               cmpx      #$0021
+                    beq       L3844
+                    cmpx      #$0022
+                    lbeq      L3844
+                    cmpx      #$0023
+                    lbeq      L3844
+L389F               leax      $45FD,pcr
+L38A3               pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+L38AA               clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    ldd       $14,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L4086
+                    bra       L38D9
+
+L38BE               ldd       $10,s
+                    pshs      d
+                    lbsr      L3988
+                    std       ,s
+                    ldd       $08,s
+                    pshs      d
+                    leax      $4601,pcr
+L38D0               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+L38D9               leas      $08,s
+                    lbra      L39D6
+
+L38DE               ldd       $06,s
+                    pshs      d
+                    lbsr      L448F
+                    leas      $02,s
+                    ldx       $10,s
+                    bra       L392D
+
+L38EC               leax      $460D,pcr
+                    pshs      x
+                    lbsr      L43F7
+                    leas      $02,s
+                    leax      $08,s
+                    bra       L390E
+
+L38FB               pshs      u
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    bra       L3910
+
+L390E               leas      -$08,x
+L3910               ldd       $06,s
+                    pshs      d
+                    lbsr      L43E8
+L3917               leas      $02,s
+                    lbsr      L43DD
+                    lbra      L39D6
+
+L391F               leax      L4610,pcr
+                    pshs      x
+                    lbsr      L4824
+                    leas      $02,s
+                    lbra      L39D6
+
+L392D               cmpx      #$0070
+                    beq       L38EC
+                    cmpx      #$0036
+                    beq       L38FB
+                    bra       L391F
+
+L3939               ldd       >$0057,y
+                    pshs      d
+                    lbsr      L4824
+                    leas      $02,s
+                    lbra      L39D6
+
+L3947               cmpx      #$0075
+                    lbeq      L36A7
+                    cmpx      #$0081
+                    lbeq      L3792
+                    cmpx      #$0079
+                    lbeq      L37D1
+                    cmpx      #$0051
+                    lbeq      L380B
+                    cmpx      #$004F
+                    lbeq      L381A
+                    cmpx      #$0050
+                    lbeq      L3824
+                    cmpx      #$007F
+                    lbeq      L3830
+                    cmpx      #$0073
+                    lbeq      L38BE
+                    cmpx      #$0074
+                    lbeq      L38DE
+                    bra       L3939
+
+L3988               pshs      u
+                    ldx       $04,s
+                    bra       L39A7
+
+L398E               ldd       #$0064
+                    puls      pc,u
+L3993               ldd       #$0078
+                    puls      pc,u
+L3998               ldd       #$0079
+                    puls      pc,u
+L399D               ldd       #$0075
+                    puls      pc,u
+L39A2               ldd       #$0020
+                    puls      pc,u
+L39A7               cmpx      #$0070
+                    beq       L398E
+                    cmpx      #$0071
+                    beq       L3993
+                    cmpx      #$0076
+                    beq       L3998
+                    cmpx      #$006F
+                    beq       L399D
+                    bra       L39A2
+                    puls      pc,u
+L39BF               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      L4618,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+L39D6               leas      $08,s
+                    puls      pc,u
+L39DA               pshs      u
+                    ldx       $04,s
+                    lbra      L3AFA
+
+L39E1               ldd       #$0002
+                    pshs      d
+                    ldd       #$0093
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    leas      $04,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0093
+                    pshs      d
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$0075
+                    pshs      d
+                    lbsr      L3293
+                    leas      $08,s
+                    ldd       #$0070
+                    pshs      d
+                    ldd       #$007A
+                    pshs      d
+                    lbsr      L3293
+                    lbra      L3BD6
+
+L3A31               leax      L4624,pcr
+                    pshs      x
+                    lbsr      L43D2
+                    lbra      L40CD
+
+L3A3D               leax      $4647,pcr
+                    bra       L3A7D
+
+L3A43               leax      $464E,pcr
+                    bra       L3A90
+
+L3A49               leax      $4654,pcr
+                    bra       L3A90
+
+L3A4F               leax      $465A,pcr
+                    bra       L3A90
+
+L3A55               leax      L4660,pcr
+                    bra       L3A90
+
+L3A5B               leax      $4666,pcr
+                    bra       L3A90
+
+L3A61               leax      $466C,pcr
+                    bra       L3A90
+
+L3A67               leax      $4672,pcr
+                    bra       L3A90
+
+L3A6D               leax      $4677,pcr
+                    bra       L3A90
+
+L3A73               leax      $467D,pcr
+                    bra       L3A7D
+
+L3A79               leax      $4683,pcr
+L3A7D               pshs      x
+                    lbsr      L3E6F
+                    leas      $02,s
+                    ldd       $000D
+                    subd      #$0002
+                    lbra      L3E8A
+
+L3A8C               leax      $4689,pcr
+L3A90               pshs      x
+                    lbsr      L3E6F
+                    lbra      L40CD
+
+L3A98               leax      $4690,pcr
+                    bra       L3ABA
+
+L3A9E               leax      L4696,pcr
+                    bra       L3ABA
+
+L3AA4               leax      L469E,pcr
+                    bra       L3ABA
+
+L3AAA               leax      $46A5,pcr
+                    bra       L3ABA
+
+L3AB0               leax      $46AC,pcr
+                    bra       L3ABA
+
+L3AB6               leax      $46B2,pcr
+L3ABA               pshs      x
+                    lbsr      L3E6F
+                    leas      $02,s
+                    ldd       $000D
+                    subd      #$0004
+                    lbra      L3E8A
+
+L3AC9               ldd       #$0002
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      L3BD3
+
+L3AD5               leax      L46B8,pcr
+                    pshs      x
+                    lbsr      L4824
+                    leas      $02,s
+                    ldd       >$0057,y
+                    pshs      d
+                    lbsr      L43F7
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    lbsr      L43DD
+                    lbra      L3BC1
+
+L3AFA               cmpx      #$006E
+                    lbeq      L39E1
+                    cmpx      #$008B
+                    lbeq      L3A31
+                    cmpx      #$0089
+                    lbeq      L3A3D
+                    cmpx      #$0050
+                    lbeq      L3A43
+                    cmpx      #$0051
+                    lbeq      L3A49
+                    cmpx      #$0052
+                    lbeq      L3A4F
+                    cmpx      #$0053
+                    lbeq      L3A55
+                    cmpx      #$0054
+                    lbeq      L3A5B
+                    cmpx      #$0057
+                    lbeq      L3A61
+                    cmpx      #$0058
+                    lbeq      L3A67
+                    cmpx      #$0059
+                    lbeq      L3A6D
+                    cmpx      #$0056
+                    lbeq      L3A73
+                    cmpx      #$0055
+                    lbeq      L3A79
+                    cmpx      #$005A
+                    lbeq      L3A8C
+                    cmpx      #$005B
+                    lbeq      L3A8C
+                    cmpx      #$005E
+                    lbeq      L3A8C
+                    cmpx      #$005C
+                    lbeq      L3A8C
+                    cmpx      #$005F
+                    lbeq      L3A8C
+                    cmpx      #$005D
+                    lbeq      L3A8C
+                    cmpx      #$0043
+                    lbeq      L3A98
+                    cmpx      #$0044
+                    lbeq      L3A9E
+                    cmpx      #$0083
+                    lbeq      L3AA4
+                    cmpx      #$0086
+                    lbeq      L3AAA
+                    cmpx      #$003C
+                    lbeq      L3AB0
+                    cmpx      #$003E
+                    lbeq      L3AB0
+                    cmpx      #$003D
+                    lbeq      L3AB6
+                    cmpx      #$003F
+                    lbeq      L3AB6
+                    cmpx      #$004A
+                    lbeq      L3AC9
+                    lbra      L3AD5
+
+L3BC1               puls      pc,u
+L3BC3               pshs      u
+                    ldu       $06,s
+                    ldx       $04,s
+                    lbra      L3CD6
+
+L3BCC               ldd       #$0004
+                    pshs      d
+                    pshs      u
+L3BD3               lbsr      L3D91
+L3BD6               leas      $04,s
+                    puls      pc,u
+L3BDA               leax      $46C7,pcr
+                    pshs      x
+                    lbsr      L3E8E
+                    leas      $02,s
+                    ldd       $000D
+                    subd      #$0008
+                    lbra      L3E8A
+
+L3BED               cmpu      #$0005
+                    bne       L3BF8
+                    ldd       #$0033
+                    bra       L3BFB
+
+L3BF8               ldd       #$0037
+L3BFB               pshs      d
+                    leax      $46CF,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+                    puls      pc,u
+L3C0E               cmpu      #$0005
+                    bne       L3C1A
+                    leax      L46DA,pcr
+                    bra       L3C1E
+
+L3C1A               leax      $46E1,pcr
+L3C1E               tfr       x,d
+                    pshs      d
+                    lbsr      L3E8E
+                    lbra      L3E66
+
+L3C28               leax      $46E8,pcr
+                    bra       L3C44
+
+L3C2E               leax      $46EE,pcr
+                    bra       L3C44
+
+L3C34               leax      $46F4,pcr
+                    bra       L3C44
+
+L3C3A               leax      L46FA,pcr
+                    bra       L3C44
+
+L3C40               leax      $4700,pcr
+L3C44               pshs      x
+                    lbsr      L3E8E
+                    leas      $02,s
+                    ldd       $000D
+                    addd      #$0008
+                    lbra      L3E8A
+
+L3C53               leax      $4707,pcr
+                    bra       L3CA9
+
+L3C59               cmpu      #$0005
+                    bne       L3C65
+                    leax      L470D,pcr
+                    bra       L3C7B
+
+L3C65               leax      $4713,pcr
+                    bra       L3C7B
+
+L3C6B               cmpu      #$0005
+                    bne       L3C77
+                    leax      $4719,pcr
+                    bra       L3C7B
+
+L3C77               leax      L471F,pcr
+L3C7B               tfr       x,d
+                    pshs      d
+                    bra       L3CAB
+
+L3C81               leax      L4725,pcr
+                    bra       L3CA9
+
+L3C87               leax      $472B,pcr
+                    bra       L3CA9
+
+L3C8D               leax      $4731,pcr
+                    bra       L3CA9
+
+L3C93               leax      $4737,pcr
+                    bra       L3CA9
+
+L3C99               leax      $473D,pcr
+                    bra       L3CA9
+
+L3C9F               leax      $4743,pcr
+                    bra       L3CA9
+
+L3CA5               leax      $4749,pcr
+L3CA9               pshs      x
+L3CAB               lbsr      L3E8E
+                    lbra      L40CD
+
+L3CB1               leax      $474F,pcr
+                    pshs      x
+                    lbsr      L4824
+                    leas      $02,s
+                    ldd       >$0057,y
+                    pshs      d
+                    lbsr      L43F7
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    lbsr      L43DD
+                    lbra      L3D8F
+
+L3CD6               cmpx      #$004B
+                    lbeq      L3BCC
+                    cmpx      #$006E
+                    lbeq      L3BDA
+                    cmpx      #$008B
+                    lbeq      L3BED
+                    cmpx      #$0089
+                    lbeq      L3C0E
+                    cmpx      #$0050
+                    lbeq      L3C28
+                    cmpx      #$0051
+                    lbeq      L3C2E
+                    cmpx      #$0052
+                    lbeq      L3C34
+                    cmpx      #$0053
+                    lbeq      L3C3A
+                    cmpx      #$005A
+                    lbeq      L3C40
+                    cmpx      #$005B
+                    lbeq      L3C40
+                    cmpx      #$005E
+                    lbeq      L3C40
+                    cmpx      #$005C
+                    lbeq      L3C40
+                    cmpx      #$005F
+                    lbeq      L3C40
+                    cmpx      #$005D
+                    lbeq      L3C40
+                    cmpx      #$0043
+                    lbeq      L3C53
+                    cmpx      #$003C
+                    lbeq      L3C59
+                    cmpx      #$003E
+                    lbeq      L3C59
+                    cmpx      #$003D
+                    lbeq      L3C6B
+                    cmpx      #$003F
+                    lbeq      L3C6B
+                    cmpx      #$008D
+                    lbeq      L3C81
+                    cmpx      #$008C
+                    lbeq      L3C87
+                    cmpx      #$0090
+                    lbeq      L3C8D
+                    cmpx      #$008E
+                    lbeq      L3C93
+                    cmpx      #$0092
+                    lbeq      L3C99
+                    cmpx      #$0091
+                    lbeq      L3C9F
+                    cmpx      #$008F
+                    lbeq      L3CA5
+                    lbra      L3CB1
+
+L3D8F               puls      pc,u
+L3D91               pshs      u,d
+                    leax      L475F,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $000B
+                    addd      #$0001
+                    std       $000B
+                    std       ,s
+                    pshs      d
+                    lbsr      L4415
+                    leas      $02,s
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L3DD1
+                    leas      $04,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4420
+                    leas      $02,s
+                    leax      $4764,pcr
+                    pshs      x
+                    lbsr      L43D2
+                    leas      $02,s
+                    lbra      L40CD
+
+L3DD1               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    lbsr      $4B89
+                    ldd       $08,s
+                    cmpd      #$0001
+                    bne       L3DEC
+                    pshs      u
+                    lbsr      L4408
+L3DE7               leas      $02,s
+                    lbra      L3E4C
+
+L3DEC               cmpu      #$0000
+                    bne       L3E1D
+                    ldd       #$0001
+                    std       ,s
+                    bra       L3E04
+
+L3DF9               leax      $476B,pcr
+                    pshs      x
+                    lbsr      L43F7
+                    leas      $02,s
+L3E04               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      $08,s
+                    blt       L3DF9
+                    ldd       #$0030
+                    pshs      d
+                    lbsr      L43E8
+                    bra       L3DE7
+
+L3E1D               clra
+                    clrb
+                    bra       L3E43
+
+L3E21               ldd       ,u++
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       $08,s
+                    addd      #$FFFF
+                    cmpd      ,s
+                    beq       L3E3E
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+L3E3E               ldd       ,s
+                    addd      #$0001
+L3E43               std       ,s
+                    ldd       ,s
+                    cmpd      $08,s
+                    blt       L3E21
+L3E4C               lbsr      L43DD
+                    lbra      L40CD
+
+L3E52               pshs      u
+                    ldd       >$0051,y
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L43D2
+L3E66               leas      $02,s
+                    ldd       $000D
+                    addd      #$0002
+                    bra       L3E8A
+
+L3E6F               pshs      u
+                    ldd       >$0051,y
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L43D2
+                    leas      $02,s
+                    ldd       $000D
+                    addd      #$0004
+L3E8A               std       $000D
+                    puls      pc,u
+L3E8E               pshs      u
+                    ldd       >$0051,y
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L43D2
+                    lbra      L40CD
+
+L3EA5               pshs      u
+                    ldu       $04,s
+                    leas      -$06,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       $0C,s
+                    cmpd      #$0077
+                    bne       L3ED5
+                    ldd       [$0e,s]
+                    cmpd      #$0002
+                    bne       L3EC5
+                    ldd       #$0001
+                    bra       L3EC7
+
+L3EC5               clra
+                    clrb
+L3EC7               std       $02,s
+                    ldx       $0e,s
+                    ldd       $06,x
+                    std       $0C,s
+                    ldx       $0e,s
+                    ldd       $08,x
+                    std       $0e,s
+L3ED5               leax      ,u
+                    bra       L3EED
+
+L3ED9               leax      L476E,pcr
+                    bra       L3EE9
+
+L3EDF               leax      $4772,pcr
+                    bra       L3EE9
+
+L3EE5               leax      $4775,pcr
+L3EE9               stx       $04,s
+                    bra       L3EFC
+
+L3EED               cmpx      #$0057
+                    beq       L3ED9
+                    cmpx      #$0058
+                    beq       L3EDF
+                    cmpx      #$0059
+                    beq       L3EE5
+L3EFC               ldx       $0C,s
+                    lbra      L405C
+
+L3F01               ldd       $02,s
+                    beq       L3F23
+                    cmpu      #$0057
+                    bne       L3F16
+                    ldd       >$0055,y
+                    pshs      d
+                    lbsr      L43D2
+                    leas      $02,s
+L3F16               ldd       $04,s
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    clra
+                    clrb
+                    bra       L3F50
+
+L3F23               ldd       $04,s
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       #$0061
+                    pshs      d
+                    lbsr      L4086
+                    leas      $08,s
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       #$0001
+L3F50               pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       #$0062
+                    pshs      d
+                    lbsr      L4086
+                    leas      $08,s
+                    lbra      L44A2
+
+L3F69               ldd       $0e,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      $5FAE
+                    clra
+                    std       ,s
+                    tfr       d,x
+                    bra       L3FC3
+
+L3F7A               cmpu      #$0057
+                    bne       L3FCE
+                    ldd       >$0055,y
+                    pshs      d
+                    bra       L3F9A
+
+L3F88               cmpu      #$0057
+                    beq       L3FCE
+                    cmpu      #$0059
+                    bne       L3FA1
+                    leax      $4779,pcr
+                    pshs      x
+L3F9A               lbsr      L43D2
+                    leas      $02,s
+                    bra       L3FCE
+
+L3FA1               ldd       $04,s
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0061
+                    pshs      d
+                    lbsr      L4086
+                    leas      $08,s
+                    bra       L3FCE
+
+L3FC3               stx       -$02,s
+                    beq       L3F7A
+                    cmpx      #$00FF
+                    beq       L3F88
+                    bra       L3FA1
+
+L3FCE               ldd       $0e,s
+                    clra
+                    std       ,s
+                    tfr       d,x
+                    bra       L4024
+
+L3FD7               cmpu      #$0057
+                    lbne      L44A2
+                    leax      $477E,pcr
+                    bra       L3FF7
+
+L3FE5               cmpu      #$0057
+                    lbeq      L44A2
+                    cmpu      #$0059
+                    bne       L4001
+                    leax      $4783,pcr
+L3FF7               pshs      x
+                    lbsr      L43D2
+                    leas      $02,s
+                    lbra      L44A2
+
+L4001               ldd       $04,s
+                    pshs      d
+                    lbsr      L43B9
+                    leas      $02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    ldd       #$0036
+                    pshs      d
+                    ldd       #$0062
+                    pshs      d
+                    lbsr      L4086
+                    leas      $08,s
+                    lbra      L44A2
+
+L4024               stx       -$02,s
+                    beq       L3FD7
+                    cmpx      #$00FF
+                    beq       L3FE5
+                    bra       L4001
+
+L402F               ldd       $04,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $4788,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $08,s
+                    ldd       $000D
+                    addd      #$0002
+                    std       $000D
+                    lbra      L44A2
+
+L4050               leax      $479B,pcr
+                    pshs      x
+                    lbsr      L4824
+                    lbra      L432E
+
+L405C               cmpx      #$0034
+                    lbeq      L3F01
+                    cmpx      #$0094
+                    lbeq      L3F01
+                    cmpx      #$0095
+                    lbeq      L3F01
+                    cmpx      #$0093
+                    lbeq      L3F01
+                    cmpx      #$0036
+                    lbeq      L3F69
+                    cmpx      #$006E
+                    beq       L402F
+                    bra       L4050
+
+L4086               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    bsr       L40D1
+                    leas      $06,s
+                    lbsr      L43DD
+                    puls      pc,u
+L40B0               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L40CF
+                    cmpu      #$0000
+                    ble       L40C8
+                    ldd       #$002B
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+L40C8               pshs      u
+                    lbsr      L4408
+L40CD               leas      $02,s
+L40CF               puls      pc,u
+L40D1               pshs      u,y,x,d
+                    ldd       $0a,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L40E6
+                    ldd       #$005B
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+L40E6               ldd       $0a,s
+                    anda      #$7f
+                    tfr       d,x
+                    lbra      L42E3
+
+L40EF               ldu       $0C,s
+                    ldd       $06,u
+                    cmpd      #$0041
+                    bne       L4110
+                    ldd       #$0023
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       $0a,u
+                    pshs      d
+                    ldd       #$0077
+                    bra       L411D
+
+L4110               ldd       $0e,s
+                    addd      $14,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+L411D               pshs      d
+                    bsr       L40D1
+                    leas      $06,s
+                    lbra      L44A2
+
+L4126               ldd       #$0023
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    ldd       $0C,s
+                    lbra      L4268
+
+L4135               leax      $47AC,pcr
+                    pshs      x
+                    lbsr      L43F7
+                    leas      $02,s
+                    ldd       $0e,s
+                    pshs      d
+                    lbsr      L40B0
+                    leas      $02,s
+                    ldd       >$004d,y
+                    pshs      d
+                    lbsr      L43F7
+                    lbra      L42DF
+
+L4155               ldd       $0C,s
+                    std       ,s
+                    lbeq      L4266
+                    ldd       [,s]
+                    std       $02,s
+                    tfr       d,x
+                    lbra      L4233
+
+L4166               ldx       ,s
+                    ldd       $04,x
+                    subd      $000D
+                    addd      $0e,s
+                    std       $0C,s
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       >$004f,y
+                    lbra      L4224
+
+L417E               ldd       L0023
+                    bne       L419A
+                    ldd       $0a,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L4190
+                    ldd       #$003E
+                    bra       L4193
+
+L4190               ldd       #$003C
+L4193               pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+L419A               ldx       ,s
+                    ldd       $04,x
+                    pshs      d
+                    lbsr      L4420
+                    leas      $02,s
+                    leax      $06,s
+                    bra       L41D3
+
+L41A9               ldd       L0023
+                    bne       L41C5
+                    ldd       $0a,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    beq       L41BB
+                    ldd       #$003E
+                    bra       L41BE
+
+L41BB               ldd       #$003C
+L41BE               pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+L41C5               ldd       ,s
+                    addd      #$0004
+                    pshs      d
+                    lbsr      L4433
+                    leas      $02,s
+                    bra       L41D5
+
+L41D3               leas      -$06,x
+L41D5               ldd       $0e,s
+                    pshs      d
+                    lbsr      L40B0
+                    leas      $02,s
+                    ldd       $0a,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L420B
+                    ldd       L0023
+                    lbne      L431B
+                    ldd       $02,s
+                    cmpd      #$0021
+                    lbeq      L431B
+                    ldd       $02,s
+                    cmpd      #$0022
+                    lbeq      L431B
+                    ldd       $02,s
+                    cmpd      #$0023
+                    lbeq      L431B
+L420B               ldx       ,s
+                    ldd       $02,x
+                    clra
+                    andb      #$30
+                    cmpd      #$0030
+                    bne       L4220
+                    leax      $47B3,pcr
+                    pshs      x
+                    bra       L4226
+
+L4220               ldd       >$004d,y
+L4224               pshs      d
+L4226               lbsr      L43F7
+                    lbra      L42DF
+
+L422C               leax      $47B8,pcr
+                    lbra      L42DA
+
+L4233               cmpx      #$000D
+                    lbeq      L4166
+                    cmpx      #$0023
+                    lbeq      L417E
+                    cmpx      #$000F
+                    lbeq      L419A
+                    cmpx      #$0021
+                    lbeq      L41A9
+                    cmpx      #$0022
+                    lbeq      L41A9
+                    cmpx      #$000E
+                    lbeq      L41C5
+                    cmpx      #$000C
+                    lbeq      L41C5
+                    bra       L422C
+
+L4266               ldd       $0e,s
+L4268               pshs      d
+                    lbsr      L4408
+                    lbra      L42DF
+
+L4270               ldd       $0C,s
+                    addd      $0e,s
+                    std       $0C,s
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       #$002C
+                    pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    ldd       $0a,s
+                    anda      #$7f
+                    tfr       d,x
+                    bra       L42A6
+
+L428F               ldd       #$0078
+                    bra       L429C
+
+L4294               ldd       #$0079
+                    bra       L429C
+
+L4299               ldd       #$0075
+L429C               pshs      d
+                    lbsr      L43E8
+                    leas      $02,s
+                    lbra      L431B
+
+L42A6               cmpx      #$0093
+                    beq       L428F
+                    cmpx      #$0094
+                    beq       L4294
+                    cmpx      #$0095
+                    beq       L4299
+                    bra       L431B
+
+L42B7               ldd       >$004f,y
+                    pshs      d
+                    lbsr      L43F7
+                    leas      $02,s
+                    leax      $47C6,pcr
+                    pshs      x
+                    lbsr      L43F7
+                    leas      $02,s
+                    ldd       $000D
+                    addd      #$0002
+                    std       $000D
+                    bra       L431B
+
+L42D6               leax      L47C9,pcr
+L42DA               pshs      x
+                    lbsr      L4824
+L42DF               leas      $02,s
+                    bra       L431B
+
+L42E3               cmpx      #$0077
+                    lbeq      L40EF
+                    cmpx      #$0036
+                    lbeq      L4126
+                    cmpx      #$0080
+                    lbeq      L4135
+                    cmpx      #$0034
+                    lbeq      L4155
+                    cmpx      #$0093
+                    lbeq      L4270
+                    cmpx      #$0094
+                    lbeq      L4270
+                    cmpx      #$0095
+                    lbeq      L4270
+                    cmpx      #$006E
+                    beq       L42B7
+                    bra       L42D6
+
+L431B               ldd       $0a,s
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    lbeq      L44A2
+                    ldd       #$005D
+                    pshs      d
+                    lbsr      L43E8
+L432E               leas      $02,s
+                    lbra      L44A2
+
+L4333               pshs      u
+                    ldx       $04,s
+                    bra       L4382
+
+L4339               leax      $47D5,pcr
+                    pshs      x
+                    lbsr      L4824
+                    leas      $02,s
+L4344               leax      $47DC,pcr
+                    bra       L437E
+
+L434A               leax      L47E0,pcr
+                    bra       L437E
+
+L4350               leax      L47E4,pcr
+                    bra       L437E
+
+L4356               leax      L47E8,pcr
+                    bra       L437E
+
+L435C               leax      L47EC,pcr
+                    bra       L437E
+
+L4362               leax      L47F0,pcr
+                    bra       L437E
+
+L4368               leax      L47F4,pcr
+                    bra       L437E
+
+L436E               leax      L47F8,pcr
+                    bra       L437E
+
+L4374               leax      L47FC,pcr
+                    bra       L437E
+
+L437A               leax      L4800,pcr
+L437E               tfr       x,d
+                    puls      pc,u
+L4382               cmpx      #$005A
+                    beq       L4344
+                    cmpx      #$005B
+                    beq       L434A
+                    cmpx      #$005C
+                    beq       L4350
+                    cmpx      #$005D
+                    beq       L4356
+                    cmpx      #$005E
+                    beq       L435C
+                    cmpx      #$005F
+                    beq       L4362
+                    cmpx      #$0060
+                    beq       L4368
+                    cmpx      #$0061
+                    beq       L436E
+                    cmpx      #$0062
+                    beq       L4374
+                    cmpx      #$0063
+                    beq       L437A
+                    lbra      L4339
+                    puls      pc,u
+L43B9               pshs      u
+                    ldd       $0005
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L43F7
+                    lbra      L446E
+
+L43D2               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L43B9
+                    lbra      L4488
+
+L43DD               pshs      u
+                    ldd       $0005
+                    pshs      d
+                    ldd       #$000D
+                    bra       L43F0
+
+L43E8               pshs      u
+                    ldd       $0005
+                    pshs      d
+                    ldd       $06,s
+L43F0               pshs      d
+                    lbsr      L515F
+                    bra       L4404
+
+L43F7               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+L4404               leas      $04,s
+                    puls      pc,u
+L4408               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      L4804,pcr
+                    lbra      L4499
+
+L4415               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L4420
+                    lbra      L4488
+
+L4420               pshs      u
+                    ldd       #$005F
+                    pshs      d
+                    bsr       L43E8
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L4408
+                    bra       L446E
+
+L4433               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      $4807,pcr
+                    lbra      L4499
+
+L4440               pshs      u,d
+                    ldd       $06,s
+                    subd      $000D
+                    std       ,s
+                    beq       L446C
+                    leax      $480C,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L4408
+                    leas      $02,s
+                    ldd       >$004f,y
+                    pshs      d
+                    lbsr      L43F7
+                    leas      $02,s
+                    lbsr      L43DD
+L446C               ldd       $06,s
+L446E               leas      $02,s
+                    puls      pc,u
+L4472               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L4433
+                    leas      $02,s
+                    ldd       $06,s
+                    beq       L448A
+                    ldd       #$003A
+                    pshs      d
+                    lbsr      L43E8
+L4488               leas      $02,s
+L448A               lbsr      L43DD
+                    puls      pc,u
+L448F               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    leax      L4812,pcr
+L4499               pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+L44A2               leas      $06,s
+                    puls      pc,u
+L44A6               pshs      u
+                    ldd       $04,s
+                    pshs      d
+                    bsr       L448F
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       #$005F
+                    pshs      d
+                    leax      L481A,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $08,s
+                    puls      pc,u
+                    bge       $4545
+                    neg       $002C
+                    com       >$006C
+                    fcb       $62
+                    com       $7220
+                    neg       $006C
+                    fcb       $62
+                    fcb       $72
+                    fcb       $61
+                    bra       L44DC
+
+L44DC               com       $0C,s
+                    fcb       $72
+                    fcb       $61
+                    neg       $0075
+                    jmp       $0b,s
+                    jmp       $0f,s
+                    asr       $6E20
+                    clr       -$10,s
+                    fcb       $65
+                    fcb       $72
+                    fcb       $61
+                    lsr       $6F72
+                    bra       L452D
+                    bra       L44F5
+
+L44F5               bra       L4567
+                    com       $6873
+                    bra       $4521
+                    com       $0d,x
+                    neg       $006C
+                    fcb       $62
+                    neg       $0070
+                    fcb       $75
+                    inc       -$0d,s
+                    bra       $457D
+                    bge       $457A
+                    com       $0d,x
+                    neg       $0063
+                    com       $0d,s
+                    fcb       $75
+                    inc       -$0C,s
+                    neg       $0063
+                    com       -$0b,s
+                    lsr       $09,s
+                    ror       >$0063
+                    com       $04,s
+                    rol       -$0a,s
+                    neg       $0063
+                    com       $01,s
+                    com       $6C00
+L4527               com       $03,s
+                    fcb       $61
+                    com       $7200
+L452D               com       $03,s
+                    inc       -$0d,s
+                    fcb       $72
+                    neg       $0063
+                    com       -$0b,s
+                    tst       $0f,s
+                    lsr       0,x
+L453A               com       $03,s
+                    tst       $0f,s
+                    lsr       0,x
+L4540               jmp       $05,s
+                    asr       $01,s
+                    tst       L0020
+                    jmp       $05,s
+                    asr       $02,s
+                    tst       L0020
+                    com       L6263
+                    fcb       $61
+                    bra       $4575
+                    leax      0,x
+L4554               com       $0f,s
+                    tst       $01,s
+                    tst       L0020
+                    com       $0f,s
+                    tst       $02,s
+                    neg       $006C
+                    fcb       $65
+                    fcb       $61
+                    asl       $2000
+L4565               inc       $05,s
+L4567               fcb       $61
+                    com       $2000
+L456B               bge       $45E5
+                    tst       $0000
+L456F               dec       -$0d,s
+                    fcb       $72
+                    bra       L4574
+
+L4574               com       $6578
+                    neg       $006C
+                    lsr       0,x
+L457B               fcb       $61
+                    com       $6C62
+                    tst       L0020
+                    fcb       $72
+                    clr       $0C,s
+                    fcb       $61
+                    neg       $0061
+                    com       $7261
+                    tst       L0020
+                    fcb       $72
+                    clr       -$0e,s
+                    fcb       $62
+                    neg       $006C
+                    com       $7261
+                    tst       L0020
+                    fcb       $72
+                    clr       -$0e,s
+                    fcb       $62
+                    neg       $006C
+                    lsr       -$07,s
+                    bra       L45A1
+
+L45A1               inc       $04,s
+                    fcb       $75
+                    bra       L45A6
+
+L45A6               inc       $05,s
+                    fcb       $61
+                    asl       $2000
+L45AC               bcs       L4612
+                    bge       L45D5
+                    com       $0d,x
+                    neg       L0064
+                    bge       $45DB
+                    com       $0d,x
+                    neg       $0073
+                    fcb       $65
+                    asl       >$0061
+                    lsr       $03,s
+                    fcb       $61
+                    bra       $45E6
+                    leax      0,x
+L45C5               com       L6263
+                    fcb       $61
+                    bra       L45EE
+                    leax      0,x
+L45CD               bcs       $4633
+                    bge       L45F6
+                    com       $0d,x
+                    neg       $0063
+L45D5               inc       -$0e,s
+                    fcb       $61
+                    tst       L0020
+                    com       $0C,s
+                    fcb       $72
+                    fcb       $62
+                    neg       $006C
+                    lsr       0,x
+L45E2               bra       L4657
+                    lsr       $2563
+                    bra       L4616
+                    leas      $0C,y
+                    com       $0D00
+L45EE               com       $0d,s
+                    neg       >$0073
+                    lsr       >$0073
+L45F6               fcb       $75
+                    fcb       $62
+                    neg       $0061
+                    lsr       $04,s
+                    neg       $006C
+                    fcb       $65
+                    fcb       $61
+                    neg       L0020
+                    fcb       $65
+                    asl       $6720
+                    bcs       L466B
+                    bge       L462F
+                    com       $0d,x
+                    neg       L0064
+                    bge       L4610
+L4610               inca
+                    fcb       $45
+L4612               fcb       $41
+                    bra       L4676
+                    fcb       $72
+L4616               asr       0,x
+L4618               bra       L468E
+                    ror       -$0e,s
+                    bra       $4643
+                    com       $0C,y
+                    bcs       $4685
+                    tst       $0000
+L4624               inc       $04,s
+                    fcb       $61
+                    bra       L4659
+                    bge       $46A3
+                    tst       L0020
+                    clr       -$0e,s
+L462F               fcb       $61
+                    bra       L4663
+                    bge       $46AC
+                    tst       L0020
+                    clr       -$0e,s
+                    fcb       $61
+                    bra       L466D
+                    bge       L46B5
+                    tst       L0020
+                    clr       -$0e,s
+                    fcb       $61
+                    bra       $4677
+                    bge       $46BE
+                    neg       $005F
+                    inc       $0d,s
+                    clr       -$0a,s
+                    fcb       $65
+                    neg       $005F
+                    inc       $01,s
+                    lsr       $04,s
+                    neg       $005F
+                    inc       -$0d,s
+L4657               fcb       $75
+                    fcb       $62
+L4659               neg       $005F
+                    inc       $0d,s
+                    fcb       $75
+                    inc       0,x
+L4660               clrb
+                    inc       $04,s
+L4663               rol       -$0a,s
+                    neg       $005F
+                    inc       $0d,s
+                    clr       $04,s
+L466B               neg       $005F
+L466D               inc       $01,s
+                    jmp       $04,s
+                    neg       $005F
+                    inc       $0f,s
+                    fcb       $72
+L4676               neg       $005F
+                    inc       -$08,s
+                    clr       -$0e,s
+                    neg       $005F
+                    inc       -$0d,s
+                    asl       $0C,s
+                    neg       $005F
+                    inc       -$0d,s
+                    asl       -$0e,s
+                    neg       $005F
+                    inc       $03,s
+                    tst       -$10,s
+L468E               fcb       $72
+                    neg       $005F
+                    inc       $0e,s
+                    fcb       $65
+                    asr       0,x
+L4696               clrb
+                    inc       $03,s
+                    clr       $0d,s
+                    neg       $6C00
+L469E               clrb
+                    inc       $09,s
+                    lsr       $6F6C
+                    neg       $005F
+                    inc       -$0b,s
+                    lsr       $6F6C
+                    neg       $005F
+                    inc       $09,s
+                    jmp       $03,s
+                    neg       $005F
+                    inc       $04,s
+L46B5               fcb       $65
+                    com       0,x
+L46B8               com       $0f,s
+                    lsr       $07,s
+                    fcb       $65
+                    jmp       0,y
+                    blt       $46E1
+                    inc       $0f,s
+                    jmp       $07,s
+                    com       >$005F
+                    lsr       -$0d,s
+                    lsr       L6163
+                    fcb       $6b
+                    neg       L0020
+                    inc       $04,s
+                    fcb       $61
+                    bra       L46FA
+                    com       $0C,y
+                    asl       $0D00
+L46DA               clrb
+                    ror       $0d,s
+                    clr       -$0a,s
+                    fcb       $65
+                    neg       $005F
+                    lsr       $0d,s
+                    clr       -$0a,s
+                    fcb       $65
+                    neg       $005F
+                    lsr       $01,s
+                    lsr       $04,s
+                    neg       $005F
+                    lsr       -$0d,s
+                    fcb       $75
+                    fcb       $62
+                    neg       $005F
+                    lsr       $0d,s
+                    fcb       $75
+                    inc       0,x
+L46FA               clrb
+                    lsr       $04,s
+                    rol       -$0a,s
+                    neg       $005F
+                    lsr       $03,s
+                    tst       -$10,s
+                    fcb       $72
+                    neg       $005F
+                    lsr       $0e,s
+                    fcb       $65
+                    asr       0,x
+L470D               clrb
+                    ror       $09,s
+                    jmp       $03,s
+                    neg       $005F
+                    lsr       $09,s
+                    jmp       $03,s
+                    neg       $005F
+                    ror       $04,s
+                    fcb       $65
+                    com       0,x
+L471F               clrb
+                    lsr       $04,s
+                    fcb       $65
+                    com       0,x
+L4725               clrb
+                    lsr       -$0C,s
+                    clr       $06,s
+                    neg       $005F
+                    ror       -$0C,s
+                    clr       $04,s
+                    neg       $005F
+                    inc       -$0C,s
+                    clr       $04,s
+                    neg       $005F
+                    rol       -$0C,s
+                    clr       $04,s
+                    neg       $005F
+                    fcb       $75
+                    lsr       $6F64
+                    neg       $005F
+                    lsr       -$0C,s
+                    clr       $0C,s
+                    neg       $005F
+                    lsr       -$0C,s
+                    clr       $09,s
+                    neg       $0063
+                    clr       $04,s
+                    asr       $05,s
+                    jmp       0,y
+                    blt       L4778
+                    ror       $0C,s
+                    clr       $01,s
+                    lsr       $7300
+L475F               fcb       $62
+                    com       $7220
+                    neg       $0070
+                    fcb       $75
+                    inc       -$0d,s
+                    bra       L47E2
+                    neg       $0030
+                    bge       L476E
+L476E               fcb       $61
+                    jmp       $04,s
+                    neg       $006F
+                    fcb       $72
+                    neg       $0065
+                    clr       -$0e,s
+L4778               neg       $0063
+                    clr       $0d,s
+                    fcb       $61
+                    neg       $0063
+                    inc       -$0e,s
+                    fcb       $62
+                    neg       $0063
+                    clr       $0d,s
+                    fcb       $62
+                    neg       L0020
+                    bcs       L47FE
+                    fcb       $61
+                    bra       $47BA
+                    com       $2B0D
+                    bra       $47B8
+                    com       $6220
+                    bge       $480B
+                    bmi       $47A7
+                    neg       $0063
+                    clr       $0d,s
+                    neg       $696C
+                    fcb       $65
+                    fcb       $72
+                    bra       $4819
+                    fcb       $72
+                    clr       -$0b,s
+                    fcb       $62
+                    inc       $05,s
+                    neg       $005F
+                    ror       $0C,s
+                    fcb       $61
+                    com       $03,s
+                    neg       $002C
+                    neg       $6372
+                    neg       $0073
+                    lsr       $6F72
+                    fcb       $61
+                    asr       $05,s
+                    bra       L4826
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    neg       L002B
+                    bmi       L47C9
+L47C9               lsr       $05,s
+                    fcb       $72
+                    fcb       $65
+                    ror       $05,s
+                    fcb       $72
+                    fcb       $65
+                    jmp       $03,s
+                    fcb       $65
+                    neg       $0072
+                    fcb       $65
+                    inc       0,y
+                    clr       -$10,s
+                    neg       $0065
+                    fcb       $71
+                    bra       L47E0
+
+L47E0               jmp       $05,s
+
+L47E2               bra       L47E4
+
+L47E4               inc       $05,s
+                    bra       L47E8
+
+L47E8               inc       -$0C,s
+                    bra       L47EC
+
+L47EC               asr       $05,s
+                    bra       L47F0
+
+L47F0               asr       -$0C,s
+                    bra       L47F4
+
+L47F4               inc       -$0d,s
+                    bra       L47F8
+
+L47F8               inc       $0f,s
+                    bra       L47FC
+
+L47FC               asl       -$0d,s
+L47FE               bra       L4800
+
+L4800               asl       $09,s
+                    bra       L4804
+
+L4804               bcs       $486A
+                    neg       $0025
+                    bgt       $4842
+                    com       >$006C
+                    fcb       $65
+                    fcb       $61
+                    com       $2000
+L4812               bra       L4880
+                    fcb       $65
+                    fcb       $61
+                    bcs       L487B
+                    bra       L481A
+
+L481A               bcs       $487F
+                    bcs       L4882
+                    bge       $4890
+                    com       -$0e,s
+                    tst       $0000
+L4824               pshs      u
+L4826               ldd       $04,s
+                    pshs      d
+                    ldd       $0282,y
+                    pshs      d
+                    bsr       L484C
+                    lbra      L4ACA
+
+L4835               pshs      u
+                    leax      L4B2F,pcr
+                    pshs      x
+                    ldd       $0282,y
+                    pshs      d
+                    bsr       L4880
+                    leas      $04,s
+                    lbsr      L0AE0
+                    puls      pc,u
+L484C               pshs      u
+                    leas      -$32,s
+                    leax      $4B3D,pcr
+                    pshs      x
+                    leax      $02,s
+                    pshs      x
+                    lbsr      L5600
+                    leas      $04,s
+                    ldd       $38,s
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    lbsr      L5618
+                    leas      $04,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $38,s
+                    pshs      d
+                    bsr       L4880
+                    leas      $04,s
+L487B               leas      $32,s
+                    puls      pc,u
+L4880               pshs      u
+L4882               ldu       $04,s
+                    ldd       $0e,u
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $10,u
+                    pshs      d
+                    lbsr      L4939
+                    lbra      L4ADF
+
+L4897               pshs      u
+                    ldd       $02DA,y
+                    addd      #$0001
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L5EF1
+                    std       $02DA,y
+                    cmpd      $02DC,y
+                    bne       L48C6
+                    ldd       $02DC,y
+                    addd      #$0001
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L5EF1
+                    std       $02DC,y
+L48C6               ldd       $02DA,y
+                    pshs      d
+                    ldd       #$0006
+                    lbsr      $5E90
+                    leax      $029e,y
+                    leax      d,x
+                    leau      ,x
+                    ldd       $04,s
+                    std       ,u
+                    leax      $02,u
+                    pshs      x
+                    leax      $08,s
+                    lbsr      $5E24
+                    puls      pc,u
+L48E9               pshs      u,d
+                    ldd       $02DA,y
+                    bra       L491A
+
+L48F1               ldd       ,s
+                    pshs      d
+                    ldd       #$0006
+                    lbsr      $5E90
+                    leax      $029e,y
+                    leax      d,x
+                    leau      ,x
+                    ldd       ,u
+                    cmpd      $06,s
+                    bne       L490E
+                    leax      $02,u
+                    bra       L492D
+
+L490E               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    bge       L491C
+                    ldd       #$0009
+L491A               std       ,s
+L491C               ldd       ,s
+                    cmpd      $02DC,y
+                    bne       L48F1
+                    bsr       $492B
+                    stu       $FFFF
+                    stu       L3510
+L492D               leau      $0254,y
+                    pshs      u
+                    lbsr      $5E24
+                    lbra      L4A87
+
+L4939               pshs      u
+                    leas      -$05,s
+                    leax      $0262,y
+                    pshs      x
+                    leax      L4B4F,pcr
+                    pshs      x
+                    lbsr      L2D40
+                    leas      $04,s
+                    ldd       $09,s
+                    pshs      d
+                    ldd       $0f,s
+                    pshs      d
+                    leax      L4B54,pcr
+                    pshs      x
+                    lbsr      L2D40
+                    leas      $06,s
+                    ldd       $0b,s
+                    pshs      d
+                    leax      L4B5E,pcr
+                    pshs      x
+                    lbsr      L2D40
+                    leas      $04,s
+                    ldd       $02DE,y
+                    bne       L498D
+                    leax      L4B6E,pcr
+                    pshs      x
+                    ldd       $0280,y
+                    pshs      d
+                    lbsr      L4F07
+                    leas      $04,s
+                    std       $02DE,y
+                    beq       L49B2
+L498D               leax      $01,s
+                    pshs      x
+                    ldd       $0f,s
+                    pshs      d
+                    lbsr      L48E9
+                    leas      $02,s
+                    lbsr      $5E24
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       $49AB
+                    stu       $FFFF
+                    stu       L3510
+                    lbsr      $5DC0
+                    bne       L49B7
+L49B2               leax      $05,s
+                    lbra      L4A31
+
+L49B7               clra
+                    clrb
+                    pshs      d
+                    leax      $03,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $02DE,y
+                    pshs      d
+                    lbsr      L4F9F
+                    leas      $08,s
+L49D0               leax      $00CE,y
+                    pshs      x
+                    ldd       $02DE,y
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    stb       $02,s
+                    sex
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    ldb       ,s
+                    cmpb      #$0d
+                    bne       L49D0
+                    bra       L4A03
+
+L49F3               leax      $00CE,y
+                    pshs      x
+                    ldd       #$0020
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+L4A03               ldd       $09,s
+                    addd      #$FFFF
+                    std       $09,s
+                    subd      #$FFFF
+                    bgt       L49F3
+                    leax      $00CE,y
+                    pshs      x
+                    ldd       #$005E
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    leax      $00CE,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    bra       L4A33
+
+L4A31               leas      -$05,x
+L4A33               ldd       $0009
+                    addd      #$0001
+                    std       $0009
+                    cmpd      #start
+                    ble       L4A66
+                    leax      $00CE,y
+                    pshs      x
+                    lbsr      L528A
+                    leas      $02,s
+                    leax      $4B70,pcr
+                    pshs      x
+                    leax      $00DB,y
+                    pshs      x
+                    lbsr      L2D55
+                    leas      $04,s
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L622A
+                    leas      $02,s
+L4A66               leas      $05,s
+                    puls      pc,u
+L4A6A               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L4A89
+                    ldd       $0a,u
+                    pshs      d
+                    bsr       L4A6A
+                    leas      $02,s
+                    ldd       $0C,u
+                    pshs      d
+                    lbsr      L4A6A
+                    leas      $02,s
+                    pshs      u
+                    bsr       L4A8B
+L4A87               leas      $02,s
+L4A89               puls      pc,u
+L4A8B               pshs      u
+                    ldu       $04,s
+                    stu       -$02,s
+                    beq       L4ACC
+                    ldx       $06,u
+                    bra       L4AB1
+
+L4A97               ldd       #$000D
+                    bra       L4AA4
+
+L4A9C               ldd       #$0008
+                    bra       L4AA4
+
+L4AA1               ldd       #$0004
+L4AA4               pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L3204
+                    leas      $04,s
+                    bra       L4AC0
+
+L4AB1               cmpx      #$0034
+                    beq       L4A97
+                    cmpx      #$004B
+                    beq       L4A9C
+                    cmpx      #$004A
+                    beq       L4AA1
+L4AC0               ldd       #$0016
+                    pshs      d
+                    pshs      u
+                    lbsr      L3204
+L4ACA               leas      $04,s
+L4ACC               puls      pc,u
+L4ACE               pshs      u
+                    ldd       #$0016
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    bsr       L4B11
+L4ADF               leas      $06,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       $04,s
+                    asra
+                    rorb
+                    asra
+                    rorb
+                    andb      #$F0
+                    pshs      d
+                    ldd       $06,s
+                    clra
+                    andb      #$0f
+                    addd      ,s++
+                    puls      pc,u
+L4AF8               pshs      u
+                    ldu       $04,s
+                    cmpu      #$004C
+                    blt       L4B0D
+                    cmpu      #$0063
+                    bgt       L4B0D
+                    ldd       #$0001
+                    bra       L4B0F
+
+L4B0D               clra
+                    clrb
+L4B0F               puls      pc,u
+L4B11               pshs      u
+                    ldu       $04,s
+                    bra       L4B21
+
+L4B17               ldb       ,u+
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    stb       -$01,x
+L4B21               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L4B17
+                    puls      pc,u
+L4B2F               clr       -$0b,s
+                    lsr       $206F
+                    ror       0,y
+                    tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       >$0063
+                    clr       $0d,s
+                    neg       $696C
+                    fcb       $65
+                    fcb       $72
+                    bra       L4BAC
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       L4B7A
+                    bra       L4B4F
+
+L4B4F               bcs       $4BC4
+                    abx
+                    bra       L4B54
+
+L4B54               inc       $09,s
+                    jmp       $05,s
+                    bra       L4B7F
+                    lsr       0,y
+                    bra       L4B5E
+
+L4B5E               bpl       L4B8A
+                    bpl       $4B8C
+                    bra       L4B84
+                    bcs       $4BD9
+                    bra       L4B88
+                    bpl       L4B94
+                    bpl       $4B96
+                    tst       $0000
+L4B6E               fcb       $72
+                    neg       $0074
+                    fcb       $6f,$6f,$20,$6d,$61,$6e,$79,$20
+                    fcb       $65
+L4B7A               fcb       $72,$72,$6f,$72,$73
+L4B7F               fcb       $20,$2d,$20,$41,$42
+L4B84               fcb       $4f,$52,$54,$0d
+L4B88               neg       $0034
+L4B8A               nega
+                    leax      L4D07,pcr
+                    pshs      x
+                    lbsr      L43B9
+L4B94               lbra      L4C8F
+
+L4B97               pshs      u
+                    ldu       $04,s
+                    pshs      u
+                    leax      L4D0C,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+L4BAC               ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L4472
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $000D
+                    std       $000F
+                    std       L0017
+                    leax      L4D17,pcr
+                    pshs      x
+                    lbsr      L43D2
+                    leas      $02,s
+                    ldd       $0011
+                    bne       L4BE3
+                    ldd       $08,s
+                    std       $0025
+                    pshs      d
+                    leax      $4D1E,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+L4BE3               ldd       $0013
+                    lbeq      L4C91
+                    leax      L4D39,pcr
+                    pshs      x
+                    lbsr      L43B9
+                    leas      $02,s
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4420
+                    leas      $02,s
+                    leax      L4D3F,pcr
+                    pshs      x
+                    lbsr      L43F7
+                    leas      $02,s
+                    pshs      u
+                    lbsr      L4433
+                    leas      $02,s
+                    leax      L4D53,pcr
+                    pshs      x
+                    lbsr      L43F7
+                    lbra      L4C8F
+
+L4C1B               pshs      u
+                    ldd       $0011
+                    bne       L4C3D
+                    ldd       L0017
+                    subd      $000F
+                    addd      #$FFC0
+                    pshs      d
+                    ldd       $0025
+                    pshs      d
+                    leax      L4D77,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $08,s
+L4C3D               puls      pc,u
+L4C3F               pshs      u
+                    ldd       $04,s
+                    beq       L4C4B
+                    leax      L4D84,pcr
+                    bra       L4C4F
+
+L4C4B               leax      $4D8D,pcr
+L4C4F               tfr       x,d
+                    pshs      d
+                    bra       L4C5D
+
+L4C55               pshs      u
+                    leax      $4D93,pcr
+                    pshs      x
+L4C5D               lbsr      L43D2
+                    bra       L4C8F
+
+L4C62               pshs      u,d
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L53D8
+                    std       ,s
+                    lbsr      L4420
+                    bra       L4C78
+
+L4C72               ldd       ,s
+                    pshs      d
+                    bsr       L4C93
+L4C78               leas      $02,s
+                    ldd       $0003
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       ,s
+                    bne       L4C72
+                    clra
+                    clrb
+                    pshs      d
+                    bsr       L4C93
+                    leas      $02,s
+L4C8F               leas      $02,s
+L4C91               puls      pc,u
+L4C93               pshs      u
+                    ldd       $02E0,y
+                    bne       L4CAA
+                    leax      $4D9B,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $04,s
+L4CAA               ldd       $04,s
+                    cmpd      #$0020
+                    blt       L4CBA
+                    ldd       $04,s
+                    cmpd      #$0022
+                    bne       L4CCF
+L4CBA               ldd       $04,s
+                    pshs      d
+                    leax      L4DA2,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $06,s
+                    bra       L4CFF
+
+L4CCF               ldd       $0005
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    ldd       $02E0,y
+                    addd      #$0001
+                    std       $02E0,y
+                    subd      #$0001
+                    cmpd      #$004B
+                    blt       L4D05
+                    leax      L4DAE,pcr
+                    pshs      x
+                    ldd       $0005
+                    pshs      d
+                    lbsr      L2D55
+                    leas      $04,s
+L4CFF               clra
+                    clrb
+                    std       $02E0,y
+L4D05               puls      pc,u
+L4D07               ror       $04,s
+                    fcb       $62
+                    bra       L4D0C
+
+L4D0C               bra       L4D82
+                    lsr       $6C20
+                    bcs       L4D41
+                    fcb       $38
+                    com       $0D00
+L4D17               neg       $7368
+                    com       $2075
+                    neg       L0020
+                    inc       $04,s
+                    lsr       0,y
+                    bls       L4D84
+                    bcs       L4D8B
+                    tst       L0020
+                    inc       $02,s
+                    com       $7220
+                    clrb
+                    com       $746B
+                    com       $08,s
+                    fcb       $65
+                    com       $0b,s
+                    tst       $0000
+L4D39               inc       $05,s
+                    fcb       $61
+                    asl       $2000
+L4D3F               bge       $4DB1
+L4D41               com       -$0e,s
+                    tst       L0020
+                    neg       $7368
+                    com       $2078
+                    tst       L0020
+                    inc       $05,s
+                    fcb       $61
+                    asl       $2000
+L4D53               bge       $4DC5
+                    com       -$0e,s
+                    tst       L0020
+                    neg       $7368
+                    com       $2078
+                    tst       L0020
+                    inc       $02,s
+                    com       $7220
+                    clrb
+                    neg       $726F
+                    ror       $0d,x
+                    bra       L4DDA
+                    fcb       $65
+                    fcb       $61
+                    com       $2034
+                    bge       L4DE8
+                    tst       $0000
+L4D77               clrb
+                    bcs       L4DDE
+                    bra       $4DE1
+                    fcb       $71
+                    fcb       $75
+                    bra       $4DA5
+                    lsr       $0d,x
+L4D82               tst       $0000
+L4D84               ror       $7365
+                    com       -$0C,s
+                    bra       $4DEF
+
+L4D8B               neg       >L0076
+                    com       $6563
+                    lsr       >$0065
+                    jmp       $04,s
+                    com       $6563
+                    lsr       >L0020
+                    ror       $03,s
+                    com       0,y
+                    bhi       L4DA2
+L4DA2               bhi       $4DB1
+                    bra       $4E0C
+                    com       $02,s
+                    bra       $4DCE
+                    bcs       L4E24
+                    tst       $0000
+L4DAE               bhi       $4DBD
+                    neg       $0034
+                    nega
+                    leau      $00C1,y
+L4DB7               ldd       $06,u
+                    clra
+                    andb      #$03
+                    lbeq      L4E28
+                    leau      $0d,u
+                    pshs      u
+                    leax      $0191,y
+                    cmpx      ,s++
+                    bhi       L4DB7
+                    ldd       #$00C8
+                    std       $0260,y
+                    lbra      L4E2C
+                    puls      pc,u
+L4DD8               pshs      u
+L4DDA               ldu       $08,s
+                    bne       L4DE2
+L4DDE               bsr       $4DB1
+                    tfr       d,u
+L4DE2               stu       -$02,s
+                    beq       L4E2C
+                    ldd       $04,s
+L4DE8               std       $08,u
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$2b
+                    beq       L4DFA
+                    ldx       $06,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L4E00
+L4DFA               ldd       $06,u
+                    orb       #$03
+                    bra       L4E1E
+
+L4E00               ldd       $06,u
+                    pshs      d
+                    ldb       [$08,s]
+                    cmpb      #$72
+                    beq       L4E12
+                    ldb       [$08,s]
+                    cmpb      #$64
+                    bne       L4E17
+L4E12               ldd       #$0001
+                    bra       L4E1A
+
+L4E17               ldd       #$0002
+L4E1A               ora       ,s+
+                    orb       ,s+
+L4E1E               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+L4E24               std       $04,u
+                    std       ,u
+L4E28               tfr       u,d
+                    puls      pc,u
+L4E2C               clra
+                    clrb
+                    puls      pc,u
+L4E30               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $0a,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L4E61
+
+L4E43               ldx       $0a,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L4E50
+                    ldd       #$0007
+                    bra       L4E58
+
+L4E50               ldd       #$0004
+                    bra       L4E58
+
+L4E55               ldd       #$0003
+L4E58               std       ,s
+                    bra       L4E71
+
+L4E5C               leax      $04,s
+                    lbra      L4EC9
+
+L4E61               stx       -$02,s
+                    beq       L4E71
+                    cmpx      #$0078
+                    beq       L4E43
+                    cmpx      #$002B
+                    beq       L4E55
+                    bra       L4E5C
+
+L4E71               ldb       [$0a,s]
+                    sex
+                    tfr       d,x
+                    lbra      L4ED6
+
+L4E7A               ldd       ,s
+                    orb       #$01
+                    bra       L4EBC
+
+L4E80               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      $605B
+                    leas      $04,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L4EAB
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L6131
+                    leas      $08,s
+                    bra       L4EF0
+
+L4EAB               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      $607C
+                    bra       L4EC3
+
+L4EB8               ldd       ,s
+                    orb       #$81
+L4EBC               pshs      d
+                    pshs      u
+                    lbsr      $605B
+L4EC3               leas      $04,s
+                    std       $02,s
+                    bra       L4EF0
+
+L4EC9               leas      -$04,x
+L4ECB               ldd       #$00CB
+                    std       $0260,y
+                    clra
+                    clrb
+                    bra       L4EF2
+
+L4ED6               cmpx      #$0072
+                    lbeq      L4E7A
+                    cmpx      #$0061
+                    lbeq      L4E80
+                    cmpx      #$0077
+                    beq       L4EAB
+                    cmpx      #$0064
+                    beq       L4EB8
+                    bra       L4ECB
+
+L4EF0               ldd       $02,s
+L4EF2               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      L4F52
+
+L4F07               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L4E30
+                    leas      $04,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L4F22
+                    clra
+                    clrb
+                    bra       L4F57
+
+L4F22               clra
+                    clrb
+                    bra       L4F4A
+                    pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L5250
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L4E30
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L4F48
+                    clra
+                    clrb
+                    bra       L4F57
+
+L4F48               ldd       $08,s
+L4F4A               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+L4F52               lbsr      L4DD8
+                    leas      $06,s
+L4F57               puls      pc,u
+L4F59               pshs      u
+                    ldu       $04,s
+                    leas      -$06,s
+                    clra
+                    clrb
+                    bra       L4F90
+
+L4F63               ldd       $0C,s
+                    std       $04,s
+                    bra       L4F7F
+
+L4F69               ldd       $10,s
+                    pshs      d
+                    lbsr      L5376
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    beq       L4F99
+                    ldd       ,s
+                    stb       ,u+
+L4F7F               ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    subd      #$FFFF
+                    bgt       L4F69
+                    ldd       $02,s
+                    addd      #$0001
+L4F90               std       $02,s
+                    ldd       $02,s
+                    cmpd      $0e,s
+                    blt       L4F63
+L4F99               ldd       $02,s
+                    leas      $06,s
+                    puls      pc,u
+L4F9F               pshs      u
+                    ldu       $04,s
+                    leas      -$06,s
+                    cmpu      #$0000
+                    beq       L4FB2
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L4FB8
+L4FB2               ldd       #$FFFF
+                    lbra      L50DB
+
+L4FB8               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L4FCB
+                    pshs      u
+                    lbsr      L54CA
+                    leas      $02,s
+                    lbra      L50A1
+
+L4FCB               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L4FEA
+                    pshs      u
+                    lbsr      L528A
+                    leas      $02,s
+                    ldd       $06,u
+                    anda      #$FE
+                    std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    lbra      L509F
+
+L4FEA               ldd       ,u
+                    cmpd      $04,u
+                    lbcc      L50A1
+                    leax      $02,s
+                    pshs      x
+                    leax      $0e,s
+                    lbsr      $5E24
+                    ldx       $10,s
+                    lbra      L506E
+
+L5002               leax      $02,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    pshs      u
+                    lbsr      L50F6
+                    leas      $02,s
+                    lbsr      $5DAB
+                    lbsr      $5E24
+L501B               ldd       $0b,u
+                    lbsr      $5E0B
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    leax      $06,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L5038
+                    neg       $0000
+                    neg       $0000
+L5038               puls      x
+                    lbsr      $5DC0
+                    bge       L5046
+                    leax      $06,s
+                    lbsr      $5DE4
+                    bra       L5048
+
+L5046               leax      $06,s
+L5048               lbsr      $5DC0
+                    blt       L507B
+                    ldd       $04,s
+                    addd      ,u
+                    std       ,s
+                    cmpd      $02,u
+                    bcs       L507B
+                    ldd       ,s
+                    cmpd      $04,u
+                    bcc       L507B
+                    ldd       ,s
+                    std       ,u
+                    ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    lbra      L50D9
+                    bra       L507B
+
+L506E               stx       -$02,s
+                    lbeq      L5002
+                    cmpx      #$0001
+                    lbeq      L501B
+L507B               ldd       $10,s
+                    cmpd      #$0001
+                    bne       L509D
+                    leax      $0C,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $04,u
+                    subd      ,u
+                    lbsr      $5E0B
+                    lbsr      $5DAB
+                    lbsr      $5E24
+L509D               ldd       $04,u
+L509F               std       ,u
+L50A1               ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    ldd       $10,s
+                    pshs      d
+                    leax      $0e,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L6131
+                    leas      $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       $50CD
+                    stu       $FFFF
+                    stu       L3510
+                    lbsr      $5DC0
+                    bne       L50D9
+                    ldd       #$FFFF
+                    bra       L50DB
+
+L50D9               clra
+                    clrb
+L50DB               leas      $06,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    lbsr      L4F9F
+                    leas      $08,s
+                    puls      pc,u
+L50F6               pshs      u
+                    ldu       $04,s
+                    beq       L5103
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L5116
+L5103               bsr       $5109
+                    stu       $FFFF
+                    stu       L3510
+                    leau      $0254,y
+                    pshs      u
+                    lbsr      $5E24
+                    puls      pc,u
+L5116               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L5126
+                    pshs      u
+                    lbsr      L54CA
+                    leas      $02,s
+L5126               ldd       #$0001
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L6131
+                    leas      $08,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L514F
+                    ldd       $02,u
+                    bra       L5151
+
+L514F               ldd       $04,u
+L5151               pshs      d
+                    ldd       ,u
+                    subd      ,s++
+                    lbsr      $5E0B
+                    lbsr      $5D96
+                    puls      pc,u
+L515F               pshs      u
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       L5183
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    lbne      L529B
+                    pshs      u
+                    lbsr      L54CA
+                    leas      $02,s
+L5183               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       L51BF
+                    ldd       #$0001
+                    pshs      d
+                    leax      $07,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L51A4
+                    leax      L6121,pcr
+                    bra       L51A8
+
+L51A4               leax      L6108,pcr
+L51A8               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       L5200
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      L529B
+
+L51BF               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L51CF
+                    pshs      u
+                    lbsr      L52B8
+                    leas      $02,s
+L51CF               ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L51F5
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L5200
+                    ldd       $04,s
+                    cmpd      #$000D
+                    bne       L5200
+L51F5               pshs      u
+                    lbsr      L52B8
+                    std       ,s++
+                    lbne      L529B
+L5200               ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      L5FBA
+                    pshs      d
+                    lbsr      L515F
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      L515F
+                    lbra      L5372
+                    pshs      u,d
+L5229               leau      $00C1,y
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L523D
+
+L5233               tfr       u,d
+                    leau      $0d,u
+                    pshs      d
+                    bsr       L5250
+                    leas      $02,s
+L523D               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    blt       L5233
+                    lbra      L52B4
+
+L5250               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       L5260
+                    ldd       $06,u
+                    bne       L5266
+L5260               ldd       #$FFFF
+                    lbra      L52B4
+
+L5266               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       L5275
+                    pshs      u
+                    bsr       L528A
+                    leas      $02,s
+                    bra       L5277
+
+L5275               clra
+                    clrb
+L5277               std       ,s
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L606A
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $06,u
+                    ldd       ,s
+                    bra       L52B4
+
+L528A               pshs      u
+                    ldu       $04,s
+                    beq       L529B
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       L52A0
+L529B               ldd       #$FFFF
+                    puls      pc,u
+L52A0               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L52B0
+                    pshs      u
+                    lbsr      L54CA
+                    leas      $02,s
+L52B0               pshs      u
+                    bsr       L52B8
+L52B4               leas      $02,s
+                    puls      pc,u
+L52B8               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L52EA
+                    ldd       ,u
+                    cmpd      $04,u
+                    beq       L52EA
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L50F6
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L6131
+                    leas      $08,s
+L52EA               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      L5362
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L5362
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L5339
+                    ldd       $02,u
+                    bra       L5331
+
+L530A               ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L6121
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L5327
+                    leax      $04,s
+                    bra       L5351
+
+L5327               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+L5331               std       ,u
+                    ldd       $02,s
+                    bne       L530A
+                    bra       L5362
+
+L5339               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L6108
+                    leas      $06,s
+                    cmpd      $02,s
+                    beq       L5362
+                    bra       L5353
+
+L5351               leas      -$04,x
+L5353               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       L5372
+
+L5362               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+L5372               leas      $04,s
+                    puls      pc,u
+L5376               pshs      u
+                    ldu       $04,s
+                    beq       L53C2
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L53C2
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L539E
+                    ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldb       ,x
+                    clra
+                    lbra      L54C8
+
+L539E               pshs      u
+                    lbsr      L5411
+                    lbra      L54C6
+                    pshs      u
+                    ldu       $06,s
+                    beq       L53C2
+                    ldd       $06,u
+                    clra
+                    andb      #$01
+                    beq       L53C2
+                    ldd       $04,s
+                    cmpd      #$FFFF
+                    beq       L53C2
+                    ldd       ,u
+                    cmpd      $02,u
+                    bhi       L53C7
+L53C2               ldd       #$FFFF
+                    puls      pc,u
+L53C7               ldd       ,u
+                    addd      #$FFFF
+                    std       ,u
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       $04,s
+                    puls      pc,u
+L53D8               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    pshs      u
+                    lbsr      L5376
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L53FC
+                    pshs      u
+                    lbsr      L5376
+                    leas      $02,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L5401
+L53FC               ldd       #$FFFF
+                    bra       L540D
+
+L5401               ldd       $02,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      $5FD1
+                    addd      ,s
+L540D               leas      $04,s
+                    puls      pc,u
+L5411               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$31
+                    cmpd      #$8001
+                    beq       L5437
+                    ldd       $06,u
+                    clra
+                    andb      #$31
+                    cmpd      #$0001
+                    lbne      L54B0
+                    pshs      u
+                    lbsr      L54CA
+                    leas      $02,s
+L5437               leax      $00C1,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L5454
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L5454
+                    leax      $00CE,y
+                    pshs      x
+                    lbsr      L528A
+                    leas      $02,s
+L5454               ldd       $06,u
+                    clra
+                    andb      #$08
+                    beq       L5480
+                    ldd       $0b,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L5474
+                    leax      L60F8,pcr
+                    bra       L5478
+
+L5474               leax      L60D7,pcr
+L5478               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    bra       L5492
+
+L5480               ldd       #$0001
+                    pshs      d
+                    leax      $0a,u
+                    stx       $02,u
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L60D7
+L5492               leas      $06,s
+                    std       ,s
+                    ldd       ,s
+                    bgt       L54B5
+                    ldd       $06,u
+                    pshs      d
+                    ldd       $02,s
+                    beq       L54A7
+                    ldd       #$0020
+                    bra       L54AA
+
+L54A7               ldd       #$0010
+L54AA               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+L54B0               ldd       #$FFFF
+                    bra       L54C6
+
+L54B5               ldd       $02,u
+                    addd      #$0001
+                    std       ,u
+                    ldd       $02,u
+                    addd      ,s
+                    std       $04,u
+                    ldb       [$02,u]
+                    clra
+L54C6               leas      $02,s
+L54C8               puls      pc,u
+L54CA               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       L5502
+                    leas      -$20,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      $5FEC
+                    leas      $06,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       L54F6
+                    ldd       #$0040
+                    bra       L54F9
+
+L54F6               ldd       #$0080
+L54F9               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $20,s
+L5502               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       L550F
+                    puls      pc,u
+L550F               ldd       $0b,u
+                    bne       L5524
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L551F
+                    ldd       #$0080
+                    bra       L5522
+
+L551F               ldd       #$0100
+L5522               std       $0b,u
+L5524               ldd       $02,u
+                    bne       L5539
+                    ldd       $0b,u
+                    pshs      d
+                    lbsr      L61EF
+                    leas      $02,s
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       L5541
+L5539               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       L5550
+
+L5541               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+L5550               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    puls      pc,u
+L555A               pshs      u
+                    ldd       $0C,s
+                    beq       L5596
+                    ldd       $0e,s
+                    beq       L557D
+                    leax      $04,s
+                    lbsr      $5D52
+                    ldd       $14,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    leax      >$0059,y
+                    leax      d,x
+                    lbsr      L56AA
+                    bra       L5598
+
+L557D               leax      $04,s
+                    lbsr      $5D52
+                    ldd       $14,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    leax      >$0059,y
+                    leax      d,x
+                    lbsr      L56B2
+                    bra       L5598
+
+L5596               leax      $04,s
+L5598               leau      $0254,y
+                    pshs      u
+                    lbsr      L5D79
+                    puls      pc,u
+L55A3               pshs      u
+                    ldd       $0C,s
+                    cmpd      #$0009
+                    ble       L55D3
+                    leax      $04,s
+                    pshs      x
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      $5F44
+                    addd      #$0009
+                    pshs      d
+                    leax      $0a,s
+                    lbsr      $5D52
+                    lbsr      L555A
+                    leas      $0C,s
+                    lbsr      L5D79
+L55D3               ldd       $0e,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L5EF1
+                    pshs      d
+                    leax      $08,s
+                    lbsr      $5D52
+                    lbsr      L555A
+                    leas      $0C,s
+                    puls      pc,u
+L55EF               pshs      u
+                    ldu       $04,s
+L55F3               ldb       ,u+
+                    bne       L55F3
+                    tfr       u,d
+                    subd      $04,s
+                    addd      #$FFFF
+                    puls      pc,u
+L5600               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L560A               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L560A
+                    bra       L563F
+
+L5618               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L5622               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L5622
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L5633               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L5633
+L563F               ldd       $06,s
+                    leas      $02,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    bra       L565B
+
+L564B               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L5659
+                    clra
+                    clrb
+                    puls      pc,u
+L5659               leau      $01,u
+L565B               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L564B
+                    ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+                    puls      pc,u
+L5676               ldx       $02,s
+                    lbsr      $5D52
+                    bsr       L567E
+                    rts
+
+L567E               pshs      u
+                    leas      -$1e,s
+                    tfr       s,u
+                    clr       $1d,u
+                    clr       $19,u
+                    lbsr      $58F8
+                    lbra      L571D
+
+L5691               ldd       ,x
+                    eora      #$80
+                    lbra      $5CB6
+                    lbsr      L5B10
+                    lbsr      L57F2
+                    lbra      L571D
+                    lbsr      L5B10
+                    lbsr      L57C8
+                    lbra      L571D
+
+L56AA               lbsr      L5B10
+                    lbsr      $596B
+                    bra       L571D
+
+L56B2               lbsr      L5B10
+                    lbsr      $5997
+                    bra       L571D
+
+L56BA               lbsr      $5CB4
+                    lbra      $5BB4
+                    bsr       L56BA
+                    ldd       $02,x
+                    rts
+                    ldd       ,x
+                    std       $0254,y
+                    ldd       $02,x
+                    leax      $0254,y
+                    std       $02,x
+                    lbra      $5B54
+                    leax      $0254,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+                    lbra      $5B54
+                    leax      $0254,y
+                    std       $02,x
+                    clr       ,x
+                    clr       $01,x
+                    lbra      $5B54
+
+L56F3               ldd       ,x
+                    std       $0254,y
+                    lda       $02,x
+                    ldb       $07,x
+                    leax      $0254,y
+                    std       $02,x
+                    rts
+                    ldd       ,x
+                    std       $0254,y
+                    ldd       $02,x
+                    leax      $0254,y
+                    sta       $02,x
+                    stb       $07,x
+                    clr       $03,x
+                    clr       $04,x
+                    clr       $05,x
+                    clr       $06,x
+                    rts
+
+L571D               leax      $0254,y
+                    ldd       $22,u
+                    std       ,x
+                    ldd       $24,u
+                    std       $02,x
+                    ldd       $26,u
+                    std       $04,x
+                    ldd       $28,u
+                    std       $06,x
+                    leas      $1e,u
+                    puls      u
+                    puls      d
+                    std       $06,s
+                    leas      $06,s
+                    rts
+                    lda       $02,s
+                    eora      ,x
+                    bmi       L57B0
+                    lda       $02,s
+                    bmi       L5783
+                    lda       $09,s
+                    beq       L577C
+                    ldb       $07,x
+                    beq       L57B4
+                    cmpa      $07,x
+                    bne       L5787
+                    ldd       $02,s
+                    cmpd      ,x
+                    bne       L5787
+                    ldd       $04,s
+                    cmpd      $02,x
+                    bne       L5787
+                    ldd       $06,s
+                    cmpd      $04,x
+                    bne       L5787
+                    lda       $08,s
+                    anda      #$FE
+                    pshs      a
+                    ldb       $06,x
+                    andb      #$FE
+                    cmpa      ,s+
+                    bne       L5787
+                    bra       L57B8
+
+L577C               lda       $07,x
+                    bne       L57C3
+                    clra
+                    bra       L57B8
+
+L5783               lda       $07,x
+                    cmpa      $09,s
+L5787               bhi       L57B4
+                    bcs       L57C3
+                    ldd       ,x
+                    cmpd      $02,s
+                    bne       L5787
+                    ldd       $02,x
+                    cmpd      $04,s
+                    bne       L5787
+                    ldd       $04,x
+                    cmpd      $06,s
+                    bne       L5787
+                    lda       $06,x
+                    anda      #$FE
+                    pshs      a
+                    lda       $08,s
+                    anda      #$FE
+                    cmpa      ,s+
+                    bne       L5787
+                    bra       L57B8
+
+L57B0               lda       ,x
+                    bpl       L57C3
+L57B4               lda       #$01
+                    andcc     #$FE
+L57B8               pshs      cc
+                    ldd       $01,s
+                    std       $09,s
+                    puls      cc
+                    leas      $08,s
+                    rts
+
+L57C3               clra
+                    cmpa      #$01
+                    bra       L57B8
+
+L57C8               lda       $17,u
+                    beq       L57E9
+                    ldb       $1C,u
+                    eorb      #$80
+                    stb       $1C,u
+                    eorb      $18,u
+                    stb       $19,u
+                    ldb       $29,u
+                    bne       L57FB
+                    lbsr      $5C84
+                    lda       $22,u
+                    lbra      $593B
+
+L57E9               lda       $22,u
+                    ldb       $18,u
+                    lbra      $593E
+
+L57F2               lbeq      $5C84
+                    lda       $17,u
+                    beq       L57E9
+L57FB               suba      $29,u
+                    beq       $582C
+                    sta       ,u
+                    bcs       $5832
+                    ldb       $17,u
+                    stb       $29,u
+                    ldd       $22,u
+                    lsra
+L580E               rorb
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $0f,x
+                    eorb      #$27
+                    ror       $28,u
+                    dec       ,u
+                    bne       L580E
+                    std       $22,u
+L5826               lda       $19,u
+                    bmi       L58A2
+                    bra       L5853
+                    inc       ,u
+                    orcc      #$01
+                    bra       L5826
+                    ldd       $10,u
+L5836               lsra
+                    rorb
+                    ror       $12,u
+                    ror       $13,u
+                    ror       $14,u
+                    ror       $15,u
+                    ror       $16,u
+                    inc       ,u
+                    bne       L5836
+                    std       $10,u
+                    lda       $19,u
+                    bmi       L58A5
+L5853               ldd       $27,u
+                    adcb      $16,u
+                    adca      $15,u
+                    std       $27,u
+                    ldd       $25,u
+                    adcb      $14,u
+                    adca      $13,u
+                    std       $25,u
+                    ldb       $24,u
+                    adcb      $12,u
+                    stb       $24,u
+                    ldd       $22,u
+                    adcb      $11,u
+                    adca      $10,u
+                    std       $22,u
+                    bcc       L589A
+                    inc       $29,u
+                    ror       $22,u
+                    ror       $23,u
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+L589A               lda       $1C,u
+                    sta       $19,u
+                    bra       L58F9
+
+L58A2               rola
+                    coma
+                    asra
+L58A5               ldd       $27,u
+                    sbcb      $16,u
+                    sbca      $15,u
+                    std       $27,u
+                    ldd       $25,u
+                    sbcb      $14,u
+                    sbca      $13,u
+                    std       $25,u
+                    ldd       $23,u
+                    sbcb      $12,u
+                    sbca      $11,u
+                    std       $23,u
+                    lda       $22,u
+                    sbca      $10,u
+                    sta       $22,u
+                    lda       $18,u
+                    bcc       L58F6
+                    com       $22,u
+                    com       $23,u
+                    com       $24,u
+                    com       $25,u
+                    com       $26,u
+                    com       $27,u
+                    com       $28,u
+                    lda       ,u
+                    beq       L58F3
+                    lbsr      L5C42
+L58F3               lda       $1C,u
+L58F6               sta       $19,u
+L58F9               clr       ,u
+L58FB               lda       $22,u
+                    bmi       L593C
+                    ora       $23,u
+                    ora       $24,u
+                    ora       $25,u
+                    ora       $26,u
+                    ora       $27,u
+                    ora       $28,u
+                    beq       L5950
+                    ldd       $22,u
+L5917               dec       $29,u
+                    bne       L591F
+                    dec       $1d,u
+L591F               asl       ,u
+                    rol       $28,u
+                    rol       $27,u
+                    rol       $26,u
+                    rol       $25,u
+                    rol       $24,u
+                    rolb
+                    rola
+                    bpl       L5917
+                    stb       $23,u
+                    ldb       $29,u
+                    beq       L5954
+L593C               ldb       $19,u
+                    anda      #$7f
+                    andb      #$80
+                    pshs      b
+                    adda      ,s+
+                    sta       $22,u
+                    tst       $1d,u
+                    bne       L5954
+L594F               rts
+
+L5950               sta       $29,u
+                    rts
+
+L5954               lda       $1d,u
+                    ldb       $29,u
+                    subd      #$0000
+                    beq       L5967
+                    bmi       L5967
+L5961               ldd       #$0028
+                    lbra      $5FDE
+
+L5967               lbsr      L5992
+                    bra       L5961
+                    beq       L5992
+                    lda       $17,u
+                    beq       L5992
+                    lbsr      L5A0E
+                    clra
+                    ldb       $29,u
+                    addb      $17,u
+                    adca      #$00
+                    subd      #$0080
+                    stb       $29,u
+                    sta       $1d,u
+                    lbsr      L58FB
+                    lda       ,u
+                    bpl       L594F
+                    lbra      L5C42
+
+L5992               clra
+                    sta       $29,u
+                    bra       L59F8
+                    ldb       $17,u
+                    bne       L59A3
+                    ldd       #$0029
+                    lbra      $5FDE
+
+L59A3               tsta
+                    beq       L5992
+                    lbsr      L5A6C
+                    clra
+                    ldb       $29,u
+                    subb      $17,u
+                    sbca      #$00
+                    addd      #$0081
+                    sta       $1d,u
+                    stb       $29,u
+                    lda       $06,u
+                    coma
+                    asra
+                    ror       $22,u
+                    ror       $23,u
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+                    ror       ,u
+                    lbsr      L58FB
+                    lda       ,u
+                    bpl       L5A0D
+                    lbra      L5C42
+
+L59E0               pshs      a
+                    ldd       $22,u
+                    std       ,u
+                    ldd       $24,u
+                    std       $02,u
+                    ldd       $26,u
+                    std       $04,u
+                    ldb       $28,u
+                    stb       $06,u
+                    puls      a
+L59F8               sta       $22,u
+                    sta       $23,u
+                    sta       $24,u
+                    sta       $25,u
+                    sta       $26,u
+                    sta       $27,u
+                    sta       $28,u
+L5A0D               rts
+
+L5A0E               clra
+                    bsr       L59E0
+                    ldb       #$38
+                    stb       $08,u
+L5A15               lda       $06,u
+                    lsra
+                    bcc       L5A44
+                    ldd       $27,u
+                    addd      $15,u
+                    std       $27,u
+                    ldd       $25,u
+                    adcb      $14,u
+                    adca      $13,u
+                    std       $25,u
+                    ldd       $23,u
+                    adcb      $12,u
+                    adca      $11,u
+                    std       $23,u
+                    lda       $22,u
+                    adca      $10,u
+                    sta       $22,u
+L5A44               ror       $22,u
+                    ror       $23,u
+                    ror       $24,u
+                    ror       $25,u
+                    ror       $26,u
+                    ror       $27,u
+                    ror       $28,u
+                    ror       ,u
+                    ror       $01,u
+                    ror       $02,u
+                    ror       $03,u
+                    ror       $04,u
+                    ror       $05,u
+                    ror       $06,u
+                    dec       $08,u
+                    bne       L5A15
+                    rts
+
+L5A6C               clra
+                    lbsr      L59E0
+                    ldb       #$39
+                    stb       $08,u
+L5A74               ldb       ,u
+                    cmpb      $10,u
+                    bcs       L5AAB
+                    ldd       $05,u
+                    subd      $15,u
+                    std       $0d,u
+                    ldd       $03,u
+                    sbcb      $14,u
+                    sbca      $13,u
+                    std       $0b,u
+                    ldb       $02,u
+                    sbcb      $12,u
+                    stb       $0a,u
+                    ldd       ,u
+                    sbcb      $11,u
+                    sbca      $10,u
+                    bcs       L5AAB
+                    std       ,u
+                    lda       $0a,u
+                    sta       $02,u
+                    ldd       $0b,u
+                    std       $03,u
+                    ldd       $0d,u
+                    std       $05,u
+L5AAB               rol       $28,u
+                    rol       $27,u
+                    rol       $26,u
+                    rol       $25,u
+                    rol       $24,u
+                    rol       $23,u
+                    rol       $22,u
+                    rol       $06,u
+                    rol       $05,u
+                    rol       $04,u
+                    rol       $03,u
+                    rol       $02,u
+                    rol       $01,u
+                    rol       ,u
+                    dec       $08,u
+                    bhi       L5A74
+                    beq       L5AF9
+                    ldd       $05,u
+                    subd      $15,u
+                    std       $05,u
+                    ldd       $03,u
+                    sbcb      $14,u
+                    sbca      $13,u
+                    std       $03,u
+                    ldd       $01,u
+                    sbcb      $12,u
+                    sbca      $11,u
+                    std       $01,u
+                    lda       ,u
+                    sbca      $10,u
+                    sta       ,u
+                    clra
+                    bra       L5AAB
+
+L5AF9               ror       ,u
+                    com       $22,u
+                    com       $23,u
+                    com       $24,u
+                    com       $25,u
+                    com       $26,u
+                    com       $27,u
+                    com       $28,u
+L5B10               rts
+
+L5B11               puls      d
+                    pshs      u
+                    leas      -$1e,s
+                    tfr       s,u
+                    pshs      d
+                    clr       $1d,u
+                    ldd       $06,x
+                    std       $16,u
+                    ldd       $04,x
+                    std       $14,u
+                    ldd       $02,x
+                    std       $12,u
+                    ldd       ,x
+                    stb       $11,u
+                    tfr       a,b
+                    sta       $1C,u
+                    ora       #$80
+                    sta       $10,u
+                    eorb      $22,u
+                    stb       $19,u
+                    lda       $22,u
+                    sta       $18,u
+                    ora       #$80
+                    sta       $22,u
+                    lda       $29,u
+                    rts
+                    leax      $22,u
+                    lda       #$A0
+                    sta       $07,x
+                    clr       $04,x
+                    clr       $05,x
+                    clr       $06,x
+                    lda       ,x
+                    tfr       a,b
+                    orb       $01,x
+                    orb       $02,x
+                    orb       $03,x
+                    beq       L5BA1
+                    ldb       $01,x
+                    tsta
+                    bpl       L5B83
+                    pshs      d
+                    clra
+                    clrb
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,s
+                    sbca      ,s
+                    leas      $02,s
+                    bvs       L5B8D
+L5B83               dec       $07,x
+                    asl       $03,x
+                    rol       $02,x
+                    rolb
+                    rola
+                    bpl       L5B83
+L5B8D               anda      #$7f
+                    tst       ,x
+                    bpl       L5B95
+                    ora       #$80
+L5B95               std       ,x
+                    rts
+                    leax      $22,u
+                    clr       $04,x
+                    clr       $05,x
+                    clr       $06,x
+L5BA1               clr       $07,x
+L5BA3               clr       ,x
+                    clr       $01,x
+                    clr       $02,x
+                    clr       $03,x
+                    rts
+
+L5BAC               ldd       #$002A
+                    lbra      $5FDE
+                    leax      $22,u
+                    ldb       $07,x
+                    beq       L5BA3
+                    subb      #$81
+                    bcs       L5C34
+                    negb
+                    addb      #$1f
+                    bmi       L5BAC
+                    bne       L5BD9
+                    ldd       ,x
+                    cmpd      #$8000
+                    bne       L5BAC
+                    lda       $02,x
+                    ora       $03,x
+                    ora       $04,x
+                    ora       $05,x
+                    ora       $06,x
+                    bne       L5BAC
+                    rts
+
+L5BD9               pshs      b
+                    ldd       ,x
+                    bmi       L5BEF
+                    ora       #$80
+L5BE1               lsra
+                    rorb
+                    ror       $02,x
+                    ror       $03,x
+                    dec       ,s
+                    bne       L5BE1
+                    std       ,x
+                    puls      pc,b
+L5BEF               clr       ,-s
+L5BF1               lsra
+                    rorb
+                    ror       $02,x
+                    ror       $03,x
+                    ror       $04,x
+                    ror       $05,x
+                    ror       $06,x
+                    bcc       L5C01
+                    inc       ,s
+L5C01               dec       $01,s
+                    bne       L5BF1
+                    std       ,x
+                    ldd       ,s++
+                    bne       L5C13
+                    lda       $04,x
+                    ora       $05,x
+                    ora       $06,x
+                    beq       L5C24
+L5C13               ldd       $02,x
+                    addd      #$0001
+                    std       $02,x
+                    ldd       ,x
+                    adcb      #$00
+                    adca      #$00
+                    bcs       L5BAC
+                    std       ,x
+L5C24               clra
+                    clrb
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       ,x
+                    rts
+
+L5C34               lda       ,x
+                    lbpl      L5BA3
+                    ldd       #$FFFF
+                    std       $02,x
+                    std       ,x
+                    rts
+
+L5C42               inc       $28,u
+                    bne       L5C78
+                    inc       $27,u
+                    bne       L5C78
+                    inc       $26,u
+                    bne       L5C78
+                    inc       $25,u
+                    bne       L5C78
+                    inc       $24,u
+                    bne       L5C78
+                    inc       $23,u
+                    bne       L5C78
+                    ldb       $22,u
+                    tfr       b,a
+                    anda      #$7f
+                    inca
+                    bpl       L5C6F
+                    inc       $29,u
+                    anda      #$7f
+L5C6F               andb      #$80
+                    pshs      b
+                    adda      ,s+
+                    sta       $22,u
+L5C78               rts
+
+L5C79               neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       L0081
+                    leax      >L5C79,pcr
+                    pshs      a
+                    ldd       ,x
+                    std       $22,u
+                    ldd       $02,x
+                    std       $24,u
+                    ldd       $04,x
+                    std       $26,u
+                    ldd       $06,x
+                    std       $28,u
+                    puls      pc,a
+L5C9D               pshs      a
+                    ldd       $22,u
+                    std       ,x
+                    ldd       $24,u
+                    std       $02,x
+                    ldd       $26,u
+                    std       $04,x
+                    ldd       $28,u
+                    std       $06,x
+                    puls      pc,a
+                    ldd       ,x
+                    std       $0254,y
+                    ldd       $02,x
+                    std       $0256,y
+                    ldd       $04,x
+                    std       $0258,y
+                    ldd       $06,x
+                    leax      $0254,y
+                    std       $06,x
+                    rts
+                    pshs      x
+                    bsr       L5D53
+                    leax      L5C79,pcr
+                    pshs      x
+                    lbsr      L5B11
+                    lbsr      $57F3
+L5CDF               ldx       $2a,u
+                    bsr       L5C9D
+                    ldx       $1e,u
+                    leas      $2a,u
+                    tfr       x,u
+                    puls      pc,x
+                    pshs      x
+                    bsr       L5D53
+                    leax      >L5C79,pcr
+                    pshs      x
+                    lbsr      L5B11
+                    lbsr      $57C9
+                    bra       L5CDF
+                    pshs      x
+                    bsr       $5D3C
+                    leax      L5C79,pcr
+                    pshs      x
+                    lbsr      L5B11
+                    lbsr      $57F3
+                    ldx       $2a,u
+                    ldd       $22,u
+                    std       ,x
+                    lda       $24,u
+                    ldb       $29,u
+                    std       $02,x
+                    ldx       $0f,u
+                    exg       u,y
+                    eorb      #$2a
+                    tfr       x,u
+                    puls      pc,x
+                    pshs      x
+                    bsr       L5D3D
+                    leax      $5C7A,pcr
+                    pshs      x
+                    lbsr      $5B12
+                    lbsr      $57CA
+                    bra       $5D11
+
+L5D3D               leas      -$08,s
+                    ldd       $08,s
+                    std       ,s
+                    clra
+                    clrb
+                    std       $05,s
+                    std       $07,s
+                    ldd       ,x
+                    std       $02,s
+                    ldd       $02,x
+                    sta       $04,s
+                    stb       $09,s
+L5D53               rts
+                    leas      -$08,s
+                    ldd       $08,s
+                    std       ,s
+                    ldd       ,x
+                    std       $02,s
+                    ldd       $02,x
+                    std       $04,s
+                    ldd       $04,x
+                    std       $06,s
+                    ldd       $06,x
+                    std       $08,s
+                    rts
+                    pshs      u
+                    ldu       $04,s
+                    exg       x,u
+                    ldd       ,u
+                    std       ,x
+                    ldd       $02,u
+                    std       $02,x
+L5D79               bra       L5D91
+                    pshs      u
+                    ldu       $04,s
+                    exg       x,u
+                    ldd       ,u
+                    std       ,x
+                    ldd       $02,u
+                    std       $02,x
+                    ldd       $04,u
+                    std       $04,x
+                    ldd       $06,u
+                    std       $06,x
+L5D91               puls      u
+                    puls      d
+                    std       ,s
+                    rts
+                    ldd       $04,s
+                    addd      $02,x
+                    std       $0256,y
+                    ldd       $02,s
+                    adcb      $01,x
+                    adca      ,x
+                    std       $0254,y
+                    lbra      L5E74
+                    ldd       $04,s
+                    subd      $02,x
+                    std       $0256,y
+                    ldd       $02,s
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       $0254,y
+                    lbra      L5E74
+                    ldd       $02,s
+                    cmpd      ,x
+                    bne       L5DDB
+                    ldd       $04,s
+                    cmpd      $02,x
+                    beq       L5DDB
+                    bcs       L5DD8
+                    lda       #$01
+                    andcc     #$FE
+                    bra       L5DDB
+
+L5DD8               clra
+                    cmpa      #$01
+L5DDB               pshs      cc
+                    ldd       $01,s
+                    std       $05,s
+                    puls      cc
+                    leas      $04,s
+                    rts
+                    lbsr      L5E83
+                    ldd       #$0000
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       ,x
+                    rts
+                    ldd       ,x
+                    coma
+                    comb
+                    std       $0254,y
+                    ldd       $02,x
+                    coma
+                    comb
+                    leax      $0254,y
+                    std       $02,x
+                    rts
+                    leax      $0254,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+                    rts
+                    leax      $0254,y
+                    std       $02,x
+                    clr       ,x
+                    clr       $01,x
+                    rts
+                    pshs      y
+                    ldy       $04,s
+                    ldd       ,x
+                    std       ,y
+                    ldd       $02,x
+                    std       $02,y
+                    puls      x
+                    exg       y,x
+                    puls      d
+                    std       ,s
+                    rts
+                    ldx       $02,s
+                    pshs      b
+                    lbsr      L5E83
+                    puls      b
+                    tstb
+                    beq       L5E53
+L5E48               asl       $03,x
+                    rol       $02,x
+                    rol       $01,x
+                    rol       ,x
+                    decb
+                    bne       L5E48
+L5E53               puls      d
+                    std       ,s
+                    rts
+                    ldx       $02,s
+                    pshs      b
+                    lbsr      L5E83
+                    puls      b
+                    tstb
+                    beq       L5E6F
+L5E64               asr       ,x
+                    ror       $01,x
+                    ror       $02,x
+                    ror       $03,x
+                    decb
+                    bne       L5E64
+L5E6F               puls      d
+                    std       ,s
+                    rts
+
+L5E74               tfr       cc,a
+                    puls      x
+                    stx       $02,s
+                    leas      $02,s
+                    leax      $0254,y
+                    tfr       a,cc
+                    rts
+
+L5E83               ldd       ,x
+                    std       $0254,y
+                    ldd       $02,x
+                    leax      $0254,y
+                    std       $02,x
+                    rts
+                    tsta
+                    bne       L5EA7
+                    tst       $02,s
+                    bne       L5EA7
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+L5EA7               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L5EC4
+                    inc       ,s
+L5EC4               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L5ED1
+                    inc       ,s
+L5ED1               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+                    rts
+                    clr       $02E2,y
+                    leax      >L5F2D,pcr
+                    stx       $02E3,y
+L5EF1               bra       L5F07
+                    leax      >L5F46,pcr
+                    stx       $02E3,y
+                    clr       $02E2,y
+                    tst       $02,s
+                    bpl       L5F07
+                    inc       $02E2,y
+L5F07               subd      #$0000
+                    bne       L5F12
+                    puls      x
+                    ldd       ,s++
+                    jmp       ,x
+
+L5F12               ldx       $02,s
+                    pshs      x
+                    jsr       [$02E3,y]
+                    ldd       ,s
+                    std       $02,s
+                    tfr       x,d
+                    tst       $02E2,y
+                    beq       L5F2A
+                    nega
+                    negb
+                    sbca      #$00
+L5F2A               std       ,s++
+                    rts
+
+L5F2D               subd      #$0000
+                    beq       L5F3C
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    bra       L5F6A
+
+L5F3C               puls      d
+                    std       ,s
+                    ldd       #$002D
+                    lbra      L5FDF
+
+L5F46               subd      #$0000
+                    beq       L5F3C
+                    pshs      d
+                    leas      -$02,s
+                    clr       ,s
+                    clr       $01,s
+                    tsta
+                    bpl       L5F5E
+                    nega
+                    negb
+                    sbca      #$00
+                    inc       $01,s
+                    std       $02,s
+L5F5E               ldd       $06,s
+                    bpl       L5F6A
+                    nega
+                    negb
+                    sbca      #$00
+                    com       $01,s
+                    std       $06,s
+L5F6A               lda       #$01
+L5F6C               inca
+                    asl       $03,s
+                    rol       $02,s
+                    bpl       L5F6C
+                    sta       ,s
+                    ldd       $06,s
+                    clr       $06,s
+                    clr       $07,s
+L5F7B               subd      $02,s
+                    bcc       L5F85
+                    addd      $02,s
+                    andcc     #$FE
+                    bra       L5F87
+
+L5F85               orcc      #$01
+L5F87               rol       $07,s
+                    rol       $06,s
+                    lsr       $02,s
+                    ror       $03,s
+                    dec       ,s
+                    bne       L5F7B
+                    std       $02,s
+                    tst       $01,s
+                    beq       L5FA1
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+L5FA1               ldx       $04,s
+                    ldd       $06,s
+                    std       $04,s
+                    stx       $06,s
+                    ldx       $02,s
+                    ldd       $04,s
+                    leas      $06,s
+                    rts
+                    tstb
+                    beq       L5FC6
+L5FB3               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L5FB3
+L5FBA               bra       L5FC6
+                    tstb
+                    beq       L5FC6
+L5FBF               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L5FBF
+L5FC6               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+                    leas      $04,s
+                    rts
+                    tstb
+                    beq       L5FC6
+L5FD6               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       L5FD6
+                    bra       L5FC6
+
+L5FDF               std       $0260,y
+                    pshs      y,b
+                    os9       F$ID
+                    puls      y,b
+                    os9       F$Send
+                    rts
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       L6021
+                    cmpb      #$01
+                    beq       L6023
+                    cmpb      #$06
+                    beq       L6023
+                    cmpb      #$02
+                    beq       L6009
+                    cmpb      #$05
+                    beq       L6009
+                    ldb       #$D0
+                    lbra      L621E
+
+L6009               pshs      u
+                    os9       I$GetStt
+                    bcc       L6015
+                    puls      u
+                    lbra      L621E
+
+L6015               stx       [$08,s]
+                    ldx       $08,s
+                    stu       $02,x
+                    puls      u
+                    clra
+                    clrb
+                    rts
+
+L6021               ldx       $06,s
+L6023               os9       I$GetStt
+                    lbra      L6227
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       L6038
+                    cmpb      #$02
+                    beq       L6040
+                    ldb       #$D0
+                    lbra      L621E
+
+L6038               ldx       $06,s
+                    os9       I$SetStt
+                    lbra      L6227
+
+L6040               pshs      u
+                    ldx       $08,s
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u
+                    lbra      L6227
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    bcs       L605A
+                    os9       I$Close
+L605A               lbra      L6227
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    lbcs      L621E
+                    tfr       a,b
+L606A               clra
+                    rts
+                    lda       $03,s
+                    os9       I$Close
+                    lbra      L6227
+                    ldx       $02,s
+                    ldb       $05,s
+                    os9       I$MakDir
+                    lbra      L6227
+                    ldx       $02,s
+                    lda       $05,s
+                    tfr       a,b
+                    andb      #$24
+                    orb       #$0b
+                    os9       I$Create
+                    bcs       L6091
+L608D               tfr       a,b
+                    clra
+                    rts
+
+L6091               cmpb      #$DA
+                    lbne      L621E
+                    lda       $05,s
+                    bita      #$80
+                    lbne      L621E
+                    anda      #$07
+                    ldx       $02,s
+                    os9       I$Open
+                    lbcs      L621E
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+                    bcc       L608D
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+                    lbra      L621E
+                    ldx       $02,s
+                    os9       I$Delete
+                    lbra      L6227
+                    lda       $03,s
+                    os9       I$Dup
+                    lbcs      L621E
+                    tfr       a,b
+L60D7               clra
+                    rts
+                    pshs      y
+                    ldx       $06,s
+                    lda       $05,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$Read
+L60E7               bcc       L60F6
+                    cmpb      #$D3
+                    bne       L60F1
+                    clra
+                    clrb
+                    puls      pc,y,x
+L60F1               puls      y,x
+                    lbra      L621E
+
+L60F6               tfr       y,d
+L60F8               puls      pc,y,x
+                    pshs      y
+                    lda       $05,s
+                    ldx       $06,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$ReadLn
+L6108               bra       L60E7
+                    pshs      y
+                    ldy       $08,s
+                    beq       L611F
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$Write
+L6118               bcc       L611F
+                    puls      y
+                    lbra      L621E
+
+L611F               tfr       y,d
+L6121               puls      pc,y
+                    pshs      y
+                    ldy       $08,s
+                    beq       L611F
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$WritLn
+L6131               bra       L6118
+                    pshs      u
+                    ldd       $0a,s
+                    bne       L6141
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       L6175
+
+L6141               cmpd      #$0001
+                    beq       L616C
+                    cmpd      #$0002
+                    beq       L6161
+                    ldb       #$F7
+L614F               clra
+                    std       $0260,y
+                    ldd       #$FFFF
+                    leax      $0254,y
+                    std       ,x
+                    std       $02,x
+                    puls      pc,u
+L6161               lda       $05,s
+L6163               ldb       #$02
+                    os9       I$GetStt
+                    bcs       L614F
+                    bra       L6175
+
+L616C               lda       $05,s
+                    ldb       #$05
+                    os9       I$GetStt
+L6173               bcs       L614F
+L6175               tfr       u,d
+                    addd      $08,s
+                    std       $0256,y
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       L614F
+                    tfr       d,x
+                    std       $0254,y
+                    lda       $05,s
+                    os9       I$Seek
+                    bcs       L614F
+                    leax      $0254,y
+L6198               puls      pc,u
+                    ldd       $0252,y
+                    pshs      d
+                    ldd       $04,s
+                    cmpd      $02E5,y
+                    bcs       L61CE
+                    addd      $0252,y
+                    pshs      y
+                    subd      ,s
+                    os9       F$Mem
+                    tfr       y,d
+                    puls      y
+                    bcc       L61C0
+                    ldd       #$FFFF
+                    leas      $02,s
+                    rts
+
+L61C0               std       $0252,y
+                    addd      $02E5,y
+                    subd      ,s
+                    std       $02E5,y
+L61CE               leas      $02,s
+                    ldd       $02E5,y
+                    pshs      d
+                    subd      $04,s
+                    std       $02E5,y
+                    ldd       $0252,y
+                    subd      ,s++
+                    pshs      d
+                    clra
+                    ldx       ,s
+L61E7               sta       ,x+
+                    cmpx      $0252,y
+                    bcs       L61E7
+L61EF               puls      pc,d
+                    ldd       $02,s
+                    addd      $025C,y
+                    bcs       L621A
+                    cmpd      $025e,y
+                    bcc       L621A
+                    pshs      d
+                    ldx       $025C,y
+                    clra
+L6207               cmpx      ,s
+                    bcc       L620F
+                    sta       ,x+
+                    bra       L6207
+
+L620F               ldd       $025C,y
+                    puls      x
+                    stx       $025C,y
+                    rts
+
+L621A               ldd       #$FFFF
+                    rts
+
+L621E               clra
+                    std       $0260,y
+                    ldd       #$FFFF
+                    rts
+
+L6227               bcs       L621E
+                    clra
+L622A               clrb
+                    rts
+                    lbsr      L6237
+                    lbsr      L5229
+                    ldd       $02,s
+                    os9       F$Exit
+L6237               rts
+                    neg       $0003
+                    neg       $0000
+                    fcb       $4b
+                    fcb       $01
+                    addb      0,x
+                    fcb       $02
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       L0020
+                    neg       $0040
+                    neg       $0080
+                    fcb       $01
+                    neg       $0002
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       L0020
+                    neg       $0040
+                    neg       L0027
+                    fcb       $10
+                    com       $00E8
+                    neg       L0064
+                    neg       $000A
+L6263               neg       $0000
+                    lsra
+                    adcb      #$44
+                    ldd       #$44CF
+                    lsra
+                    bitb      $0044
+                    addb      $0044
+                    subb      0,x
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    suba      #$20
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    anda      #$48
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $87
+                    dec       >$0000
+                    neg       $0000
+                    neg       $0000
+                    ora       #$1C
+                    nega
+                    neg       $0000
+                    neg       $0000
+                    neg       $008E
+                    coma
+                    negb
+                    neg       $0000
+                    neg       $0000
+                    neg       L0091
+                    lsr       L2400
+                    neg       $0000
+                    neg       $0000
+                    anda      $0018
+                    lda       $0080
+                    neg       $0000
+                    neg       $0000
+                    eora      $003E
+                    cmpx      $2000
+                    neg       $0000
+                    neg       L009B
+                    jmp       $0b,s
+                    bvc       L62BD
+L62BD               neg       $0000
+                    neg       $009E
+                    fcb       $15
+                    fcb       $02
+                    adcb      >$0000
+                    neg       $0000
+                    sbca      $0d,y
+                    asl       $EBC5
+                    cmpx      $02,s
+                    neg       L00C3
+                    rola
+                    sbcb      $C9CD
+                    lsr       $0067
+                    clra
+                    andb      0,x
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    leax      0,y
+                    bra       L63EE
+                    bra       L63F0
+                    bra       L63F2
+                    bra       L63F4
+                    bra       L63F6
+                    bra       L63F8
+                    bra       L63FA
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    bra       $6406
+                    bra       $6408
+                    bra       $640A
+                    bra       L642E
+                    fcb       $42
+                    fcb       $42
+L63EE               fcb       $42
+                    fcb       $42
+L63F0               fcb       $42
+                    fcb       $02
+L63F2               fcb       $02
+                    fcb       $02
+L63F4               fcb       $02
+                    fcb       $02
+L63F6               fcb       $02
+                    fcb       $02
+L63F8               fcb       $02
+                    fcb       $02
+L63FA               fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    bra       L6427
+                    bra       L6429
+                    bra       $642B
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    bra       $6447
+
+L6427               bra       $6449
+L6429               fcb       $01
+                    neg       $0006
+                    neg       L0057
+L642E               neg       L0055
+                    neg       L0053
+                    neg       L0051
+                    neg       L004F
+                    neg       L004D
+                    neg       $0001
+                    neg       $0001
+                    com       $0e,y
+                    neg       L6173
+
+                    emod
+eom                 equ       *
+                    end

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       3431
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.pass2/
                     fcb       edition
 
-L0015               lda       ,y+
+copybytes           lda       ,y+
 L0017               sta       ,u+
 L0019               leax      -$01,x
-L001B               bne       L0015
+L001B               bne       copybytes
 L001D               rts
 
-start               pshs      y
+_start              pshs      y
 L0020               pshs      u
 L0022               clra
 L0023               clrb
@@ -37,12 +37,12 @@ L002D               leax      $02E7,x
 L0033               leay      $6235,pcr
 L0037               ldx       ,y++
                     beq       L003F
-                    bsr       L0015
+                    bsr       copybytes
 L003D               ldu       $02,s
 L003F               leau      >$0027,u
 L0043               ldx       ,y++
 L0045               beq       L004A
-L0047               bsr       L0015
+L0047               bsr       copybytes
                     clra
 L004A               cmpu      ,s
 L004D               beq       L0053
@@ -118,30 +118,28 @@ L00E1               leax      $0212,u
                     pshs      x
                     ldd       0,x
                     adcb      #$02
-                    fcb       $4e
+                    fcb       $4E
                     pshs      d
                     leay      ,u
-                    bsr       L00FC
-                    lbsr      L017E
+                    bsr       stkinit
+                    lbsr      main
                     clr       ,-s
                     clr       ,-s
-                    lbsr      L622A
-L00FC               leax      $02E7,y
+                    lbsr      exit
+stkinit             leax      $02E7,y
 L0100               stx       $025C,y
                     sts       $0250,y
                     sts       $025e,y
                     ldd       #$FF82
-L0111               leax      d,s
+stkcheck            leax      d,s
                     cmpx      $025e,y
                     bcc       L0123
                     cmpx      $025C,y
                     bcs       L013D
                     stx       $025e,y
 L0123               rts
-L0124               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+L0124               fcc       /**** STACK OVERFLOW ****/
+                    fcb       $0D
 L013D               leax      L0124,pcr
                     ldb       #$CF
                     pshs      b
@@ -170,9 +168,9 @@ L016C               ldd       ,y++
                     leas      $04,s
                     rts
 
-L017E               pshs      u
+main                pshs      u
                     ldd       #$FF86
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$24,s
                     lbra      L028F
 
@@ -195,7 +193,7 @@ L01A9               ldd       #$0001
                     lbra      L0231
 
 L01B1               ldd       #$0001
-                    std       L0015
+                    std       copybytes
                     leax      L0B05,pcr
                     pshs      x
                     lbsr      L09DC
@@ -215,7 +213,7 @@ L01C4               leau      $01,u
 
 L01DB               leau      -$01,u
                     pshs      u
-                    leax      $0B0F,pcr
+                    leax      L0B0F,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
@@ -267,7 +265,7 @@ L023B               ldd       $0003
 L0259               stu       $0280,y
                     bra       L028F
 
-L025F               leax      $0B46,pcr
+L025F               leax      L0B46,pcr
                     pshs      x
                     pshs      u
                     lbsr      L4F07
@@ -829,7 +827,7 @@ L076F               ldd       $0003
                     puls      pc,u
 L0788               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       $0003
                     pshs      d
@@ -1044,7 +1042,7 @@ L0957               tfr       u,d
                     puls      pc,u
 L095D               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$08,s
                     stu       $06,s
@@ -1105,7 +1103,7 @@ L09D8               leas      $08,s
                     puls      pc,u
 L09DC               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       $0005
                     beq       L09EA
                     puls      pc,u
@@ -1129,7 +1127,7 @@ L09EA               leax      L0BA7,pcr
 L0A15               puls      pc,u
 L0A17               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,s
                     lbra      L0AAA
@@ -1141,7 +1139,7 @@ L0A26               pshs      u
                     bra       L0A3A
 
 L0A31               pshs      u
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     bra       L0A3C
 
@@ -1206,7 +1204,7 @@ L0AAA               cmpx      #$0008
 L0AC1               puls      pc,u
 L0AC3               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     leax      L0BB8,pcr
@@ -1218,7 +1216,7 @@ L0AC3               pshs      u
                     puls      pc,u
 L0AE0               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       $0284,y
                     beq       L0AF9
                     ldd       $0284,y
@@ -1227,29 +1225,18 @@ L0AE0               pshs      u
                     leas      $02,s
 L0AF9               ldd       #$0001
                     pshs      d
-                    lbsr      L622A
+                    lbsr      exit
                     leas      $02,s
                     puls      pc,u
-L0B05               ble       L0B6B
-                    fcb       $65
-                    ror       L2F6E
-                    fcb       $75
-                    inc       $0C,s
-                    neg       L0062
-                    fcb       $61,$64,$20,$61,$72,$67,$75,$6d
-                    fcb       $65,$6e,$74,$3a,$20,$25,$73
-                    fcb       $0d,$00
-L0B21               fcb       $62,$61,$64,$20,$6f,$70,$74,$69
-                    fcb       $6f,$6e,$20,$66,$6C,$61,$67,$3a
-                    fcb       $20,$2b,$25,$63,$0d,$00
-L0B37               lsr       $6F6F
-                    bra       $0BA9
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       L0BA7
-                    rol       $0C,s
-                    fcb       $65
-                    com       >$0072
+L0B05               fcc       |/dev/null|
+                    fcb       $00
+L0B0F               fcc       /bad argument: %s/
+                    fcb       $0D,$00
+L0B21               fcc       /bad option flag: +%c/
+                    fcb       $0D,$00
+L0B37               fcc       /too many files/
+                    fcb       $00
+L0B46               fcb       $72
                     neg       $0063
                     fcb       $61
                     jmp       $07,y
@@ -1258,19 +1245,13 @@ L0B37               lsr       $6F6F
                     bra       L0B79
                     com       $0D00
 L0B57               neg       L0062
-                    fcb       $61,$64,$20,$61,$63,$74,$69,$6f
-                    fcb       $6e,$20,$63,$6f,$64,$65,$3a,$20
-                    fcb       $25,$64
-L0B6B               fcb       $0d,$00
-L0B6D               fcb       $62,$61,$64,$20,$63,$6f,$64,$65
-                    fcb       $20,$69,$6e,$20
-L0B79               fcb       $69,$6e,$74,$65,$72,$6d,$65,$64
-                    fcb       $69,$61,$74,$65,$20,$66,$69,$6C
-                    fcb       $65,$3a,$20,$25,$30,$32,$78
-                    fcb       $0d,$00
-L0B92               fcb       $62,$61,$64,$20,$6e,$6f,$64,$65
-                    fcb       $20,$74,$79,$70,$65,$3a,$20,$25
-                    fcb       $30,$32,$78,$0d,$00
+                    fcc       /ad action code: %d/
+                    fcb       $0D,$00
+L0B6D               fcc       /bad code in /
+L0B79               fcc       /intermediate file: %02x/
+                    fcb       $0D,$00
+L0B92               fcc       /bad node type: %02x/
+                    fcb       $0D,$00
 L0BA7               asr       >$0063
                     fcb       $61
                     jmp       $07,y
@@ -1279,14 +1260,13 @@ L0BA7               asr       >$0063
                     bra       $0BDA
                     com       $0D00
 L0BB8               bra       $0C26
-                    fcb       $65
-                    fcb       $61
+                    fcb       $65,$61
                     com       L2025
                     lsr       $0C,y
                     com       $0D00
 L0BC4               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L0C2E
@@ -1308,7 +1288,7 @@ L0BC4               pshs      u
 
 L0BF8               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L1C1E
@@ -1330,7 +1310,7 @@ L0C2A               std       $06,u
 L0C2C               puls      pc,u
 L0C2E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       ,u
                     bra       L0C59
@@ -1340,7 +1320,7 @@ L0C3C               pshs      u
                     bra       L0C55
 
 L0C43               pshs      u
-                    lbsr      $29FD
+                    lbsr      L29FD
                     bra       L0C55
 
 L0C4A               pshs      u
@@ -1362,7 +1342,7 @@ L0C59               cmpx      #$0008
 L0C6C               puls      pc,u
 L0C6E               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     lbra      L0CE1
@@ -1431,7 +1411,7 @@ L0CE1               cmpx      #$0037
 L0D03               puls      pc,u
 L0D05               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -1521,7 +1501,7 @@ L0DAA               ldd       $0a,u
 
 L0DC8               ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       #$008F
                     pshs      d
@@ -1641,7 +1621,7 @@ L0EF8               tfr       u,d
                     puls      pc,u
 L0EFE               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -1989,7 +1969,7 @@ L1216               ldd       #$0070
 
 L1220               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       #$0000
                     bra       L1244
 
@@ -2010,7 +1990,7 @@ L1244               cmpu      #$000E
 
 L124D               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       #$0001
@@ -2078,7 +2058,7 @@ L124D               pshs      u
 
 L12E9               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -2134,7 +2114,7 @@ L1361               leas      $06,s
                     puls      pc,u
 L1365               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldd       $000D
                     std       ,s
@@ -2170,7 +2150,7 @@ L13A9               ldd       ,u
                     cmpd      #$0006
                     bne       L13CA
 L13B9               pshs      u
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
@@ -2234,7 +2214,7 @@ L1402               ldx       $02,s
 
 L1441               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $06,u
@@ -2277,7 +2257,7 @@ L149B               leas      $02,s
                     puls      pc,u
 L149F               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L14CD
@@ -2303,7 +2283,7 @@ L14CD               cmpx      #$0050
 
 L14DB               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $12,x
                     cmpd      #$0002
@@ -2313,7 +2293,7 @@ L14DB               pshs      u
 
 L14F3               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L1512
@@ -2339,7 +2319,7 @@ L152A               clra
 L152C               puls      pc,u
 L152E               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$80
@@ -2366,7 +2346,7 @@ L152E               pshs      u
 L1566               puls      pc,u
 L1568               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -2532,7 +2512,7 @@ L16AE               pshs      u
 
 L16CC               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -2781,7 +2761,7 @@ L18E5               pshs      u
 
 L1905               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$7f
@@ -2814,7 +2794,7 @@ L193E               ldd       #$0071
                     puls      pc,u
 L1954               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $0a,u
@@ -2964,7 +2944,7 @@ L1A97               leas      $04,s
                     puls      pc,u
 L1A9B               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -3123,7 +3103,7 @@ L1BD8               ldd       $0e,s
 
 L1BE5               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     bsr       L1C1E
@@ -3147,7 +3127,7 @@ L1C17               ldd       #$0071
                     puls      pc,u
 L1C1E               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -3441,7 +3421,7 @@ L1EB0               leas      $08,s
                     puls      pc,u
 L1EB4               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$006F
                     beq       L1ECC
@@ -3454,45 +3434,21 @@ L1ECC               ldd       #$0001
 L1ED1               clra
                     clrb
 L1ED3               puls      pc,u
-L1ED5               lsr       $7261
-                    jmp       -$0d,s
-                    inc       $01,s
-                    lsr       $696F
-                    jmp       0,x
-
+L1ED5               fcc       /translation/
+                    fcb       $00
 L1EE1               bcs       $1F5B
                     tst       $0000
-L1EE5               fcb       $62
-                    rol       $0e,s
-                    fcb       $61
-                    fcb       $72
-                    rol       $206F
-                    neg       $2E00
-L1EF0               rol       $0e,s
-                    lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-                    rol       $0f,s
-                    jmp       0,x
-
-L1EFC               rol       $0e,s
-                    lsr       $09,s
-                    fcb       $72
-                    fcb       $65
-                    com       -$0C,s
-                    rol       $0f,s
-                    jmp       0,x
-
-L1F08               asl       $2074
-                    fcb       $72
-                    fcb       $61
-                    jmp       -$0d,s
-                    inc       $01,s
-                    lsr       $6500
+L1EE5               fcc       /binary op./
+                    fcb       $00
+L1EF0               fcc       /indirection/
+                    fcb       $00
+L1EFC               fcc       /indirection/
+                    fcb       $00
+L1F08               fcc       /x translate/
+                    fcb       $00
 L1F14               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
@@ -3624,7 +3580,7 @@ L201D               ldd       $06,u
                     bne       L2027
 L2025               ldu       $0a,u
 L2027               pshs      u
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       ,u
                     pshs      d
@@ -3698,7 +3654,7 @@ L20EA               leas      $04,s
                     puls      pc,u
 L20EE               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldd       $0a,x
@@ -3914,7 +3870,7 @@ L22B5               ldd       $02,s
                     puls      pc,u
 L22CB               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L22E9
@@ -3935,7 +3891,7 @@ L22E9               cmpx      #$0034
                     lbra      L2502
                     pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0034
@@ -3949,7 +3905,7 @@ L22E9               cmpx      #$0034
 
 L2324               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -4080,7 +4036,7 @@ L2463               leas      $04,s
                     puls      pc,u
 L2467               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L2491
 
@@ -4105,7 +4061,7 @@ L2491               cmpx      #$005A
                     puls      pc,u
 L249F               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L24BD
 
@@ -4133,7 +4089,7 @@ L24BD               cmpx      #$005A
                     puls      pc,u
 L24E7               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -4148,7 +4104,7 @@ L2502               clra
 L2504               puls      pc,u
 L2506               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L2521
@@ -4160,7 +4116,7 @@ L2506               pshs      u
                     puls      pc,u
 L2521               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       $06,u
@@ -4205,7 +4161,7 @@ L2578               ldd       $0a,u
 
 L2587               ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       $0a,u
                     pshs      d
@@ -4567,7 +4523,7 @@ L28F8               leas      $06,s
                     puls      pc,u
 L28FC               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L2939
@@ -4603,7 +4559,7 @@ L2939               cmpx      #$0034
 L294A               puls      pc,u
 L294C               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $08,u
@@ -4677,12 +4633,11 @@ L29D2               ldd       #$0070
                     std       $08,u
                     leas      $02,s
                     puls      pc,u
-L29F7               inc       $0f,s
-                    jmp       $07,s
-                    com       >$0034
-                    nega
+L29F7               fcc       /longs/
+                    fcb       $00
+L29FD               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L2A18
@@ -4694,7 +4649,7 @@ L29F7               inc       $0f,s
                     puls      pc,u
 L2A18               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0111
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$08,s
                     ldd       ,u
@@ -4736,7 +4691,7 @@ L2A62               ldd       $0a,u
 
 L2A6B               ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
 L2A72               leas      $02,s
                     leax      $08,s
                     bra       L2A46
@@ -4759,7 +4714,7 @@ L2A78               ldd       $08,u
                     leas      $04,s
                     lbra      L2C3C
 
-L2AA1               leax      $29FD,pcr
+L2AA1               leax      L29FD,pcr
                     pshs      x
                     pshs      u
                     lbsr      L12E9
@@ -4768,7 +4723,7 @@ L2AA1               leax      $29FD,pcr
 
 L2AB0               ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
@@ -4797,7 +4752,7 @@ L2AD0               ldd       #$0080
                     leas      $04,s
                     ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
@@ -4838,7 +4793,7 @@ L2B43               pshs      u
 
 L2B4C               ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
@@ -4848,7 +4803,7 @@ L2B4C               ldd       $0a,u
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
@@ -4861,7 +4816,7 @@ L2B7B               leax      $08,s
 
 L2B80               ldd       $0a,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
@@ -4871,7 +4826,7 @@ L2B80               ldd       $0a,u
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     leax      $08,s
                     lbra      L2C1E
@@ -4885,7 +4840,7 @@ L2BA6               leas      -$08,x
                     ldx       $04,s
                     ldd       $0a,x
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
@@ -4900,7 +4855,7 @@ L2BA6               leas      -$08,x
 
 L2BD8               ldd       $04,s
                     pshs      d
-                    lbsr      $29FD
+                    lbsr      L29FD
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
@@ -5024,9 +4979,8 @@ L2C60               cmpx      #$0080
 
 L2D35               leas      $08,s
                     puls      pc,u
-L2D39               ror       $0C,s
-                    clr       $01,s
-                    lsr       $7300
+L2D39               fcc       /floats/
+                    fcb       $00
 L2D40               pshs      u
                     leax      $00CE,y
                     stx       L001B
@@ -5046,7 +5000,7 @@ L2D55               pshs      u
                     pshs      x
                     ldd       $08,s
 L2D66               pshs      d
-                    bsr       L2D8D
+                    bsr       doprnt
                     leas      $04,s
                     puls      pc,u
                     pshs      u
@@ -5058,13 +5012,13 @@ L2D66               pshs      d
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       L2D8D
+                    bsr       doprnt
                     leas      $04,s
                     clra
                     clrb
                     stb       [L001B,y]
                     puls      pc,u
-L2D8D               pshs      u
+doprnt              pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L2DA5
@@ -5300,7 +5254,7 @@ L2F61               ldd       ,s
                     std       ,s
                     ldd       $0C,s
                     subd      >$0043,y
-L2F6E               std       $0C,s
+                    std       $0C,s
 L2F70               ldd       $0C,s
                     blt       L2F61
                     leax      >$0043,y
@@ -5782,13 +5736,13 @@ L333C               pshs      u
 L3350               leax      $450D,pcr
                     bra       L337E
 
-L3356               leax      $4514,pcr
+L3356               leax      L4514,pcr
                     bra       L337E
 
-L335C               leax      $451B,pcr
+L335C               leax      L451B,pcr
                     bra       L337E
 
-L3362               leax      $4521,pcr
+L3362               leax      L4521,pcr
                     bra       L337E
 
 L3368               leax      L4527,pcr
@@ -5797,7 +5751,7 @@ L3368               leax      L4527,pcr
 L336E               leax      L452D,pcr
                     bra       L337E
 
-L3374               leax      $4533,pcr
+L3374               leax      L4533,pcr
                     bra       L337E
 
 L337A               leax      L453A,pcr
@@ -5811,7 +5765,7 @@ L3386               leax      L4540,pcr
 L338D               leax      L4554,pcr
                     lbra      L34A2
 
-L3394               leax      $455F,pcr
+L3394               leax      L455F,pcr
                     pshs      x
                     lbsr      L43B9
                     leas      $02,s
@@ -5922,14 +5876,14 @@ L346D               leax      $4578,pcr
 L3492               leax      L457B,pcr
                     bra       L34A2
 
-L3498               leax      $4586,pcr
+L3498               leax      L4586,pcr
                     bra       L34A2
 
-L349E               leax      $4591,pcr
+L349E               leax      L4591,pcr
 L34A2               pshs      x
                     lbra      L3783
 
-L34A7               leax      $459C,pcr
+L34A7               leax      L459C,pcr
                     pshs      x
                     lbsr      L43B9
                     leas      $02,s
@@ -6214,7 +6168,7 @@ L3783               lbsr      L43D2
 L3786               leas      $02,s
                     lbra      L39D6
 
-L378B               leax      $45DF,pcr
+L378B               leax      L45DF,pcr
                     lbra      L380F
 
 L3792               ldd       $10,s
@@ -6224,7 +6178,7 @@ L3792               ldd       $10,s
                     bne       L37B7
                     ldd       $06,s
                     pshs      d
-                    leax      L45E2,pcr
+                    leax      $45E2,pcr
 L37A9               pshs      x
                     ldd       $0005
                     pshs      d
@@ -6507,37 +6461,37 @@ L3A31               leax      L4624,pcr
                     lbsr      L43D2
                     lbra      L40CD
 
-L3A3D               leax      $4647,pcr
+L3A3D               leax      L4647,pcr
                     bra       L3A7D
 
-L3A43               leax      $464E,pcr
+L3A43               leax      L464E,pcr
                     bra       L3A90
 
-L3A49               leax      $4654,pcr
+L3A49               leax      L4654,pcr
                     bra       L3A90
 
-L3A4F               leax      $465A,pcr
+L3A4F               leax      L465A,pcr
                     bra       L3A90
 
 L3A55               leax      L4660,pcr
                     bra       L3A90
 
-L3A5B               leax      $4666,pcr
+L3A5B               leax      L4666,pcr
                     bra       L3A90
 
-L3A61               leax      $466C,pcr
+L3A61               leax      L466C,pcr
                     bra       L3A90
 
-L3A67               leax      $4672,pcr
+L3A67               leax      L4672,pcr
                     bra       L3A90
 
 L3A6D               leax      $4677,pcr
                     bra       L3A90
 
-L3A73               leax      $467D,pcr
+L3A73               leax      L467D,pcr
                     bra       L3A7D
 
-L3A79               leax      $4683,pcr
+L3A79               leax      L4683,pcr
 L3A7D               pshs      x
                     lbsr      L3E6F
                     leas      $02,s
@@ -6545,12 +6499,12 @@ L3A7D               pshs      x
                     subd      #$0002
                     lbra      L3E8A
 
-L3A8C               leax      $4689,pcr
+L3A8C               leax      L4689,pcr
 L3A90               pshs      x
                     lbsr      L3E6F
                     lbra      L40CD
 
-L3A98               leax      $4690,pcr
+L3A98               leax      L4690,pcr
                     bra       L3ABA
 
 L3A9E               leax      L4696,pcr
@@ -6559,13 +6513,13 @@ L3A9E               leax      L4696,pcr
 L3AA4               leax      L469E,pcr
                     bra       L3ABA
 
-L3AAA               leax      $46A5,pcr
+L3AAA               leax      L46A5,pcr
                     bra       L3ABA
 
-L3AB0               leax      $46AC,pcr
+L3AB0               leax      L46AC,pcr
                     bra       L3ABA
 
-L3AB6               leax      $46B2,pcr
+L3AB6               leax      L46B2,pcr
 L3ABA               pshs      x
                     lbsr      L3E6F
                     leas      $02,s
@@ -6664,7 +6618,7 @@ L3BCC               ldd       #$0004
 L3BD3               lbsr      L3D91
 L3BD6               leas      $04,s
                     puls      pc,u
-L3BDA               leax      $46C7,pcr
+L3BDA               leax      L46C7,pcr
                     pshs      x
                     lbsr      L3E8E
                     leas      $02,s
@@ -6679,7 +6633,7 @@ L3BED               cmpu      #$0005
 
 L3BF8               ldd       #$0037
 L3BFB               pshs      d
-                    leax      $46CF,pcr
+                    leax      L46CF,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
@@ -6691,25 +6645,25 @@ L3C0E               cmpu      #$0005
                     leax      L46DA,pcr
                     bra       L3C1E
 
-L3C1A               leax      $46E1,pcr
+L3C1A               leax      L46E1,pcr
 L3C1E               tfr       x,d
                     pshs      d
                     lbsr      L3E8E
                     lbra      L3E66
 
-L3C28               leax      $46E8,pcr
+L3C28               leax      L46E8,pcr
                     bra       L3C44
 
-L3C2E               leax      $46EE,pcr
+L3C2E               leax      L46EE,pcr
                     bra       L3C44
 
-L3C34               leax      $46F4,pcr
+L3C34               leax      L46F4,pcr
                     bra       L3C44
 
 L3C3A               leax      L46FA,pcr
                     bra       L3C44
 
-L3C40               leax      $4700,pcr
+L3C40               leax      L4700,pcr
 L3C44               pshs      x
                     lbsr      L3E8E
                     leas      $02,s
@@ -6717,7 +6671,7 @@ L3C44               pshs      x
                     addd      #$0008
                     lbra      L3E8A
 
-L3C53               leax      $4707,pcr
+L3C53               leax      L4707,pcr
                     bra       L3CA9
 
 L3C59               cmpu      #$0005
@@ -6725,12 +6679,12 @@ L3C59               cmpu      #$0005
                     leax      L470D,pcr
                     bra       L3C7B
 
-L3C65               leax      $4713,pcr
+L3C65               leax      L4713,pcr
                     bra       L3C7B
 
 L3C6B               cmpu      #$0005
                     bne       L3C77
-                    leax      $4719,pcr
+                    leax      L4719,pcr
                     bra       L3C7B
 
 L3C77               leax      L471F,pcr
@@ -6741,27 +6695,27 @@ L3C7B               tfr       x,d
 L3C81               leax      L4725,pcr
                     bra       L3CA9
 
-L3C87               leax      $472B,pcr
+L3C87               leax      L472B,pcr
                     bra       L3CA9
 
-L3C8D               leax      $4731,pcr
+L3C8D               leax      L4731,pcr
                     bra       L3CA9
 
-L3C93               leax      $4737,pcr
+L3C93               leax      L4737,pcr
                     bra       L3CA9
 
-L3C99               leax      $473D,pcr
+L3C99               leax      L473D,pcr
                     bra       L3CA9
 
-L3C9F               leax      $4743,pcr
+L3C9F               leax      L4743,pcr
                     bra       L3CA9
 
-L3CA5               leax      $4749,pcr
+L3CA5               leax      L4749,pcr
 L3CA9               pshs      x
 L3CAB               lbsr      L3E8E
                     lbra      L40CD
 
-L3CB1               leax      $474F,pcr
+L3CB1               leax      L474F,pcr
                     pshs      x
                     lbsr      L4824
                     leas      $02,s
@@ -6853,7 +6807,7 @@ L3D91               pshs      u,d
                     pshs      d
                     lbsr      L4420
                     leas      $02,s
-                    leax      $4764,pcr
+                    leax      L4764,pcr
                     pshs      x
                     lbsr      L43D2
                     leas      $02,s
@@ -6877,7 +6831,7 @@ L3DEC               cmpu      #$0000
                     std       ,s
                     bra       L3E04
 
-L3DF9               leax      $476B,pcr
+L3DF9               leax      L476B,pcr
                     pshs      x
                     lbsr      L43F7
                     leas      $02,s
@@ -6980,7 +6934,7 @@ L3EC7               std       $02,s
 L3ED5               leax      ,u
                     bra       L3EED
 
-L3ED9               leax      L476E,pcr
+L3ED9               leax      $476E,pcr
                     bra       L3EE9
 
 L3EDF               leax      $4772,pcr
@@ -7102,14 +7056,14 @@ L3FCE               ldd       $0e,s
 
 L3FD7               cmpu      #$0057
                     lbne      L44A2
-                    leax      $477E,pcr
+                    leax      L477E,pcr
                     bra       L3FF7
 
 L3FE5               cmpu      #$0057
                     lbeq      L44A2
                     cmpu      #$0059
                     bne       L4001
-                    leax      $4783,pcr
+                    leax      L4783,pcr
 L3FF7               pshs      x
                     lbsr      L43D2
                     leas      $02,s
@@ -7142,7 +7096,7 @@ L402F               ldd       $04,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      $4788,pcr
+                    leax      L4788,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
@@ -7253,7 +7207,7 @@ L4126               ldd       #$0023
                     ldd       $0C,s
                     lbra      L4268
 
-L4135               leax      $47AC,pcr
+L4135               leax      L47AC,pcr
                     pshs      x
                     lbsr      L43F7
                     leas      $02,s
@@ -7355,7 +7309,7 @@ L420B               ldx       ,s
                     andb      #$30
                     cmpd      #$0030
                     bne       L4220
-                    leax      $47B3,pcr
+                    leax      L47B3,pcr
                     pshs      x
                     bra       L4226
 
@@ -7427,7 +7381,7 @@ L42B7               ldd       >$004f,y
                     pshs      d
                     lbsr      L43F7
                     leas      $02,s
-                    leax      $47C6,pcr
+                    leax      L47C6,pcr
                     pshs      x
                     lbsr      L43F7
                     leas      $02,s
@@ -7436,7 +7390,7 @@ L42B7               ldd       >$004f,y
                     std       $000D
                     bra       L431B
 
-L42D6               leax      L47C9,pcr
+L42D6               leax      $47C9,pcr
 L42DA               pshs      x
                     lbsr      L4824
 L42DF               leas      $02,s
@@ -7475,11 +7429,11 @@ L4333               pshs      u
                     ldx       $04,s
                     bra       L4382
 
-L4339               leax      $47D5,pcr
+L4339               leax      L47D5,pcr
                     pshs      x
                     lbsr      L4824
                     leas      $02,s
-L4344               leax      $47DC,pcr
+L4344               leax      L47DC,pcr
                     bra       L437E
 
 L434A               leax      L47E0,pcr
@@ -7662,32 +7616,17 @@ L44A6               pshs      u
                     bge       $4545
                     neg       $002C
                     com       >$006C
-                    fcb       $62
-                    com       $7220
-                    neg       $006C
-                    fcb       $62
-                    fcb       $72
-                    fcb       $61
-                    bra       L44DC
-
-L44DC               com       $0C,s
-                    fcb       $72
-                    fcb       $61
-                    neg       $0075
-                    jmp       $0b,s
-                    jmp       $0f,s
-                    asr       $6E20
-                    clr       -$10,s
-                    fcb       $65
-                    fcb       $72
-                    fcb       $61
-                    lsr       $6F72
-                    bra       L452D
-                    bra       L44F5
-
+                    fcc       /bsr /
+                    fcb       $00
+                    fcc       /lbra /
+                    fcb       $00
+                    fcc       /clra/
+                    fcb       $00
+                    fcc       /unknown operator : /
+                    fcb       $00
 L44F5               bra       L4567
                     com       $6873
-                    bra       $4521
+                    bra       L4521
                     com       $0d,x
                     neg       $006C
                     fcb       $62
@@ -7698,108 +7637,81 @@ L44F5               bra       L4567
                     bge       $457A
                     com       $0d,x
                     neg       $0063
-                    com       $0d,s
-                    fcb       $75
-                    inc       -$0C,s
-                    neg       $0063
-                    com       -$0b,s
-                    lsr       $09,s
-                    ror       >$0063
-                    com       $04,s
-                    rol       -$0a,s
-                    neg       $0063
-                    com       $01,s
-                    com       $6C00
-L4527               com       $03,s
-                    fcb       $61
-                    com       $7200
-L452D               com       $03,s
-                    inc       -$0d,s
-                    fcb       $72
-                    neg       $0063
-                    com       -$0b,s
-                    tst       $0f,s
-                    lsr       0,x
-L453A               com       $03,s
-                    tst       $0f,s
-                    lsr       0,x
+                    fcc       /cmult/
+                    fcb       $00
+L4514               fcc       /ccudiv/
+                    fcb       $00
+L451B               fcc       /ccdiv/
+                    fcb       $00
+L4521               fcc       /ccasl/
+                    fcb       $00
+L4527               fcc       /ccasr/
+                    fcb       $00
+L452D               fcc       /cclsr/
+                    fcb       $00
+L4533               fcc       /ccumod/
+                    fcb       $00
+L453A               fcc       /ccmod/
+                    fcb       $00
 L4540               jmp       $05,s
                     asr       $01,s
                     tst       L0020
                     jmp       $05,s
                     asr       $02,s
                     tst       L0020
-                    com       L6263
-                    fcb       $61
-                    bra       $4575
-                    leax      0,x
+                    fcc       /sbca #0/
+                    fcb       $00
 L4554               com       $0f,s
                     tst       $01,s
                     tst       L0020
-                    com       $0f,s
-                    tst       $02,s
-                    neg       $006C
-                    fcb       $65
-                    fcb       $61
-                    asl       $2000
-L4565               inc       $05,s
-L4567               fcb       $61
-                    com       $2000
+                    fcc       /comb/
+                    fcb       $00
+L455F               fcc       /leax /
+                    fcb       $00
+L4565               fcb       $6C,$65
+L4567               fcb       $61,$73,$20
+                    fcb       $00
 L456B               bge       $45E5
                     tst       $0000
-L456F               dec       -$0d,s
-                    fcb       $72
-                    bra       L4574
-
+L456F               fcc       /jsr /
+                    fcb       $00
 L4574               com       $6578
                     neg       $006C
                     lsr       0,x
 L457B               fcb       $61
                     com       $6C62
                     tst       L0020
-                    fcb       $72
-                    clr       $0C,s
-                    fcb       $61
-                    neg       $0061
+                    fcc       /rola/
+                    fcb       $00
+L4586               fcb       $61
                     com       $7261
                     tst       L0020
-                    fcb       $72
-                    clr       -$0e,s
-                    fcb       $62
-                    neg       $006C
-                    com       $7261
+                    fcc       /rorb/
+                    fcb       $00
+L4591               inc       -$0d,s
+                    fcb       $72,$61
                     tst       L0020
-                    fcb       $72
-                    clr       -$0e,s
-                    fcb       $62
-                    neg       $006C
-                    lsr       -$07,s
-                    bra       L45A1
-
-L45A1               inc       $04,s
-                    fcb       $75
-                    bra       L45A6
-
-L45A6               inc       $05,s
-                    fcb       $61
-                    asl       $2000
+                    fcc       /rorb/
+                    fcb       $00
+L459C               fcc       /ldy /
+                    fcb       $00
+L45A1               fcc       /ldu /
+                    fcb       $00
+L45A6               fcc       /leax /
+                    fcb       $00
 L45AC               bcs       L4612
                     bge       L45D5
                     com       $0d,x
                     neg       L0064
-                    bge       $45DB
+                    bge       L45DB
                     com       $0d,x
                     neg       $0073
                     fcb       $65
                     asl       >$0061
-                    lsr       $03,s
-                    fcb       $61
-                    bra       $45E6
-                    leax      0,x
-L45C5               com       L6263
-                    fcb       $61
-                    bra       L45EE
-                    leax      0,x
+                    fcc       /dca #0/
+                    fcb       $00
+L45C5               fcc       /sbca #0/
+                    fcb       $00
 L45CD               bcs       $4633
                     bge       L45F6
                     com       $0d,x
@@ -7807,26 +7719,24 @@ L45CD               bcs       $4633
 L45D5               inc       -$0e,s
                     fcb       $61
                     tst       L0020
-                    com       $0C,s
-                    fcb       $72
-                    fcb       $62
-                    neg       $006C
-                    lsr       0,x
-L45E2               bra       L4657
-                    lsr       $2563
-                    bra       L4616
-                    leas      $0C,y
-                    com       $0D00
+                    fcb       $63
+L45DB               fcb       $6C,$72,$62
+                    fcb       $00
+L45DF               inc       $04,s
+                    neg       L0020
+                    com       $7425
+                    com       0,y
+                    blt       L461C
+                    bge       L465F
+                    tst       $0000
 L45EE               com       $0d,s
                     neg       >$0073
                     lsr       >$0073
-L45F6               fcb       $75
-                    fcb       $62
+L45F6               fcb       $75,$62
                     neg       $0061
                     lsr       $04,s
                     neg       $006C
-                    fcb       $65
-                    fcb       $61
+                    fcb       $65,$61
                     neg       L0020
                     fcb       $65
                     asl       $6720
@@ -7835,265 +7745,212 @@ L45F6               fcb       $75
                     com       $0d,x
                     neg       L0064
                     bge       L4610
-L4610               inca
-                    fcb       $45
-L4612               fcb       $41
-                    bra       L4676
-                    fcb       $72
-L4616               asr       0,x
+L4610               fcb       $4C,$45
+L4612               fcc       /A arg/
+                    fcb       $00
 L4618               bra       L468E
                     ror       -$0e,s
-                    bra       $4643
+L461C               bra       L4643
                     com       $0C,y
-                    bcs       $4685
+                    bcs       L4685
                     tst       $0000
 L4624               inc       $04,s
                     fcb       $61
                     bra       L4659
-                    bge       $46A3
+                    bge       L46A3
                     tst       L0020
                     clr       -$0e,s
 L462F               fcb       $61
                     bra       L4663
-                    bge       $46AC
+                    bge       L46AC
                     tst       L0020
                     clr       -$0e,s
                     fcb       $61
                     bra       L466D
                     bge       L46B5
                     tst       L0020
-                    clr       -$0e,s
-                    fcb       $61
-                    bra       $4677
-                    bge       $46BE
-                    neg       $005F
-                    inc       $0d,s
-                    clr       -$0a,s
-                    fcb       $65
-                    neg       $005F
-                    inc       $01,s
-                    lsr       $04,s
-                    neg       $005F
-                    inc       -$0d,s
-L4657               fcb       $75
-                    fcb       $62
-L4659               neg       $005F
-                    inc       $0d,s
-                    fcb       $75
-                    inc       0,x
+                    fcc       /ora /
+L4643               fcb       $33,$2C,$78
+                    fcb       $00
+L4647               clrb
+                    fcc       /lmove/
+                    fcb       $00
+L464E               clrb
+                    fcc       /ladd/
+                    fcb       $00
+L4654               clrb
+                    fcc       /lsub/
+L4659               fcb       $00
+L465A               clrb
+                    fcc       /lmul/
+L465F               fcb       $00
 L4660               clrb
-                    inc       $04,s
-L4663               rol       -$0a,s
-                    neg       $005F
-                    inc       $0d,s
-                    clr       $04,s
-L466B               neg       $005F
-L466D               inc       $01,s
-                    jmp       $04,s
-                    neg       $005F
+                    fcb       $6C,$64
+L4663               fcb       $69,$76
+                    fcb       $00
+L4666               clrb
+                    fcc       /lmod/
+L466B               fcb       $00
+L466C               clrb
+L466D               fcc       /land/
+                    fcb       $00
+L4672               clrb
                     inc       $0f,s
                     fcb       $72
-L4676               neg       $005F
-                    inc       -$08,s
-                    clr       -$0e,s
                     neg       $005F
-                    inc       -$0d,s
-                    asl       $0C,s
-                    neg       $005F
-                    inc       -$0d,s
-                    asl       -$0e,s
-                    neg       $005F
-                    inc       $03,s
-                    tst       -$10,s
+                    fcc       /lxor/
+                    fcb       $00
+L467D               clrb
+                    fcc       /lshl/
+                    fcb       $00
+L4683               clrb
+                    fcb       $6C
+L4685               fcb       $73,$68,$72
+                    fcb       $00
+L4689               clrb
+                    fcc       /lcmp/
 L468E               fcb       $72
-                    neg       $005F
-                    inc       $0e,s
-                    fcb       $65
-                    asr       0,x
+                    fcb       $00
+L4690               clrb
+                    fcc       /lneg/
+                    fcb       $00
 L4696               clrb
-                    inc       $03,s
-                    clr       $0d,s
-                    neg       $6C00
+                    fcc       /lcompl/
+                    fcb       $00
 L469E               clrb
-                    inc       $09,s
-                    lsr       $6F6C
-                    neg       $005F
-                    inc       -$0b,s
-                    lsr       $6F6C
-                    neg       $005F
-                    inc       $09,s
-                    jmp       $03,s
-                    neg       $005F
-                    inc       $04,s
-L46B5               fcb       $65
-                    com       0,x
-L46B8               com       $0f,s
-                    lsr       $07,s
-                    fcb       $65
-                    jmp       0,y
-                    blt       $46E1
-                    inc       $0f,s
-                    jmp       $07,s
-                    com       >$005F
-                    lsr       -$0d,s
-                    lsr       L6163
-                    fcb       $6b
-                    neg       L0020
-                    inc       $04,s
-                    fcb       $61
+                    fcc       /lito/
+L46A3               fcb       $6C
+                    fcb       $00
+L46A5               clrb
+                    fcc       /lutol/
+                    fcb       $00
+L46AC               clrb
+                    fcc       /linc/
+                    fcb       $00
+L46B2               clrb
+                    fcb       $6C,$64
+L46B5               fcb       $65,$63
+                    fcb       $00
+L46B8               fcc       /codgen - longs/
+                    fcb       $00
+L46C7               clrb
+                    fcc       /dstack/
+                    fcb       $00
+L46CF               bra       L473D
+                    lsr       $01,s
                     bra       L46FA
                     com       $0C,y
                     asl       $0D00
 L46DA               clrb
-                    ror       $0d,s
-                    clr       -$0a,s
-                    fcb       $65
-                    neg       $005F
-                    lsr       $0d,s
-                    clr       -$0a,s
-                    fcb       $65
-                    neg       $005F
-                    lsr       $01,s
-                    lsr       $04,s
-                    neg       $005F
-                    lsr       -$0d,s
-                    fcb       $75
-                    fcb       $62
-                    neg       $005F
-                    lsr       $0d,s
-                    fcb       $75
-                    inc       0,x
+                    fcc       /fmove/
+                    fcb       $00
+L46E1               clrb
+                    fcc       /dmove/
+                    fcb       $00
+L46E8               clrb
+                    fcc       /dadd/
+                    fcb       $00
+L46EE               clrb
+                    fcc       /dsub/
+                    fcb       $00
+L46F4               clrb
+                    fcc       /dmul/
+                    fcb       $00
 L46FA               clrb
-                    lsr       $04,s
-                    rol       -$0a,s
-                    neg       $005F
-                    lsr       $03,s
-                    tst       -$10,s
-                    fcb       $72
-                    neg       $005F
-                    lsr       $0e,s
-                    fcb       $65
-                    asr       0,x
+                    fcc       /ddiv/
+                    fcb       $00
+L4700               clrb
+                    fcc       /dcmpr/
+                    fcb       $00
+L4707               clrb
+                    fcc       /dneg/
+                    fcb       $00
 L470D               clrb
-                    ror       $09,s
-                    jmp       $03,s
-                    neg       $005F
-                    lsr       $09,s
-                    jmp       $03,s
-                    neg       $005F
-                    ror       $04,s
-                    fcb       $65
-                    com       0,x
+                    fcc       /finc/
+                    fcb       $00
+L4713               clrb
+                    fcc       /dinc/
+                    fcb       $00
+L4719               clrb
+                    fcc       /fdec/
+                    fcb       $00
 L471F               clrb
-                    lsr       $04,s
-                    fcb       $65
-                    com       0,x
+                    fcc       /ddec/
+                    fcb       $00
 L4725               clrb
-                    lsr       -$0C,s
-                    clr       $06,s
-                    neg       $005F
-                    ror       -$0C,s
-                    clr       $04,s
-                    neg       $005F
-                    inc       -$0C,s
-                    clr       $04,s
-                    neg       $005F
-                    rol       -$0C,s
-                    clr       $04,s
-                    neg       $005F
-                    fcb       $75
-                    lsr       $6F64
-                    neg       $005F
-                    lsr       -$0C,s
-                    clr       $0C,s
-                    neg       $005F
-                    lsr       -$0C,s
-                    clr       $09,s
-                    neg       $0063
-                    clr       $04,s
-                    asr       $05,s
-                    jmp       0,y
-                    blt       L4778
-                    ror       $0C,s
-                    clr       $01,s
-                    lsr       $7300
-L475F               fcb       $62
-                    com       $7220
-                    neg       $0070
-                    fcb       $75
-                    inc       -$0d,s
-                    bra       L47E2
-                    neg       $0030
-                    bge       L476E
-L476E               fcb       $61
+                    fcc       /dtof/
+                    fcb       $00
+L472B               clrb
+                    fcc       /ftod/
+                    fcb       $00
+L4731               clrb
+                    fcc       /ltod/
+                    fcb       $00
+L4737               clrb
+                    fcc       /itod/
+                    fcb       $00
+L473D               clrb
+                    fcc       /utod/
+                    fcb       $00
+L4743               clrb
+                    fcc       /dtol/
+                    fcb       $00
+L4749               clrb
+                    fcc       /dtoi/
+                    fcb       $00
+L474F               fcc       /codgen - floats/
+                    fcb       $00
+L475F               fcc       /bsr /
+                    fcb       $00
+L4764               fcc       /puls x/
+                    fcb       $00
+L476B               leax      $0C,y
+                    neg       $0061
                     jmp       $04,s
                     neg       $006F
                     fcb       $72
                     neg       $0065
                     clr       -$0e,s
-L4778               neg       $0063
-                    clr       $0d,s
-                    fcb       $61
                     neg       $0063
-                    inc       -$0e,s
-                    fcb       $62
-                    neg       $0063
-                    clr       $0d,s
-                    fcb       $62
-                    neg       L0020
-                    bcs       L47FE
-                    fcb       $61
-                    bra       $47BA
-                    com       $2B0D
+                    fcb       $6F,$6D,$61
+                    fcb       $00
+L477E               fcc       /clrb/
+                    fcb       $00
+L4783               fcc       /comb/
+                    fcb       $00
+L4788               bra       L47AF
+                    com       $6120
+                    bge       L4802
+                    bmi       L479E
                     bra       $47B8
                     com       $6220
                     bge       $480B
-                    bmi       $47A7
+                    bmi       L47A7
                     neg       $0063
-                    clr       $0d,s
-                    neg       $696C
-                    fcb       $65
-                    fcb       $72
-                    bra       $4819
-                    fcb       $72
-                    clr       -$0b,s
-                    fcb       $62
-                    inc       $05,s
-                    neg       $005F
-                    ror       $0C,s
-                    fcb       $61
-                    com       $03,s
-                    neg       $002C
-                    neg       $6372
+                    fcb       $6F,$6D
+L479E               fcc       /piler tro/
+L47A7               fcc       /uble/
+                    fcb       $00
+L47AC               clrb
+                    fcb       $66,$6C
+L47AF               fcb       $61,$63,$63
+                    fcb       $00
+L47B3               bge       $4825
+                    com       -$0e,s
                     neg       $0073
-                    lsr       $6F72
-                    fcb       $61
-                    asr       $05,s
-                    bra       L4826
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    neg       L002B
-                    bmi       L47C9
-L47C9               lsr       $05,s
-                    fcb       $72
-                    fcb       $65
-                    ror       $05,s
-                    fcb       $72
-                    fcb       $65
-                    jmp       $03,s
-                    fcb       $65
-                    neg       $0072
-                    fcb       $65
-                    inc       0,y
-                    clr       -$10,s
-                    neg       $0065
-                    fcb       $71
+                    fcc       /torage error/
+                    fcb       $00
+L47C6               bmi       $47F3
+                    neg       L0064
+                    fcc       /ereference/
+                    fcb       $00
+L47D5               fcc       /rel op/
+                    fcb       $00
+L47DC               fcb       $65,$71
                     bra       L47E0
 
 L47E0               jmp       $05,s
-
-L47E2               bra       L47E4
+                    bra       L47E4
 
 L47E4               inc       $05,s
                     bra       L47E8
@@ -8114,31 +7971,27 @@ L47F8               inc       $0f,s
                     bra       L47FC
 
 L47FC               asl       -$0d,s
-L47FE               bra       L4800
+                    bra       L4800
 
 L4800               asl       $09,s
-                    bra       L4804
+L4802               bra       L4804
 
 L4804               bcs       $486A
                     neg       $0025
                     bgt       $4842
                     com       >$006C
-                    fcb       $65
-                    fcb       $61
-                    com       $2000
+                    fcc       /eas /
+                    fcb       $00
 L4812               bra       L4880
-                    fcb       $65
-                    fcb       $61
-                    bcs       L487B
-                    bra       L481A
-
+                    fcc       /ea%c /
+                    fcb       $00
 L481A               bcs       $487F
                     bcs       L4882
                     bge       $4890
                     com       -$0e,s
                     tst       $0000
 L4824               pshs      u
-L4826               ldd       $04,s
+                    ldd       $04,s
                     pshs      d
                     ldd       $0282,y
                     pshs      d
@@ -8156,7 +8009,7 @@ L4835               pshs      u
                     puls      pc,u
 L484C               pshs      u
                     leas      -$32,s
-                    leax      $4B3D,pcr
+                    leax      L4B3D,pcr
                     pshs      x
                     leax      $02,s
                     pshs      x
@@ -8174,7 +8027,7 @@ L484C               pshs      u
                     pshs      d
                     bsr       L4880
                     leas      $04,s
-L487B               leas      $32,s
+                    leas      $32,s
                     puls      pc,u
 L4880               pshs      u
 L4882               ldu       $04,s
@@ -8358,7 +8211,7 @@ L4A31               leas      -$05,x
 L4A33               ldd       $0009
                     addd      #$0001
                     std       $0009
-                    cmpd      #start
+                    cmpd      #_start
                     ble       L4A66
                     leax      $00CE,y
                     pshs      x
@@ -8372,7 +8225,7 @@ L4A33               ldd       $0009
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      L622A
+                    lbsr      exit
                     leas      $02,s
 L4A66               leas      $05,s
                     puls      pc,u
@@ -8475,34 +8328,15 @@ L4B21               ldd       $08,s
                     subd      #$FFFF
                     bne       L4B17
                     puls      pc,u
-L4B2F               clr       -$0b,s
-                    lsr       $206F
-                    ror       0,y
-                    tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       >$0063
-                    clr       $0d,s
-                    neg       $696C
-                    fcb       $65
-                    fcb       $72
-                    bra       L4BAC
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       L4B7A
-                    bra       L4B4F
-
+L4B2F               fcc       /out of memory/
+                    fcb       $00
+L4B3D               fcc       /compiler error - /
+                    fcb       $00
 L4B4F               bcs       $4BC4
                     abx
                     bra       L4B54
-
-L4B54               inc       $09,s
-                    jmp       $05,s
-                    bra       L4B7F
-                    lsr       0,y
-                    bra       L4B5E
-
+L4B54               fcc       /line %d  /
+                    fcb       $00
 L4B5E               bpl       L4B8A
                     bpl       $4B8C
                     bra       L4B84
@@ -8513,11 +8347,9 @@ L4B5E               bpl       L4B8A
                     tst       $0000
 L4B6E               fcb       $72
                     neg       $0074
-                    fcb       $6f,$6f,$20,$6d,$61,$6e,$79,$20
-                    fcb       $65
-L4B7A               fcb       $72,$72,$6f,$72,$73
-L4B7F               fcb       $20,$2d,$20,$41,$42
-L4B84               fcb       $4f,$52,$54,$0d
+                    fcc       /oo many errors - AB/
+L4B84               fcb       $4F,$52,$54
+                    fcb       $0D
 L4B88               neg       $0034
 L4B8A               nega
                     leax      L4D07,pcr
@@ -8534,7 +8366,7 @@ L4B97               pshs      u
                     pshs      d
                     lbsr      L2D55
                     leas      $06,s
-L4BAC               ldd       $06,s
+                    ldd       $06,s
                     pshs      d
                     pshs      u
                     lbsr      L4472
@@ -8553,7 +8385,7 @@ L4BAC               ldd       $06,s
                     ldd       $08,s
                     std       $0025
                     pshs      d
-                    leax      $4D1E,pcr
+                    leax      L4D1E,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
@@ -8603,13 +8435,13 @@ L4C3F               pshs      u
                     leax      L4D84,pcr
                     bra       L4C4F
 
-L4C4B               leax      $4D8D,pcr
+L4C4B               leax      L4D8D,pcr
 L4C4F               tfr       x,d
                     pshs      d
                     bra       L4C5D
 
 L4C55               pshs      u
-                    leax      $4D93,pcr
+                    leax      L4D93,pcr
                     pshs      x
 L4C5D               lbsr      L43D2
                     bra       L4C8F
@@ -8642,7 +8474,7 @@ L4C91               puls      pc,u
 L4C93               pshs      u
                     ldd       $02E0,y
                     bne       L4CAA
-                    leax      $4D9B,pcr
+                    leax      L4D9B,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
@@ -8686,21 +8518,19 @@ L4CFF               clra
                     clrb
                     std       $02E0,y
 L4D05               puls      pc,u
-L4D07               ror       $04,s
-                    fcb       $62
-                    bra       L4D0C
-
+L4D07               fcc       /fdb /
+                    fcb       $00
 L4D0C               bra       L4D82
                     lsr       $6C20
                     bcs       L4D41
                     fcb       $38
                     com       $0D00
-L4D17               neg       $7368
-                    com       $2075
-                    neg       L0020
-                    inc       $04,s
-                    lsr       0,y
-                    bls       L4D84
+L4D17               fcc       /pshs u/
+                    fcb       $00
+L4D1E               bra       L4D8C
+                    lsr       $04,s
+                    bra       $4D47
+                    clrb
                     bcs       L4D8B
                     tst       L0020
                     inc       $02,s
@@ -8711,18 +8541,16 @@ L4D17               neg       $7368
                     fcb       $65
                     com       $0b,s
                     tst       $0000
-L4D39               inc       $05,s
-                    fcb       $61
-                    asl       $2000
+L4D39               fcc       /leax /
+                    fcb       $00
 L4D3F               bge       $4DB1
 L4D41               com       -$0e,s
                     tst       L0020
                     neg       $7368
                     com       $2078
                     tst       L0020
-                    inc       $05,s
-                    fcb       $61
-                    asl       $2000
+                    fcc       /leax /
+                    fcb       $00
 L4D53               bge       $4DC5
                     com       -$0e,s
                     tst       L0020
@@ -8735,32 +8563,27 @@ L4D53               bge       $4DC5
                     neg       $726F
                     ror       $0d,x
                     bra       L4DDA
-                    fcb       $65
-                    fcb       $61
+                    fcb       $65,$61
                     com       $2034
                     bge       L4DE8
                     tst       $0000
 L4D77               clrb
                     bcs       L4DDE
                     bra       $4DE1
-                    fcb       $71
-                    fcb       $75
+                    fcb       $71,$75
                     bra       $4DA5
                     lsr       $0d,x
 L4D82               tst       $0000
-L4D84               ror       $7365
-                    com       -$0C,s
-                    bra       $4DEF
-
-L4D8B               neg       >L0076
-                    com       $6563
-                    lsr       >$0065
-                    jmp       $04,s
-                    com       $6563
-                    lsr       >L0020
-                    ror       $03,s
-                    com       0,y
-                    bhi       L4DA2
+L4D84               fcc       /vsect d/
+L4D8B               fcb       $70
+L4D8C               fcb       $00
+L4D8D               fcc       /vsect/
+                    fcb       $00
+L4D93               fcc       /endsect/
+                    fcb       $00
+L4D9B               bra       $4E03
+                    fcc       /cc "/
+                    fcb       $00
 L4DA2               bhi       $4DB1
                     bra       $4E0C
                     com       $02,s
@@ -11145,7 +10968,7 @@ L614F               clra
                     std       $02,x
                     puls      pc,u
 L6161               lda       $05,s
-L6163               ldb       #$02
+                    ldb       #$02
                     os9       I$GetStt
                     bcs       L614F
                     bra       L6175
@@ -11231,317 +11054,129 @@ L621E               clra
 
 L6227               bcs       L621E
                     clra
-L622A               clrb
+exit                clrb
                     rts
                     lbsr      L6237
                     lbsr      L5229
                     ldd       $02,s
                     os9       F$Exit
-L6237               rts
-                    neg       $0003
-                    neg       $0000
-                    fcb       $4b
-                    fcb       $01
-                    addb      0,x
-                    fcb       $02
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       L0020
-                    neg       $0040
-                    neg       $0080
-                    fcb       $01
-                    neg       $0002
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       L0020
-                    neg       $0040
-                    neg       L0027
-                    fcb       $10
-                    com       $00E8
-                    neg       L0064
-                    neg       $000A
-L6263               neg       $0000
-                    lsra
-                    adcb      #$44
-                    ldd       #$44CF
-                    lsra
-                    bitb      $0044
-                    addb      $0044
-                    subb      0,x
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    suba      #$20
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    anda      #$48
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $87
-                    dec       >$0000
-                    neg       $0000
-                    neg       $0000
-                    ora       #$1C
-                    nega
-                    neg       $0000
-                    neg       $0000
-                    neg       $008E
-                    coma
-                    negb
-                    neg       $0000
-                    neg       $0000
-                    neg       L0091
-                    lsr       L2400
-                    neg       $0000
-                    neg       $0000
-                    anda      $0018
-                    lda       $0080
-                    neg       $0000
-                    neg       $0000
-                    eora      $003E
-                    cmpx      $2000
-                    neg       $0000
-                    neg       L009B
-                    jmp       $0b,s
-                    bvc       L62BD
-L62BD               neg       $0000
-                    neg       $009E
-                    fcb       $15
-                    fcb       $02
-                    adcb      >$0000
-                    neg       $0000
-                    sbca      $0d,y
-                    asl       $EBC5
-                    cmpx      $02,s
-                    neg       L00C3
-                    rola
-                    sbcb      $C9CD
-                    lsr       $0067
-                    clra
-                    andb      0,x
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+* ------------------------------------------------------------------
+* L6237 - cc1-style init image for the work block (see _start);
+* pure data: rts stub + count/block table + reloc dirs + module name.
+* ------------------------------------------------------------------
+L6237               fcb       $39       init table / work-block image
+                    fcb       $00,$03,$00,$00
+                    fcb       $4B
+                    fcb       $01,$EB,$00,$02,$00,$04,$00,$08
+                    fcb       $00,$10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00,$80,$01,$00,$02,$00,$04,$00
+                    fcb       $08,$00,$10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$00
+                    fcb       $44
+                    fcb       $C9
+                    fcb       $44
+                    fcb       $CC
+                    fcb       $44
+                    fcb       $CF
+                    fcb       $44
+                    fcb       $D5
+                    fcb       $44
+                    fcb       $DB
+                    fcb       $44
+                    fcb       $E0,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $80
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$00,$00,$84
+                    fcb       $48
+                    fcb       $00,$00,$00,$00,$00,$00,$87
+                    fcb       $7A
+                    fcb       $00,$00,$00,$00,$00,$00,$8A,$1C
+                    fcb       $40
+                    fcb       $00,$00,$00,$00,$00,$8E
+                    fcb       $43,$50
+                    fcb       $00,$00,$00,$00,$00,$91
+                    fcb       $74,$24
+                    fcb       $00,$00,$00,$00,$00,$94,$18,$96
+                    fcb       $80,$00,$00,$00,$00,$98
+                    fcb       $3E
+                    fcb       $BC
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$9B
+                    fcb       $6E,$6B,$28
+                    fcb       $00,$00,$00,$00,$9E,$15,$02,$F9
+                    fcb       $00,$00,$00,$00,$A2
+                    fcb       $2D,$78
+                    fcb       $EB,$C5,$AC
+                    fcb       $62
+                    fcb       $00,$C3
+                    fcb       $49
+                    fcb       $F2,$C9,$CD,$04
+                    fcb       $67,$4F
+                    fcb       $E4,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    leax      0,y
-                    bra       L63EE
-                    bra       L63F0
-                    bra       L63F2
-                    bra       L63F4
-                    bra       L63F6
-                    bra       L63F8
-                    bra       L63FA
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    bra       $6406
-                    bra       $6408
-                    bra       $640A
-                    bra       L642E
-                    fcb       $42
-                    fcb       $42
-L63EE               fcb       $42
-                    fcb       $42
-L63F0               fcb       $42
-                    fcb       $02
-L63F2               fcb       $02
-                    fcb       $02
-L63F4               fcb       $02
-                    fcb       $02
-L63F6               fcb       $02
-                    fcb       $02
-L63F8               fcb       $02
-                    fcb       $02
-L63FA               fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    bra       L6427
-                    bra       L6429
-                    bra       $642B
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    bra       $6447
-
-L6427               bra       $6449
-L6429               fcb       $01
-                    neg       $0006
-                    neg       L0057
-L642E               neg       L0055
-                    neg       L0053
-                    neg       L0051
-                    neg       L004F
-                    neg       L004D
-                    neg       $0001
-                    neg       $0001
-                    com       $0e,y
-                    neg       L6173
-
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
+                    fcb       $11,$11,$01,$11,$11,$01,$01,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01
+                    fcc       /0               HHHHHHHHHH       BBBBBB/
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02
+                    fcc       /      DDDDDD/
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04
+                    fcc       /    /
+                    fcb       $01,$00,$06,$00
+                    fcb       $57
+                    fcb       $00
+                    fcb       $55
+                    fcb       $00
+                    fcb       $53
+                    fcb       $00
+                    fcb       $51
+                    fcb       $00
+                    fcb       $4F
+                    fcb       $00
+                    fcb       $4D
+                    fcb       $00,$01,$00,$01
+                    fcc       /c.pas/
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       3431
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.pass2/
                     fcb       edition
 
-L0015               lda       ,y+
+copybytes           lda       ,y+
 L0017               sta       ,u+
 L0019               leax      -$01,x
-L001B               bne       L0015
+L001B               bne       copybytes
 L001D               rts
 
-start               pshs      y
+_start              pshs      y
 L0020               pshs      u
 L0022               clra
 L0023               clrb
@@ -37,12 +37,12 @@ L002D               leax      $02E7,x
 L0033               leay      L6235,pcr
 L0037               ldx       ,y++
                     beq       L003F
-                    bsr       L0015
+                    bsr       copybytes
 L003D               ldu       $02,s
 L003F               leau      >$0027,u
 L0043               ldx       ,y++
 L0045               beq       L004A
-L0047               bsr       L0015
+L0047               bsr       copybytes
                     clra
 L004A               cmpu      ,s
 L004D               beq       L0053
@@ -119,17 +119,17 @@ L00E1               leax      $0212,u
                     ldd       $024e,u
                     pshs      d
                     leay      ,u
-                    bsr       L00FB
-                    lbsr      L017D
+                    bsr       stkinit
+                    lbsr      main
                     clr       ,-s
                     clr       ,-s
-                    lbsr      L6229
-L00FB               leax      $02E7,y
+                    lbsr      exit
+stkinit             leax      $02E7,y
 L00FF               stx       $025C,y
                     sts       $0250,y
                     sts       $025e,y
                     ldd       #$FF82
-L0110               leax      d,s
+stkcheck            leax      d,s
                     cmpx      $025e,y
                     bcc       L0122
                     cmpx      $025C,y
@@ -167,9 +167,9 @@ L016B               ldd       ,y++
                     leas      $04,s
                     rts
 
-L017D               pshs      u
+main                pshs      u
                     ldd       #$FF86
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$24,s
                     lbra      L028E
 
@@ -192,7 +192,7 @@ L01A8               ldd       #$0001
                     lbra      L0230
 
 L01B0               ldd       #$0001
-                    std       L0015
+                    std       copybytes
                     leax      L0B04,pcr
                     pshs      x
                     lbsr      L09DB
@@ -216,7 +216,7 @@ L01DA               leau      -$01,u
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
 L01F2               ldd       #$0001
@@ -230,7 +230,7 @@ L01F9               ldb       ,u
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
                     bra       L0230
@@ -258,7 +258,7 @@ L023A               ldd       $0003
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $04,s
                     lbsr      L0ADF
 L0258               stu       $0280,y
@@ -276,7 +276,7 @@ L025E               leax      L0B45,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
 L0285               stu       $0284,y
@@ -483,7 +483,7 @@ L044F               ldd       $22,s
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
                     bra       L048D
@@ -764,7 +764,7 @@ L06B7               ldd       $1a,s
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
                     lbra      L076E
@@ -826,7 +826,7 @@ L076E               ldd       $0003
                     puls      pc,u
 L0787               pshs      u
                     ldd       #$FFAA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$0a,s
                     ldd       $0003
                     pshs      d
@@ -1021,7 +1021,7 @@ L0926               ldd       $06,s
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
                     bra       L0956
@@ -1041,7 +1041,7 @@ L0956               tfr       u,d
                     puls      pc,u
 L095C               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$08,s
                     stu       $06,s
@@ -1102,7 +1102,7 @@ L09D7               leas      $08,s
                     puls      pc,u
 L09DB               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $0005
                     beq       L09E9
                     puls      pc,u
@@ -1120,13 +1120,13 @@ L09E9               leax      L0BA6,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbsr      L0ADF
 L0A14               puls      pc,u
 L0A16               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,s
                     lbra      L0AA9
@@ -1203,19 +1203,19 @@ L0AA9               cmpx      #$0008
 L0AC0               puls      pc,u
 L0AC2               pshs      u
                     ldd       #$FFB6
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     leax      L0BB7,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L0ADF               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $0284,y
                     beq       L0AF8
                     ldd       $0284,y
@@ -1224,7 +1224,7 @@ L0ADF               pshs      u
                     leas      $02,s
 L0AF8               ldd       #$0001
                     pshs      d
-                    lbsr      L6229
+                    lbsr      exit
                     leas      $02,s
                     puls      pc,u
 L0B04               fcc       |/dev/null|
@@ -1265,7 +1265,7 @@ L0BB7               bra       $0C25
                     com       L0D00
 L0BC3               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L0C2D
@@ -1287,7 +1287,7 @@ L0BC3               pshs      u
 
 L0BF7               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     lbsr      L1C1D
@@ -1309,7 +1309,7 @@ L0C29               std       $06,u
 L0C2B               puls      pc,u
 L0C2D               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       ,u
                     bra       L0C58
@@ -1341,7 +1341,7 @@ L0C58               cmpx      #$0008
 L0C6B               puls      pc,u
 L0C6D               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     lbra      L0CE0
@@ -1410,7 +1410,7 @@ L0D00               bra       L0CBF
 L0D02               puls      pc,u
 L0D04               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
@@ -1620,7 +1620,7 @@ L0EF7               tfr       u,d
                     puls      pc,u
 L0EFD               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -1968,7 +1968,7 @@ L1215               ldd       #$0070
 
 L121F               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       #$0000
                     bra       L1243
 
@@ -1989,7 +1989,7 @@ L1243               cmpu      #$000E
 
 L124C               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       #$0001
@@ -2057,7 +2057,7 @@ L124C               pshs      u
 
 L12E8               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -2113,7 +2113,7 @@ L1360               leas      $06,s
                     puls      pc,u
 L1364               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldd       $000D
                     std       ,s
@@ -2213,7 +2213,7 @@ L1401               ldx       $02,s
 
 L1440               pshs      u
                     ldd       #$FFB8
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $06,u
@@ -2256,7 +2256,7 @@ L149A               leas      $02,s
                     puls      pc,u
 L149E               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L14CC
@@ -2282,7 +2282,7 @@ L14CC               cmpx      #$0050
 
 L14DA               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $12,x
                     cmpd      #$0002
@@ -2292,7 +2292,7 @@ L14DA               pshs      u
 
 L14F2               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldx       $06,u
                     bra       L1511
@@ -2318,7 +2318,7 @@ L1529               clra
 L152B               puls      pc,u
 L152D               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$80
@@ -2345,7 +2345,7 @@ L152D               pshs      u
 L1565               puls      pc,u
 L1567               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -2511,7 +2511,7 @@ L16AD               pshs      u
 
 L16CB               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -2760,7 +2760,7 @@ L18E4               pshs      u
 
 L1904               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$7f
@@ -2793,7 +2793,7 @@ L193D               ldd       #$0071
                     puls      pc,u
 L1953               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $0a,u
@@ -2943,7 +2943,7 @@ L1A96               leas      $04,s
                     puls      pc,u
 L1A9A               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -3102,7 +3102,7 @@ L1BD7               ldd       $0e,s
 
 L1BE4               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     pshs      u
                     bsr       L1C1D
@@ -3126,7 +3126,7 @@ L1C16               ldd       #$0071
                     puls      pc,u
 L1C1D               pshs      u
                     ldd       #$FFAC
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -3420,7 +3420,7 @@ L1EAF               leas      $08,s
                     puls      pc,u
 L1EB3               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     cmpd      #$006F
                     beq       L1ECB
@@ -3447,7 +3447,7 @@ L1F07               fcc       /x translate/
                     fcb       $00
 L1F13               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
@@ -3653,7 +3653,7 @@ L20E9               leas      $04,s
                     puls      pc,u
 L20ED               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     leas      -$06,s
                     ldx       $0C,s
                     ldd       $0a,x
@@ -3869,7 +3869,7 @@ L22B4               ldd       $02,s
                     puls      pc,u
 L22CA               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L22E8
@@ -3890,7 +3890,7 @@ L22E8               cmpx      #$0034
                     lbra      L2501
                     pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0034
@@ -3904,7 +3904,7 @@ L22E8               cmpx      #$0034
 
 L2323               pshs      u
                     ldd       #$FFB0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -4035,7 +4035,7 @@ L2462               leas      $04,s
                     puls      pc,u
 L2466               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L2490
 
@@ -4060,7 +4060,7 @@ L2490               cmpx      #$005A
                     puls      pc,u
 L249E               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     bra       L24BC
 
@@ -4088,7 +4088,7 @@ L24BC               cmpx      #$005A
                     puls      pc,u
 L24E6               pshs      u
                     ldd       #$FFC0
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
@@ -4103,7 +4103,7 @@ L2501               clra
 L2503               puls      pc,u
 L2505               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L2520
@@ -4115,7 +4115,7 @@ L2505               pshs      u
                     puls      pc,u
 L2520               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$06,s
                     ldd       $06,u
@@ -4522,7 +4522,7 @@ L28F7               leas      $06,s
                     puls      pc,u
 L28FB               pshs      u
                     ldd       #$FFB4
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldx       $04,s
                     ldx       $06,x
                     bra       L2938
@@ -4558,7 +4558,7 @@ L2938               cmpx      #$0034
 L2949               puls      pc,u
 L294B               pshs      u
                     ldd       #$FFB2
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $08,u
@@ -4636,7 +4636,7 @@ L29F6               fcc       /longs/
                     fcb       $00
 L29FC               pshs      u
                     ldd       #$FFBA
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     bsr       L2A17
@@ -4648,7 +4648,7 @@ L29FC               pshs      u
                     puls      pc,u
 L2A17               pshs      u
                     ldd       #$FFAE
-                    lbsr      L0110
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$08,s
                     ldd       ,u
@@ -4990,7 +4990,7 @@ L2D3F               pshs      u
                     ldd       $06,s
                     bra       L2D65
 
-L2D54               pshs      u
+fprintf             pshs      u
                     ldd       $04,s
                     std       L001B
                     ldd       #$0001
@@ -4999,7 +4999,7 @@ L2D54               pshs      u
                     pshs      x
                     ldd       $08,s
 L2D65               pshs      d
-                    bsr       L2D8C
+                    bsr       doprnt
                     leas      $04,s
                     puls      pc,u
                     pshs      u
@@ -5011,13 +5011,13 @@ L2D65               pshs      d
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       L2D8C
+                    bsr       doprnt
                     leas      $04,s
                     clra
                     clrb
                     stb       [L001B,y]
                     puls      pc,u
-L2D8C               pshs      u
+doprnt              pshs      u
                     ldu       $04,s
                     leas      -$0b,s
                     bra       L2DA4
@@ -5685,7 +5685,7 @@ L32CD               ldd       $0e,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       $000D
                     subd      #$0002
@@ -5938,7 +5938,7 @@ L350F               std       $06,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     lbra      L38D8
 
 L352A               ldd       $10,s
@@ -6181,7 +6181,7 @@ L3791               ldd       $10,s
 L37A8               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     lbra      L39D5
 
@@ -6308,7 +6308,7 @@ L38BD               ldd       $10,s
 L38CF               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
 L38D8               leas      $08,s
                     lbra      L39D5
 
@@ -6414,7 +6414,7 @@ L39BE               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
 L39D5               leas      $08,s
                     puls      pc,u
 L39D9               pshs      u
@@ -6636,7 +6636,7 @@ L3BFA               pshs      d
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     puls      pc,u
 L3C0D               cmpu      #$0005
@@ -7099,7 +7099,7 @@ L402E               ldd       $04,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $08,s
                     ldd       $000D
                     addd      #$0002
@@ -7521,7 +7521,7 @@ L43F6               pshs      u
                     pshs      d
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
 L4403               leas      $04,s
                     puls      pc,u
 L4407               pshs      u
@@ -7593,7 +7593,7 @@ L448E               pshs      u
 L4498               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
 L44A1               leas      $06,s
                     puls      pc,u
 L44A5               pshs      u
@@ -7609,7 +7609,7 @@ L44A5               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
                     bge       $4544
@@ -8210,7 +8210,7 @@ L4A30               leas      -$05,x
 L4A32               ldd       $0009
                     addd      #$0001
                     std       $0009
-                    cmpd      #start
+                    cmpd      #_start
                     ble       L4A65
                     leax      $00CE,y
                     pshs      x
@@ -8220,11 +8220,11 @@ L4A32               ldd       $0009
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      L6229
+                    lbsr      exit
                     leas      $02,s
 L4A65               leas      $05,s
                     puls      pc,u
@@ -8363,7 +8363,7 @@ L4B96               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     ldd       $06,s
                     pshs      d
@@ -8388,7 +8388,7 @@ L4B96               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
 L4BE2               ldd       $0013
                     lbeq      L4C90
@@ -8425,7 +8425,7 @@ L4C1A               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $08,s
 L4C3C               puls      pc,u
 L4C3E               pshs      u
@@ -8477,7 +8477,7 @@ L4C92               pshs      u
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $04,s
 L4CA9               ldd       $04,s
                     cmpd      #$0020
@@ -8491,7 +8491,7 @@ L4CB9               ldd       $04,s
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $06,s
                     bra       L4CFE
 
@@ -8511,7 +8511,7 @@ L4CCE               ldd       $0005
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D54
+                    lbsr      fprintf
                     leas      $04,s
 L4CFE               clra
                     clrb
@@ -11082,269 +11082,129 @@ L6224               bcs       L621B
                     clrb
                     rts
 
-L6229               lbsr      L6234
+exit                lbsr      L6234
                     lbsr      L5226
 L622F               ldd       $02,s
                     os9       F$Exit
 L6234               rts
 
-L6235               neg       $0003
-                    neg       $0000
+* ------------------------------------------------------------------
+* L6235 - cc1-style init image for the work block (see _start):
+* rts stub + count/block table + relocation dirs + module-name string.
+* ------------------------------------------------------------------
+L6235               fcb       $00,$03,$00,$00 init table / work-block image
                     fcb       $4B
-                    fcb       $01
-                    addb      0,x
-                    fcb       $02
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       L0020
-                    neg       $0040
-                    neg       $0080
-                    fcb       $01
-                    neg       $0002
-                    neg       $0004
-                    neg       $0008
-                    neg       $0010
-                    neg       L0020
-                    neg       $0040
-                    neg       L0027
-                    fcb       $10
-                    com       $00E8
-                    neg       L0064
-                    neg       $000A
-                    neg       $0000
-                    lsra
-                    adcb      #$44
-                    ldd       #$44CF
-                    lsra
-                    bitb      $0044
-                    addb      $0044
-                    subb      0,x
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    suba      #$20
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    anda      #$48
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $87
-                    dec       >$0000
-                    neg       $0000
-                    neg       $0000
-                    ora       #$1C
-                    nega
-                    neg       $0000
-                    neg       $0000
-                    neg       $008E
-                    coma
-                    negb
-                    neg       $0000
-                    neg       $0000
-                    neg       L0091
-                    lsr       L2400
-                    neg       $0000
-                    neg       $0000
-                    anda      $0018
-                    lda       $0080
-                    neg       $0000
-                    neg       $0000
-                    eora      $003E
-                    cmpx      L2000
-                    neg       $0000
-                    neg       L009B
-                    jmp       $0b,s
-                    bvc       L62BA
-L62BA               neg       $0000
-                    neg       $009E
-                    fcb       $15,$02
-                    adcb      >$0000
-                    neg       $0000
-                    sbca      $0d,y
-                    asl       $EBC5
-                    cmpx      $02,s
-                    neg       L00C3
-                    rola
-                    sbcb      $C9CD
-                    lsr       $0067
-                    clra
-                    andb      0,x
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    fcb       $01,$EB,$00,$02,$00,$04,$00,$08
+                    fcb       $00,$10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00,$80,$01,$00,$02,$00,$04,$00
+                    fcb       $08,$00,$10,$00
+                    fcb       $20
+                    fcb       $00
+                    fcb       $40
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$00
+                    fcb       $44
+                    fcb       $C9
+                    fcb       $44
+                    fcb       $CC
+                    fcb       $44
+                    fcb       $CF
+                    fcb       $44
+                    fcb       $D5
+                    fcb       $44
+                    fcb       $DB
+                    fcb       $44
+                    fcb       $E0,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $80
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$00,$00,$84
+                    fcb       $48
+                    fcb       $00,$00,$00,$00,$00,$00,$87
+                    fcb       $7A
+                    fcb       $00,$00,$00,$00,$00,$00,$8A,$1C
+                    fcb       $40
+                    fcb       $00,$00,$00,$00,$00,$8E
+                    fcb       $43,$50
+                    fcb       $00,$00,$00,$00,$00,$91
+                    fcb       $74,$24
+                    fcb       $00,$00,$00,$00,$00,$94,$18,$96
+                    fcb       $80,$00,$00,$00,$00,$98
+                    fcb       $3E
+                    fcb       $BC
+                    fcb       $20
+                    fcb       $00,$00,$00,$00,$9B
+                    fcb       $6E,$6B,$28
+                    fcb       $00,$00,$00,$00,$9E,$15,$02,$F9
+                    fcb       $00,$00,$00,$00,$A2
+                    fcb       $2D,$78
+                    fcb       $EB,$C5,$AC
+                    fcb       $62
+                    fcb       $00,$C3
+                    fcb       $49
+                    fcb       $F2,$C9,$CD,$04
+                    fcb       $67,$4F
+                    fcb       $E4,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    fcb       $01,$01,$01,$01,$01,$01,$01,$01,$11,$11,$01,$11,$11,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01
-                    leax      0,y
-                    bra       L63EB
-                    bra       L63ED
-                    bra       L63EF
-                    bra       L63F1
-                    bra       L63F3
-                    bra       L63F5
-                    bra       L63F7
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    bra       $6403
-                    bra       $6405
-                    bra       $6407
-                    bra       L642B
-                    fcb       $42,$42
-L63EB               fcb       $42,$42
-L63ED               fcb       $42
-                    fcb       $02
-L63EF               fcb       $02,$02
-L63F1               fcb       $02,$02
-L63F3               fcb       $02,$02
-L63F5               fcb       $02,$02
-L63F7               fcb       $02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02
-                    bra       L6424
-                    bra       L6426
-                    bra       $6428
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    bra       $6444
-
-L6424               bra       $6446
-L6426               fcb       $01
-                    neg       $0006
-                    neg       L0057
-L642B               neg       L0055
-                    neg       L0053
-                    neg       L0051
-                    neg       L004F
-                    neg       L004D
-                    neg       $0001
-                    neg       $0001
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
+                    fcb       $11,$11,$01,$11,$11,$01,$01,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01
+                    fcc       /0               HHHHHHHHHH       BBBBBB/
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02
+                    fcc       /      DDDDDD/
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04
+                    fcc       /    /
+                    fcb       $01,$00,$06,$00
+                    fcb       $57
+                    fcb       $00
+                    fcb       $55
+                    fcb       $00
+                    fcb       $53
+                    fcb       $00
+                    fcb       $51
+                    fcb       $00
+                    fcb       $4F
+                    fcb       $00
+                    fcb       $4D
+                    fcb       $00,$01,$00,$01
                     fcc       /c.pass2/
                     fcb       $00
-
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -136,22 +136,38 @@ stkcheck            leax      d,s
                     bcs       L013C
                     stx       $025e,y
 L0122               rts
-L0123               fcc       /**** STACK OVERFLOW ****/
-                    fcb       $0D
+
+L0123               bpl       $014F
+                    bpl       L0151
+                    bra       L017C
+                    lsrb
+                    fcb       $41
+                    coma
+                    fcb       $4B
+                    bra       $017E
+                    rorb
+                    fcb       $45,$52
+                    rora
+                    inca
+                    clra
+                    asrb
+                    bra       L0162
+                    bpl       $0164
+                    bpl       L0149
 L013C               leax      L0123,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
-                    os9       I$WritLn
+L0149               os9       I$WritLn
                     clr       ,-s
                     lbsr      L622F
-                    ldd       $0250,y
+L0151               ldd       $0250,y
                     subd      $025e,y
                     rts
                     ldd       $025e,y
                     subd      $025C,y
-                    rts
+L0162               rts
 
 L0163               pshs      x
                     leax      d,y
@@ -165,7 +181,7 @@ L016B               ldd       ,y++
                     cmpy      ,s
                     bne       L016B
                     leas      $04,s
-                    rts
+L017C               rts
 
 main                pshs      u
                     ldd       #$FF86
@@ -272,7 +288,7 @@ L025E               leax      L0B45,pcr
                     std       $0003
                     bne       L0285
                     pshs      u
-                    leax      $0B47,pcr
+                    leax      L0B47,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
@@ -461,7 +477,7 @@ L0421               ldd       $0282,y
                     leas      $02,s
                     lbra      L048D
 
-L042F               lbsr      $4B88
+L042F               lbsr      L4B88
                     clra
                     clrb
                     pshs      d
@@ -479,7 +495,7 @@ L042F               lbsr      $4B88
 
 L044F               ldd       $22,s
                     pshs      d
-                    leax      $0B57,pcr
+                    leax      L0B57,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
@@ -1116,7 +1132,7 @@ L09E9               leax      L0BA6,pcr
                     bne       L0A14
                     ldd       $04,s
                     pshs      d
-                    leax      $0BA8,pcr
+                    leax      L0BA8,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
@@ -1236,33 +1252,22 @@ L0B20               fcc       /bad option flag: +%c/
 L0B36               fcc       /too many files/
                     fcb       $00
 L0B45               fcb       $72
-                    neg       $0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       L206F
-                    neg       $656E
-                    bra       L0B78
-                    com       L0D00
-L0B56               neg       L0062
-                    fcc       /ad action code: %d/
+                    fcb       $00
+L0B47               fcc       /can't open %s/
                     fcb       $0D,$00
-L0B6C               fcc       /bad code in /
-L0B78               fcc       /intermediate file: %02x/
+L0B56               fcb       $00
+L0B57               fcc       /bad action code: %d/
+                    fcb       $0D,$00
+L0B6C               fcc       /bad code in intermediate file: %02x/
                     fcb       $0D,$00
 L0B91               fcc       /bad node type: %02x/
                     fcb       $0D,$00
-L0BA6               asr       >$0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       L206F
-                    neg       $656E
-                    bra       $0BD9
-                    com       L0D00
-L0BB7               bra       $0C25
-                    fcb       $65,$61
-                    com       $2025
-                    lsr       $0C,y
-                    com       L0D00
+L0BA6               fcb       $77
+                    fcb       $00
+L0BA8               fcc       /can't open %s/
+                    fcb       $0D,$00
+L0BB7               fcc       / leas %d,s/
+                    fcb       $0D,$00
 L0BC3               pshs      u
                     ldd       #$FFB4
                     lbsr      stkcheck
@@ -1405,7 +1410,7 @@ L0CE0               cmpx      #$0037
                     beq       L0D02
                     cmpx      #$0076
                     beq       L0D02
-L0D00               bra       L0CBF
+                    bra       L0CBF
 
 L0D02               puls      pc,u
 L0D04               pshs      u
@@ -3435,8 +3440,8 @@ L1ED0               clra
 L1ED2               puls      pc,u
 L1ED4               fcc       /translation/
                     fcb       $00
-L1EE0               bcs       $1F5A
-                    tst       $0000
+L1EE0               fcb       $25,$78
+                    fcb       $0D,$00
 L1EE4               fcc       /binary op./
                     fcb       $00
 L1EEF               fcc       /indirection/
@@ -3584,7 +3589,7 @@ L2026               pshs      u
                     ldd       ,u
                     pshs      d
                     ldd       #$008B
-L2034               pshs      d
+                    pshs      d
                     ldd       #$0087
                     pshs      d
                     lbsr      L3292
@@ -5710,7 +5715,7 @@ L32FA               ldd       $10,s
                     std       $10,s
                     ldd       #$005A
                     std       $0e,s
-L331D               leax      $44FE,pcr
+L331D               leax      L44FE,pcr
                     pshs      x
                     lbsr      L43B8
                     leas      $02,s
@@ -5720,7 +5725,7 @@ L331D               leax      $44FE,pcr
                     std       ,s
                     lbra      L3400
 
-L3334               leax      $4501,pcr
+L3334               leax      L4501,pcr
                     lbra      L34A1
 
 L333B               pshs      u
@@ -5732,7 +5737,7 @@ L333B               pshs      u
                     leas      $06,s
                     lbra      L39D5
 
-L334F               leax      $450C,pcr
+L334F               leax      L450C,pcr
                     bra       L337D
 
 L3355               leax      L4513,pcr
@@ -5857,7 +5862,7 @@ L3445               leax      L456E,pcr
 L3466               leax      L4573,pcr
                     bra       L34A1
 
-L346C               leax      $4577,pcr
+L346C               leax      L4577,pcr
                     pshs      x
                     lbsr      L43B8
                     leas      $02,s
@@ -5945,7 +5950,7 @@ L352A               ldd       $10,s
                     pshs      d
                     lbsr      L3987
                     std       ,s
-                    leax      $45B2,pcr
+                    leax      L45B2,pcr
                     lbra      L37A8
 
 L353B               cmpx      #$0077
@@ -6036,10 +6041,10 @@ L3548               cmpx      #$007A
                     ldx       $0C,s
                     bra       L3666
 
-L364D               leax      $45B8,pcr
+L364D               leax      L45B8,pcr
                     bra       L365D
 
-L3653               leax      $45BC,pcr
+L3653               leax      L45BC,pcr
                     bra       L365D
 
 L3659               leax      L45C4,pcr
@@ -6161,7 +6166,7 @@ L3765               ldd       $0e,s
                     bne       L378A
                     cmpu      #$0000
                     bne       L378A
-                    leax      $45D3,pcr
+                    leax      L45D3,pcr
                     pshs      x
 L3782               lbsr      L43D1
 L3785               leas      $02,s
@@ -6177,7 +6182,7 @@ L3791               ldd       $10,s
                     bne       L37B6
                     ldd       $06,s
                     pshs      d
-                    leax      $45E1,pcr
+                    leax      L45E1,pcr
 L37A8               pshs      x
                     ldd       $0005
                     pshs      d
@@ -6218,10 +6223,10 @@ L37FA               pshs      d
 L37FF               leas      $04,s
                     lbra      L39D5
 
-L3804               leax      $45F1,pcr
+L3804               leax      L45F1,pcr
                     bra       L380E
 
-L380A               leax      $45F4,pcr
+L380A               leax      L45F4,pcr
 L380E               pshs      x
                     lbsr      L43B8
                     leas      $02,s
@@ -6232,7 +6237,7 @@ L3819               ldd       #$0043
                     pshs      d
                     lbsr      L3292
                     leas      $02,s
-L3823               leax      $45F8,pcr
+L3823               leax      L45F8,pcr
                     lbra      L38A2
 
 L382A               leas      -$08,x
@@ -6283,7 +6288,7 @@ L388B               cmpx      #$0021
                     lbeq      L3843
                     cmpx      #$0023
                     lbeq      L3843
-L389E               leax      $45FC,pcr
+L389E               leax      L45FC,pcr
 L38A2               pshs      x
                     lbsr      L43B8
                     leas      $02,s
@@ -6304,7 +6309,7 @@ L38BD               ldd       $10,s
                     std       ,s
                     ldd       $08,s
                     pshs      d
-                    leax      $4600,pcr
+                    leax      L4600,pcr
 L38CF               pshs      x
                     ldd       $0005
                     pshs      d
@@ -6319,7 +6324,7 @@ L38DD               ldd       $06,s
                     ldx       $10,s
                     bra       L392C
 
-L38EB               leax      $460C,pcr
+L38EB               leax      L460C,pcr
                     pshs      x
                     lbsr      L43F6
                     leas      $02,s
@@ -6484,7 +6489,7 @@ L3A60               leax      L466B,pcr
 L3A66               leax      L4671,pcr
                     bra       L3A8F
 
-L3A6C               leax      $4676,pcr
+L3A6C               leax      L4676,pcr
                     bra       L3A8F
 
 L3A72               leax      L467C,pcr
@@ -6815,7 +6820,7 @@ L3D90               pshs      u,d
 L3DD0               pshs      u
                     ldu       $04,s
                     leas      -$02,s
-                    lbsr      $4B88
+                    lbsr      L4B88
                     ldd       $08,s
                     cmpd      #$0001
                     bne       L3DEB
@@ -6933,13 +6938,13 @@ L3EC6               std       $02,s
 L3ED4               leax      ,u
                     bra       L3EEC
 
-L3ED8               leax      $476D,pcr
+L3ED8               leax      L476D,pcr
                     bra       L3EE8
 
-L3EDE               leax      $4771,pcr
+L3EDE               leax      L4771,pcr
                     bra       L3EE8
 
-L3EE4               leax      $4774,pcr
+L3EE4               leax      L4774,pcr
 L3EE8               stx       $04,s
                     bra       L3EFB
 
@@ -7018,7 +7023,7 @@ L3F87               cmpu      #$0057
                     beq       L3FCD
                     cmpu      #$0059
                     bne       L3FA0
-                    leax      $4778,pcr
+                    leax      L4778,pcr
                     pshs      x
 L3F99               lbsr      L43D1
                     leas      $02,s
@@ -7106,7 +7111,7 @@ L402E               ldd       $04,s
                     std       $000D
                     lbra      L44A1
 
-L404F               leax      $479A,pcr
+L404F               leax      L479A,pcr
                     pshs      x
                     lbsr      L4823
                     lbra      L432D
@@ -7317,7 +7322,7 @@ L4223               pshs      d
 L4225               lbsr      L43F6
                     lbra      L42DE
 
-L422B               leax      $47B7,pcr
+L422B               leax      L47B7,pcr
                     lbra      L42D9
 
 L4232               cmpx      #$000D
@@ -7389,7 +7394,7 @@ L42B6               ldd       >$004f,y
                     std       $000D
                     bra       L431A
 
-L42D5               leax      $47C8,pcr
+L42D5               leax      L47C8,pcr
 L42D9               pshs      x
                     lbsr      L4823
 L42DE               leas      $02,s
@@ -7549,7 +7554,7 @@ L441F               pshs      u
 L4432               pshs      u
                     ldd       $04,s
                     pshs      d
-                    leax      $4806,pcr
+                    leax      L4806,pcr
                     lbra      L4498
 
 L443F               pshs      u,d
@@ -7557,7 +7562,7 @@ L443F               pshs      u,d
                     subd      $000D
                     std       ,s
                     beq       L446B
-                    leax      $480B,pcr
+                    leax      L480B,pcr
                     pshs      x
                     lbsr      L43B8
                     leas      $02,s
@@ -7612,10 +7617,11 @@ L44A5               pshs      u
                     lbsr      fprintf
                     leas      $08,s
                     puls      pc,u
-                    bge       $4544
-                    neg       $002C
-                    com       >$006C
-                    fcc       /bsr /
+                    fcb       $2C,$79
+                    fcb       $00
+                    fcb       $2C,$73
+                    fcb       $00
+L44CF               fcc       /lbsr /
                     fcb       $00
                     fcc       /lbra /
                     fcb       $00
@@ -7623,20 +7629,13 @@ L44A5               pshs      u
                     fcb       $00
                     fcc       /unknown operator : /
                     fcb       $00
-L44F4               bra       L4566
-                    com       $6873
-                    bra       L4520
-                    com       $0d,x
-                    neg       $006C
-                    fcb       $62
-                    neg       $0070
-                    fcb       $75
-                    inc       -$0d,s
-                    bra       $457C
-                    bge       $4579
-                    com       $0d,x
-                    neg       $0063
-                    fcc       /cmult/
+L44F4               fcc       / pshs %c/
+                    fcb       $0D,$00
+L44FE               fcb       $6C,$62
+                    fcb       $00
+L4501               fcc       /puls u,pc/
+                    fcb       $0D,$00
+L450C               fcc       /ccmult/
                     fcb       $00
 L4513               fcc       /ccudiv/
                     fcb       $00
@@ -7652,45 +7651,39 @@ L4532               fcc       /ccumod/
                     fcb       $00
 L4539               fcc       /ccmod/
                     fcb       $00
-L453F               jmp       $05,s
-                    asr       $01,s
-                    tst       L0020
-                    jmp       $05,s
-                    asr       $02,s
-                    tst       L0020
-                    fcc       /sbca #0/
+L453F               fcc       /nega/
+                    fcb       $0D
+                    fcc       / negb/
+                    fcb       $0D
+                    fcc       / sbca #0/
                     fcb       $00
-L4553               com       $0f,s
-                    tst       $01,s
-                    tst       L0020
-                    fcc       /comb/
+L4553               fcc       /coma/
+                    fcb       $0D
+                    fcc       / comb/
                     fcb       $00
 L455E               fcc       /leax /
                     fcb       $00
-L4564               fcb       $6C,$65
-L4566               fcb       $61,$73,$20
+L4564               fcc       /leas /
                     fcb       $00
-L456A               bge       $45E4
-                    tst       $0000
+L456A               fcb       $2C,$78
+                    fcb       $0D,$00
 L456E               fcc       /jsr /
                     fcb       $00
-L4573               com       $6578
-                    neg       $006C
-                    lsr       0,x
-L457A               fcb       $61
-                    com       $6C62
-                    tst       L0020
-                    fcc       /rola/
+L4573               fcb       $73,$65,$78
                     fcb       $00
-L4585               fcb       $61
-                    com       $7261
-                    tst       L0020
-                    fcc       /rorb/
+L4577               fcb       $6C,$64
                     fcb       $00
-L4590               inc       -$0d,s
-                    fcb       $72,$61
-                    tst       L0020
-                    fcc       /rorb/
+L457A               fcc       /aslb/
+                    fcb       $0D
+                    fcc       / rola/
+                    fcb       $00
+L4585               fcc       /asra/
+                    fcb       $0D
+                    fcc       / rorb/
+                    fcb       $00
+L4590               fcc       /lsra/
+                    fcb       $0D
+                    fcc       / rorb/
                     fcb       $00
 L459B               fcc       /ldy /
                     fcb       $00
@@ -7698,204 +7691,131 @@ L45A0               fcc       /ldu /
                     fcb       $00
 L45A5               fcc       /leax /
                     fcb       $00
-L45AB               bcs       L4611
-                    bge       L45D4
-                    com       $0d,x
-                    neg       L0064
-                    bge       L45DA
-                    com       $0d,x
-                    neg       $0073
-                    fcb       $65
-                    asl       >$0061
-                    fcc       /dca #0/
+L45AB               fcc       /%d,%c/
+                    fcb       $0D,$00
+L45B2               fcc       /d,%c/
+                    fcb       $0D,$00
+L45B8               fcb       $73,$65,$78
+                    fcb       $00
+L45BC               fcc       /adca #0/
                     fcb       $00
 L45C4               fcc       /sbca #0/
                     fcb       $00
-L45CC               bcs       $4632
-                    bge       L45F5
-                    com       $0d,x
-                    neg       $0063
-L45D4               inc       -$0e,s
-                    fcb       $61
-                    tst       L0020
-                    fcb       $63
-L45DA               fcb       $6C,$72,$62
+L45CC               fcc       /%d,%c/
+                    fcb       $0D,$00
+L45D3               fcc       /clra/
+                    fcb       $0D
+                    fcc       / clrb/
                     fcb       $00
-L45DE               inc       $04,s
-                    neg       L0020
-                    com       $7425
-                    com       0,y
-                    blt       L461B
-                    bge       L465E
-                    tst       $0000
-L45ED               com       $0d,s
-                    neg       >$0073
-                    lsr       >$0073
-L45F5               fcb       $75,$62
-                    neg       $0061
-                    lsr       $04,s
-                    neg       $006C
-                    fcb       $65,$61
-                    neg       L0020
-                    fcb       $65
-                    asl       $6720
-                    bcs       L466A
-                    bge       L462E
-                    com       $0d,x
-                    neg       L0064
-                    bge       L460F
-L460F               fcb       $4C,$45
-L4611               fcc       /A arg/
+L45DE               fcb       $6C,$64
                     fcb       $00
-L4617               bra       L468D
-                    ror       -$0e,s
-L461B               bra       L4642
-                    com       $0C,y
-                    bcs       L4684
-                    tst       $0000
-L4623               inc       $04,s
-                    fcb       $61
-                    bra       L4658
-                    bge       L46A2
-                    tst       L0020
-                    clr       -$0e,s
-L462E               fcb       $61
-                    bra       L4662
-                    bge       L46AB
-                    tst       L0020
-                    clr       -$0e,s
-                    fcb       $61
-                    bra       L466C
-                    bge       L46B4
-                    tst       L0020
-                    fcc       /ora /
-L4642               fcb       $33,$2C,$78
+L45E1               fcc       / st%c -2,s/
+                    fcb       $0D,$00
+L45ED               fcb       $63,$6D,$70
                     fcb       $00
-L4646               clrb
-                    fcc       /lmove/
+L45F1               fcb       $73,$74
                     fcb       $00
-L464D               clrb
-                    fcc       /ladd/
+L45F4               fcb       $73,$75,$62
                     fcb       $00
-L4653               clrb
-                    fcc       /lsub/
-L4658               fcb       $00
-L4659               clrb
-                    fcc       /lmul/
-L465E               fcb       $00
-L465F               clrb
-                    fcb       $6C,$64
-L4662               fcb       $69,$76
+L45F8               fcb       $61,$64,$64
                     fcb       $00
-L4665               clrb
-                    fcc       /lmod/
-L466A               fcb       $00
-L466B               clrb
-L466C               fcc       /land/
+L45FC               fcb       $6C,$65,$61
                     fcb       $00
-L4671               clrb
-                    inc       $0f,s
-                    fcb       $72
-                    neg       $005F
-                    fcc       /lxor/
+L4600               fcc       / exg %c,%c/
+                    fcb       $0D,$00
+L460C               fcb       $64,$2C
                     fcb       $00
-L467C               clrb
-                    fcc       /lshl/
+L460F               fcc       /LEA arg/
                     fcb       $00
-L4682               clrb
-                    fcb       $6C
-L4684               fcb       $73,$68,$72
+L4617               fcc       / tfr %c,%c/
+                    fcb       $0D,$00
+L4623               fcc       /lda 0,x/
+                    fcb       $0D
+                    fcc       / ora 1,x/
+                    fcb       $0D
+                    fcc       / ora 2,x/
+                    fcb       $0D
+                    fcc       / ora 3,x/
                     fcb       $00
-L4688               clrb
-                    fcc       /lcmp/
-L468D               fcb       $72
+L4646               fcc       /_lmove/
                     fcb       $00
-L468F               clrb
-                    fcc       /lneg/
+L464D               fcc       /_ladd/
                     fcb       $00
-L4695               clrb
-                    fcc       /lcompl/
+L4653               fcc       /_lsub/
                     fcb       $00
-L469D               clrb
-                    fcc       /lito/
-L46A2               fcb       $6C
+L4659               fcc       /_lmul/
                     fcb       $00
-L46A4               clrb
-                    fcc       /lutol/
+L465F               fcc       /_ldiv/
                     fcb       $00
-L46AB               clrb
-                    fcc       /linc/
+L4665               fcc       /_lmod/
                     fcb       $00
-L46B1               clrb
-                    fcb       $6C,$64
-L46B4               fcb       $65,$63
+L466B               fcc       /_land/
+                    fcb       $00
+L4671               fcc       /_lor/
+                    fcb       $00
+L4676               fcc       /_lxor/
+                    fcb       $00
+L467C               fcc       /_lshl/
+                    fcb       $00
+L4682               fcc       /_lshr/
+                    fcb       $00
+L4688               fcc       /_lcmpr/
+                    fcb       $00
+L468F               fcc       /_lneg/
+                    fcb       $00
+L4695               fcc       /_lcompl/
+                    fcb       $00
+L469D               fcc       /_litol/
+                    fcb       $00
+L46A4               fcc       /_lutol/
+                    fcb       $00
+L46AB               fcc       /_linc/
+                    fcb       $00
+L46B1               fcc       /_ldec/
                     fcb       $00
 L46B7               fcc       /codgen - longs/
                     fcb       $00
-L46C6               clrb
-                    fcc       /dstack/
+L46C6               fcc       /_dstack/
                     fcb       $00
-L46CE               bra       L473C
-                    lsr       $01,s
-                    bra       L46F9
-                    com       $0C,y
-                    asl       L0D00
-L46D9               clrb
-                    fcc       /fmove/
+L46CE               fcc       / lda %c,x/
+                    fcb       $0D,$00
+L46D9               fcc       /_fmove/
                     fcb       $00
-L46E0               clrb
-                    fcc       /dmove/
+L46E0               fcc       /_dmove/
                     fcb       $00
-L46E7               clrb
-                    fcc       /dadd/
+L46E7               fcc       /_dadd/
                     fcb       $00
-L46ED               clrb
-                    fcc       /dsub/
+L46ED               fcc       /_dsub/
                     fcb       $00
-L46F3               clrb
-                    fcc       /dmul/
+L46F3               fcc       /_dmul/
                     fcb       $00
-L46F9               clrb
-                    fcc       /ddiv/
+L46F9               fcc       /_ddiv/
                     fcb       $00
-L46FF               clrb
-                    fcc       /dcmpr/
+L46FF               fcc       /_dcmpr/
                     fcb       $00
-L4706               clrb
-                    fcc       /dneg/
+L4706               fcc       /_dneg/
                     fcb       $00
-L470C               clrb
-                    fcc       /finc/
+L470C               fcc       /_finc/
                     fcb       $00
-L4712               clrb
-                    fcc       /dinc/
+L4712               fcc       /_dinc/
                     fcb       $00
-L4718               clrb
-                    fcc       /fdec/
+L4718               fcc       /_fdec/
                     fcb       $00
-L471E               clrb
-                    fcc       /ddec/
+L471E               fcc       /_ddec/
                     fcb       $00
-L4724               clrb
-                    fcc       /dtof/
+L4724               fcc       /_dtof/
                     fcb       $00
-L472A               clrb
-                    fcc       /ftod/
+L472A               fcc       /_ftod/
                     fcb       $00
-L4730               clrb
-                    fcc       /ltod/
+L4730               fcc       /_ltod/
                     fcb       $00
-L4736               clrb
-                    fcc       /itod/
+L4736               fcc       /_itod/
                     fcb       $00
-L473C               clrb
-                    fcc       /utod/
+L473C               fcc       /_utod/
                     fcb       $00
-L4742               clrb
-                    fcc       /dtol/
+L4742               fcc       /_dtol/
                     fcb       $00
-L4748               clrb
-                    fcc       /dtoi/
+L4748               fcc       /_dtoi/
                     fcb       $00
 L474E               fcc       /codgen - floats/
                     fcb       $00
@@ -7903,92 +7823,68 @@ L475E               fcc       /bsr /
                     fcb       $00
 L4763               fcc       /puls x/
                     fcb       $00
-L476A               leax      $0C,y
-                    neg       $0061
-                    jmp       $04,s
-                    neg       $006F
-                    fcb       $72
-                    neg       $0065
-                    clr       -$0e,s
-                    neg       $0063
-                    fcb       $6F,$6D,$61
+L476A               fcb       $30,$2C
+                    fcb       $00
+L476D               fcb       $61,$6E,$64
+                    fcb       $00
+L4771               fcb       $6F,$72
+                    fcb       $00
+L4774               fcb       $65,$6F,$72
+                    fcb       $00
+L4778               fcc       /coma/
                     fcb       $00
 L477D               fcc       /clrb/
                     fcb       $00
 L4782               fcc       /comb/
                     fcb       $00
-L4787               bra       L47AE
-                    com       L6120
-                    bge       L4801
-                    bmi       L479D
-                    bra       $47B7
-                    com       L6220
-                    bge       $480A
-                    bmi       L47A6
-                    neg       $0063
-                    fcb       $6F,$6D
-L479D               fcc       /piler tro/
-L47A6               fcc       /uble/
+L4787               fcc       / %sa ,s+/
+                    fcb       $0D
+                    fcc       / %sb ,s+/
+                    fcb       $0D,$00
+L479A               fcc       /compiler trouble/
                     fcb       $00
-L47AB               clrb
-                    fcb       $66,$6C
-L47AE               fcb       $61,$63,$63
+L47AB               fcc       /_flacc/
                     fcb       $00
-L47B2               bge       $4824
-                    com       -$0e,s
-                    neg       $0073
-                    fcc       /torage error/
+L47B2               fcc       /,pcr/
                     fcb       $00
-L47C5               bmi       $47F2
-                    neg       L0064
-                    fcc       /ereference/
+L47B7               fcc       /storage error/
+                    fcb       $00
+L47C5               fcb       $2B,$2B
+                    fcb       $00
+L47C8               fcc       /dereference/
                     fcb       $00
 L47D4               fcc       /rel op/
                     fcb       $00
-L47DB               fcb       $65,$71
-                    bra       L47DF
-
-L47DF               jmp       $05,s
-                    bra       L47E3
-
-L47E3               inc       $05,s
-                    bra       L47E7
-
-L47E7               inc       -$0C,s
-                    bra       L47EB
-
-L47EB               asr       $05,s
-                    bra       L47EF
-
-L47EF               asr       -$0C,s
-                    bra       L47F3
-
-L47F3               inc       -$0d,s
-                    bra       L47F7
-
-L47F7               inc       $0f,s
-                    bra       L47FB
-
-L47FB               asl       -$0d,s
-                    bra       L47FF
-
-L47FF               asl       $09,s
-L4801               bra       L4803
-
-L4803               bcs       $4869
-                    neg       $0025
-                    bgt       $4841
-                    com       >$006C
-                    fcc       /eas /
+L47DB               fcb       $65,$71,$20
                     fcb       $00
-L4811               bra       L487F
-                    fcc       /ea%c /
+L47DF               fcb       $6E,$65,$20
                     fcb       $00
-L4819               bcs       $487E
-                    bcs       L4881
-                    bge       $488F
-                    com       -$0e,s
-                    tst       $0000
+L47E3               fcb       $6C,$65,$20
+                    fcb       $00
+L47E7               fcb       $6C,$74,$20
+                    fcb       $00
+L47EB               fcb       $67,$65,$20
+                    fcb       $00
+L47EF               fcb       $67,$74,$20
+                    fcb       $00
+L47F3               fcb       $6C,$73,$20
+                    fcb       $00
+L47F7               fcb       $6C,$6F,$20
+                    fcb       $00
+L47FB               fcb       $68,$73,$20
+                    fcb       $00
+L47FF               fcb       $68,$69,$20
+                    fcb       $00
+L4803               fcb       $25,$64
+                    fcb       $00
+L4806               fcc       /%.8s/
+                    fcb       $00
+L480B               fcc       /leas /
+                    fcb       $00
+L4811               fcc       / lea%c /
+                    fcb       $00
+L4819               fcc       /%c%d,pcr/
+                    fcb       $0D,$00
 L4823               pshs      u
                     ldd       $04,s
                     pshs      d
@@ -8029,7 +7925,7 @@ L484B               pshs      u
                     leas      $32,s
                     puls      pc,u
 L487F               pshs      u
-L4881               ldu       $04,s
+                    ldu       $04,s
                     ldd       $0e,u
                     pshs      d
                     ldd       $08,s
@@ -8216,7 +8112,7 @@ L4A32               ldd       $0009
                     pshs      x
                     lbsr      L5289
                     leas      $02,s
-                    leax      $4B6F,pcr
+                    leax      L4B6F,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
@@ -8331,30 +8227,21 @@ L4B2E               fcc       /out of memory/
                     fcb       $00
 L4B3C               fcc       /compiler error - /
                     fcb       $00
-L4B4E               bcs       $4BC3
-                    abx
-                    bra       L4B53
+L4B4E               fcc       /%s: /
+                    fcb       $00
 L4B53               fcc       /line %d  /
                     fcb       $00
-L4B5D               bpl       L4B89
-                    bpl       $4B8B
-                    bra       L4B83
-                    bcs       $4BD8
-                    bra       L4B87
-                    bpl       L4B93
-                    bpl       $4B95
-                    tst       $0000
+L4B5D               fcc       /****  %s  ****/
+                    fcb       $0D,$00
 L4B6D               fcb       $72
-                    neg       $0074
-                    fcc       /oo many errors - AB/
-L4B83               fcb       $4F,$52,$54
-                    fcb       $0D
-L4B87               neg       $0034
-L4B89               nega
+                    fcb       $00
+L4B6F               fcc       /too many errors - ABORT/
+                    fcb       $0D,$00
+L4B88               pshs      u
                     leax      L4D06,pcr
                     pshs      x
                     lbsr      L43B8
-L4B93               lbra      L4C8E
+                    lbra      L4C8E
 
 L4B96               pshs      u
                     ldu       $04,s
@@ -8519,79 +8406,47 @@ L4CFE               clra
 L4D04               puls      pc,u
 L4D06               fcc       /fdb /
                     fcb       $00
-L4D0B               bra       L4D81
-                    lsr       $6C20
-                    bcs       L4D40
-                    fcb       $38
-                    com       L0D00
+L4D0B               fcc       / ttl %.8s/
+                    fcb       $0D,$00
 L4D16               fcc       /pshs u/
                     fcb       $00
-L4D1D               bra       L4D8B
-                    lsr       $04,s
-                    bra       $4D46
-                    clrb
-                    bcs       L4D8A
-                    tst       L0020
-                    inc       $02,s
-                    com       $7220
-                    clrb
-                    com       $746B
-                    com       $08,s
-                    fcb       $65
-                    com       $0b,s
-                    tst       $0000
+L4D1D               fcc       / ldd #_%d/
+                    fcb       $0D
+                    fcc       / lbsr _stkcheck/
+                    fcb       $0D,$00
 L4D38               fcc       /leax /
                     fcb       $00
-L4D3E               bge       $4DB0
-L4D40               com       -$0e,s
-                    tst       L0020
-                    neg       $7368
-                    com       $2078
-                    tst       L0020
-                    fcc       /leax /
+L4D3E               fcc       /,pcr/
+                    fcb       $0D
+                    fcc       / pshs x/
+                    fcb       $0D
+                    fcc       / leax /
                     fcb       $00
-L4D52               bge       $4DC4
-                    com       -$0e,s
-                    tst       L0020
-                    neg       $7368
-                    com       $2078
-                    tst       L0020
-                    inc       $02,s
-                    com       $7220
-                    clrb
-                    neg       $726F
-                    ror       $0d,x
-                    bra       L4DD9
-                    fcb       $65,$61
-                    com       L2034
-                    bge       L4DE7
-                    tst       $0000
-L4D76               clrb
-                    bcs       L4DDD
-                    bra       $4DE0
-                    fcb       $71,$75
-                    bra       $4DA4
-                    lsr       $0d,x
-L4D81               tst       $0000
-L4D83               fcc       /vsect d/
-L4D8A               fcb       $70
-L4D8B               fcb       $00
+L4D52               fcc       /,pcr/
+                    fcb       $0D
+                    fcc       / pshs x/
+                    fcb       $0D
+                    fcc       / lbsr _prof/
+                    fcb       $0D
+                    fcc       / leas 4,s/
+                    fcb       $0D,$00
+L4D76               fcc       /_%d equ %d/
+                    fcb       $0D,$0D,$00
+L4D83               fcc       /vsect dp/
+                    fcb       $00
 L4D8C               fcc       /vsect/
                     fcb       $00
 L4D92               fcc       /endsect/
                     fcb       $00
-L4D9A               bra       $4E02
-                    fcc       /cc "/
+L4D9A               fcc       / fcc "/
                     fcb       $00
-L4DA1               bhi       $4DB0
-                    bra       $4E0B
-                    com       $02,s
-                    bra       $4DCD
-                    bcs       L4E23
-                    tst       $0000
-L4DAD               bhi       $4DBC
-                    neg       $0034
-                    nega
+L4DA1               fcb       $22
+                    fcb       $0D
+                    fcc       / fcb $%x/
+                    fcb       $0D,$00
+L4DAD               fcb       $22
+                    fcb       $0D,$00
+L4DB0               pshs      u
                     leau      $00C1,y
 L4DB6               ldd       $06,u
                     clra
@@ -8607,14 +8462,14 @@ L4DB6               ldd       $06,u
                     lbra      L4E2B
                     puls      pc,u
 L4DD7               pshs      u
-L4DD9               ldu       $08,s
+                    ldu       $08,s
                     bne       L4DE1
-L4DDD               bsr       $4DB0
+                    bsr       L4DB0
                     tfr       d,u
 L4DE1               stu       -$02,s
                     beq       L4E2B
                     ldd       $04,s
-L4DE7               std       $08,u
+                    std       $08,u
                     ldx       $06,s
                     ldb       $01,x
                     cmpb      #$2b
@@ -8644,7 +8499,7 @@ L4E19               ora       ,s+
 L4E1D               std       $06,u
                     ldd       $02,u
                     addd      $0b,u
-L4E23               std       $04,u
+                    std       $04,u
                     std       ,u
 L4E27               tfr       u,d
                     puls      pc,u
@@ -11074,7 +10929,7 @@ L6217               ldd       #$FFFF
 
 L621B               clra
                     std       $0260,y
-L6220               ldd       #$FFFF
+                    ldd       #$FFFF
                     rts
 
 L6224               bcs       L621B

--- a/3rdparty/packages/ccompiler/c.pass2_dis.asm
+++ b/3rdparty/packages/ccompiler/c.pass2_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $05
 
-                    mod       eom,name,tylg,atrv,_start,size
+                    mod       eom,name,tylg,atrv,start,size
 
 u0000               rmb       3431
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /c.pass2/
                     fcb       edition
 
-copybytes           lda       ,y+
+L0015               lda       ,y+
 L0017               sta       ,u+
 L0019               leax      -$01,x
-L001B               bne       copybytes
+L001B               bne       L0015
 L001D               rts
 
-_start              pshs      y
+start               pshs      y
 L0020               pshs      u
 L0022               clra
 L0023               clrb
@@ -34,15 +34,15 @@ L0029               ldx       ,s
 L002B               leau      ,x
 L002D               leax      $02E7,x
                     pshs      x
-L0033               leay      $6235,pcr
+L0033               leay      L6235,pcr
 L0037               ldx       ,y++
                     beq       L003F
-                    bsr       copybytes
+                    bsr       L0015
 L003D               ldu       $02,s
 L003F               leau      >$0027,u
 L0043               ldx       ,y++
 L0045               beq       L004A
-L0047               bsr       copybytes
+L0047               bsr       L0015
                     clra
 L004A               cmpu      ,s
 L004D               beq       L0053
@@ -114,240 +114,231 @@ L00CD               cmpa      #$0d
 L00DD               clr       -$01,x
                     bra       L0085
 
-* ------------------------------------------------------------------
-* SPURIOUS $00 below (defect in the c.pass2 FCB source, same as c.pass1).
-* cstart.a's real crt0 loads 'ldd argc,u' (EC C9 02 4E); the stray $00
-* makes it 'ldd 0,x' + 'adcb #2' (EC 00 C9 02 ..).  Here the trailing $4E
-* is an undefined 1-byte opcode, so the decode re-syncs at 'pshs d' and
-* 'lbsr main' survives.  Bytes below are byte-faithful to the defective
-* FCB; the genuine binary uses the clean 'ldd argc,u' form.
-* ------------------------------------------------------------------
 L00E1               leax      $0212,u
                     pshs      x
-                    ldd       0,x
-                    adcb      #$02
-                    fcb       $4E
+                    ldd       $024e,u
                     pshs      d
                     leay      ,u
-                    bsr       stkinit
-                    lbsr      main
+                    bsr       L00FB
+                    lbsr      L017D
                     clr       ,-s
                     clr       ,-s
-                    lbsr      exit
-stkinit             leax      $02E7,y
-L0100               stx       $025C,y
+                    lbsr      L6229
+L00FB               leax      $02E7,y
+L00FF               stx       $025C,y
                     sts       $0250,y
                     sts       $025e,y
                     ldd       #$FF82
-stkcheck            leax      d,s
+L0110               leax      d,s
                     cmpx      $025e,y
-                    bcc       L0123
+                    bcc       L0122
                     cmpx      $025C,y
-                    bcs       L013D
+                    bcs       L013C
                     stx       $025e,y
-L0123               rts
-L0124               fcc       /**** STACK OVERFLOW ****/
+L0122               rts
+L0123               fcc       /**** STACK OVERFLOW ****/
                     fcb       $0D
-L013D               leax      L0124,pcr
+L013C               leax      L0123,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
                     os9       I$WritLn
                     clr       ,-s
-                    lbsr      $6230
+                    lbsr      L622F
                     ldd       $0250,y
                     subd      $025e,y
                     rts
                     ldd       $025e,y
                     subd      $025C,y
-L0163               rts
-                    pshs      x
+                    rts
+
+L0163               pshs      x
                     leax      d,y
                     leax      d,x
                     pshs      x
-L016C               ldd       ,y++
+L016B               ldd       ,y++
                     leax      d,u
                     ldd       ,x
                     addd      $02,s
                     std       ,x
                     cmpy      ,s
-                    bne       L016C
+                    bne       L016B
                     leas      $04,s
                     rts
 
-main                pshs      u
+L017D               pshs      u
                     ldd       #$FF86
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$24,s
-                    lbra      L028F
+                    lbra      L028E
 
-L018C               ldx       $2a,s
+L018B               ldx       $2a,s
                     leax      $02,x
                     stx       $2a,s
                     ldu       ,x
                     ldb       ,u
                     cmpb      #$2d
-                    lbne      L023B
-                    lbra      L0231
+                    lbne      L023A
+                    lbra      L0230
 
-L01A1               ldb       ,u
+L01A0               ldb       ,u
                     sex
                     tfr       d,x
-                    lbra      L0215
+                    lbra      L0214
 
-L01A9               ldd       #$0001
+L01A8               ldd       #$0001
                     std       $0011
-                    lbra      L0231
+                    lbra      L0230
 
-L01B1               ldd       #$0001
-                    std       copybytes
-                    leax      L0B05,pcr
+L01B0               ldd       #$0001
+                    std       L0015
+                    leax      L0B04,pcr
                     pshs      x
-                    lbsr      L09DC
+                    lbsr      L09DB
                     leas      $02,s
-                    lbra      L0231
+                    lbra      L0230
 
-L01C4               leau      $01,u
+L01C3               leau      $01,u
                     ldb       ,u
                     cmpb      #$3d
-                    bne       L01DB
+                    bne       L01DA
                     leau      $01,u
                     pshs      u
-                    lbsr      L09DC
+                    lbsr      L09DB
                     leas      $02,s
                     leax      $24,s
-                    lbra      L028C
+                    lbra      L028B
 
-L01DB               leau      -$01,u
+L01DA               leau      -$01,u
                     pshs      u
-                    leax      L0B0F,pcr
+                    leax      L0B0E,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-L01F3               ldd       #$0001
+                    lbsr      L0ADF
+L01F2               ldd       #$0001
                     std       $0013
-                    bra       L0231
+                    bra       L0230
 
-L01FA               ldb       ,u
+L01F9               ldb       ,u
                     sex
                     pshs      d
-                    leax      L0B21,pcr
+                    leax      L0B20,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-                    bra       L0231
+                    lbsr      L0ADF
+                    bra       L0230
 
-L0215               cmpx      #$0073
-                    lbeq      L01A9
+L0214               cmpx      #$0073
+                    lbeq      L01A8
                     cmpx      #$006E
-                    lbeq      L01B1
+                    lbeq      L01B0
                     cmpx      #$006F
-                    lbeq      L01C4
+                    lbeq      L01C3
                     cmpx      #$0070
-                    beq       L01F3
-                    bra       L01FA
+                    beq       L01F2
+                    bra       L01F9
 
-L0231               leau      $01,u
+L0230               leau      $01,u
                     ldb       ,u
-                    lbne      L01A1
-                    bra       L028F
+                    lbne      L01A0
+                    bra       L028E
 
-L023B               ldd       $0003
-                    beq       L025F
+L023A               ldd       $0003
+                    beq       L025E
                     ldd       $0280,y
-                    beq       L0259
-                    leax      L0B37,pcr
+                    beq       L0258
+                    leax      L0B36,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $04,s
-                    lbsr      L0AE0
-L0259               stu       $0280,y
-                    bra       L028F
+                    lbsr      L0ADF
+L0258               stu       $0280,y
+                    bra       L028E
 
-L025F               leax      L0B46,pcr
+L025E               leax      L0B45,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L4F07
+                    lbsr      L4F06
                     leas      $04,s
                     std       $0003
-                    bne       L0286
+                    bne       L0285
                     pshs      u
-                    leax      $0B48,pcr
+                    leax      $0B47,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-L0286               stu       $0284,y
-                    bra       L028F
+                    lbsr      L0ADF
+L0285               stu       $0284,y
+                    bra       L028E
 
-L028C               leas      -$24,x
-L028F               ldd       $28,s
+L028B               leas      -$24,x
+L028E               ldd       $28,s
                     addd      #$FFFF
                     std       $28,s
-                    lbne      L018C
+                    lbne      L018B
                     ldd       $0005
-                    bne       L02A6
+                    bne       L02A5
                     leax      $00CE,y
                     stx       $0005
-L02A6               ldd       $0003
-                    bne       L02B0
+L02A5               ldd       $0003
+                    bne       L02AF
                     leax      $00C1,y
                     stx       $0003
-L02B0               ldd       $0280,y
-                    bne       L02BE
-                    leax      L0B57,pcr
+L02AF               ldd       $0280,y
+                    bne       L02BD
+                    leax      L0B56,pcr
                     stx       $0280,y
-L02BE               lbra      L076F
+L02BD               lbra      L076E
 
-L02C1               ldx       $1a,s
-                    lbra      L06D4
+L02C0               ldx       $1a,s
+                    lbra      L06D3
 
-L02C7               ldd       $0003
+L02C6               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1a,s
                     cmpd      #$FFFF
-                    beq       L02F0
+                    beq       L02EF
                     ldd       $0005
                     pshs      d
                     ldd       $1C,s
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
                     ldd       $1a,s
                     cmpd      #$000D
-                    bne       L02C7
-L02F0               lbra      L076F
+                    bne       L02C6
+L02EF               lbra      L076E
 
-L02F3               ldd       $0003
+L02F2               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $0007
                     leax      $14,s
                     pshs      x
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     clra
-                    lbsr      $5E0B
+                    lbsr      L5E0A
                     pshs      x
                     ldd       #$0010
-                    lbsr      $5E3A
-                    lbsr      $5E24
+                    lbsr      L5E39
+                    lbsr      L5E23
                     leax      $14,s
                     pshs      x
                     ldd       $02,x
@@ -356,11 +347,11 @@ L02F3               ldd       $0003
                     pshs      d
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
-                    lbsr      $5E0B
-                    lbsr      $5D96
-                    lbsr      $5E24
+                    lbsr      L5E0A
+                    lbsr      L5D95
+                    lbsr      L5E23
                     leax      $14,s
                     ldd       $02,x
                     pshs      d
@@ -368,76 +359,76 @@ L02F3               ldd       $0003
                     pshs      d
                     ldd       $0007
                     pshs      d
-                    lbsr      L4897
+                    lbsr      L4896
                     leas      $06,s
-                    lbra      L076F
+                    lbra      L076E
 
-L0351               ldd       $0003
+L0350               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $22,s
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $000B
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $000D
                     ldd       L0017
                     cmpd      $000D
-                    ble       L037E
+                    ble       L037D
                     ldd       $000D
                     std       L0017
-L037E               ldx       $22,s
-                    bra       L03C4
+L037D               ldx       $22,s
+                    bra       L03C3
 
-L0383               ldd       $0003
+L0382               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $1e,s
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $20,s
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1C,s
-                    bra       L03D3
+                    bra       L03D2
 
-L03A9               ldd       $0003
+L03A8               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       L0023
-                    bra       L03D3
+                    bra       L03D2
 
-L03B6               ldd       $0003
+L03B5               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $18,s
-                    bra       L03D3
+                    bra       L03D2
 
-L03C4               cmpx      #$0002
-                    beq       L0383
+L03C3               cmpx      #$0002
+                    beq       L0382
                     cmpx      #$0005
-                    beq       L03A9
+                    beq       L03A8
                     cmpx      #$0012
-                    beq       L03B6
-L03D3               lbsr      L0788
+                    beq       L03B5
+L03D2               lbsr      L0787
                     std       $0282,y
                     ldx       $22,s
-                    lbra      L046B
+                    lbra      L046A
 
-L03E0               ldd       $1C,s
+L03DF               ldd       $1C,s
                     pshs      d
                     ldd       $22,s
                     pshs      d
@@ -445,32 +436,32 @@ L03E0               ldd       $1C,s
                     pshs      d
                     ldd       $0282,y
                     pshs      d
-                    lbsr      L1F14
+                    lbsr      L1F13
                     leas      $08,s
-                    lbra      L048E
+                    lbra      L048D
 
-L03FD               ldd       $18,s
+L03FC               ldd       $18,s
                     pshs      d
                     ldd       $0282,y
                     pshs      d
-                    lbsr      L0A17
+                    lbsr      L0A16
                     leas      $04,s
-                    lbra      L048E
+                    lbra      L048D
 
-L0410               ldd       $0282,y
+L040F               ldd       $0282,y
                     pshs      d
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     std       $0282,y
-                    lbra      L048E
+                    lbra      L048D
 
-L0422               ldd       $0282,y
+L0421               ldd       $0282,y
                     pshs      d
-                    lbsr      L0BF8
+                    lbsr      L0BF7
                     leas      $02,s
-                    lbra      L048E
+                    lbra      L048D
 
-L0430               lbsr      $4B89
+L042F               lbsr      $4B88
                     clra
                     clrb
                     pshs      d
@@ -478,208 +469,208 @@ L0430               lbsr      $4B89
                     pshs      d
                     ldd       #$0077
                     pshs      d
-                    lbsr      L40D1
+                    lbsr      L40D0
                     leas      $06,s
-                    lbsr      L43DD
+                    lbsr      L43DC
                     clra
                     clrb
                     std       L0023
-                    bra       L048E
+                    bra       L048D
 
-L0450               ldd       $22,s
+L044F               ldd       $22,s
                     pshs      d
-                    leax      $0B58,pcr
+                    leax      $0B57,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-                    bra       L048E
+                    lbsr      L0ADF
+                    bra       L048D
 
-L046B               cmpx      #$0002
-                    lbeq      L03E0
+L046A               cmpx      #$0002
+                    lbeq      L03DF
                     cmpx      #$0012
-                    lbeq      L03FD
+                    lbeq      L03FC
                     cmpx      #$0004
-                    lbeq      L0410
+                    lbeq      L040F
                     cmpx      #$0001
-                    lbeq      L0422
+                    lbeq      L0421
                     cmpx      #$0005
-                    beq       L0430
-                    bra       L0450
+                    beq       L042F
+                    bra       L044F
 
-L048E               ldd       $0282,y
+L048D               ldd       $0282,y
                     pshs      d
-                    lbsr      L4A6A
-                    lbra      L0511
+                    lbsr      L4A69
+                    lbra      L0510
 
-L049A               ldd       $0003
+L0499               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
-                    lbsr      L4415
-                    lbra      L0511
+                    lbsr      L4414
+                    lbra      L0510
 
-L04A9               ldd       $1a,s
+L04A8               ldd       $1a,s
                     cmpd      #$0064
-                    bne       L04B7
+                    bne       L04B6
                     ldd       #$0001
-                    bra       L04B9
+                    bra       L04B8
 
-L04B7               clra
+L04B6               clra
                     clrb
-L04B9               pshs      d
-                    lbsr      L4C3F
-                    bra       L0511
+L04B8               pshs      d
+                    lbsr      L4C3E
+                    bra       L0510
 
-L04C0               lbsr      L4C55
-                    lbra      L076F
+L04BF               lbsr      L4C54
+                    lbra      L076E
 
-L04C6               ldd       $1a,s
+L04C5               ldd       $1a,s
                     cmpd      #$FFFF
-                    beq       L04FC
+                    beq       L04FB
                     ldd       $1a,s
                     cmpd      #$005C
-                    bne       L04E4
+                    bne       L04E3
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1a,s
-L04E4               ldd       $1a,s
+L04E3               ldd       $1a,s
                     pshs      d
-                    lbsr      L4C93
+                    lbsr      L4C92
                     leas      $02,s
-L04EE               ldd       $0003
+L04ED               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1a,s
-                    bne       L04C6
-L04FC               clra
+                    bne       L04C5
+L04FB               clra
                     clrb
                     pshs      d
-                    lbsr      L4C93
-                    bra       L0511
+                    lbsr      L4C92
+                    bra       L0510
 
-L0505               ldd       $0003
+L0504               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
-                    lbsr      L0AC3
-L0511               leas      $02,s
-                    lbra      L076F
+                    lbsr      L0AC2
+L0510               leas      $02,s
+                    lbra      L076E
 
-L0516               clra
+L0515               clra
                     clrb
                     pshs      d
                     clra
                     clrb
                     pshs      d
                     ldd       #$0012
-                    lbra      L057E
+                    lbra      L057D
 
-L0524               ldd       $0003
+L0523               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $18,s
                     pshs      d
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
                     ldd       #$007D
-                    bra       L057E
+                    bra       L057D
 
-L0540               clra
+L053F               clra
                     clrb
                     pshs      d
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
                     ldd       #$001D
-                    bra       L057E
+                    bra       L057D
 
-L0552               clra
+L0551               clra
                     clrb
                     pshs      d
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
                     ldd       #$007C
-                    bra       L057E
+                    bra       L057D
 
-L0564               ldd       $0003
+L0563               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $18,s
                     pshs      d
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
                     ldd       #$0009
-L057E               pshs      d
-                    lbsr      L3293
+L057D               pshs      d
+                    lbsr      L3292
                     leas      $06,s
-                    lbra      L076F
+                    lbra      L076E
 
-L0588               ldd       $0003
+L0587               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
                     ldd       #$0076
-                    bra       L05A2
+                    bra       L05A1
 
-L0596               ldd       $0003
+L0595               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
                     ldd       #$006F
-L05A2               pshs      d
-                    lbsr      L3293
+L05A1               pshs      d
+                    lbsr      L3292
                     leas      $04,s
-                    lbra      L076F
+                    lbra      L076E
 
-L05AC               ldd       $0003
+L05AB               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $18,s
                     ldd       $0011
-                    bne       L05C7
+                    bne       L05C6
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $000B
-L05C7               leau      ,s
-                    bra       L05D0
+L05C6               leau      ,s
+                    bra       L05CF
 
-L05CB               ldd       $1a,s
+L05CA               ldd       $1a,s
                     stb       ,u+
-L05D0               ldd       $0003
+L05CF               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1a,s
-                    bne       L05CB
+                    bne       L05CA
                     clra
                     clrb
                     stb       ,u
                     ldd       $0013
-                    beq       L05F2
+                    beq       L05F1
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $1a,s
-L05F2               ldd       $1a,s
+L05F1               ldd       $1a,s
                     pshs      d
                     ldd       $000B
                     pshs      d
@@ -687,17 +678,17 @@ L05F2               ldd       $1a,s
                     pshs      d
                     leax      $06,s
                     pshs      x
-                    lbsr      L4B97
+                    lbsr      L4B96
                     leas      $08,s
-                    lbra      L076F
+                    lbra      L076E
 
-L060C               lbsr      L4C1B
-                    lbra      L076F
+L060B               lbsr      L4C1A
+                    lbra      L076E
 
-L0612               leas      -$0a,s
+L0611               leas      -$0a,s
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       ,s
                     ldd       $0003
@@ -708,253 +699,253 @@ L0612               leas      -$0a,s
                     pshs      d
                     leax      $08,s
                     pshs      x
-                    lbsr      L4F59
+                    lbsr      L4F58
                     leas      $08,s
                     leax      $02,s
                     pshs      x
-                    lbsr      L095D
+                    lbsr      L095C
                     leas      $02,s
                     ldd       ,s
                     cmpd      #$0006
-                    bne       L0655
+                    bne       L0654
                     ldd       #$0004
                     pshs      d
                     leax      $04,s
                     pshs      x
-                    lbsr      L3DD1
-                    bra       L0671
+                    lbsr      L3DD0
+                    bra       L0670
 
-L0655               leas      -$04,s
+L0654               leas      -$04,s
                     leax      ,s
                     pshs      x
                     leax      $08,s
-                    lbsr      L56F3
-                    lbsr      $5D69
+                    lbsr      L56F2
+                    lbsr      L5D68
                     ldd       #$0002
                     pshs      d
                     leax      $02,s
                     pshs      x
-                    lbsr      L3DD1
+                    lbsr      L3DD0
                     leas      $04,s
-L0671               leas      $04,s
+L0670               leas      $04,s
                     leas      $0a,s
-                    lbra      L076F
+                    lbra      L076E
                     leas      $0a,s
-L067A               lbsr      L4C62
-                    lbra      L076F
+L0679               lbsr      L4C61
+                    lbra      L076E
 
-L0680               leau      $0262,y
-                    bra       L069F
+L067F               leau      $0262,y
+                    bra       L069E
 
-L0686               ldd       $1a,s
+L0685               ldd       $1a,s
                     cmpd      #$FFFF
-                    beq       L06B1
+                    beq       L06B0
                     leax      $027f,y
                     pshs      x
                     cmpu      ,s++
-                    beq       L069F
+                    beq       L069E
                     ldd       $1a,s
                     stb       ,u+
-L069F               ldd       $0003
+L069E               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1a,s
                     cmpd      #$000D
-                    bne       L0686
-L06B1               clra
+                    bne       L0685
+L06B0               clra
                     clrb
                     stb       ,u
-                    lbra      L076F
+                    lbra      L076E
 
-L06B8               ldd       $1a,s
+L06B7               ldd       $1a,s
                     pshs      d
-                    leax      L0B6D,pcr
+                    leax      L0B6C,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-                    lbra      L076F
+                    lbsr      L0ADF
+                    lbra      L076E
 
-L06D4               cmpx      #$002A
-                    lbeq      L02C7
+L06D3               cmpx      #$002A
+                    lbeq      L02C6
                     cmpx      #$004F
-                    lbeq      L02F3
+                    lbeq      L02F2
                     cmpx      #$0054
-                    lbeq      L0351
+                    lbeq      L0350
                     cmpx      #$006C
-                    lbeq      L049A
+                    lbeq      L0499
                     cmpx      #$0076
-                    lbeq      L04A9
+                    lbeq      L04A8
                     cmpx      #$0064
-                    lbeq      L04A9
+                    lbeq      L04A8
                     cmpx      #$0065
-                    lbeq      L04C0
+                    lbeq      L04BF
                     cmpx      #$0073
-                    lbeq      L04EE
+                    lbeq      L04ED
                     cmpx      #$004D
-                    lbeq      L0505
+                    lbeq      L0504
                     cmpx      #$0072
-                    lbeq      L0516
+                    lbeq      L0515
                     cmpx      #$004A
-                    lbeq      L0524
+                    lbeq      L0523
                     cmpx      #$0047
-                    lbeq      L0540
+                    lbeq      L053F
                     cmpx      #$006A
-                    lbeq      L0552
+                    lbeq      L0551
                     cmpx      #$0044
-                    lbeq      L0564
+                    lbeq      L0563
                     cmpx      #$0059
-                    lbeq      L0588
+                    lbeq      L0587
                     cmpx      #$0055
-                    lbeq      L0596
+                    lbeq      L0595
                     cmpx      #$0053
-                    lbeq      L05AC
+                    lbeq      L05AB
                     cmpx      #$0045
-                    lbeq      L060C
+                    lbeq      L060B
                     cmpx      #$0066
-                    lbeq      L0612
+                    lbeq      L0611
                     cmpx      #$0070
-                    lbeq      L067A
+                    lbeq      L0679
                     cmpx      #$0046
-                    lbeq      L0680
+                    lbeq      L067F
                     cmpx      #$000D
-                    beq       L076F
-                    lbra      L06B8
+                    beq       L076E
+                    lbra      L06B7
 
-L076F               ldd       $0003
+L076E               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $1a,s
                     cmpd      #$FFFF
-                    lbne      L02C1
+                    lbne      L02C0
                     leas      $24,s
                     puls      pc,u
-L0788               pshs      u
+L0787               pshs      u
                     ldd       #$FFAA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$0a,s
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $06,s
                     ldd       #$0016
                     pshs      d
-                    lbsr      $3110
+                    lbsr      $310F
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    bne       L07B0
-                    lbsr      L4835
-L07B0               ldd       $0003
+                    bne       L07AF
+                    lbsr      L4834
+L07AF               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       ,u
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $02,u
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $06,u
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $0e,u
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     clra
                     std       $10,u
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $12,u
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     std       $14,u
                     ldx       $06,u
-                    lbra      L08F5
+                    lbra      L08F4
 
-L0806               ldd       #$000D
+L0805               ldd       #$000D
                     pshs      d
-                    lbsr      $3110
+                    lbsr      $310F
                     leas      $02,s
                     std       $08,s
                     std       $08,u
                     ldd       $08,s
-                    bne       L081B
-                    lbsr      L4835
-L081B               ldd       $0003
+                    bne       L081A
+                    lbsr      L4834
+L081A               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     ldx       $08,s
                     std       $02,x
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       [$08,s]
                     ldx       [$08,s]
-                    bra       L086B
+                    bra       L086A
 
-L0839               ldd       $08,s
+L0838               ldd       $08,s
                     addd      #$0004
                     std       $04,s
-L0840               ldd       $0003
+L083F               ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     ldx       $04,s
                     leax      $01,x
                     stx       $04,s
                     stb       -$01,x
-                    bne       L0840
+                    bne       L083F
                     clra
                     clrb
                     stb       [$04,s]
-                    lbra      L090A
+                    lbra      L0909
 
-L085B               ldd       $0003
+L085A               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
                     ldx       $08,s
                     std       $04,x
-                    lbra      L090A
+                    lbra      L0909
 
-L086B               cmpx      #$000E
-                    beq       L0839
+L086A               cmpx      #$000E
+                    beq       L0838
                     cmpx      #$000C
-                    lbeq      L0839
+                    lbeq      L0838
                     cmpx      #$0021
-                    lbeq      L0839
+                    lbeq      L0838
                     cmpx      #$0022
-                    lbeq      L0839
-                    bra       L085B
+                    lbeq      L0838
+                    bra       L085A
 
-L0887               ldd       #$0004
+L0886               ldd       #$0004
                     pshs      d
-                    lbsr      $3110
+                    lbsr      $310F
                     leas      $02,s
                     std       $02,s
-                    bne       L0898
-                    lbsr      L4835
-L0898               ldd       $0003
+                    bne       L0897
+                    lbsr      L4834
+L0897               ldd       $0003
                     pshs      d
                     ldd       #$0001
                     pshs      d
@@ -962,19 +953,19 @@ L0898               ldd       $0003
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L4F59
+                    lbsr      L4F58
                     leas      $08,s
                     ldd       $02,s
-                    bra       L08F1
+                    bra       L08F0
 
-L08B3               ldd       #$0008
+L08B2               ldd       #$0008
                     pshs      d
-                    lbsr      $3110
+                    lbsr      $310F
                     leas      $02,s
                     std       ,s
-                    bne       L08C4
-                    lbsr      L4835
-L08C4               ldd       $0003
+                    bne       L08C3
+                    lbsr      L4834
+L08C3               ldd       $0003
                     pshs      d
                     ldd       #$0001
                     pshs      d
@@ -982,75 +973,75 @@ L08C4               ldd       $0003
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L4F59
+                    lbsr      L4F58
                     leas      $08,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L095D
+                    lbsr      L095C
                     leas      $02,s
                     ldd       ,s
-                    bra       L08F1
+                    bra       L08F0
 
-L08E8               ldd       $0003
+L08E7               ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     leas      $02,s
-L08F1               std       $08,u
-                    bra       L090A
+L08F0               std       $08,u
+                    bra       L0909
 
-L08F5               cmpx      #$0034
-                    lbeq      L0806
+L08F4               cmpx      #$0034
+                    lbeq      L0805
                     cmpx      #$004A
-                    lbeq      L0887
+                    lbeq      L0886
                     cmpx      #$004B
-                    beq       L08B3
-                    bra       L08E8
+                    beq       L08B2
+                    bra       L08E7
 
-L090A               clra
+L0909               clra
                     clrb
                     std       $0a,u
                     ldx       $06,s
-                    bra       L0941
+                    bra       L0940
 
-L0912               lbsr      L0788
+L0911               lbsr      L0787
                     std       $0a,u
-L0917               lbsr      L0788
-                    bra       L0923
+L0916               lbsr      L0787
+                    bra       L0922
 
-L091C               lbsr      L0788
+L091B               lbsr      L0787
                     std       $0a,u
-L0921               clra
+L0920               clra
                     clrb
-L0923               std       $0C,u
-                    bra       L0957
+L0922               std       $0C,u
+                    bra       L0956
 
-L0927               ldd       $06,s
+L0926               ldd       $06,s
                     pshs      d
-                    leax      L0B92,pcr
+                    leax      L0B91,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-                    bra       L0957
+                    lbsr      L0ADF
+                    bra       L0956
 
-L0941               cmpx      #$0042
-                    beq       L0912
+L0940               cmpx      #$0042
+                    beq       L0911
                     cmpx      #$0052
-                    beq       L0917
+                    beq       L0916
                     cmpx      #$004C
-                    beq       L091C
+                    beq       L091B
                     cmpx      #$004E
-                    beq       L0921
-                    bra       L0927
+                    beq       L0920
+                    bra       L0926
 
-L0957               tfr       u,d
+L0956               tfr       u,d
                     leas      $0a,s
                     puls      pc,u
-L095D               pshs      u
+L095C               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$08,s
                     stu       $06,s
@@ -1065,19 +1056,19 @@ L095D               pshs      u
                     clra
                     andb      #$80
                     std       ,s
-                    beq       L098C
+                    beq       L098B
                     ldb       [$06,s]
                     clra
                     andb      #$7f
                     stb       [$06,s]
-L098C               leax      ,u
+L098B               leax      ,u
                     pshs      x
                     pshs      u
-                    lbsr      L5676
+                    lbsr      L5675
                     leas      $02,s
-                    lbsr      L5D79
+                    lbsr      L5D78
                     ldd       $02,s
-                    bge       L09AA
+                    bge       L09A9
                     ldd       $02,s
                     nega
                     negb
@@ -1085,10 +1076,10 @@ L098C               leax      ,u
                     std       $02,s
                     clra
                     clrb
-                    bra       L09AD
+                    bra       L09AC
 
-L09AA               ldd       #$0001
-L09AD               std       $04,s
+L09A9               ldd       #$0001
+L09AC               std       $04,s
                     leax      ,u
                     pshs      x
                     ldd       $06,s
@@ -1096,192 +1087,192 @@ L09AD               std       $04,s
                     ldd       $06,s
                     pshs      d
                     leax      ,u
-                    lbsr      $5D52
-                    lbsr      L55A3
+                    lbsr      L5D51
+                    lbsr      L55A2
                     leas      $0C,s
-                    lbsr      L5D79
+                    lbsr      L5D78
                     ldd       ,s
-                    beq       L09D8
+                    beq       L09D7
                     leax      ,u
                     pshs      x
                     leax      ,u
-                    lbsr      L5691
-                    lbsr      L5D79
-L09D8               leas      $08,s
+                    lbsr      L5690
+                    lbsr      L5D78
+L09D7               leas      $08,s
                     puls      pc,u
-L09DC               pshs      u
+L09DB               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldd       $0005
-                    beq       L09EA
+                    beq       L09E9
                     puls      pc,u
-L09EA               leax      L0BA7,pcr
+L09E9               leax      L0BA6,pcr
                     pshs      x
                     ldd       $06,s
                     pshs      d
-                    lbsr      L4F07
+                    lbsr      L4F06
                     leas      $04,s
                     std       $0005
-                    bne       L0A15
+                    bne       L0A14
                     ldd       $04,s
                     pshs      d
-                    leax      $0BA9,pcr
+                    leax      $0BA8,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbsr      L0AE0
-L0A15               puls      pc,u
-L0A17               pshs      u
+                    lbsr      L0ADF
+L0A14               puls      pc,u
+L0A16               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldx       $06,s
-                    lbra      L0AAA
+                    lbra      L0AA9
 
-L0A26               pshs      u
-                    lbsr      L2506
+L0A25               pshs      u
+                    lbsr      L2505
                     leas      $02,s
                     leax      ,s
-                    bra       L0A3A
+                    bra       L0A39
 
-L0A31               pshs      u
-                    lbsr      L29FD
+L0A30               pshs      u
+                    lbsr      L29FC
                     leas      $02,s
-                    bra       L0A3C
+                    bra       L0A3B
 
-L0A3A               leas      ,x
-L0A3C               ldd       $06,u
+L0A39               leas      ,x
+L0A3B               ldd       $06,u
                     cmpd      #$0080
-                    lbeq      L0AC1
+                    lbeq      L0AC0
                     ldd       #$0080
                     pshs      d
                     ldd       #$006F
                     pshs      d
                     ldd       #$007F
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       #$006F
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldx       $06,s
-                    bra       L0A93
+                    bra       L0A92
 
-L0A6D               ldd       $06,s
+L0A6C               ldd       $06,s
                     pshs      d
                     ldd       #$0089
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L0AC1
+                    bra       L0AC0
 
-L0A82               ldd       #$0089
+L0A81               ldd       #$0089
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-                    bra       L0AC1
+                    bra       L0AC0
 
-L0A93               cmpx      #$0005
-                    beq       L0A6D
+L0A92               cmpx      #$0005
+                    beq       L0A6C
                     cmpx      #$0006
-                    lbeq      L0A6D
-                    bra       L0A82
+                    lbeq      L0A6C
+                    bra       L0A81
 
-L0AA1               pshs      u
-                    lbsr      L0BC4
+L0AA0               pshs      u
+                    lbsr      L0BC3
                     leas      $02,s
-                    bra       L0AC1
+                    bra       L0AC0
 
-L0AAA               cmpx      #$0008
-                    lbeq      L0A26
+L0AA9               cmpx      #$0008
+                    lbeq      L0A25
                     cmpx      #$0005
-                    lbeq      L0A31
+                    lbeq      L0A30
                     cmpx      #$0006
-                    lbeq      L0A31
-                    bra       L0AA1
+                    lbeq      L0A30
+                    bra       L0AA0
 
-L0AC1               puls      pc,u
-L0AC3               pshs      u
+L0AC0               puls      pc,u
+L0AC2               pshs      u
                     ldd       #$FFB6
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    leax      L0BB8,pcr
+                    leax      L0BB7,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
                     puls      pc,u
-L0AE0               pshs      u
+L0ADF               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldd       $0284,y
-                    beq       L0AF9
+                    beq       L0AF8
                     ldd       $0284,y
                     pshs      d
-                    lbsr      $60C2
+                    lbsr      L60C1
                     leas      $02,s
-L0AF9               ldd       #$0001
+L0AF8               ldd       #$0001
                     pshs      d
-                    lbsr      exit
+                    lbsr      L6229
                     leas      $02,s
                     puls      pc,u
-L0B05               fcc       |/dev/null|
+L0B04               fcc       |/dev/null|
                     fcb       $00
-L0B0F               fcc       /bad argument: %s/
+L0B0E               fcc       /bad argument: %s/
                     fcb       $0D,$00
-L0B21               fcc       /bad option flag: +%c/
+L0B20               fcc       /bad option flag: +%c/
                     fcb       $0D,$00
-L0B37               fcc       /too many files/
+L0B36               fcc       /too many files/
                     fcb       $00
-L0B46               fcb       $72
+L0B45               fcb       $72
                     neg       $0063
                     fcb       $61
                     jmp       $07,y
-                    lsr       $206F
+                    lsr       L206F
                     neg       $656E
-                    bra       L0B79
-                    com       $0D00
-L0B57               neg       L0062
+                    bra       L0B78
+                    com       L0D00
+L0B56               neg       L0062
                     fcc       /ad action code: %d/
                     fcb       $0D,$00
-L0B6D               fcc       /bad code in /
-L0B79               fcc       /intermediate file: %02x/
+L0B6C               fcc       /bad code in /
+L0B78               fcc       /intermediate file: %02x/
                     fcb       $0D,$00
-L0B92               fcc       /bad node type: %02x/
+L0B91               fcc       /bad node type: %02x/
                     fcb       $0D,$00
-L0BA7               asr       >$0063
+L0BA6               asr       >$0063
                     fcb       $61
                     jmp       $07,y
-                    lsr       $206F
+                    lsr       L206F
                     neg       $656E
-                    bra       $0BDA
-                    com       $0D00
-L0BB8               bra       $0C26
+                    bra       $0BD9
+                    com       L0D00
+L0BB7               bra       $0C25
                     fcb       $65,$61
-                    com       L2025
+                    com       $2025
                     lsr       $0C,y
-                    com       $0D00
-L0BC4               pshs      u
+                    com       L0D00
+L0BC3               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     pshs      u
-                    lbsr      L0C2E
+                    lbsr      L0C2D
                     leas      $02,s
                     ldd       $06,u
                     cmpd      #$0070
-                    beq       L0C2C
+                    beq       L0C2B
                     pshs      u
                     ldd       #$0077
                     pshs      d
@@ -1289,21 +1280,21 @@ L0BC4               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
-                    bra       L0C2A
+                    bra       L0C29
 
-L0BF8               pshs      u
+L0BF7               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     pshs      u
-                    lbsr      L1C1E
+                    lbsr      L1C1D
                     leas      $02,s
                     ldd       $06,u
                     cmpd      #$0071
-                    beq       L0C2C
+                    beq       L0C2B
                     pshs      u
                     ldd       #$0077
                     pshs      d
@@ -1311,67 +1302,67 @@ L0BF8               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0071
-L0C2A               std       $06,u
-L0C2C               puls      pc,u
-L0C2E               pshs      u
+L0C29               std       $06,u
+L0C2B               puls      pc,u
+L0C2D               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldx       ,u
-                    bra       L0C59
+                    bra       L0C58
 
-L0C3C               pshs      u
-                    lbsr      L2506
-                    bra       L0C55
+L0C3B               pshs      u
+                    lbsr      L2505
+                    bra       L0C54
 
-L0C43               pshs      u
-                    lbsr      L29FD
-                    bra       L0C55
+L0C42               pshs      u
+                    lbsr      L29FC
+                    bra       L0C54
 
-L0C4A               pshs      u
-                    lbsr      L0D05
+L0C49               pshs      u
+                    lbsr      L0D04
                     leas      $02,s
                     pshs      u
-                    bsr       L0C6E
-L0C55               leas      $02,s
-                    bra       L0C6C
+                    bsr       L0C6D
+L0C54               leas      $02,s
+                    bra       L0C6B
 
-L0C59               cmpx      #$0008
-                    beq       L0C3C
+L0C58               cmpx      #$0008
+                    beq       L0C3B
                     cmpx      #$0005
-                    beq       L0C43
+                    beq       L0C42
                     cmpx      #$0006
-                    lbeq      L0C43
-                    bra       L0C4A
+                    lbeq      L0C42
+                    bra       L0C49
 
-L0C6C               puls      pc,u
-L0C6E               pshs      u
+L0C6B               puls      pc,u
+L0C6D               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldx       $06,u
-                    lbra      L0CE1
+                    lbra      L0CE0
 
-L0C7D               pshs      u
+L0C7C               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0071
                     std       $06,u
                     clra
                     clrb
                     std       $08,u
-                    lbra      L0D03
+                    lbra      L0D02
 
-L0C9F               ldd       $0a,u
+L0C9E               ldd       $0a,u
                     pshs      d
                     ldd       #$0077
                     pshs      d
@@ -1379,123 +1370,123 @@ L0C9F               ldd       $0a,u
                     pshs      d
                     ldd       #$007F
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     clra
                     clrb
                     std       $08,u
                     ldd       #$0071
-                    bra       L0CDD
+                    bra       L0CDC
 
-L0CC0               pshs      u
+L0CBF               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L0CDA
+                    bra       L0CD9
                     leas      ,x
-L0CDA               ldd       #$0070
-L0CDD               std       $06,u
-                    bra       L0D03
+L0CD9               ldd       #$0070
+L0CDC               std       $06,u
+                    bra       L0D02
 
-L0CE1               cmpx      #$0037
-                    lbeq      L0C7D
+L0CE0               cmpx      #$0037
+                    lbeq      L0C7C
                     cmpx      #$0041
-                    beq       L0C9F
+                    beq       L0C9E
                     cmpx      #$0071
-                    beq       L0D03
+                    beq       L0D02
                     cmpx      #$0070
-                    beq       L0D03
+                    beq       L0D02
                     cmpx      #$006F
-                    beq       L0D03
+                    beq       L0D02
                     cmpx      #$0076
-                    beq       L0D03
-                    bra       L0CC0
+                    beq       L0D02
+L0D00               bra       L0CBF
 
-L0D03               puls      pc,u
-L0D05               pshs      u
+L0D02               puls      pc,u
+L0D04               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     std       ,s
                     cmpd      #$0030
-                    bne       L0D4E
+                    bne       L0D4D
                     leas      -$02,s
                     ldd       $0C,u
                     std       ,s
                     ldd       $0a,u
                     pshs      d
-                    bsr       L0D05
+                    bsr       L0D04
                     std       ,s
-                    lbsr      L4A6A
+                    lbsr      L4A69
                     leas      $02,s
                     pshs      u
                     ldd       $02,s
                     pshs      d
-                    lbsr      L4ACE
+                    lbsr      L4ACD
                     leas      $04,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L4A8B
+                    lbsr      L4A8A
                     leas      $02,s
                     pshs      u
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     leas      $02,s
-                    lbra      L0EF8
+                    lbra      L0EF7
 
-L0D4E               ldd       ,u
+L0D4D               ldd       ,u
                     cmpd      #$0008
-                    bne       L0D60
+                    bne       L0D5F
                     pshs      u
-                    lbsr      L2521
+                    lbsr      L2520
                     leas      $02,s
-                    lbra      L0EF8
+                    lbra      L0EF7
 
-L0D60               ldd       ,u
+L0D5F               ldd       ,u
                     cmpd      #$0005
-                    beq       L0D70
+                    beq       L0D6F
                     ldd       ,u
                     cmpd      #$0006
-                    bne       L0D7A
-L0D70               pshs      u
-                    lbsr      L2A18
+                    bne       L0D79
+L0D6F               pshs      u
+                    lbsr      L2A17
                     leas      $02,s
-                    lbra      L0EF8
+                    lbra      L0EF7
 
-L0D7A               ldd       ,s
+L0D79               ldd       ,s
                     pshs      d
-                    lbsr      L4AF8
+                    lbsr      L4AF7
                     std       ,s++
-                    beq       L0D93
+                    beq       L0D92
                     pshs      u
                     ldd       $02,s
                     pshs      d
-                    lbsr      L0EFE
+                    lbsr      L0EFD
                     leas      $04,s
-                    lbra      L0EF8
+                    lbra      L0EF7
 
-L0D93               ldx       ,s
-                    lbra      L0E5F
+L0D92               ldx       ,s
+                    lbra      L0E5E
 
-L0D98               pshs      u
-                    lbsr      L1568
-                    lbra      L0E28
+L0D97               pshs      u
+                    lbsr      L1567
+                    lbra      L0E27
 
-L0DA0               ldd       $0a,u
+L0D9F               ldd       $0a,u
                     pshs      d
-                    lbsr      L0D05
-                    lbra      L0E28
+                    lbsr      L0D04
+                    lbra      L0E27
 
-L0DAA               ldd       $0a,u
+L0DA9               ldd       $0a,u
                     pshs      d
-                    lbsr      L2521
+                    lbsr      L2520
                     leas      $02,s
                     ldd       $0a,u
                     pshs      d
@@ -1503,133 +1494,133 @@ L0DAA               ldd       $0a,u
                     pshs      d
                     ldd       #$0084
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L0E0F
+                    bra       L0E0E
 
-L0DC8               ldd       $0a,u
+L0DC7               ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       #$008F
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
-                    bra       L0E0D
+                    lbsr      L3292
+                    bra       L0E0C
 
-L0DE0               pshs      u
-                    lbsr      L1954
-                    bra       L0E28
+L0DDF               pshs      u
+                    lbsr      L1953
+                    bra       L0E27
 
-L0DE7               pshs      u
-                    lbsr      L124D
-                    bra       L0E28
+L0DE6               pshs      u
+                    lbsr      L124C
+                    bra       L0E27
 
-L0DEE               ldd       $0a,u
+L0DED               ldd       $0a,u
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $02,s
-                    bra       L0E0F
+                    bra       L0E0E
 
-L0E02               leax      L0BC4,pcr
+L0E01               leax      L0BC3,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L12E9
-L0E0D               leas      $04,s
-L0E0F               ldd       #$0070
+                    lbsr      L12E8
+L0E0C               leas      $04,s
+L0E0E               ldd       #$0070
                     std       $06,u
-                    lbra      L0EF8
+                    lbra      L0EF7
 
-L0E17               ldd       #$0070
+L0E16               ldd       #$0070
                     pshs      d
                     pshs      u
-                    lbsr      L1A9B
-                    bra       L0E5A
+                    lbsr      L1A9A
+                    bra       L0E59
 
-L0E23               pshs      u
-                    lbsr      L1365
-L0E28               leas      $02,s
-                    lbra      L0EF8
+L0E22               pshs      u
+                    lbsr      L1364
+L0E27               leas      $02,s
+                    lbra      L0EF7
 
-L0E2D               ldd       ,s
+L0E2C               ldd       ,s
                     cmpd      #$00A0
-                    blt       L0E40
+                    blt       L0E3F
                     ldd       ,s
                     pshs      d
                     pshs      u
-                    lbsr      L16CC
-                    bra       L0E5A
+                    lbsr      L16CB
+                    bra       L0E59
 
-L0E40               leax      L1ED5,pcr
+L0E3F               leax      L1ED4,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
                     ldd       ,s
                     pshs      d
-                    leax      L1EE1,pcr
+                    leax      L1EE0,pcr
                     pshs      x
-                    lbsr      L2D40
-L0E5A               leas      $04,s
-                    lbra      L0EF8
+                    lbsr      L2D3F
+L0E59               leas      $04,s
+                    lbra      L0EF7
 
-L0E5F               cmpx      #$0037
-                    lbeq      L0EF8
+L0E5E               cmpx      #$0037
+                    lbeq      L0EF7
                     cmpx      #$0034
-                    lbeq      L0EF8
+                    lbeq      L0EF7
                     cmpx      #$0076
-                    lbeq      L0EF8
+                    lbeq      L0EF7
                     cmpx      #$006F
-                    lbeq      L0EF8
+                    lbeq      L0EF7
                     cmpx      #$0041
-                    beq       L0EF8
+                    beq       L0EF7
                     cmpx      #$0036
-                    beq       L0EF8
+                    beq       L0EF7
                     cmpx      #$0078
-                    lbeq      L0D98
+                    lbeq      L0D97
                     cmpx      #$0085
-                    lbeq      L0DA0
+                    lbeq      L0D9F
                     cmpx      #$0084
-                    lbeq      L0DAA
+                    lbeq      L0DA9
                     cmpx      #$008F
-                    lbeq      L0DC8
+                    lbeq      L0DC7
                     cmpx      #$0042
-                    lbeq      L0DE0
+                    lbeq      L0DDF
                     cmpx      #$0040
-                    lbeq      L0DE7
+                    lbeq      L0DE6
                     cmpx      #$0047
-                    lbeq      L0DE7
+                    lbeq      L0DE6
                     cmpx      #$0048
-                    lbeq      L0DE7
+                    lbeq      L0DE6
                     cmpx      #$0044
-                    lbeq      L0DEE
+                    lbeq      L0DED
                     cmpx      #$0043
-                    lbeq      L0DEE
+                    lbeq      L0DED
                     cmpx      #$0064
-                    lbeq      L0E02
+                    lbeq      L0E01
                     cmpx      #$003C
-                    lbeq      L0E17
+                    lbeq      L0E16
                     cmpx      #$003E
-                    lbeq      L0E17
+                    lbeq      L0E16
                     cmpx      #$003D
-                    lbeq      L0E17
+                    lbeq      L0E16
                     cmpx      #$003F
-                    lbeq      L0E17
+                    lbeq      L0E16
                     cmpx      #$0065
-                    lbeq      L0E23
-                    lbra      L0E2D
+                    lbeq      L0E22
+                    lbra      L0E2C
 
-L0EF8               tfr       u,d
+L0EF7               tfr       u,d
                     leas      $02,s
                     puls      pc,u
-L0EFE               pshs      u
+L0EFD               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$06,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -1638,85 +1629,85 @@ L0EFE               pshs      u
                     std       $04,s
                     ldd       ,u
                     cmpd      #$0007
-                    bne       L0F40
+                    bne       L0F3F
                     ldx       $0a,s
-                    bra       L0F2F
+                    bra       L0F2E
 
-L0F1E               ldd       #$004E
-                    bra       L0F2B
+L0F1D               ldd       #$004E
+                    bra       L0F2A
 
-L0F23               ldd       #$004C
-                    bra       L0F2B
+L0F22               ldd       #$004C
+                    bra       L0F2A
 
-L0F28               ldd       #$004D
-L0F2B               std       $0a,s
-                    bra       L0F74
+L0F27               ldd       #$004D
+L0F2A               std       $0a,s
+                    bra       L0F73
 
-L0F2F               cmpx      #$0053
-                    beq       L0F1E
+L0F2E               cmpx      #$0053
+                    beq       L0F1D
                     cmpx      #$0054
-                    beq       L0F23
+                    beq       L0F22
                     cmpx      #$0055
-                    beq       L0F28
-                    bra       L0F74
+                    beq       L0F27
+                    bra       L0F73
 
-L0F40               ldx       $0a,s
-                    bra       L0F68
+L0F3F               ldx       $0a,s
+                    bra       L0F67
 
-L0F44               ldd       $06,u
+L0F43               ldd       $06,u
                     cmpd      #$0041
-                    bne       L0F74
+                    bne       L0F73
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0036
-                    beq       L0F74
+                    beq       L0F73
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L1C1E
+                    lbsr      L1C1D
                     leas      $02,s
                     clra
                     clrb
                     std       L0019
-                    lbra      L1361
-                    bra       L0F74
+                    lbra      L1360
+                    bra       L0F73
 
-L0F68               cmpx      #$0050
-                    beq       L0F44
+L0F67               cmpx      #$0050
+                    beq       L0F43
                     cmpx      #$0051
-                    lbeq      L0F44
-L0F74               ldx       $0a,s
-                    lbra      L1168
+                    lbeq      L0F43
+L0F73               ldx       $0a,s
+                    lbra      L1167
 
-L0F79               ldd       $04,s
+L0F78               ldd       $04,s
                     pshs      d
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    bne       L0FAB
+                    bne       L0FAA
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0C2E
+                    lbsr      L0C2D
                     leas      $02,s
                     ldx       $04,s
                     ldd       $06,x
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$006E
                     ldx       $04,s
                     std       $06,x
                     pshs      u
-                    lbsr      L0BC4
-                    bra       L0FB9
+                    lbsr      L0BC3
+                    bra       L0FB8
 
-L0FAB               pshs      u
-                    lbsr      L0BC4
+L0FAA               pshs      u
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0D05
-L0FB9               leas      $02,s
+                    lbsr      L0D04
+L0FB8               leas      $02,s
                     ldd       $04,s
                     pshs      d
                     ldd       #$0077
@@ -1724,264 +1715,264 @@ L0FB9               leas      $02,s
                     ldd       #$0070
                     pshs      d
                     ldd       #$0051
-                    lbra      L1064
+                    lbra      L1063
 
-L0FCF               pshs      u
-                    lbsr      L22CB
+L0FCE               pshs      u
+                    lbsr      L22CA
                     std       ,s++
-                    beq       L0FE3
+                    beq       L0FE2
                     ldd       $04,s
                     pshs      d
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    beq       L0FEB
-L0FE3               ldd       $06,u
+                    beq       L0FEA
+L0FE2               ldd       $06,u
                     cmpd      #$0036
-                    bne       L0FF7
-L0FEB               leas      -$02,s
+                    bne       L0FF6
+L0FEA               leas      -$02,s
                     stu       ,s
                     ldu       $06,s
                     ldd       ,s
                     std       $06,s
                     leas      $02,s
-L0FF7               ldd       $06,u
+L0FF6               ldd       $06,u
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    beq       L1022
+                    beq       L1021
                     ldd       $06,u
-L1004               pshs      d
+L1003               pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       #$006E
                     ldx       $04,s
                     std       $06,x
-                    bra       L1053
+                    bra       L1052
 
-L1022               pshs      u
-                    lbsr      L0BC4
+L1021               pshs      u
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    bne       L1039
+                    bne       L1038
                     ldd       #$0070
-                    bra       L1004
+                    bra       L1003
 
-L1039               ldd       $04,s
+L1038               ldd       $04,s
                     pshs      d
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldd       $0a,s
                     cmpd      #$0050
-                    beq       L1053
+                    beq       L1052
                     ldd       $04,s
                     pshs      d
-                    lbsr      L152E
+                    lbsr      L152D
                     leas      $02,s
-L1053               ldd       $04,s
+L1052               ldd       $04,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       $10,s
-L1064               pshs      d
-                    lbsr      L3293
+L1063               pshs      d
+                    lbsr      L3292
                     leas      $08,s
-                    lbra      L120E
+                    lbra      L120D
 
-L106E               ldd       $0C,s
+L106D               ldd       $0C,s
                     pshs      d
-                    lbsr      L124D
-                    lbra      L1151
+                    lbsr      L124C
+                    lbra      L1150
 
-L1078               ldx       $04,s
+L1077               ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0036
-                    lbne      L10DC
+                    lbne      L10DB
                     ldx       $04,s
                     ldd       $08,x
                     std       ,s
-                    bra       L108E
+                    bra       L108D
 
-L108C               leas      -$06,x
-L108E               ldd       ,s
+L108B               leas      -$06,x
+L108D               ldd       ,s
                     cmpd      #$0004
-                    bhi       L10DC
+                    bhi       L10DB
                     pshs      u
-                    lbsr      L0BC4
-L109B               leas      $02,s
-                    bra       L10C6
+                    lbsr      L0BC3
+L109A               leas      $02,s
+                    bra       L10C5
 
-L109F               ldx       $0a,s
-                    bra       L10B7
+L109E               ldx       $0a,s
+                    bra       L10B6
 
-L10A3               ldd       #$0098
-                    bra       L10B0
+L10A2               ldd       #$0098
+                    bra       L10AF
 
-L10A8               ldd       #$0096
-                    bra       L10B0
+L10A7               ldd       #$0096
+                    bra       L10AF
 
-L10AD               ldd       #$0097
-L10B0               pshs      d
-                    lbsr      L3293
-                    bra       L109B
+L10AC               ldd       #$0097
+L10AF               pshs      d
+                    lbsr      L3292
+                    bra       L109A
 
-L10B7               cmpx      #$0056
-                    beq       L10A3
+L10B6               cmpx      #$0056
+                    beq       L10A2
                     cmpx      #$0055
-                    beq       L10A8
+                    beq       L10A7
                     cmpx      #$004D
-                    beq       L10AD
-L10C6               ldd       ,s
+                    beq       L10AC
+L10C5               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bne       L109F
+                    bne       L109E
                     ldd       #$0001
                     std       L0019
                     leax      $06,s
-                    lbra      L1214
+                    lbra      L1213
 
-L10DC               leax      $06,s
-                    bra       L112A
+L10DB               leax      $06,s
+                    bra       L1129
 
-L10E0               ldd       $06,u
+L10DF               ldd       $06,u
                     cmpd      #$0036
-                    bne       L10F4
+                    bne       L10F3
                     leas      -$02,s
                     stu       ,s
                     ldu       $06,s
                     ldd       ,s
                     std       $06,s
                     leas      $02,s
-L10F4               ldx       $04,s
+L10F3               ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L112C
+                    bne       L112B
                     ldx       $04,s
                     ldd       $08,x
                     pshs      d
-                    lbsr      L1220
+                    lbsr      L121F
                     leas      $02,s
                     std       ,s
-                    beq       L112C
+                    beq       L112B
                     ldd       ,s
                     ldx       $04,s
                     std       $08,x
                     ldd       $0a,s
                     cmpd      #$0052
-                    bne       L1120
+                    bne       L111F
                     ldd       #$0056
-                    bra       L1123
+                    bra       L1122
 
-L1120               ldd       #$004D
-L1123               std       $0a,s
+L111F               ldd       #$004D
+L1122               std       $0a,s
                     leax      $06,s
-                    lbra      L108C
+                    lbra      L108B
 
-L112A               leas      -$06,x
-L112C               pshs      u
-                    lbsr      L0C2E
+L1129               leas      -$06,x
+L112B               pshs      u
+                    lbsr      L0C2D
                     leas      $02,s
                     ldd       $06,u
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L3293
-L1151               leas      $02,s
-                    lbra      L120E
+                    lbsr      L3292
+L1150               leas      $02,s
+                    lbra      L120D
 
-L1156               leax      L1EE5,pcr
+L1155               leax      L1EE4,pcr
                     pshs      x
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
-                    lbra      L120E
+                    lbra      L120D
 
-L1168               cmpx      #$0051
-                    lbeq      L0F79
+L1167               cmpx      #$0051
+                    lbeq      L0F78
                     cmpx      #$0057
-                    lbeq      L0FCF
+                    lbeq      L0FCE
                     cmpx      #$0058
-                    lbeq      L0FCF
+                    lbeq      L0FCE
                     cmpx      #$0059
-                    lbeq      L0FCF
+                    lbeq      L0FCE
                     cmpx      #$0050
-                    lbeq      L0FCF
+                    lbeq      L0FCE
                     cmpx      #$005A
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$005B
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$005F
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$005D
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$005C
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$005E
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$0063
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$0061
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$0060
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$0062
-                    lbeq      L106E
+                    lbeq      L106D
                     cmpx      #$004D
-                    lbeq      L1078
+                    lbeq      L1077
                     cmpx      #$0055
-                    lbeq      L1078
+                    lbeq      L1077
                     cmpx      #$0056
-                    lbeq      L1078
+                    lbeq      L1077
                     cmpx      #$0052
-                    lbeq      L10E0
+                    lbeq      L10DF
                     cmpx      #$004E
-                    lbeq      L10F4
+                    lbeq      L10F3
                     cmpx      #$0053
-                    lbeq      L112C
+                    lbeq      L112B
                     cmpx      #$004C
-                    lbeq      L112C
+                    lbeq      L112B
                     cmpx      #$0054
-                    lbeq      L112C
-                    lbra      L1156
+                    lbeq      L112B
+                    lbra      L1155
                     leas      -$06,x
-L120E               clra
+L120D               clra
                     clrb
                     std       L0019
-                    bra       L1216
+                    bra       L1215
 
-L1214               leas      -$06,x
-L1216               ldd       #$0070
+L1213               leas      -$06,x
+L1215               ldd       #$0070
                     ldx       $0C,s
                     std       $06,x
-                    lbra      L1361
+                    lbra      L1360
 
-L1220               pshs      u
+L121F               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       #$0000
-                    bra       L1244
+                    bra       L1243
 
-L122D               tfr       u,d
+L122C               tfr       u,d
                     leau      $01,u
                     aslb
                     rola
@@ -1989,16 +1980,16 @@ L122D               tfr       u,d
                     leax      d,x
                     ldd       ,x
                     cmpd      $04,s
-                    bne       L1244
+                    bne       L1243
                     tfr       u,d
                     puls      pc,u
-L1244               cmpu      #$000E
-                    blt       L122D
-                    lbra      L152A
+L1243               cmpu      #$000E
+                    blt       L122C
+                    lbra      L1529
 
-L124D               pshs      u
+L124C               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     ldd       #$0001
@@ -2014,11 +2005,11 @@ L124D               pshs      u
                     std       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      L1F14
+                    lbsr      L1F13
                     leas      $08,s
                     ldd       $02,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     ldd       #$0001
                     pshs      d
@@ -2028,7 +2019,7 @@ L124D               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0001
                     pshs      d
@@ -2039,11 +2030,11 @@ L124D               pshs      u
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     clra
                     clrb
@@ -2054,19 +2045,19 @@ L124D               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       $02,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     ldd       #$0070
                     std       $06,u
-                    lbra      L1A97
+                    lbra      L1A96
 
-L12E9               pshs      u
+L12E8               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$06,s
                     ldd       #$0001
@@ -2083,12 +2074,12 @@ L12E9               pshs      u
                     pshs      d
                     ldd       $0a,u
                     pshs      d
-                    lbsr      L1F14
+                    lbsr      L1F13
                     leas      $08,s
                     ldu       $0C,u
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     ldd       $0a,u
                     pshs      d
@@ -2104,11 +2095,11 @@ L12E9               pshs      u
                     pshs      d
                     ldd       #$007C
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     ldd       $0C,u
                     pshs      d
@@ -2116,90 +2107,90 @@ L12E9               pshs      u
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
-L1361               leas      $06,s
+L1360               leas      $06,s
                     puls      pc,u
-L1365               pshs      u
+L1364               pshs      u
                     ldd       #$FFB2
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$04,s
                     ldd       $000D
                     std       ,s
                     ldd       $08,s
                     std       $02,s
-                    lbra      L1402
+                    lbra      L1401
 
-L137A               ldx       $02,s
+L1379               ldx       $02,s
                     ldu       $0a,x
                     ldd       ,u
                     cmpd      #$0008
-                    bne       L13A9
+                    bne       L13A8
                     ldd       $06,u
                     cmpd      #$004A
-                    bne       L1398
+                    bne       L1397
                     pshs      u
-                    lbsr      L294C
+                    lbsr      L294B
                     leas      $02,s
-                    lbra      L1402
+                    lbra      L1401
 
-L1398               pshs      u
-                    lbsr      L2506
+L1397               pshs      u
+                    lbsr      L2505
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
                     ldd       #$0088
-                    bra       L13FB
+                    bra       L13FA
 
-L13A9               ldd       ,u
+L13A8               ldd       ,u
                     cmpd      #$0005
-                    beq       L13B9
+                    beq       L13B8
                     ldd       ,u
                     cmpd      #$0006
-                    bne       L13CA
-L13B9               pshs      u
-                    lbsr      L29FD
+                    bne       L13C9
+L13B8               pshs      u
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
                     ldd       #$0087
-                    bra       L13FB
+                    bra       L13FA
 
-L13CA               pshs      u
-                    lbsr      L0D05
+L13C9               pshs      u
+                    lbsr      L0D04
                     leas      $02,s
                     ldx       $06,u
-                    bra       L13DE
+                    bra       L13DD
 
-L13D5               pshs      u
-                    lbsr      L0C6E
+L13D4               pshs      u
+                    lbsr      L0C6D
                     leas      $02,s
-                    bra       L13F4
+                    bra       L13F3
 
-L13DE               cmpx      #$0070
-                    beq       L13F4
+L13DD               cmpx      #$0070
+                    beq       L13F3
                     cmpx      #$0071
-                    beq       L13F4
+                    beq       L13F3
                     cmpx      #$006F
-                    beq       L13F4
+                    beq       L13F3
                     cmpx      #$0076
-                    beq       L13F4
-                    bra       L13D5
+                    beq       L13F3
+                    bra       L13D4
 
-L13F4               ldd       $06,u
+L13F3               ldd       $06,u
                     pshs      d
                     ldd       #$007A
-L13FB               pshs      d
-                    lbsr      L3293
+L13FA               pshs      d
+                    lbsr      L3292
                     leas      $04,s
-L1402               ldx       $02,s
+L1401               ldx       $02,s
                     ldd       $0C,x
                     std       $02,s
-                    lbne      L137A
+                    lbne      L1379
                     ldx       $08,s
                     ldd       $0a,x
                     pshs      d
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldx       $08,s
                     ldd       $0a,x
@@ -2208,132 +2199,132 @@ L1402               ldx       $02,s
                     pshs      d
                     ldd       #$0065
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L4440
+                    lbsr      L443F
                     leas      $02,s
                     std       $000D
                     ldd       #$0070
                     ldx       $08,s
                     std       $06,x
-                    lbra      L1A97
+                    lbra      L1A96
 
-L1441               pshs      u
+L1440               pshs      u
                     ldd       #$FFB8
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldx       $06,u
-                    bra       L1486
+                    bra       L1485
 
-L1451               ldd       $0a,u
+L1450               ldd       $0a,u
                     std       ,s
                     tfr       d,x
                     ldx       $06,x
-                    bra       L146A
+                    bra       L1469
 
-L145B               ldd       #$0001
-                    bra       L149B
+L145A               ldd       #$0001
+                    bra       L149A
 
-L1460               ldd       ,s
+L145F               ldd       ,s
                     pshs      d
-                    bsr       L149F
+                    bsr       L149E
                     leas      $02,s
-                    bra       L149B
+                    bra       L149A
 
-L146A               cmpx      #$0036
-                    beq       L145B
+L1469               cmpx      #$0036
+                    beq       L145A
                     cmpx      #$0034
-                    lbeq      L145B
+                    lbeq      L145A
                     cmpx      #$0076
-                    lbeq      L145B
+                    lbeq      L145A
                     cmpx      #$006F
-                    lbeq      L145B
-                    bra       L1460
+                    lbeq      L145A
+                    bra       L145F
 
-L1486               cmpx      #$0034
-                    lbeq      L145B
+L1485               cmpx      #$0034
+                    lbeq      L145A
                     cmpx      #$0036
-                    lbeq      L145B
+                    lbeq      L145A
                     cmpx      #$0042
-                    beq       L1451
+                    beq       L1450
                     clra
                     clrb
-L149B               leas      $02,s
+L149A               leas      $02,s
                     puls      pc,u
-L149F               pshs      u
+L149E               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldx       $06,u
-                    bra       L14CD
+                    bra       L14CC
 
-L14AD               ldx       $0a,u
+L14AC               ldx       $0a,u
                     ldd       $06,x
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    lbeq      L152A
+                    lbeq      L1529
                     ldx       $0C,u
                     ldd       $06,x
                     cmpd      #$0036
-                    lbne      L152A
-                    bra       L150B
-                    lbra      L152A
+                    lbne      L1529
+                    bra       L150A
+                    lbra      L1529
 
-L14CD               cmpx      #$0050
-                    beq       L14AD
+L14CC               cmpx      #$0050
+                    beq       L14AC
                     cmpx      #$0051
-                    lbeq      L14AD
-                    bra       L152A
+                    lbeq      L14AC
+                    bra       L1529
 
-L14DB               pshs      u
+L14DA               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
                     ldd       $12,x
                     cmpd      #$0002
-                    bge       L152A
+                    bge       L1529
                     ldd       #$0001
-                    bra       L152C
+                    bra       L152B
 
-L14F3               pshs      u
+L14F2               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldx       $06,u
-                    bra       L1512
+                    bra       L1511
 
-L1501               ldx       $0a,u
+L1500               ldx       $0a,u
                     ldd       $06,x
                     cmpd      #$0041
-                    bne       L152A
-L150B               ldd       #$0001
+                    bne       L1529
+L150A               ldd       #$0001
                     puls      pc,u
-                    bra       L152A
+                    bra       L1529
 
-L1512               cmpx      #$0050
-                    beq       L1501
+L1511               cmpx      #$0050
+                    beq       L1500
                     cmpx      #$0051
-                    lbeq      L1501
+                    lbeq      L1500
                     cmpx      #$0037
-                    beq       L150B
+                    beq       L150A
                     cmpx      #$0041
-                    lbeq      L150B
-L152A               clra
+                    lbeq      L150A
+L1529               clra
                     clrb
-L152C               puls      pc,u
-L152E               pshs      u
+L152B               puls      pc,u
+L152D               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    beq       L1566
+                    beq       L1565
                     ldd       $06,u
                     anda      #$7f
                     std       $06,u
@@ -2344,17 +2335,17 @@ L152E               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0093
                     std       $06,u
                     clra
                     clrb
                     std       $08,u
-L1566               puls      pc,u
-L1568               pshs      u
+L1565               puls      pc,u
+L1567               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -2363,28 +2354,28 @@ L1568               pshs      u
                     ldu       $0a,x
                     ldd       $06,u
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    lbeq      L15FE
+                    lbeq      L15FD
                     ldd       ,s
                     pshs      d
-                    lbsr      L149F
+                    lbsr      L149E
                     std       ,s++
-                    beq       L159D
+                    beq       L159C
                     ldd       ,s
                     pshs      d
-                    lbsr      L1C1E
-                    bra       L15A4
+                    lbsr      L1C1D
+                    bra       L15A3
 
-L159D               ldd       ,s
+L159C               ldd       ,s
                     pshs      d
-                    lbsr      L0D05
-L15A4               leas      $02,s
+                    lbsr      L0D04
+L15A3               leas      $02,s
                     ldx       ,s
                     ldx       $06,x
-                    bra       L15F2
+                    bra       L15F1
 
-L15AC               ldx       ,s
+L15AB               ldx       ,s
                     ldd       $0a,x
                     pshs      d
                     ldd       #$0077
@@ -2392,9 +2383,9 @@ L15AC               ldx       ,s
                     ldd       $06,u
                     pshs      d
                     ldd       #$007F
-                    bra       L15E8
+                    bra       L15E7
 
-L15C0               ldd       ,s
+L15BF               ldd       ,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
@@ -2402,109 +2393,109 @@ L15C0               ldd       ,s
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-L15D8               ldd       ,s
+L15D7               ldd       ,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
                     ldd       $06,u
                     pshs      d
                     ldd       #$0075
-L15E8               pshs      d
-                    lbsr      L3293
+L15E7               pshs      d
+                    lbsr      L3292
                     leas      $08,s
-                    lbra      L1795
+                    lbra      L1794
 
-L15F2               cmpx      #$0041
-                    beq       L15AC
+L15F1               cmpx      #$0041
+                    beq       L15AB
                     cmpx      #$0085
-                    beq       L15C0
-                    bra       L15D8
+                    beq       L15BF
+                    bra       L15D7
 
-L15FE               pshs      u
-                    lbsr      L1441
+L15FD               pshs      u
+                    lbsr      L1440
                     std       ,s++
-                    beq       L1636
+                    beq       L1635
                     ldd       ,u
                     cmpd      #$0002
-                    beq       L1636
+                    beq       L1635
                     ldd       ,s
                     pshs      d
-                    lbsr      L149F
+                    lbsr      L149E
                     std       ,s++
-                    bne       L1625
+                    bne       L1624
                     ldd       ,s
                     pshs      d
-                    lbsr      L14F3
+                    lbsr      L14F2
                     std       ,s++
-                    beq       L1636
-L1625               pshs      u
-                    lbsr      L0D05
+                    beq       L1635
+L1624               pshs      u
+                    lbsr      L0D04
                     leas      $02,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L1BE5
-                    lbra      L16AC
+                    lbsr      L1BE4
+                    lbra      L16AB
 
-L1636               ldx       ,s
+L1635               ldx       ,s
                     ldd       $06,x
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    beq       L165D
+                    beq       L165C
                     pshs      u
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldd       ,u
                     cmpd      #$0002
-                    lbne      L16AE
+                    lbne      L16AD
                     ldd       ,s
                     pshs      d
-                    lbsr      L0BC4
-                    bra       L16AC
+                    lbsr      L0BC3
+                    bra       L16AB
 
-L165D               pshs      u
-                    lbsr      L14DB
+L165C               pshs      u
+                    lbsr      L14DA
                     std       ,s++
-                    beq       L1676
+                    beq       L1675
                     ldd       ,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     pshs      u
-                    lbsr      L0D05
-                    bra       L16AC
+                    lbsr      L0D04
+                    bra       L16AB
 
-L1676               pshs      u
-                    lbsr      L0D05
+L1675               pshs      u
+                    lbsr      L0D04
                     leas      $02,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L1441
+                    lbsr      L1440
                     std       ,s++
-                    bne       L16A5
+                    bne       L16A4
                     ldd       $06,u
                     anda      #$7f
                     tfr       d,x
-                    bra       L1699
+                    bra       L1698
 
-L1690               pshs      u
-                    lbsr      L1905
+L168F               pshs      u
+                    lbsr      L1904
                     leas      $02,s
-                    bra       L16A5
+                    bra       L16A4
 
-L1699               cmpx      #$0095
-                    beq       L16A5
+L1698               cmpx      #$0095
+                    beq       L16A4
                     cmpx      #$0094
-                    beq       L16A5
-                    bra       L1690
+                    beq       L16A4
+                    bra       L168F
 
-L16A5               ldd       ,s
+L16A4               ldd       ,s
                     pshs      d
-                    lbsr      L0C2E
-L16AC               leas      $02,s
-L16AE               pshs      u
+                    lbsr      L0C2D
+L16AB               leas      $02,s
+L16AD               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldx       $04,s
@@ -2512,15 +2503,15 @@ L16AE               pshs      u
                     pshs      d
                     ldd       #$0079
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldx       ,s
                     ldd       $06,x
-                    lbra      L1797
+                    lbra      L1796
 
-L16CC               pshs      u
+L16CB               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$04,s
                     ldx       $08,s
                     ldd       $0C,x
@@ -2528,174 +2519,174 @@ L16CC               pshs      u
                     ldx       $08,s
                     ldu       $0a,x
                     pshs      u
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldd       $0a,s
                     addd      #$FFB0
                     std       $0a,s
                     ldd       ,u
                     cmpd      #$0007
-                    bne       L171A
+                    bne       L1719
                     ldx       $0a,s
-                    bra       L170B
+                    bra       L170A
 
-L16FA               ldd       #$004E
-                    bra       L1707
+L16F9               ldd       #$004E
+                    bra       L1706
 
-L16FF               ldd       #$004D
-                    bra       L1707
+L16FE               ldd       #$004D
+                    bra       L1706
 
-L1704               ldd       #$004C
-L1707               std       $0a,s
-                    bra       L171A
+L1703               ldd       #$004C
+L1706               std       $0a,s
+                    bra       L1719
 
-L170B               cmpx      #$0053
-                    beq       L16FA
+L170A               cmpx      #$0053
+                    beq       L16F9
                     cmpx      #$0055
-                    beq       L16FF
+                    beq       L16FE
                     cmpx      #$0054
-                    beq       L1704
-L171A               ldd       $06,u
+                    beq       L1703
+L1719               ldd       $06,u
                     anda      #$7f
                     std       ,s
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    lbeq      L17F0
+                    lbeq      L17EF
                     ldx       $0a,s
-                    lbra      L17CB
+                    lbra      L17CA
 
-L1730               ldx       $02,s
+L172F               ldx       $02,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L1767
+                    bne       L1766
                     ldd       $0a,s
                     cmpd      #$0050
-                    bne       L1748
+                    bne       L1747
                     ldx       $02,s
                     ldd       $08,x
-                    bra       L1750
+                    bra       L174F
 
-L1748               ldx       $02,s
+L1747               ldx       $02,s
                     ldd       $08,x
                     nega
                     negb
                     sbca      #$00
-L1750               pshs      d
+L174F               pshs      d
                     ldd       #$0036
                     pshs      d
                     ldd       $04,s
                     pshs      d
                     ldd       #$0074
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L1795
+                    bra       L1794
 
-L1767               ldd       $02,s
+L1766               ldd       $02,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $0a,s
                     cmpd      #$0051
-                    bne       L1782
+                    bne       L1781
                     ldd       #$0043
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $02,s
-L1782               ldd       #$0070
+L1781               ldd       #$0070
                     pshs      d
                     ldd       $02,s
                     pshs      d
                     ldd       #$0074
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-L1795               ldd       $06,u
-L1797               ldx       $08,s
+L1794               ldd       $06,u
+L1796               ldx       $08,s
                     std       $06,x
                     clra
                     clrb
                     ldx       $08,s
                     std       $08,x
-                    lbra      L1A97
+                    lbra      L1A96
 
-L17A4               leax      $04,s
-                    bra       L17EE
+L17A3               leax      $04,s
+                    bra       L17ED
 
-L17A8               ldd       $06,u
+L17A7               ldd       $06,u
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $02,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $02,s
-                    lbra      L18E5
+                    lbra      L18E4
 
-L17CB               cmpx      #$0050
-                    lbeq      L1730
+L17CA               cmpx      #$0050
+                    lbeq      L172F
                     cmpx      #$0051
-                    lbeq      L1730
+                    lbeq      L172F
                     cmpx      #$0057
-                    beq       L17A4
+                    beq       L17A3
                     cmpx      #$0058
-                    lbeq      L17A4
+                    lbeq      L17A3
                     cmpx      #$0059
-                    lbeq      L17A4
-                    bra       L17A8
+                    lbeq      L17A3
+                    bra       L17A7
 
-L17EE               leas      -$04,x
-L17F0               pshs      u
+L17ED               leas      -$04,x
+L17EF               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       ,u
                     cmpd      #$0002
-                    bne       L1818
+                    bne       L1817
                     ldd       #$0085
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $02,s
-L1818               ldx       $0a,s
-                    lbra      L18BF
+L1817               ldx       $0a,s
+                    lbra      L18BE
 
-L181D               ldd       $02,s
+L181C               ldd       $02,s
                     pshs      d
-                    lbsr      L1441
+                    lbsr      L1440
                     std       ,s++
-                    beq       L186E
+                    beq       L186D
                     ldd       $02,s
                     pshs      d
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldx       $0a,s
-                    bra       L1840
+                    bra       L183F
 
-L1835               ldd       $02,s
+L1834               ldd       $02,s
                     pshs      d
-                    lbsr      L152E
+                    lbsr      L152D
                     leas      $02,s
-                    bra       L1853
+                    bra       L1852
 
-L1840               cmpx      #$0057
-                    beq       L1835
+L183F               cmpx      #$0057
+                    beq       L1834
                     cmpx      #$0058
-                    lbeq      L1835
+                    lbeq      L1834
                     cmpx      #$0059
-                    lbeq      L1835
-L1853               ldd       $02,s
+                    lbeq      L1834
+L1852               ldd       $02,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
@@ -2703,84 +2694,84 @@ L1853               ldd       $02,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    lbra      L18E5
+                    lbra      L18E4
 
-L186E               ldd       ,s
+L186D               ldd       ,s
                     cmpd      #$0094
-                    beq       L1885
+                    beq       L1884
                     ldd       ,s
                     cmpd      #$0095
-                    beq       L1885
+                    beq       L1884
                     pshs      u
-                    lbsr      L1905
+                    lbsr      L1904
                     leas      $02,s
-L1885               ldd       #$0070
+L1884               ldd       #$0070
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $02,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $0a,s
                     cmpd      #$0051
-                    bne       L18AA
+                    bne       L18A9
                     ldd       #$004F
                     std       $0a,s
-L18AA               ldd       #$006E
+L18A9               ldd       #$006E
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L18E5
+                    bra       L18E4
 
-L18BF               cmpx      #$0057
-                    lbeq      L181D
+L18BE               cmpx      #$0057
+                    lbeq      L181C
                     cmpx      #$0058
-                    lbeq      L181D
+                    lbeq      L181C
                     cmpx      #$0059
-                    lbeq      L181D
+                    lbeq      L181C
                     cmpx      #$0050
-                    lbeq      L181D
+                    lbeq      L181C
                     cmpx      #$0051
-                    lbeq      L181D
-                    lbra      L186E
+                    lbeq      L181C
+                    lbra      L186D
 
-L18E5               pshs      u
+L18E4               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$0079
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
                     ldx       $08,s
                     std       $06,x
-                    lbra      L1A97
+                    lbra      L1A96
 
-L1905               pshs      u
+L1904               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       $06,u
                     anda      #$7f
                     cmpd      #$0034
-                    bne       L191B
+                    bne       L191A
                     puls      pc,u
-L191B               pshs      u
-                    lbsr      L152E
+L191A               pshs      u
+                    lbsr      L152D
                     leas      $02,s
                     ldd       $08,u
-                    beq       L193E
+                    beq       L193D
                     ldd       $08,u
                     pshs      d
                     ldd       #$0036
@@ -2789,26 +2780,26 @@ L191B               pshs      u
                     pshs      d
                     ldd       #$0074
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-L193E               ldd       #$0071
+L193D               ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$806E
                     std       $06,u
                     puls      pc,u
-L1954               pshs      u
+L1953               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $0a,u
                     std       $02,s
                     pshs      d
-                    lbsr      L1C1E
+                    lbsr      L1C1D
                     leas      $02,s
                     ldx       $02,s
                     ldd       $06,x
@@ -2816,14 +2807,14 @@ L1954               pshs      u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    lbeq      L19D8
+                    lbeq      L19D7
                     ldd       ,s
                     anda      #$7f
                     std       ,s
                     tfr       d,x
-                    bra       L19B0
+                    bra       L19AF
 
-L1984               ldx       $02,s
+L1983               ldx       $02,s
                     ldd       $08,x
                     pshs      d
                     ldd       $02,s
@@ -2832,66 +2823,66 @@ L1984               ldx       $02,s
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L19CC
+                    bra       L19CB
 
-L199F               leax      L1EF0,pcr
+L199E               leax      L1EEF,pcr
                     pshs      x
                     ldd       $04,s
                     pshs      d
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
-                    bra       L19CC
+                    bra       L19CB
 
-L19B0               cmpx      #$0034
-                    beq       L1984
+L19AF               cmpx      #$0034
+                    beq       L1983
                     cmpx      #$0093
-                    lbeq      L1984
+                    lbeq      L1983
                     cmpx      #$0094
-                    lbeq      L1984
+                    lbeq      L1983
                     cmpx      #$0095
-                    lbeq      L1984
-                    bra       L199F
+                    lbeq      L1983
+                    bra       L199E
 
-L19CC               ldd       #$8093
+L19CB               ldd       #$8093
                     std       ,s
                     clra
                     clrb
                     std       $08,u
-                    lbra      L1A93
+                    lbra      L1A92
 
-L19D8               ldx       ,s
-                    lbra      L1A54
+L19D7               ldx       ,s
+                    lbra      L1A53
 
-L19DD               ldd       #$0095
-                    bra       L19F0
+L19DC               ldd       #$0095
+                    bra       L19EF
 
-L19E2               ldd       #$0094
-                    bra       L19F0
+L19E1               ldd       #$0094
+                    bra       L19EF
 
-L19E7               ldd       #$0093
-                    bra       L19F0
+L19E6               ldd       #$0093
+                    bra       L19EF
 
-L19EC               ldd       ,s
+L19EB               ldd       ,s
                     ora       #$80
-L19F0               std       ,s
+L19EF               std       ,s
                     leax      $04,s
-                    bra       L1A05
+                    bra       L1A04
 
-L19F6               ldd       #$8034
+L19F5               ldd       #$8034
                     std       ,s
                     ldx       $02,s
                     ldd       $14,x
                     std       $14,u
-                    bra       L1A07
+                    bra       L1A06
 
-L1A05               leas      -$04,x
-L1A07               ldx       $02,s
+L1A04               leas      -$04,x
+L1A06               ldx       $02,s
                     ldd       $08,x
-                    bra       L1A2C
+                    bra       L1A2B
 
-L1A0D               ldd       $02,s
+L1A0C               ldd       $02,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
@@ -2899,65 +2890,65 @@ L1A0D               ldd       $02,s
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0093
                     std       ,s
                     clra
                     clrb
-L1A2C               std       $08,u
-                    bra       L1A93
+L1A2B               std       $08,u
+                    bra       L1A92
 
-L1A30               clra
+L1A2F               clra
                     clrb
                     std       $08,u
                     ldx       $02,s
                     ldd       $08,x
                     std       $14,u
                     ldd       #$0034
-                    bra       L1A50
+                    bra       L1A4F
 
-L1A40               leax      L1EFC,pcr
+L1A3F               leax      L1EFB,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
                     ldd       #$0093
-L1A50               std       ,s
-                    bra       L1A93
+L1A4F               std       ,s
+                    bra       L1A92
 
-L1A54               cmpx      #$006F
-                    lbeq      L19DD
+L1A53               cmpx      #$006F
+                    lbeq      L19DC
                     cmpx      #$0076
-                    lbeq      L19E2
+                    lbeq      L19E1
                     cmpx      #$0071
-                    lbeq      L19E7
+                    lbeq      L19E6
                     cmpx      #$0093
-                    lbeq      L19EC
+                    lbeq      L19EB
                     cmpx      #$0094
-                    lbeq      L19EC
+                    lbeq      L19EB
                     cmpx      #$0095
-                    lbeq      L19EC
+                    lbeq      L19EB
                     cmpx      #$0034
-                    lbeq      L19F6
+                    lbeq      L19F5
                     cmpx      #$0070
-                    lbeq      L1A0D
+                    lbeq      L1A0C
                     cmpx      #$0036
-                    beq       L1A30
-                    bra       L1A40
+                    beq       L1A2F
+                    bra       L1A3F
 
-L1A93               ldd       ,s
+L1A92               ldd       ,s
                     std       $06,u
-L1A97               leas      $04,s
+L1A96               leas      $04,s
                     puls      pc,u
-L1A9B               pshs      u
+L1A9A               pshs      u
                     ldd       #$FFAC
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
                     pshs      u
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldx       $0C,s
                     ldd       $06,x
@@ -2965,15 +2956,15 @@ L1A9B               pshs      u
                     ldd       $06,u
                     std       ,s
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    beq       L1AFB
+                    beq       L1AFA
                     ldx       $02,s
-                    bra       L1AED
+                    bra       L1AEC
 
-L1AC7               ldd       $0e,s
+L1AC6               ldd       $0e,s
                     cmpd      #$0070
-                    bne       L1AE7
+                    bne       L1AE6
                     pshs      u
                     ldd       #$0077
                     pshs      d
@@ -2981,54 +2972,54 @@ L1AC7               ldd       $0e,s
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L1B2C
+                    bra       L1B2B
 
-L1AE7               ldd       ,s
+L1AE6               ldd       ,s
                     std       $0e,s
-                    bra       L1B2C
+                    bra       L1B2B
 
-L1AED               cmpx      #$003E
-                    beq       L1AC7
+L1AEC               cmpx      #$003E
+                    beq       L1AC6
                     cmpx      #$003F
-                    lbeq      L1AC7
-                    bra       L1AE7
+                    lbeq      L1AC6
+                    bra       L1AE6
 
-L1AFB               ldd       $0e,s
+L1AFA               ldd       $0e,s
                     cmpd      #$0071
-                    bne       L1B12
+                    bne       L1B11
                     ldd       ,s
                     anda      #$7f
                     cmpd      #$0034
-                    beq       L1B12
+                    beq       L1B11
                     ldd       #$0070
                     std       $0e,s
-L1B12               pshs      u
+L1B11               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       $12,s
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       $0e,s
                     std       ,s
-L1B2C               ldx       $0C,s
+L1B2B               ldx       $0C,s
                     ldd       $08,x
                     std       $06,s
                     ldx       $02,s
-                    bra       L1B71
+                    bra       L1B70
 
-L1B36               ldd       $06,s
+L1B35               ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-L1B3E               ldd       ,s
+L1B3D               ldd       ,s
                     cmpd      #$0070
-                    bne       L1B58
+                    bne       L1B57
                     ldd       $06,s
                     pshs      d
                     ldd       #$0036
@@ -3036,45 +3027,45 @@ L1B3E               ldd       ,s
                     ldd       $04,s
                     pshs      d
                     ldd       #$0050
-                    bra       L1B68
+                    bra       L1B67
 
-L1B58               ldd       $06,s
+L1B57               ldd       $06,s
                     pshs      d
                     ldd       #$0036
                     pshs      d
                     ldd       $04,s
                     pshs      d
                     ldd       #$0074
-L1B68               pshs      d
-                    lbsr      L3293
+L1B67               pshs      d
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L1B7F
+                    bra       L1B7E
 
-L1B71               cmpx      #$003D
-                    beq       L1B36
+L1B70               cmpx      #$003D
+                    beq       L1B35
                     cmpx      #$003F
-                    lbeq      L1B36
-                    bra       L1B3E
+                    lbeq      L1B35
+                    bra       L1B3D
 
-L1B7F               pshs      u
+L1B7E               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       $04,s
                     pshs      d
                     ldd       #$0079
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldx       $02,s
-                    bra       L1BCA
+                    bra       L1BC9
 
-L1B98               clra
+L1B97               clra
                     clrb
-                    bra       L1BC4
+                    bra       L1BC3
 
-L1B9C               ldd       ,s
+L1B9B               ldd       ,s
                     cmpd      #$0070
-                    bne       L1BBE
+                    bne       L1BBD
                     ldd       $06,s
                     pshs      d
                     ldd       #$0036
@@ -3083,59 +3074,59 @@ L1B9C               ldd       ,s
                     pshs      d
                     ldd       #$0051
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L1BD8
+                    bra       L1BD7
 
-L1BBE               ldd       $06,s
+L1BBD               ldd       $06,s
                     nega
                     negb
                     sbca      #$00
-L1BC4               ldx       $0C,s
+L1BC3               ldx       $0C,s
                     std       $08,x
-                    bra       L1BD8
+                    bra       L1BD7
 
-L1BCA               cmpx      #$003E
-                    beq       L1B9C
+L1BC9               cmpx      #$003E
+                    beq       L1B9B
                     cmpx      #$003F
-                    lbeq      L1B9C
-                    bra       L1B98
+                    lbeq      L1B9B
+                    bra       L1B97
 
-L1BD8               ldd       $0e,s
+L1BD7               ldd       $0e,s
                     ldx       $0C,s
                     std       $06,x
                     clra
                     clrb
                     std       L0019
-                    lbra      L1EB0
+                    lbra      L1EAF
 
-L1BE5               pshs      u
+L1BE4               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     pshs      u
-                    bsr       L1C1E
+                    bsr       L1C1D
                     leas      $02,s
                     ldd       $06,u
                     cmpd      #$0071
-                    bne       L1C01
+                    bne       L1C00
                     ldd       $08,u
-                    beq       L1C17
-L1C01               pshs      u
+                    beq       L1C16
+L1C00               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-L1C17               ldd       #$0071
+L1C16               ldd       #$0071
                     std       $06,u
                     puls      pc,u
-L1C1E               pshs      u
+L1C1D               pshs      u
                     ldd       #$FFAC
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$08,s
                     ldx       $0C,s
                     ldu       $0a,x
@@ -3148,202 +3139,202 @@ L1C1E               pshs      u
                     ldd       $06,x
                     std       $02,s
                     tfr       d,x
-                    lbra      L1E50
+                    lbra      L1E4F
 
-L1C42               ldd       $0C,s
+L1C41               ldd       $0C,s
                     pshs      d
-                    lbsr      L1954
-                    lbra      L1E4C
+                    lbsr      L1953
+                    lbra      L1E4B
 
-L1C4C               ldd       #$0071
+L1C4B               ldd       #$0071
                     pshs      d
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L1A9B
+                    lbsr      L1A9A
                     leas      $04,s
-                    lbra      L1EB0
+                    lbra      L1EAF
 
-L1C5D               pshs      u
+L1C5C               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$007F
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     clra
                     clrb
-                    lbra      L1E3D
+                    lbra      L1E3C
 
-L1C78               ldd       $0C,s
+L1C77               ldd       $0C,s
                     pshs      d
-                    lbsr      L0BC4
-                    lbra      L1E4C
+                    lbsr      L0BC3
+                    lbra      L1E4B
 
-L1C82               ldd       $06,u
+L1C81               ldd       $06,u
                     cmpd      #$0041
-                    beq       L1C93
+                    beq       L1C92
                     ldx       $06,s
                     ldd       $12,x
-                    lbne      L1D31
-L1C93               ldd       $06,u
+                    lbne      L1D30
+L1C92               ldd       $06,u
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    bne       L1CA6
+                    bne       L1CA5
                     ldd       $06,u
                     cmpd      #$0041
-                    bne       L1CFA
-L1CA6               ldx       $06,s
+                    bne       L1CF9
+L1CA5               ldx       $06,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L1CC2
+                    bne       L1CC1
                     pshs      u
-                    lbsr      L1C1E
+                    lbsr      L1C1D
                     leas      $02,s
                     ldd       $06,u
                     std       ,s
                     ldx       $06,s
                     ldd       $08,x
-                    lbra      L1E27
+                    lbra      L1E26
 
-L1CC2               ldd       $06,s
+L1CC1               ldd       $06,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     pshs      u
-                    lbsr      L1C1E
+                    lbsr      L1C1D
                     leas      $02,s
                     ldd       $02,s
                     cmpd      #$0051
-                    bne       L1CE4
+                    bne       L1CE3
                     ldd       #$0043
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $02,s
-L1CE4               ldd       $06,u
+L1CE3               ldd       $06,u
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$007B
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    lbra      L1E25
+                    lbra      L1E24
 
-L1CFA               ldd       $02,s
+L1CF9               ldd       $02,s
                     cmpd      #$0050
-                    bne       L1D19
+                    bne       L1D18
                     ldd       $12,u
                     ldx       $06,s
                     cmpd      $12,x
-                    bge       L1D19
+                    bge       L1D18
                     leas      -$02,s
                     stu       ,s
                     ldu       $08,s
                     ldd       ,s
                     std       $08,s
                     leas      $02,s
-L1D19               ldd       $06,s
+L1D18               ldd       $06,s
                     pshs      d
-                    lbsr      L1441
+                    lbsr      L1440
                     std       ,s++
-                    bne       L1D36
+                    bne       L1D35
                     ldx       $06,s
                     ldd       $06,x
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    bne       L1D36
-L1D31               leax      $08,s
-                    lbra      L1E43
+                    bne       L1D35
+L1D30               leax      $08,s
+                    lbra      L1E42
 
-L1D36               pshs      u
-                    lbsr      L1C1E
+L1D35               pshs      u
+                    lbsr      L1C1D
                     leas      $02,s
                     ldd       $06,u
                     anda      #$7f
                     tfr       d,x
-                    lbra      L1D9B
+                    lbra      L1D9A
 
-L1D46               ldd       $02,s
+L1D45               ldd       $02,s
                     cmpd      #$0050
-                    bne       L1D6A
+                    bne       L1D69
                     ldx       $06,s
                     ldd       $06,x
                     cmpd      #$0036
-                    beq       L1D6A
+                    beq       L1D69
                     ldd       $06,s
                     pshs      d
-                    lbsr      L0BF8
+                    lbsr      L0BF7
                     leas      $02,s
                     clra
                     clrb
                     std       $08,u
                     leax      $08,s
-                    lbra      L1E0B
+                    lbra      L1E0A
 
-L1D6A               pshs      u
+L1D69               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     clra
                     clrb
                     std       $08,u
-                    bra       L1DD6
+                    bra       L1DD5
 
-L1D86               ldd       $06,u
+L1D85               ldd       $06,u
                     std       ,s
-                    bra       L1DD6
+                    bra       L1DD5
 
-L1D8C               leax      L1F08,pcr
+L1D8B               leax      L1F07,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
-                    bra       L1DD6
+                    bra       L1DD5
 
-L1D9B               cmpx      #$0070
-                    lbeq      L1D46
+L1D9A               cmpx      #$0070
+                    lbeq      L1D45
                     cmpx      #$0034
-                    beq       L1D6A
+                    beq       L1D69
                     cmpx      #$0037
-                    lbeq      L1D6A
+                    lbeq      L1D69
                     cmpx      #$0093
-                    lbeq      L1D6A
+                    lbeq      L1D69
                     cmpx      #$0094
-                    lbeq      L1D6A
+                    lbeq      L1D69
                     cmpx      #$0095
-                    lbeq      L1D6A
+                    lbeq      L1D69
                     cmpx      #$0071
-                    beq       L1DD6
+                    beq       L1DD5
                     cmpx      #$0076
-                    beq       L1D86
+                    beq       L1D85
                     cmpx      #$006F
-                    lbeq      L1D86
-                    bra       L1D8C
+                    lbeq      L1D85
+                    bra       L1D8B
 
-L1DD6               ldx       $06,s
+L1DD5               ldx       $06,s
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L1DE6
+                    bne       L1DE5
                     ldx       $06,s
                     ldd       $08,x
-                    bra       L1E27
+                    bra       L1E26
 
-L1DE6               ldd       $06,s
+L1DE5               ldd       $06,s
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       $02,s
                     cmpd      #$0051
-                    bne       L1E0D
+                    bne       L1E0C
                     clra
                     clrb
                     pshs      d
@@ -3352,119 +3343,119 @@ L1DE6               ldd       $06,s
                     pshs      d
                     ldd       #$0043
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L1E0D
+                    bra       L1E0C
 
-L1E0B               leas      -$08,x
-L1E0D               ldd       ,s
+L1E0A               leas      -$08,x
+L1E0C               ldd       ,s
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$007B
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       #$0071
                     std       ,s
-L1E25               clra
+L1E24               clra
                     clrb
-L1E27               std       $04,s
+L1E26               std       $04,s
                     ldd       $02,s
                     cmpd      #$0050
-                    bne       L1E35
+                    bne       L1E34
                     ldd       $04,s
-                    bra       L1E3B
+                    bra       L1E3A
 
-L1E35               ldd       $04,s
+L1E34               ldd       $04,s
                     nega
                     negb
                     sbca      #$00
-L1E3B               addd      $08,u
-L1E3D               ldx       $0C,s
+L1E3A               addd      $08,u
+L1E3C               ldx       $0C,s
                     std       $08,x
-                    bra       L1EAA
+                    bra       L1EA9
 
-L1E43               leas      -$08,x
-L1E45               ldd       $0C,s
+L1E42               leas      -$08,x
+L1E44               ldd       $0C,s
                     pshs      d
-                    lbsr      L0D05
-L1E4C               leas      $02,s
-                    bra       L1EB0
+                    lbsr      L0D04
+L1E4B               leas      $02,s
+                    bra       L1EAF
 
-L1E50               cmpx      #$0042
-                    lbeq      L1C42
+L1E4F               cmpx      #$0042
+                    lbeq      L1C41
                     cmpx      #$0034
-                    beq       L1EB0
+                    beq       L1EAF
                     cmpx      #$0076
-                    beq       L1EB0
+                    beq       L1EAF
                     cmpx      #$006F
-                    beq       L1EB0
+                    beq       L1EAF
                     cmpx      #$0036
-                    beq       L1EB0
+                    beq       L1EAF
                     cmpx      #$0037
-                    beq       L1EB0
+                    beq       L1EAF
                     cmpx      #$003E
-                    lbeq      L1C4C
+                    lbeq      L1C4B
                     cmpx      #$003C
-                    lbeq      L1C4C
+                    lbeq      L1C4B
                     cmpx      #$003D
-                    lbeq      L1C4C
+                    lbeq      L1C4B
                     cmpx      #$003F
-                    lbeq      L1C4C
+                    lbeq      L1C4B
                     cmpx      #$0041
-                    lbeq      L1C5D
+                    lbeq      L1C5C
                     cmpx      #$0085
-                    lbeq      L1C78
+                    lbeq      L1C77
                     cmpx      #$0051
-                    lbeq      L1C82
+                    lbeq      L1C81
                     cmpx      #$0050
-                    lbeq      L1C93
-                    bra       L1E45
+                    lbeq      L1C92
+                    bra       L1E44
 
-L1EAA               ldd       ,s
+L1EA9               ldd       ,s
                     ldx       $0C,s
                     std       $06,x
-L1EB0               leas      $08,s
+L1EAF               leas      $08,s
                     puls      pc,u
-L1EB4               pshs      u
+L1EB3               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldd       $04,s
                     cmpd      #$006F
-                    beq       L1ECC
+                    beq       L1ECB
                     ldd       $04,s
                     cmpd      #$0076
-                    bne       L1ED1
-L1ECC               ldd       #$0001
-                    bra       L1ED3
+                    bne       L1ED0
+L1ECB               ldd       #$0001
+                    bra       L1ED2
 
-L1ED1               clra
+L1ED0               clra
                     clrb
-L1ED3               puls      pc,u
-L1ED5               fcc       /translation/
+L1ED2               puls      pc,u
+L1ED4               fcc       /translation/
                     fcb       $00
-L1EE1               bcs       $1F5B
+L1EE0               bcs       $1F5A
                     tst       $0000
-L1EE5               fcc       /binary op./
+L1EE4               fcc       /binary op./
                     fcb       $00
-L1EF0               fcc       /indirection/
+L1EEF               fcc       /indirection/
                     fcb       $00
-L1EFC               fcc       /indirection/
+L1EFB               fcc       /indirection/
                     fcb       $00
-L1F08               fcc       /x translate/
+L1F07               fcc       /x translate/
                     fcb       $00
-L1F14               pshs      u
+L1F13               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
                     std       $02,s
                     tfr       d,x
-                    lbra      L2070
+                    lbra      L206F
 
-L1F29               ldd       #$0001
+L1F28               ldd       #$0001
                     pshs      d
                     ldd       $0e,s
                     pshs      d
@@ -3475,12 +3466,12 @@ L1F29               ldd       #$0001
                     pshs      d
                     ldd       $0a,u
                     pshs      d
-                    bsr       L1F14
+                    bsr       L1F13
                     leas      $08,s
                     leax      $04,s
-                    bra       L1F67
+                    bra       L1F66
 
-L1F49               clra
+L1F48               clra
                     clrb
                     pshs      d
                     ldd       $000B
@@ -3492,17 +3483,17 @@ L1F49               clra
                     pshs      d
                     ldd       $0a,u
                     pshs      d
-                    lbsr      L1F14
+                    lbsr      L1F13
                     leas      $08,s
-                    bra       L1F69
+                    bra       L1F68
 
-L1F67               leas      -$04,x
-L1F69               ldd       ,s
+L1F66               leas      -$04,x
+L1F68               ldd       ,s
                     pshs      d
-                    lbsr      L4415
-                    lbra      L1FD3
+                    lbsr      L4414
+                    lbra      L1FD2
 
-L1F73               ldd       #$0001
+L1F72               ldd       #$0001
                     subd      $0e,s
                     pshs      d
                     ldd       $0C,s
@@ -3510,9 +3501,9 @@ L1F73               ldd       #$0001
                     ldd       $10,s
                     pshs      d
                     ldd       $0a,u
-                    lbra      L1FE3
+                    lbra      L1FE2
 
-L1F88               ldd       $0e,s
+L1F87               ldd       $0e,s
                     pshs      d
                     ldd       $0e,s
                     pshs      d
@@ -3521,36 +3512,36 @@ L1F88               ldd       $0e,s
                     pshs      u
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L20EE
+                    lbsr      L20ED
                     leas      $0a,s
-                    lbra      L20EA
+                    lbra      L20E9
 
-L1FA2               ldd       $08,u
-                    beq       L1FB2
+L1FA1               ldd       $08,u
+                    beq       L1FB1
                     ldd       $0e,s
-                    bne       L1FB2
+                    bne       L1FB1
                     clra
                     clrb
                     pshs      d
                     ldd       $0C,s
-                    bra       L1FC4
+                    bra       L1FC3
 
-L1FB2               ldd       $0e,s
-                    lbeq      L20EA
+L1FB1               ldd       $0e,s
+                    lbeq      L20E9
                     ldd       $08,u
-                    lbne      L20EA
+                    lbne      L20E9
                     clra
                     clrb
                     pshs      d
                     ldd       $0e,s
-L1FC4               pshs      d
+L1FC3               pshs      d
                     ldd       #$007C
-                    lbra      L2067
+                    lbra      L2066
 
-L1FCC               ldd       $0a,u
+L1FCB               ldd       $0a,u
                     pshs      d
-                    lbsr      L0D05
-L1FD3               leas      $02,s
+                    lbsr      L0D04
+L1FD2               leas      $02,s
                     ldd       $0e,s
                     pshs      d
                     ldd       $0e,s
@@ -3558,111 +3549,111 @@ L1FD3               leas      $02,s
                     ldd       $0e,s
                     pshs      d
                     ldd       $0C,u
-L1FE3               pshs      d
-                    lbsr      L1F14
+L1FE2               pshs      d
+                    lbsr      L1F13
                     leas      $08,s
-                    lbra      L20EA
+                    lbra      L20E9
 
-L1FED               ldd       ,u
+L1FEC               ldd       ,u
                     cmpd      #$0008
-                    bne       L200D
+                    bne       L200C
                     pshs      u
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       #$008B
                     pshs      d
-                    ldd       #$0088
+L2000               ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-                    bra       L204E
+                    bra       L204D
 
-L200D               ldd       ,u
+L200C               ldd       ,u
                     cmpd      #$0005
-                    beq       L201D
+                    beq       L201C
                     ldd       ,u
                     cmpd      #$0006
-                    bne       L2043
-L201D               ldd       $06,u
+                    bne       L2042
+L201C               ldd       $06,u
                     cmpd      #$008C
-                    bne       L2027
-L2025               ldu       $0a,u
-L2027               pshs      u
-                    lbsr      L29FD
+                    bne       L2026
+                    ldu       $0a,u
+L2026               pshs      u
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       ,u
                     pshs      d
                     ldd       #$008B
-                    pshs      d
+L2034               pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L204E
+                    bra       L204D
 
-L2043               pshs      u
-                    lbsr      L2324
+L2042               pshs      u
+                    lbsr      L2323
                     leas      $02,s
-                    bra       L204E
+                    bra       L204D
                     leas      -$04,x
-L204E               ldd       $0e,s
-                    beq       L205B
+L204D               ldd       $0e,s
+                    beq       L205A
                     ldd       $0C,s
                     pshs      d
                     ldd       #$005A
-                    bra       L2062
+                    bra       L2061
 
-L205B               ldd       $0a,s
+L205A               ldd       $0a,s
                     pshs      d
                     ldd       #$005B
-L2062               pshs      d
+L2061               pshs      d
                     ldd       #$0082
-L2067               pshs      d
-                    lbsr      L3293
+L2066               pshs      d
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L20EA
+                    bra       L20E9
 
-L2070               cmpx      #$0047
-                    lbeq      L1F29
+L206F               cmpx      #$0047
+                    lbeq      L1F28
                     cmpx      #$0048
-                    lbeq      L1F49
+                    lbeq      L1F48
                     cmpx      #$0040
-                    lbeq      L1F73
+                    lbeq      L1F72
                     cmpx      #$005A
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$005B
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$005C
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$005D
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$005E
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$005F
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$0060
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$0061
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$0062
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$0063
-                    lbeq      L1F88
+                    lbeq      L1F87
                     cmpx      #$0036
-                    lbeq      L1FA2
+                    lbeq      L1FA1
                     cmpx      #$004B
-                    lbeq      L1FA2
+                    lbeq      L1FA1
                     cmpx      #$004A
-                    lbeq      L1FA2
+                    lbeq      L1FA1
                     cmpx      #$0030
-                    lbeq      L1FCC
-                    lbra      L1FED
+                    lbeq      L1FCB
+                    lbra      L1FEC
 
-L20EA               leas      $04,s
+L20E9               leas      $04,s
                     puls      pc,u
-L20EE               pshs      u
+L20ED               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     leas      -$06,s
                     ldx       $0C,s
                     ldd       $0a,x
@@ -3670,343 +3661,343 @@ L20EE               pshs      u
                     ldx       $0C,s
                     ldu       $0C,x
                     ldd       $12,s
-                    beq       L210C
+                    beq       L210B
                     ldd       $10,s
-                    bra       L210E
+                    bra       L210D
 
-L210C               ldd       $0e,s
-L210E               std       $02,s
+L210B               ldd       $0e,s
+L210D               std       $02,s
                     ldd       $12,s
-                    beq       L2120
+                    beq       L211F
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L2467
+                    lbsr      L2466
                     leas      $02,s
-                    bra       L2122
+                    bra       L2121
 
-L2120               ldd       $0a,s
-L2122               std       $0a,s
+L211F               ldd       $0a,s
+L2121               std       $0a,s
                     ldd       [,s]
                     cmpd      #$0008
-                    bne       L2135
+                    bne       L2134
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L2521
-                    bra       L214C
+                    lbsr      L2520
+                    bra       L214B
 
-L2135               ldd       [,s]
+L2134               ldd       [,s]
                     cmpd      #$0005
-                    beq       L2145
+                    beq       L2144
                     ldd       [,s]
                     cmpd      #$0006
-                    bne       L2153
-L2145               ldd       $0C,s
+                    bne       L2152
+L2144               ldd       $0C,s
                     pshs      d
-                    lbsr      L2A18
-L214C               leas      $02,s
+                    lbsr      L2A17
+L214B               leas      $02,s
                     leax      $06,s
-                    lbra      L22B3
+                    lbra      L22B2
 
-L2153               ldd       ,s
+L2152               ldd       ,s
                     pshs      d
-                    lbsr      L24E7
+                    lbsr      L24E6
                     std       ,s++
-                    bne       L218A
+                    bne       L2189
                     ldd       ,s
                     pshs      d
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    beq       L2172
+                    beq       L2171
                     pshs      u
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    beq       L218A
-L2172               ldd       $06,u
+                    beq       L2189
+L2171               ldd       $06,u
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    beq       L219D
+                    beq       L219C
                     ldx       ,s
                     ldd       $06,x
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    bne       L219D
-L218A               ldd       ,s
+                    bne       L219C
+L2189               ldd       ,s
                     std       $04,s
                     stu       ,s
                     ldu       $04,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L249F
+                    lbsr      L249E
                     leas      $02,s
                     std       $0a,s
-L219D               ldx       ,s
+L219C               ldx       ,s
                     ldd       $06,x
                     std       $04,s
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    lbeq      L2220
+                    lbeq      L221F
                     pshs      u
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldx       $06,u
-                    bra       L21F9
+                    bra       L21F8
 
-L21B9               pshs      u
-                    lbsr      L0C2E
+L21B8               pshs      u
+                    lbsr      L0C2D
                     leas      $02,s
                     leax      $06,s
-                    bra       L21E1
+                    bra       L21E0
 
-L21C4               pshs      u
+L21C3               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
                     std       $06,u
-                    bra       L21E3
+                    bra       L21E2
 
-L21E1               leas      -$06,x
-L21E3               ldd       $06,u
+L21E0               leas      -$06,x
+L21E2               ldd       $06,u
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$006E
                     std       $06,u
-                    lbra      L229C
+                    lbra      L229B
 
-L21F9               cmpx      #$0041
-                    beq       L21B9
+L21F8               cmpx      #$0041
+                    beq       L21B8
                     cmpx      #$0085
-                    beq       L21C4
+                    beq       L21C3
                     cmpx      #$0071
-                    beq       L21E3
+                    beq       L21E2
                     cmpx      #$0076
-                    lbeq      L21E3
+                    lbeq      L21E2
                     cmpx      #$006F
-                    lbeq      L21E3
+                    lbeq      L21E2
                     cmpx      #$0070
-                    lbeq      L21E3
-                    lbra      L229C
+                    lbeq      L21E2
+                    lbra      L229B
 
-L2220               pshs      u
-                    lbsr      L24E7
+L221F               pshs      u
+                    lbsr      L24E6
                     std       ,s++
-                    beq       L223D
+                    beq       L223C
                     ldd       $0a,s
                     cmpd      #$0060
-                    bge       L223D
+                    bge       L223C
                     ldd       ,s
                     pshs      d
-                    lbsr      L2324
+                    lbsr      L2323
                     leas      $02,s
-                    lbra      L22B5
+                    lbra      L22B4
 
-L223D               ldd       ,s
+L223C               ldd       ,s
                     pshs      d
-                    lbsr      L0C2E
+                    lbsr      L0C2D
                     leas      $02,s
                     ldx       ,s
                     ldd       $06,x
                     std       $04,s
                     pshs      u
-                    lbsr      L1441
+                    lbsr      L1440
                     std       ,s++
-                    bne       L2266
+                    bne       L2265
                     ldd       $04,s
                     cmpd      #$0070
-                    bne       L226F
+                    bne       L226E
                     pshs      u
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    beq       L226F
-L2266               pshs      u
-                    lbsr      L0D05
+                    beq       L226E
+L2265               pshs      u
+                    lbsr      L0D04
                     leas      $02,s
-                    bra       L229C
+                    bra       L229B
 
-L226F               ldd       $04,s
+L226E               ldd       $04,s
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$006E
                     ldx       ,s
                     std       $06,x
                     pshs      u
-                    lbsr      L0C2E
+                    lbsr      L0C2D
                     leas      $02,s
                     ldd       $06,u
                     std       $04,s
                     ldu       ,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L249F
+                    lbsr      L249E
                     leas      $02,s
                     std       $0a,s
-L229C               pshs      u
+L229B               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       $08,s
                     pshs      d
                     ldd       #$0081
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L22B5
+                    bra       L22B4
 
-L22B3               leas      -$06,x
-L22B5               ldd       $02,s
+L22B2               leas      -$06,x
+L22B4               ldd       $02,s
                     pshs      d
                     ldd       $0C,s
                     pshs      d
                     ldd       #$0082
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     leas      $06,s
                     puls      pc,u
-L22CB               pshs      u
+L22CA               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
                     ldx       $06,x
-                    bra       L22E9
+                    bra       L22E8
 
-L22D9               ldd       #$0001
+L22D8               ldd       #$0001
                     puls      pc,u
-L22DE               ldd       $04,s
+L22DD               ldd       $04,s
                     pshs      d
-                    lbsr      L14DB
+                    lbsr      L14DA
                     leas      $02,s
                     puls      pc,u
-L22E9               cmpx      #$0034
-                    beq       L22D9
+L22E8               cmpx      #$0034
+                    beq       L22D8
                     cmpx      #$0036
-                    lbeq      L22D9
+                    lbeq      L22D8
                     cmpx      #$0042
-                    beq       L22DE
-                    lbra      L2502
+                    beq       L22DD
+                    lbra      L2501
                     pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$0034
-                    lbne      L2502
+                    lbne      L2501
                     ldx       $04,s
                     ldd       [$08,x]
                     cmpd      #$000D
-                    lbne      L2502
+                    lbne      L2501
                     ldd       #$0001
-                    lbra      L2504
+                    lbra      L2503
 
-L2324               pshs      u
+L2323               pshs      u
                     ldd       #$FFB0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$04,s
                     clra
                     clrb
                     std       ,s
                     ldx       $06,u
-                    bra       L2389
+                    bra       L2388
 
-L2338               ldd       $0C,u
+L2337               ldd       $0C,u
                     std       $02,s
                     tfr       d,x
                     ldd       $06,x
                     cmpd      #$0036
-                    bne       L2381
+                    bne       L2380
                     ldx       $02,s
                     ldd       $08,x
                     cmpd      #$00FF
-                    lbls      L23FF
-                    bra       L2381
+                    lbls      L23FE
+                    bra       L2380
 
-L2354               ldx       $0a,u
+L2353               ldx       $0a,u
                     ldd       $06,x
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    lbeq      L23FF
+                    lbeq      L23FE
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L22CB
+                    lbsr      L22CA
                     std       ,s++
-                    lbne      L23FF
-                    bra       L2381
+                    lbne      L23FE
+                    bra       L2380
 
-L2372               ldx       $0a,u
+L2371               ldx       $0a,u
                     ldd       $06,x
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    lbeq      L23FF
-L2381               ldd       #$0001
+                    lbeq      L23FE
+L2380               ldd       #$0001
                     std       ,s
-                    lbra      L23FF
+                    lbra      L23FE
 
-L2389               cmpx      #$0057
-                    beq       L2338
+L2388               cmpx      #$0057
+                    beq       L2337
                     cmpx      #$0078
-                    beq       L2354
+                    beq       L2353
                     cmpx      #$003E
-                    beq       L2372
+                    beq       L2371
                     cmpx      #$003F
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$003D
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$003C
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$00A0
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$00A1
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$00A7
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$00A8
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$00A9
-                    lbeq      L2372
+                    lbeq      L2371
                     cmpx      #$0076
-                    beq       L2381
+                    beq       L2380
                     cmpx      #$006F
-                    lbeq      L2381
+                    lbeq      L2380
                     cmpx      #$0058
-                    lbeq      L2381
+                    lbeq      L2380
                     cmpx      #$0059
-                    lbeq      L2381
+                    lbeq      L2380
                     cmpx      #$0044
-                    lbeq      L2381
+                    lbeq      L2380
                     cmpx      #$0043
-                    lbeq      L2381
+                    lbeq      L2380
                     cmpx      #$0065
-                    lbeq      L2381
-L23FF               clra
-L2400               clrb
-                    std       L0019
+                    lbeq      L2380
+L23FE               clra
+                    clrb
+L2400               std       L0019
                     pshs      u
-                    lbsr      L0D05
+                    lbsr      L0D04
                     leas      $02,s
                     ldx       $06,u
-                    bra       L2442
+                    bra       L2441
 
-L240E               ldd       ,s
-                    bne       L2416
+L240D               ldd       ,s
+                    bne       L2415
                     ldd       L0019
-                    beq       L2463
-L2416               clra
+                    beq       L2462
+L2415               clra
                     clrb
                     pshs      d
                     ldd       #$0036
@@ -4014,162 +4005,162 @@ L2416               clra
                     ldd       $06,u
                     pshs      d
                     ldd       #$0081
-                    bra       L2439
+                    bra       L2438
 
-L2428               ldu       $0a,u
-L242A               pshs      u
+L2427               ldu       $0a,u
+L2429               pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$0070
                     pshs      d
                     ldd       #$0075
-L2439               pshs      d
-                    lbsr      L3293
+L2438               pshs      d
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L2463
+                    bra       L2462
 
-L2442               cmpx      #$0071
-                    beq       L240E
+L2441               cmpx      #$0071
+                    beq       L240D
                     cmpx      #$0070
-                    lbeq      L240E
+                    lbeq      L240D
                     cmpx      #$0076
-                    lbeq      L240E
+                    lbeq      L240D
                     cmpx      #$006F
-                    lbeq      L240E
+                    lbeq      L240D
                     cmpx      #$0085
-                    beq       L2428
-                    bra       L242A
+                    beq       L2427
+                    bra       L2429
 
-L2463               leas      $04,s
+L2462               leas      $04,s
                     puls      pc,u
-L2467               pshs      u
+L2466               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
-                    bra       L2491
+                    bra       L2490
 
-L2473               ldd       #$005B
+L2472               ldd       #$005B
                     puls      pc,u
-L2478               ldd       #$005A
+L2477               ldd       #$005A
                     puls      pc,u
-L247D               ldd       $04,s
+L247C               ldd       $04,s
                     cmpd      #$005F
-                    ble       L248A
+                    ble       L2489
                     ldd       #$00C3
-                    bra       L248D
+                    bra       L248C
 
-L248A               ldd       #$00BB
-L248D               subd      $04,s
+L2489               ldd       #$00BB
+L248C               subd      $04,s
                     puls      pc,u
-L2491               cmpx      #$005A
-                    beq       L2473
+L2490               cmpx      #$005A
+                    beq       L2472
                     cmpx      #$005B
-                    beq       L2478
-                    bra       L247D
+                    beq       L2477
+                    bra       L247C
                     puls      pc,u
-L249F               pshs      u
+L249E               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
-                    bra       L24BD
+                    bra       L24BC
 
-L24AB               ldd       $04,s
+L24AA               ldd       $04,s
                     puls      pc,u
-L24AF               ldd       $04,s
+L24AE               ldd       $04,s
                     addd      #$0002
                     puls      pc,u
-L24B6               ldd       $04,s
+L24B5               ldd       $04,s
                     addd      #$FFFE
                     puls      pc,u
-L24BD               cmpx      #$005A
-                    beq       L24AB
+L24BC               cmpx      #$005A
+                    beq       L24AA
                     cmpx      #$005B
-                    lbeq      L24AB
+                    lbeq      L24AA
                     cmpx      #$005C
-                    beq       L24AF
+                    beq       L24AE
                     cmpx      #$005D
-                    lbeq      L24AF
+                    lbeq      L24AE
                     cmpx      #$0060
-                    lbeq      L24AF
+                    lbeq      L24AE
                     cmpx      #$0061
-                    lbeq      L24AF
-                    bra       L24B6
+                    lbeq      L24AE
+                    bra       L24B5
                     puls      pc,u
-L24E7               pshs      u
+L24E6               pshs      u
                     ldd       #$FFC0
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     ldd       $06,u
                     cmpd      #$0036
-                    bne       L2502
+                    bne       L2501
                     ldd       $08,u
-                    bne       L2502
+                    bne       L2501
                     ldd       #$0001
-                    bra       L2504
+                    bra       L2503
 
-L2502               clra
+L2501               clra
                     clrb
-L2504               puls      pc,u
-L2506               pshs      u
+L2503               puls      pc,u
+L2505               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    bsr       L2521
+                    bsr       L2520
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L28FC
+                    lbsr      L28FB
                     leas      $02,s
                     puls      pc,u
-L2521               pshs      u
+L2520               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$06,s
                     ldd       $06,u
                     std       $02,s
                     tfr       d,x
-                    lbra      L2800
+                    lbra      L27FF
 
-L2536               pshs      u
-                    lbsr      L1954
+L2535               pshs      u
+                    lbsr      L1953
                     leas      $02,s
                     pshs      u
-                    lbsr      L152E
+                    lbsr      L152D
                     leas      $02,s
                     ldx       $06,u
-                    bra       L2562
+                    bra       L2561
 
-L2548               ldd       $08,u
-                    lbeq      L28F8
+L2547               ldd       $08,u
+                    lbeq      L28F7
                     pshs      u
                     ldd       #$0077
                     pshs      d
                     ldd       #$007B
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    lbra      L27D7
+                    lbra      L27D6
 
-L2562               cmpx      #$0093
-                    beq       L2548
+L2561               cmpx      #$0093
+                    beq       L2547
                     cmpx      #$0094
-                    lbeq      L2548
+                    lbeq      L2547
                     cmpx      #$0095
-                    lbeq      L2548
-                    lbra      L28F8
+                    lbeq      L2547
+                    lbra      L28F7
 
-L2578               ldd       $0a,u
+L2577               ldd       $0a,u
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       #$0086
-                    lbra      L2759
+                    lbra      L2758
 
-L2587               ldd       $0a,u
+L2586               ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       $0a,u
                     pshs      d
@@ -4177,62 +4168,62 @@ L2587               ldd       $0a,u
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    lbra      L2765
+                    lbra      L2764
 
-L25A6               ldd       $0a,u
+L25A5               ldd       $0a,u
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
                     ldd       #$0083
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-                    bra       L25C2
+                    bra       L25C1
 
-L25C0               leas      -$06,x
-L25C2               ldd       #$0080
+L25BF               leas      -$06,x
+L25C1               ldd       #$0080
                     std       $06,u
-                    lbra      L28F8
+                    lbra      L28F7
 
-L25CA               ldd       $08,u
+L25C9               ldd       $08,u
                     pshs      d
                     ldd       #$004A
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       #$0004
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3204
-                    bra       L260D
+                    lbsr      L3203
+                    bra       L260C
 
-L25EB               leax      L2506,pcr
+L25EA               leax      L2505,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L12E9
-                    bra       L260D
+                    lbsr      L12E8
+                    bra       L260C
 
-L25F8               ldd       $0a,u
+L25F7               ldd       $0a,u
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
-L260D               leas      $04,s
+                    lbsr      L3292
+L260C               leas      $04,s
                     leax      $06,s
-                    lbra      L27D5
+                    lbra      L27D4
 
-L2614               clra
+L2613               clra
                     clrb
                     pshs      d
                     ldd       #$0080
@@ -4241,48 +4232,48 @@ L2614               clra
                     pshs      d
                     ldd       #$007F
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $0a,u
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$0089
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $02,s
                     cmpd      #$003E
-                    bne       L266F
+                    bne       L266E
                     ldd       #$003F
-                    lbra      L2759
+                    lbra      L2758
 
-L266F               ldd       #$003E
-                    lbra      L2759
+L266E               ldd       #$003E
+                    lbra      L2758
 
-L2675               pshs      u
-                    lbsr      L1365
+L2674               pshs      u
+                    lbsr      L1364
                     leas      $02,s
-                    lbra      L2765
+                    lbra      L2764
 
-L267F               ldx       $0a,u
+L267E               ldx       $0a,u
                     ldd       $06,x
                     cmpd      #$004A
-                    bne       L2699
+                    bne       L2698
                     leas      -$02,s
                     ldd       $0a,u
                     std       ,s
@@ -4291,27 +4282,27 @@ L267F               ldx       $0a,u
                     ldd       ,s
                     std       $0C,u
                     leas      $02,s
-L2699               ldx       $0C,u
+L2698               ldx       $0C,u
                     ldd       $06,x
                     cmpd      #$004A
-                    lbne      L26FA
+                    lbne      L26F9
                     ldx       $0C,u
                     ldd       $08,x
                     std       $04,s
                     ldd       [$04,s]
-                    bne       L26FA
+                    bne       L26F9
                     ldx       $04,s
                     ldd       $02,x
                     pshs      d
-                    lbsr      L1220
+                    lbsr      L121F
                     leas      $02,s
                     std       ,s
-                    beq       L26FA
+                    beq       L26F9
                     ldd       #$0004
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L3204
+                    lbsr      L3203
                     leas      $04,s
                     ldd       $0C,u
                     std       $04,s
@@ -4325,94 +4316,94 @@ L2699               ldx       $0C,u
                     std       [$04,s]
                     ldd       $02,s
                     cmpd      #$0052
-                    bne       L26F1
+                    bne       L26F0
                     ldd       #$0056
-                    bra       L26F4
+                    bra       L26F3
 
-L26F1               ldd       #$0055
-L26F4               std       $02,s
+L26F0               ldd       #$0055
+L26F3               std       $02,s
                     leax      $06,s
-                    bra       L2734
+                    bra       L2733
 
-L26FA               ldd       $0a,u
+L26F9               ldd       $0a,u
                     std       $04,s
                     ldx       $04,s
                     ldd       $06,x
                     cmpd      #$004A
-                    bne       L2713
+                    bne       L2712
                     ldd       $04,s
                     pshs      d
-                    lbsr      L294C
+                    lbsr      L294B
                     leas      $02,s
-                    bra       L272B
+                    bra       L272A
 
-L2713               ldd       $04,s
+L2712               ldd       $04,s
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-L272B               ldd       $0C,u
+L272A               ldd       $0C,u
                     pshs      d
-                    lbsr      L2506
-                    bra       L2755
+                    lbsr      L2505
+                    bra       L2754
 
-L2734               leas      -$06,x
-L2736               ldd       $0a,u
+L2733               leas      -$06,x
+L2735               ldd       $0a,u
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L0BC4
-L2755               leas      $02,s
+                    lbsr      L0BC3
+L2754               leas      $02,s
                     ldd       $02,s
-L2759               pshs      d
+L2758               pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-L2765               leax      $06,s
-                    lbra      L25C0
+L2764               leax      $06,s
+                    lbra      L25BF
 
-L276A               ldd       $0a,u
+L2769               ldd       $0a,u
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     leax      $06,s
-                    bra       L27C2
+                    bra       L27C1
 
-L278F               leas      -$06,x
+L278E               leas      -$06,x
                     ldd       $0a,u
                     std       $04,s
                     pshs      d
-                    lbsr      L2506
+                    lbsr      L2505
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $02,s
                     addd      #$FFB0
@@ -4421,122 +4412,122 @@ L278F               leas      -$06,x
                     ldx       $04,s
                     std       $06,x
                     pshs      u
-                    lbsr      L2521
+                    lbsr      L2520
                     leas      $02,s
-                    bra       L27C4
+                    bra       L27C3
 
-L27C2               leas      -$06,x
-L27C4               ldd       #$0089
+L27C1               leas      -$06,x
+L27C3               ldd       #$0089
                     pshs      d
                     ldd       #$0088
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-                    bra       L27D7
+                    bra       L27D6
 
-L27D5               leas      -$06,x
-L27D7               ldd       #$0093
+L27D4               leas      -$06,x
+L27D6               ldd       #$0093
                     std       $06,u
                     clra
                     clrb
                     std       $08,u
-                    lbra      L28F8
+                    lbra      L28F7
 
-L27E3               ldd       $02,s
+L27E2               ldd       $02,s
                     cmpd      #$00A0
-                    blt       L27F0
+                    blt       L27EF
                     leax      $06,s
-                    lbra      L278F
+                    lbra      L278E
 
-L27F0               leax      L29F7,pcr
+L27EF               leax      L29F6,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
-                    lbra      L28F8
+                    lbra      L28F7
 
-L2800               cmpx      #$0080
-                    lbeq      L28F8
+L27FF               cmpx      #$0080
+                    lbeq      L28F7
                     cmpx      #$0093
-                    lbeq      L28F8
+                    lbeq      L28F7
                     cmpx      #$0094
-                    lbeq      L28F8
+                    lbeq      L28F7
                     cmpx      #$0095
-                    lbeq      L28F8
+                    lbeq      L28F7
                     cmpx      #$0034
-                    lbeq      L28F8
+                    lbeq      L28F7
                     cmpx      #$0042
-                    lbeq      L2536
+                    lbeq      L2535
                     cmpx      #$0086
-                    lbeq      L2578
+                    lbeq      L2577
                     cmpx      #$0091
-                    lbeq      L2587
+                    lbeq      L2586
                     cmpx      #$0083
-                    lbeq      L25A6
+                    lbeq      L25A5
                     cmpx      #$004A
-                    lbeq      L25CA
+                    lbeq      L25C9
                     cmpx      #$0064
-                    lbeq      L25EB
+                    lbeq      L25EA
                     cmpx      #$003C
-                    lbeq      L25F8
+                    lbeq      L25F7
                     cmpx      #$003D
-                    lbeq      L25F8
+                    lbeq      L25F7
                     cmpx      #$0044
-                    lbeq      L25F8
+                    lbeq      L25F7
                     cmpx      #$0043
-                    lbeq      L25F8
+                    lbeq      L25F7
                     cmpx      #$003E
-                    lbeq      L2614
+                    lbeq      L2613
                     cmpx      #$003F
-                    lbeq      L2614
+                    lbeq      L2613
                     cmpx      #$0065
-                    lbeq      L2675
+                    lbeq      L2674
                     cmpx      #$0052
-                    lbeq      L267F
+                    lbeq      L267E
                     cmpx      #$0053
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$005A
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$005B
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$005E
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$005C
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$005F
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$005D
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0050
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0051
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0054
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0057
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0058
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0059
-                    lbeq      L26FA
+                    lbeq      L26F9
                     cmpx      #$0056
-                    lbeq      L2736
+                    lbeq      L2735
                     cmpx      #$0055
-                    lbeq      L2736
+                    lbeq      L2735
                     cmpx      #$0078
-                    lbeq      L276A
-                    lbra      L27E3
+                    lbeq      L2769
+                    lbra      L27E2
 
-L28F8               leas      $06,s
+L28F7               leas      $06,s
                     puls      pc,u
-L28FC               pshs      u
+L28FB               pshs      u
                     ldd       #$FFB4
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldx       $04,s
                     ldx       $06,x
-                    bra       L2939
+                    bra       L2938
 
-L290A               ldd       $04,s
+L2909               ldd       $04,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
@@ -4544,30 +4535,30 @@ L290A               ldd       $04,s
                     pshs      d
                     ldd       #$007F
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L294A
+                    bra       L2949
 
-L2924               ldd       $04,s
+L2923               ldd       $04,s
                     pshs      d
                     ldd       #$0077
                     pshs      d
                     ldd       #$007B
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L294A
+                    bra       L2949
 
-L2939               cmpx      #$0034
-                    beq       L290A
+L2938               cmpx      #$0034
+                    beq       L2909
                     cmpx      #$0094
-                    beq       L2924
+                    beq       L2923
                     cmpx      #$0095
-                    lbeq      L2924
-L294A               puls      pc,u
-L294C               pshs      u
+                    lbeq      L2923
+L2949               puls      pc,u
+L294B               pshs      u
                     ldd       #$FFB2
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $08,u
@@ -4577,7 +4568,7 @@ L294C               pshs      u
                     ora       $01,x
                     ora       $02,x
                     ora       $03,x
-                    beq       L29AB
+                    beq       L29AA
                     ldx       ,s
                     ldd       $02,x
                     pshs      d
@@ -4587,13 +4578,13 @@ L294C               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       [,s]
                     pshs      d
@@ -4603,11 +4594,11 @@ L294C               pshs      u
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
-                    bra       L29D2
+                    bra       L29D1
 
-L29AB               clra
+L29AA               clra
                     clrb
                     pshs      d
                     ldd       #$0036
@@ -4616,48 +4607,48 @@ L29AB               clra
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-L29D2               ldd       #$0070
+L29D1               ldd       #$0070
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$0004
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    lbsr      L3204
+                    lbsr      L3203
                     leas      $04,s
                     clra
                     clrb
                     std       $08,u
                     leas      $02,s
                     puls      pc,u
-L29F7               fcc       /longs/
+L29F6               fcc       /longs/
                     fcb       $00
-L29FD               pshs      u
+L29FC               pshs      u
                     ldd       #$FFBA
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldd       $04,s
                     pshs      d
-                    bsr       L2A18
+                    bsr       L2A17
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L28FC
+                    lbsr      L28FB
                     leas      $02,s
                     puls      pc,u
-L2A18               pshs      u
+L2A17               pshs      u
                     ldd       #$FFAE
-                    lbsr      stkcheck
+                    lbsr      L0110
                     ldu       $04,s
                     leas      -$08,s
                     ldd       ,u
@@ -4665,52 +4656,52 @@ L2A18               pshs      u
                     ldd       $06,u
                     std       $06,s
                     tfr       d,x
-                    lbra      L2C60
+                    lbra      L2C5F
 
-L2A31               pshs      u
-                    lbsr      L2521
+L2A30               pshs      u
+                    lbsr      L2520
                     leas      $02,s
-                    lbra      L2D35
+                    lbra      L2D34
 
-L2A3B               ldd       $0a,u
+L2A3A               ldd       $0a,u
                     pshs      d
-                    lbsr      L0BC4
+                    lbsr      L0BC3
                     leas      $02,s
-                    bra       L2A48
+                    bra       L2A47
 
-L2A46               leas      -$08,x
-L2A48               ldd       $06,s
+L2A45               leas      -$08,x
+L2A47               ldd       $06,s
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-                    bra       L2A5A
+                    bra       L2A59
 
-L2A58               leas      -$08,x
-L2A5A               ldd       #$0080
+L2A57               leas      -$08,x
+L2A59               ldd       #$0080
                     std       $06,u
-                    lbra      L2D35
+                    lbra      L2D34
 
-L2A62               ldd       $0a,u
+L2A61               ldd       $0a,u
                     pshs      d
-                    lbsr      L2506
-                    bra       L2A72
+                    lbsr      L2505
+                    bra       L2A71
 
-L2A6B               ldd       $0a,u
+L2A6A               ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
-L2A72               leas      $02,s
+                    lbsr      L29FC
+L2A71               leas      $02,s
                     leax      $08,s
-                    bra       L2A46
+                    bra       L2A45
 
-L2A78               ldd       $08,u
+L2A77               ldd       $08,u
                     pshs      d
                     ldd       #$004B
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       #$0093
                     std       $06,u
@@ -4718,20 +4709,20 @@ L2A78               ldd       $08,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3204
+                    lbsr      L3203
                     leas      $04,s
-                    lbra      L2C3C
+                    lbra      L2C3B
 
-L2AA1               leax      L29FD,pcr
+L2AA0               leax      L29FC,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L12E9
+                    lbsr      L12E8
                     leas      $04,s
-                    bra       L2ACB
+                    bra       L2ACA
 
-L2AB0               ldd       $0a,u
+L2AAF               ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
@@ -4739,28 +4730,28 @@ L2AB0               ldd       $0a,u
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-L2ACB               leax      $08,s
-                    lbra      L2C35
+L2ACA               leax      $08,s
+                    lbra      L2C34
 
-L2AD0               ldd       #$0080
+L2ACF               ldd       #$0080
                     pshs      d
                     ldd       #$0071
                     pshs      d
                     ldd       #$007F
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
@@ -4768,7 +4759,7 @@ L2AD0               ldd       #$0080
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       $02,s
                     pshs      d
@@ -4776,100 +4767,100 @@ L2AD0               ldd       #$0080
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
                     ldd       $02,s
                     pshs      d
                     ldd       $08,s
                     cmpd      #$003E
-                    bne       L2B32
+                    bne       L2B31
                     ldd       #$003F
-                    bra       L2B35
+                    bra       L2B34
 
-L2B32               ldd       #$003E
-L2B35               pshs      d
+L2B31               ldd       #$003E
+L2B34               pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L2B7B
+                    bra       L2B7A
 
-L2B43               pshs      u
-                    lbsr      L1365
+L2B42               pshs      u
+                    lbsr      L1364
                     leas      $02,s
-                    bra       L2B7B
+                    bra       L2B7A
 
-L2B4C               ldd       $0a,u
+L2B4B               ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       #$006E
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-L2B7B               leax      $08,s
-                    lbra      L2A58
+L2B7A               leax      $08,s
+                    lbra      L2A57
 
-L2B80               ldd       $0a,u
+L2B7F               ldd       $0a,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     leax      $08,s
-                    lbra      L2C1E
+                    lbra      L2C1D
 
-L2BA6               leas      -$08,x
+L2BA5               leas      -$08,x
                     ldd       $0a,u
                     std       $04,s
                     ldd       $02,s
                     cmpd      #$0005
-                    bne       L2BD8
+                    bne       L2BD7
                     ldx       $04,s
                     ldd       $0a,x
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     ldd       #$008C
                     pshs      d
                     ldd       #$0087
-                    bra       L2BE9
+                    bra       L2BE8
 
-L2BD8               ldd       $04,s
+L2BD7               ldd       $04,s
                     pshs      d
-                    lbsr      L29FD
+                    lbsr      L29FC
                     leas      $02,s
                     ldd       #$0071
                     pshs      d
                     ldd       #$007A
-L2BE9               pshs      d
-                    lbsr      L3293
+L2BE8               pshs      d
+                    lbsr      L3292
                     leas      $04,s
                     ldd       $06,s
                     addd      #$FFB0
@@ -4878,118 +4869,118 @@ L2BE9               pshs      d
                     ldx       $04,s
                     std       $06,x
                     pshs      u
-                    lbsr      L2A18
+                    lbsr      L2A17
                     leas      $02,s
                     ldd       $02,s
                     cmpd      #$0005
-                    bne       L2C20
+                    bne       L2C1F
                     ldd       #$008D
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
-                    bra       L2C20
+                    bra       L2C1F
 
-L2C1E               leas      -$08,x
-L2C20               ldd       $02,s
+L2C1D               leas      -$08,x
+L2C1F               ldd       $02,s
                     pshs      d
                     ldd       #$0089
                     pshs      d
                     ldd       #$0087
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $06,s
-                    bra       L2C37
+                    bra       L2C36
 
-L2C35               leas      -$08,x
-L2C37               ldd       #$0093
+L2C34               leas      -$08,x
+L2C36               ldd       #$0093
                     std       $06,u
-L2C3C               clra
+L2C3B               clra
                     clrb
                     std       $08,u
-                    lbra      L2D35
+                    lbra      L2D34
 
-L2C43               ldd       $06,s
+L2C42               ldd       $06,s
                     cmpd      #$00A0
-                    blt       L2C50
+                    blt       L2C4F
                     leax      $08,s
-                    lbra      L2BA6
+                    lbra      L2BA5
 
-L2C50               leax      L2D39,pcr
+L2C4F               leax      L2D38,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L484C
+                    lbsr      L484B
                     leas      $04,s
-                    lbra      L2D35
+                    lbra      L2D34
 
-L2C60               cmpx      #$0080
-                    lbeq      L2D35
+L2C5F               cmpx      #$0080
+                    lbeq      L2D34
                     cmpx      #$0093
-                    lbeq      L2D35
+                    lbeq      L2D34
                     cmpx      #$0094
-                    lbeq      L2D35
+                    lbeq      L2D34
                     cmpx      #$0095
-                    lbeq      L2D35
+                    lbeq      L2D34
                     cmpx      #$0034
-                    lbeq      L2D35
+                    lbeq      L2D34
                     cmpx      #$0042
-                    lbeq      L2A31
+                    lbeq      L2A30
                     cmpx      #$0092
-                    lbeq      L2A3B
+                    lbeq      L2A3A
                     cmpx      #$008E
-                    lbeq      L2A3B
+                    lbeq      L2A3A
                     cmpx      #$0090
-                    lbeq      L2A62
+                    lbeq      L2A61
                     cmpx      #$008D
-                    lbeq      L2A6B
+                    lbeq      L2A6A
                     cmpx      #$008C
-                    lbeq      L2A6B
+                    lbeq      L2A6A
                     cmpx      #$004B
-                    lbeq      L2A78
+                    lbeq      L2A77
                     cmpx      #$0064
-                    lbeq      L2AA1
+                    lbeq      L2AA0
                     cmpx      #$003C
-                    lbeq      L2AB0
+                    lbeq      L2AAF
                     cmpx      #$003D
-                    lbeq      L2AB0
+                    lbeq      L2AAF
                     cmpx      #$0043
-                    lbeq      L2AB0
+                    lbeq      L2AAF
                     cmpx      #$003E
-                    lbeq      L2AD0
+                    lbeq      L2ACF
                     cmpx      #$003F
-                    lbeq      L2AD0
+                    lbeq      L2ACF
                     cmpx      #$0065
-                    lbeq      L2B43
+                    lbeq      L2B42
                     cmpx      #$005A
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$005B
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$005E
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$005C
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$005F
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$005D
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$0050
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$0051
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$0052
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$0053
-                    lbeq      L2B4C
+                    lbeq      L2B4B
                     cmpx      #$0078
-                    lbeq      L2B80
-                    lbra      L2C43
+                    lbeq      L2B7F
+                    lbra      L2C42
 
-L2D35               leas      $08,s
+L2D34               leas      $08,s
                     puls      pc,u
-L2D39               fcc       /floats/
+L2D38               fcc       /floats/
                     fcb       $00
-L2D40               pshs      u
+L2D3F               pshs      u
                     leax      $00CE,y
                     stx       L001B
                     ldd       #$0001
@@ -4997,9 +4988,9 @@ L2D40               pshs      u
                     leax      $06,s
                     pshs      x
                     ldd       $06,s
-                    bra       L2D66
+                    bra       L2D65
 
-L2D55               pshs      u
+L2D54               pshs      u
                     ldd       $04,s
                     std       L001B
                     ldd       #$0001
@@ -5007,8 +4998,8 @@ L2D55               pshs      u
                     leax      $08,s
                     pshs      x
                     ldd       $08,s
-L2D66               pshs      d
-                    bsr       doprnt
+L2D65               pshs      d
+                    bsr       L2D8C
                     leas      $04,s
                     puls      pc,u
                     pshs      u
@@ -5020,28 +5011,28 @@ L2D66               pshs      d
                     pshs      x
                     ldd       $08,s
                     pshs      d
-                    bsr       doprnt
+                    bsr       L2D8C
                     leas      $04,s
                     clra
                     clrb
                     stb       [L001B,y]
                     puls      pc,u
-doprnt              pshs      u
+L2D8C               pshs      u
                     ldu       $04,s
                     leas      -$0b,s
-                    bra       L2DA5
+                    bra       L2DA4
 
-L2D95               ldb       $08,s
-                    lbeq      L2F05
+L2D94               ldb       $08,s
+                    lbeq      L2F04
                     ldb       $08,s
                     sex
                     pshs      d
-                    lbsr      L30E4
+                    lbsr      L30E3
                     leas      $02,s
-L2DA5               ldb       ,u+
+L2DA4               ldb       ,u+
                     stb       $08,s
                     cmpb      #$25
-                    bne       L2D95
+                    bne       L2D94
                     ldb       ,u+
                     stb       $08,s
                     clra
@@ -5050,30 +5041,30 @@ L2DA5               ldb       ,u+
                     std       $06,s
                     ldb       $08,s
                     cmpb      #$2d
-                    bne       L2DC8
+                    bne       L2DC7
                     ldd       #$0001
                     std       L001D
                     ldb       ,u+
                     stb       $08,s
-                    bra       L2DCC
+                    bra       L2DCB
 
-L2DC8               clra
+L2DC7               clra
                     clrb
                     std       L001D
-L2DCC               ldb       $08,s
+L2DCB               ldb       $08,s
                     cmpb      #$30
-                    bne       L2DD7
+                    bne       L2DD6
                     ldd       #$0030
-                    bra       L2DDA
+                    bra       L2DD9
 
-L2DD7               ldd       #$0020
-L2DDA               std       $001F
-                    bra       L2DF8
+L2DD6               ldd       #$0020
+L2DD9               std       $001F
+                    bra       L2DF7
 
-L2DDE               ldd       $06,s
+L2DDD               ldd       $06,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      $5E90
+                    lbsr      L5E8F
                     pshs      d
                     ldb       $0a,s
                     sex
@@ -5082,32 +5073,32 @@ L2DDE               ldd       $06,s
                     std       $06,s
                     ldb       ,u+
                     stb       $08,s
-L2DF8               ldb       $08,s
+L2DF7               ldb       $08,s
                     sex
                     leax      $0192,y
                     leax      d,x
                     ldb       ,x
                     clra
                     andb      #$08
-                    bne       L2DDE
+                    bne       L2DDD
                     ldb       $08,s
                     cmpb      #$2e
-                    bne       L2E41
+                    bne       L2E40
                     ldd       #$0001
                     std       $04,s
-                    bra       L2E2B
+                    bra       L2E2A
 
-L2E15               ldd       $02,s
+L2E14               ldd       $02,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      $5E90
+                    lbsr      L5E8F
                     pshs      d
                     ldb       $0a,s
                     sex
                     addd      #$FFD0
                     addd      ,s++
                     std       $02,s
-L2E2B               ldb       ,u+
+L2E2A               ldb       ,u+
                     stb       $08,s
                     ldb       $08,s
                     sex
@@ -5116,138 +5107,138 @@ L2E2B               ldb       ,u+
                     ldb       ,x
                     clra
                     andb      #$08
-                    bne       L2E15
-                    bra       L2E45
+                    bne       L2E14
+                    bra       L2E44
 
-L2E41               clra
+L2E40               clra
                     clrb
                     std       $04,s
-L2E45               ldb       $08,s
+L2E44               ldb       $08,s
                     sex
                     tfr       d,x
-                    lbra      L2EE7
+                    lbra      L2EE6
 
-L2E4D               ldd       $06,s
+L2E4C               ldd       $06,s
                     pshs      d
                     ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L2F09
-                    bra       L2E75
+                    lbsr      L2F08
+                    bra       L2E74
 
-L2E62               ldd       $06,s
+L2E61               ldd       $06,s
                     pshs      d
                     ldx       $13,s
                     leax      $02,x
                     stx       $13,s
                     ldd       -$02,x
                     pshs      d
-                    lbsr      L2FCA
-L2E75               std       ,s
-                    lbra      L2ED2
+                    lbsr      L2FC9
+L2E74               std       ,s
+                    lbra      L2ED1
 
-L2E7A               ldx       $11,s
+L2E79               ldx       $11,s
                     leax      $02,x
                     stx       $11,s
                     ldd       -$02,x
-                    lbra      L2EDD
+                    lbra      L2EDC
 
-L2E87               ldx       $11,s
+L2E86               ldx       $11,s
                     leax      $02,x
                     stx       $11,s
                     ldd       -$02,x
                     std       $09,s
                     ldd       $04,s
-                    beq       L2ECA
+                    beq       L2EC9
                     ldd       $09,s
                     std       $04,s
-                    bra       L2EA9
+                    bra       L2EA8
 
-L2E9D               ldb       [$09,s]
-                    beq       L2EB5
+L2E9C               ldb       [$09,s]
+                    beq       L2EB4
                     ldd       $09,s
                     addd      #$0001
                     std       $09,s
-L2EA9               ldd       $02,s
+L2EA8               ldd       $02,s
                     addd      #$FFFF
                     std       $02,s
                     subd      #$FFFF
-                    bne       L2E9D
-L2EB5               ldd       $06,s
+                    bne       L2E9C
+L2EB4               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
                     subd      $06,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L3089
+                    lbsr      L3088
                     leas      $06,s
-                    bra       L2ED7
+                    bra       L2ED6
 
-L2ECA               ldd       $06,s
+L2EC9               ldd       $06,s
                     pshs      d
                     ldd       $0b,s
                     pshs      d
-L2ED2               lbsr      L3029
+L2ED1               lbsr      L3028
                     leas      $04,s
-L2ED7               lbra      L2DA5
+L2ED6               lbra      L2DA4
 
-L2EDA               ldb       $08,s
+L2ED9               ldb       $08,s
                     sex
-L2EDD               pshs      d
-                    lbsr      L30E4
+L2EDC               pshs      d
+                    lbsr      L30E3
                     leas      $02,s
-                    lbra      L2DA5
+                    lbra      L2DA4
 
-L2EE7               cmpx      #$0064
-                    lbeq      L2E4D
+L2EE6               cmpx      #$0064
+                    lbeq      L2E4C
                     cmpx      #$0078
-                    lbeq      L2E62
+                    lbeq      L2E61
                     cmpx      #$0063
-                    lbeq      L2E7A
+                    lbeq      L2E79
                     cmpx      #$0073
-                    lbeq      L2E87
-                    bra       L2EDA
+                    lbeq      L2E86
+                    bra       L2ED9
 
-L2F05               leas      $0b,s
+L2F04               leas      $0b,s
                     puls      pc,u
-L2F09               pshs      u,d
+L2F08               pshs      u,d
                     leax      $0286,y
                     stx       ,s
                     ldd       $06,s
-                    bge       L2F3E
+                    bge       L2F3D
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-                    bge       L2F33
-                    leax      L3109,pcr
+                    bge       L2F32
+                    leax      L3108,pcr
                     pshs      x
                     leax      $0286,y
                     pshs      x
-                    lbsr      L5600
+                    lbsr      L55FF
                     leas      $04,s
-                    lbra      L30E0
+                    lbra      L30DF
 
-L2F33               ldd       #$002D
+L2F32               ldd       #$002D
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-L2F3E               ldd       $06,s
+L2F3D               ldd       $06,s
                     pshs      d
                     ldd       $02,s
                     pshs      d
-                    bsr       L2F53
+                    bsr       L2F52
                     leas      $04,s
                     leax      $0286,y
                     tfr       x,d
-                    lbra      L30E0
+                    lbra      L30DF
 
-L2F53               pshs      u,y,x,d
+L2F52               pshs      u,y,x,d
                     ldu       $0a,s
                     clra
                     clrb
@@ -5255,48 +5246,48 @@ L2F53               pshs      u,y,x,d
                     clra
                     clrb
                     std       ,s
-                    bra       L2F70
+                    bra       L2F6F
 
-L2F61               ldd       ,s
+L2F60               ldd       ,s
                     addd      #$0001
                     std       ,s
                     ldd       $0C,s
                     subd      >$0043,y
                     std       $0C,s
-L2F70               ldd       $0C,s
-                    blt       L2F61
+L2F6F               ldd       $0C,s
+                    blt       L2F60
                     leax      >$0043,y
                     stx       $04,s
-                    bra       L2FB2
+                    bra       L2FB1
 
-L2F7C               ldd       ,s
+L2F7B               ldd       ,s
                     addd      #$0001
                     std       ,s
-L2F83               ldd       $0C,s
+L2F82               ldd       $0C,s
                     subd      [$04,s]
                     std       $0C,s
-                    bge       L2F7C
+                    bge       L2F7B
                     ldd       $0C,s
                     addd      [$04,s]
                     std       $0C,s
                     ldd       ,s
-                    beq       L2F9C
+                    beq       L2F9B
                     ldd       #$0001
                     std       $02,s
-L2F9C               ldd       $02,s
-                    beq       L2FA7
+L2F9B               ldd       $02,s
+                    beq       L2FA6
                     ldd       ,s
                     addd      #$0030
                     stb       ,u+
-L2FA7               clra
+L2FA6               clra
                     clrb
                     std       ,s
                     ldd       $04,s
                     addd      #$0002
                     std       $04,s
-L2FB2               ldd       $04,s
+L2FB1               ldd       $04,s
                     cmpd      $0001
-                    bne       L2F83
+                    bne       L2F82
                     ldd       $0C,s
                     addd      #$0030
                     stb       ,u+
@@ -5306,23 +5297,23 @@ L2FB2               ldd       $04,s
                     ldd       $0a,s
                     leas      $06,s
                     puls      pc,u
-L2FCA               pshs      u,x,d
+L2FC9               pshs      u,x,d
                     leax      $0286,y
                     stx       $02,s
                     leau      $0290,y
-L2FD6               ldd       $08,s
+L2FD5               ldd       $08,s
                     clra
                     andb      #$0f
                     std       ,s
                     pshs      d
                     ldd       $02,s
                     cmpd      #$0009
-                    ble       L2FEC
+                    ble       L2FEB
                     ldd       #$0057
-                    bra       L2FEF
+                    bra       L2FEE
 
-L2FEC               ldd       #$0030
-L2FEF               addd      ,s++
+L2FEB               ldd       #$0030
+L2FEE               addd      ,s++
                     stb       ,u+
                     ldd       $08,s
                     lsra
@@ -5335,154 +5326,154 @@ L2FEF               addd      ,s++
                     rorb
                     anda      #$0f
                     std       $08,s
-                    bne       L2FD6
-                    bra       L300F
+                    bne       L2FD5
+                    bra       L300E
 
-L3005               ldb       ,u
+L3004               ldb       ,u
                     ldx       $02,s
                     leax      $01,x
                     stx       $02,s
                     stb       -$01,x
-L300F               leau      -$01,u
+L300E               leau      -$01,u
                     pshs      u
                     leax      $0290,y
                     cmpx      ,s++
-                    bls       L3005
+                    bls       L3004
                     clra
                     clrb
                     stb       [$02,s]
                     leax      $0286,y
                     tfr       x,d
-                    lbra      L3105
+                    lbra      L3104
 
-L3029               pshs      u
+L3028               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     pshs      d
-                    lbsr      L55EF
+                    lbsr      L55EE
                     leas      $02,s
                     nega
                     negb
                     sbca      #$00
                     leau      d,u
                     ldd       L001D
-                    bne       L3060
-                    bra       L304D
+                    bne       L305F
+                    bra       L304C
 
-L3044               ldd       $001F
+L3043               ldd       $001F
                     pshs      d
-                    lbsr      L30E4
+                    lbsr      L30E3
                     leas      $02,s
-L304D               tfr       u,d
+L304C               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    bgt       L3044
-                    bra       L3060
+                    bgt       L3043
+                    bra       L305F
 
-L3057               ldd       ,s
+L3056               ldd       ,s
                     pshs      d
-                    lbsr      L30E4
+                    lbsr      L30E3
                     leas      $02,s
-L3060               ldx       $06,s
+L305F               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
                     sex
                     std       ,s
-                    bne       L3057
+                    bne       L3056
                     ldd       L001D
-                    lbeq      L30E0
-                    bra       L307E
+                    lbeq      L30DF
+                    bra       L307D
 
-L3075               ldd       $001F
+L3074               ldd       $001F
                     pshs      d
-                    lbsr      L30E4
+                    lbsr      L30E3
                     leas      $02,s
-L307E               tfr       u,d
+L307D               tfr       u,d
                     leau      -$01,u
                     std       -$02,s
-                    bgt       L3075
-                    lbra      L30E0
+                    bgt       L3074
+                    lbra      L30DF
 
-L3089               pshs      u
+L3088               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $0a,s
                     subd      $08,s
                     std       ,s
                     ldd       L001D
-                    bne       L30BA
-                    bra       L30A3
+                    bne       L30B9
+                    bra       L30A2
 
-L309B               ldd       $001F
+L309A               ldd       $001F
                     pshs      d
-                    bsr       L30E4
+                    bsr       L30E3
                     leas      $02,s
-L30A3               ldd       ,s
+L30A2               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bgt       L309B
-                    bra       L30BA
+                    bgt       L309A
+                    bra       L30B9
 
-L30B1               ldb       ,u+
+L30B0               ldb       ,u+
                     sex
                     pshs      d
-                    bsr       L30E4
+                    bsr       L30E3
                     leas      $02,s
-L30BA               ldd       $08,s
+L30B9               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L30B1
+                    bne       L30B0
                     ldd       L001D
-                    beq       L30E0
-                    bra       L30D4
+                    beq       L30DF
+                    bra       L30D3
 
-L30CC               ldd       $001F
+L30CB               ldd       $001F
                     pshs      d
-                    bsr       L30E4
+                    bsr       L30E3
                     leas      $02,s
-L30D4               ldd       ,s
+L30D3               ldd       ,s
                     addd      #$FFFF
                     std       ,s
                     subd      #$FFFF
-                    bgt       L30CC
-L30E0               leas      $02,s
+                    bgt       L30CB
+L30DF               leas      $02,s
                     puls      pc,u
-L30E4               pshs      u
+L30E3               pshs      u
                     ldd       $0021
                     cmpd      #$0002
-                    bne       L30FA
+                    bne       L30F9
                     ldd       $04,s
                     ldx       L001B
                     leax      $01,x
                     stx       L001B
                     stb       -$01,x
-                    bra       L3107
+                    bra       L3106
 
-L30FA               ldd       L001B
+L30F9               ldd       L001B
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L515F
-L3105               leas      $04,s
-L3107               puls      pc,u
-L3109               blt       $313E
+                    lbsr      L515E
+L3104               leas      $04,s
+L3106               puls      pc,u
+L3108               blt       $313D
                     leas      -$09,y
                     pshu      y,x,dp
                     neg       $0034
                     rorb
                     ldd       $08,s
                     pshs      d
-                    lbsr      L31AF
+                    lbsr      L31AE
                     leas      $02,s
                     std       ,s
-                    lbeq      L31A0
+                    lbeq      L319F
                     ldd       >$004b,y
                     std       $02,s
-                    bne       L313F
+                    bne       L313E
                     leax      $029a,y
                     stx       $02,s
                     tfr       x,d
@@ -5491,18 +5482,18 @@ L3109               blt       $313E
                     clra
                     clrb
                     std       $029C,y
-L313F               ldu       [$02,s]
-L3142               ldd       $02,u
+L313E               ldu       [$02,s]
+L3141               ldd       $02,u
                     cmpd      ,s
-                    bcs       L318B
+                    bcs       L318A
                     ldd       $02,u
                     cmpd      ,s
-                    bne       L3157
+                    bne       L3156
                     ldd       ,u
                     std       [$02,s]
-                    bra       L3167
+                    bra       L3166
 
-L3157               ldd       $02,u
+L3156               ldd       $02,u
                     subd      ,s
                     std       $02,u
                     aslb
@@ -5512,45 +5503,45 @@ L3157               ldd       $02,u
                     leau      d,u
                     ldd       ,s
                     std       $02,u
-L3167               ldd       $02,s
+L3166               ldd       $02,s
                     std       >$004b,y
                     stu       $02,s
-                    bra       L317B
+                    bra       L317A
 
-L3171               ldx       $02,s
+L3170               ldx       $02,s
                     leax      $01,x
                     stx       $02,s
                     clra
                     clrb
                     stb       -$01,x
-L317B               ldd       $08,s
+L317A               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L3171
+                    bne       L3170
                     tfr       u,d
-                    bra       L31AB
+                    bra       L31AA
 
-L318B               cmpu      >$004b,y
-                    bne       L31A4
+L318A               cmpu      >$004b,y
+                    bne       L31A3
                     ldd       ,s
                     pshs      d
-                    bsr       L31BC
+                    bsr       L31BB
                     leas      $02,s
                     tfr       d,u
                     stu       -$02,s
-                    bne       L31A4
-L31A0               clra
+                    bne       L31A3
+L319F               clra
                     clrb
-                    bra       L31AB
+                    bra       L31AA
 
-L31A4               stu       $02,s
+L31A3               stu       $02,s
                     ldu       ,u
-                    lbra      L3142
+                    lbra      L3141
 
-L31AB               leas      $04,s
+L31AA               leas      $04,s
                     puls      pc,u
-L31AF               pshs      u
+L31AE               pshs      u
                     ldd       $04,s
                     addd      #$0003
                     lsra
@@ -5558,63 +5549,63 @@ L31AF               pshs      u
                     lsra
                     rorb
                     puls      pc,u
-L31BC               pshs      u,d
+L31BB               pshs      u,d
                     ldd       $06,s
                     addd      #$007F
                     pshs      d
                     ldd       #$0007
-                    lbsr      L5FBA
+                    lbsr      L5FB9
                     pshs      d
                     ldd       #$0007
-                    lbsr      $5FD1
+                    lbsr      L5FD0
                     std       ,s
                     pshs      d
                     ldd       #$0004
-                    lbsr      $5E90
+                    lbsr      L5E8F
                     std       ,s
                     pshs      d
-                    lbsr      L6198
+                    lbsr      L6197
                     leas      $02,s
                     tfr       d,u
                     cmpu      #$FFFF
-                    bne       L31F3
+                    bne       L31F2
                     clra
                     clrb
-                    lbra      L328F
+                    lbra      L328E
 
-L31F3               ldd       ,s
+L31F2               ldd       ,s
                     pshs      d
                     pshs      u
-                    bsr       L3204
+                    bsr       L3203
                     leas      $04,s
                     ldd       >$004b,y
-                    lbra      L328F
+                    lbra      L328E
 
-L3204               pshs      u,d
+L3203               pshs      u,d
                     ldu       $06,s
-                    lbeq      L328F
+                    lbeq      L328E
                     ldd       $08,s
                     pshs      d
-                    lbsr      L31AF
+                    lbsr      L31AE
                     leas      $02,s
                     std       $08,s
                     ldd       >$004b,y
-                    bra       L3230
+                    bra       L322F
 
-L321D               ldd       ,s
+L321C               ldd       ,s
                     cmpd      [,s]
-                    bcs       L322E
+                    bcs       L322D
                     cmpu      ,s
-                    bhi       L323E
+                    bhi       L323D
                     cmpu      [,s]
-                    bcs       L323E
-L322E               ldd       [,s]
-L3230               std       ,s
+                    bcs       L323D
+L322D               ldd       [,s]
+L322F               std       ,s
                     cmpu      ,s
-                    bls       L321D
+                    bls       L321C
                     cmpu      [,s]
-                    lbcc      L321D
-L323E               pshs      u
+                    lbcc      L321C
+L323D               pshs      u
                     ldd       $0a,s
                     aslb
                     rola
@@ -5622,7 +5613,7 @@ L323E               pshs      u
                     rola
                     addd      ,s++
                     cmpd      [,s]
-                    bne       L3260
+                    bne       L325F
                     ldd       $08,s
                     pshs      d
                     ldx       [$02,s]
@@ -5631,10 +5622,10 @@ L323E               pshs      u
                     std       $08,s
                     ldx       ,s
                     ldd       [,x]
-                    bra       L3262
+                    bra       L3261
 
-L3260               ldd       [,s]
-L3262               std       ,u
+L325F               ldd       [,s]
+L3261               std       ,u
                     ldx       ,s
                     ldd       $02,x
                     aslb
@@ -5644,68 +5635,68 @@ L3262               std       ,u
                     addd      ,s
                     pshs      d
                     cmpu      ,s++
-                    bne       L3283
+                    bne       L3282
                     ldx       ,s
                     ldd       $02,x
                     addd      $08,s
                     std       $02,x
                     ldd       ,u
                     std       [,s]
-                    bra       L3285
+                    bra       L3284
 
-L3283               stu       [,s]
-L3285               ldd       $08,s
+L3282               stu       [,s]
+L3284               ldd       $08,s
                     std       $02,u
                     ldd       ,s
                     std       >$004b,y
-L328F               leas      $02,s
+L328E               leas      $02,s
                     puls      pc,u
-L3293               pshs      u
+L3292               pshs      u
                     ldu       $0a,s
                     leas      -$08,s
                     ldd       $0C,s
                     cmpd      #$0088
-                    bne       L32B1
+                    bne       L32B0
                     ldd       $10,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L39DA
-                    lbra      L3800
+                    lbsr      L39D9
+                    lbra      L37FF
 
-L32B1               ldd       $0C,s
+L32B0               ldd       $0C,s
                     cmpd      #$0087
-                    bne       L32C9
+                    bne       L32C8
                     ldd       $10,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L3BC3
-                    lbra      L3800
+                    lbsr      L3BC2
+                    lbra      L37FF
 
-L32C9               ldx       $0C,s
-                    lbra      L3549
+L32C8               ldx       $0C,s
+                    lbra      L3548
 
-L32CE               ldd       $0e,s
+L32CD               ldd       $0e,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     std       ,s
-                    leax      L44F5,pcr
+                    leax      L44F4,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
                     ldd       $000D
                     subd      #$0002
                     std       $000D
                     cmpd      L0017
-                    lbge      L39D6
+                    lbge      L39D5
                     ldd       $000D
                     std       L0017
-                    lbra      L39D6
+                    lbra      L39D5
 
-L32FB               ldd       $10,s
+L32FA               ldd       $10,s
                     pshs      d
                     ldd       #$0036
                     pshs      d
@@ -5713,131 +5704,131 @@ L32FB               ldd       $10,s
                     pshs      d
                     ldd       #$0081
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       $0e,s
                     std       $10,s
                     ldd       #$005A
                     std       $0e,s
-L331E               leax      $44FF,pcr
+L331D               leax      $44FE,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L4333
+                    lbsr      L4332
                     std       ,s
-                    lbra      L3401
+                    lbra      L3400
 
-L3335               leax      $4502,pcr
-                    lbra      L34A2
+L3334               leax      $4501,pcr
+                    lbra      L34A1
 
-L333C               pshs      u
+L333B               pshs      u
                     ldd       $12,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
-                    lbsr      L3EA5
+                    lbsr      L3EA4
                     leas      $06,s
-                    lbra      L39D6
+                    lbra      L39D5
 
-L3350               leax      $450D,pcr
-                    bra       L337E
+L334F               leax      $450C,pcr
+                    bra       L337D
 
-L3356               leax      L4514,pcr
-                    bra       L337E
+L3355               leax      L4513,pcr
+                    bra       L337D
 
-L335C               leax      L451B,pcr
-                    bra       L337E
+L335B               leax      L451A,pcr
+                    bra       L337D
 
-L3362               leax      L4521,pcr
-                    bra       L337E
+L3361               leax      L4520,pcr
+                    bra       L337D
 
-L3368               leax      L4527,pcr
-                    bra       L337E
+L3367               leax      L4526,pcr
+                    bra       L337D
 
-L336E               leax      L452D,pcr
-                    bra       L337E
+L336D               leax      L452C,pcr
+                    bra       L337D
 
-L3374               leax      L4533,pcr
-                    bra       L337E
+L3373               leax      L4532,pcr
+                    bra       L337D
 
-L337A               leax      L453A,pcr
-L337E               pshs      x
-                    lbsr      L3E52
-                    lbra      L3786
+L3379               leax      L4539,pcr
+L337D               pshs      x
+                    lbsr      L3E51
+                    lbra      L3785
 
-L3386               leax      L4540,pcr
-                    lbra      L34A2
+L3385               leax      L453F,pcr
+                    lbra      L34A1
 
-L338D               leax      L4554,pcr
-                    lbra      L34A2
+L338C               leax      L4553,pcr
+                    lbra      L34A1
 
-L3394               leax      L455F,pcr
+L3393               leax      L455E,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $000D
                     nega
                     negb
                     sbca      #$00
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
                     ldd       >$004f,y
                     pshs      d
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
-                    lbsr      L43DD
-L33BA               ldd       >$0053,y
+                    lbsr      L43DC
+L33B9               ldd       >$0053,y
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $0e,s
-                    bra       L3409
+                    bra       L3408
 
-L33C9               ldd       >$0053,y
+L33C8               ldd       >$0053,y
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $10,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
-                    leax      L4565,pcr
+                    leax      L4564,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $000D
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
-                    leax      L456B,pcr
+                    leax      L456A,pcr
                     pshs      x
-L3401               lbsr      L43F7
+L3400               lbsr      L43F6
                     leas      $02,s
                     ldd       $10,s
-L3409               pshs      d
-                    lbsr      L4415
-                    lbra      L3786
+L3408               pshs      d
+                    lbsr      L4414
+                    lbra      L3785
 
-L3411               ldd       #$0004
+L3410               ldd       #$0004
                     std       $000F
                     ldx       $10,s
                     ldd       $06,x
                     cmpd      #$0034
-                    bne       L3446
+                    bne       L3445
                     ldx       $10,s
                     ldd       $08,x
                     std       $04,s
-                    beq       L3446
+                    beq       L3445
                     ldd       >$0051,y
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     clra
                     clrb
@@ -5845,12 +5836,12 @@ L3411               ldd       #$0004
                     ldd       $06,s
                     addd      #$0004
                     pshs      d
-                    lbsr      L4472
-                    lbra      L3800
+                    lbsr      L4471
+                    lbra      L37FF
 
-L3446               leax      L456F,pcr
+L3445               leax      L456E,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     clra
                     clrb
@@ -5859,16 +5850,16 @@ L3446               leax      L456F,pcr
                     pshs      d
                     ldd       $12,s
                     pshs      d
-                    lbsr      L40D1
+                    lbsr      L40D0
                     leas      $06,s
-                    lbra      L34D9
+                    lbra      L34D8
 
-L3467               leax      L4574,pcr
-                    bra       L34A2
+L3466               leax      L4573,pcr
+                    bra       L34A1
 
-L346D               leax      $4578,pcr
+L346C               leax      $4577,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       #$0002
                     pshs      d
@@ -5878,160 +5869,160 @@ L346D               leax      $4578,pcr
                     pshs      d
                     ldd       #$0064
                     pshs      d
-                    lbsr      L4086
-                    lbra      L38D9
+                    lbsr      L4085
+                    lbra      L38D8
 
-L3492               leax      L457B,pcr
-                    bra       L34A2
+L3491               leax      L457A,pcr
+                    bra       L34A1
 
-L3498               leax      L4586,pcr
-                    bra       L34A2
+L3497               leax      L4585,pcr
+                    bra       L34A1
 
-L349E               leax      L4591,pcr
-L34A2               pshs      x
-                    lbra      L3783
+L349D               leax      L4590,pcr
+L34A1               pshs      x
+                    lbra      L3782
 
-L34A7               leax      L459C,pcr
+L34A6               leax      L459B,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     leax      $08,s
-                    bra       L34C3
+                    bra       L34C2
 
-L34B6               leax      L45A1,pcr
+L34B5               leax      L45A0,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
-                    bra       L34C5
+                    bra       L34C4
 
-L34C3               leas      -$08,x
-L34C5               ldd       $0e,s
+L34C2               leas      -$08,x
+L34C4               ldd       $0e,s
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
                     ldd       >$004f,y
                     pshs      d
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
-L34D9               lbsr      L43DD
-                    lbra      L39D6
+L34D8               lbsr      L43DC
+                    lbra      L39D5
 
-L34DF               leax      L45A6,pcr
+L34DE               leax      L45A5,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldx       $0e,s
-                    bra       L353C
+                    bra       L353B
 
-L34EE               ldx       $10,s
+L34ED               ldx       $10,s
                     ldd       $06,x
                     std       $06,s
                     cmpd      #$0094
-                    bne       L3500
+                    bne       L34FF
                     ldd       #$0079
-                    bra       L3510
+                    bra       L350F
 
-L3500               ldd       $06,s
+L34FF               ldd       $06,s
                     cmpd      #$0095
-                    bne       L350D
+                    bne       L350C
                     ldd       #$0075
-                    bra       L3510
+                    bra       L350F
 
-L350D               ldd       #$0078
-L3510               std       $06,s
+L350C               ldd       #$0078
+L350F               std       $06,s
                     pshs      d
                     ldx       $12,s
                     ldd       $08,x
                     pshs      d
-                    leax      L45AC,pcr
+                    leax      L45AB,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
-                    lbra      L38D9
+                    lbsr      L2D54
+                    lbra      L38D8
 
-L352B               ldd       $10,s
+L352A               ldd       $10,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     std       ,s
-                    leax      $45B3,pcr
-                    lbra      L37A9
+                    leax      $45B2,pcr
+                    lbra      L37A8
 
-L353C               cmpx      #$0077
-                    beq       L34EE
+L353B               cmpx      #$0077
+                    beq       L34ED
                     cmpx      #$0070
-                    beq       L352B
-                    lbra      L39D6
+                    beq       L352A
+                    lbra      L39D5
 
-L3549               cmpx      #$007A
-                    lbeq      L32CE
+L3548               cmpx      #$007A
+                    lbeq      L32CD
                     cmpx      #$007D
-                    lbeq      L32FB
+                    lbeq      L32FA
                     cmpx      #$0082
-                    lbeq      L331E
+                    lbeq      L331D
                     cmpx      #$0012
-                    lbeq      L3335
+                    lbeq      L3334
                     cmpx      #$0057
-                    lbeq      L333C
+                    lbeq      L333B
                     cmpx      #$0058
-                    lbeq      L333C
+                    lbeq      L333B
                     cmpx      #$0059
-                    lbeq      L333C
+                    lbeq      L333B
                     cmpx      #$0052
-                    lbeq      L3350
+                    lbeq      L334F
                     cmpx      #$004E
-                    lbeq      L3356
+                    lbeq      L3355
                     cmpx      #$0053
-                    lbeq      L335C
+                    lbeq      L335B
                     cmpx      #$0056
-                    lbeq      L3362
+                    lbeq      L3361
                     cmpx      #$0055
-                    lbeq      L3368
+                    lbeq      L3367
                     cmpx      #$004D
-                    lbeq      L336E
+                    lbeq      L336D
                     cmpx      #$004C
-                    lbeq      L3374
+                    lbeq      L3373
                     cmpx      #$0054
-                    lbeq      L337A
+                    lbeq      L3379
                     cmpx      #$0043
-                    lbeq      L3386
+                    lbeq      L3385
                     cmpx      #$0044
-                    lbeq      L338D
+                    lbeq      L338C
                     cmpx      #$001D
-                    lbeq      L3394
+                    lbeq      L3393
                     cmpx      #$007C
-                    lbeq      L33BA
+                    lbeq      L33B9
                     cmpx      #$0009
-                    lbeq      L33C9
+                    lbeq      L33C8
                     cmpx      #$0065
-                    lbeq      L3411
+                    lbeq      L3410
                     cmpx      #$0085
-                    lbeq      L3467
+                    lbeq      L3466
                     cmpx      #$0084
-                    lbeq      L346D
+                    lbeq      L346C
                     cmpx      #$0098
-                    lbeq      L3492
+                    lbeq      L3491
                     cmpx      #$0096
-                    lbeq      L3498
+                    lbeq      L3497
                     cmpx      #$0097
-                    lbeq      L349E
+                    lbeq      L349D
                     cmpx      #$0076
-                    lbeq      L34A7
+                    lbeq      L34A6
                     cmpx      #$006F
-                    lbeq      L34B6
+                    lbeq      L34B5
                     cmpx      #$007B
-                    lbeq      L34DF
+                    lbeq      L34DE
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     leas      $02,s
                     std       $06,s
                     ldd       $10,s
                     cmpd      #$0077
-                    lbne      L36A2
+                    lbne      L36A1
                     ldd       $06,u
                     cmpd      #$0085
-                    bne       L3685
+                    bne       L3684
                     ldd       $0a,u
                     pshs      d
                     ldd       #$0077
@@ -6040,85 +6031,85 @@ L3549               cmpx      #$007A
                     pshs      d
                     ldd       $12,s
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldx       $0C,s
-                    bra       L3667
+                    bra       L3666
 
-L364E               leax      $45B9,pcr
-                    bra       L365E
+L364D               leax      $45B8,pcr
+                    bra       L365D
 
-L3654               leax      $45BD,pcr
-                    bra       L365E
+L3653               leax      $45BC,pcr
+                    bra       L365D
 
-L365A               leax      L45C5,pcr
-L365E               pshs      x
-                    lbsr      L43D2
+L3659               leax      L45C4,pcr
+L365D               pshs      x
+                    lbsr      L43D1
                     leas      $02,s
-                    bra       L367D
+                    bra       L367C
 
-L3667               cmpx      #$0075
-                    beq       L364E
+L3666               cmpx      #$0075
+                    beq       L364D
                     cmpx      #$004F
-                    beq       L3654
+                    beq       L3653
                     cmpx      #$0050
-                    lbeq      L3654
+                    lbeq      L3653
                     cmpx      #$0051
-                    beq       L365A
-L367D               ldd       #$0070
+                    beq       L3659
+L367C               ldd       #$0070
                     std       $06,u
-                    lbra      L39D6
+                    lbra      L39D5
 
-L3685               ldd       ,u
+L3684               ldd       ,u
                     cmpd      #$0002
-                    bne       L36A2
+                    bne       L36A1
                     ldd       $0C,s
                     cmpd      #$007F
-                    beq       L36A2
+                    beq       L36A1
                     ldd       $06,s
                     cmpd      #$0078
-                    beq       L36A2
+                    beq       L36A1
                     ldd       #$0062
                     std       $06,s
-L36A2               ldx       $0C,s
-                    lbra      L3947
+L36A1               ldx       $0C,s
+                    lbra      L3946
 
-L36A7               ldd       $10,s
+L36A6               ldd       $10,s
                     cmpd      #$0077
-                    lbne      L3766
+                    lbne      L3765
                     ldd       $08,u
                     std       ,s
                     ldd       $06,u
                     std       $02,s
                     tfr       d,x
-                    lbra      L3742
+                    lbra      L3741
 
-L36BF               ldd       $0e,s
+L36BE               ldd       $0e,s
                     cmpd      #$0070
-                    beq       L36E4
+                    beq       L36E3
                     ldd       $06,s
                     pshs      d
-                    lbsr      L448F
+                    lbsr      L448E
                     leas      $02,s
                     ldd       $02,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     std       ,s
                     ldd       $02,s
                     pshs      d
-                    leax      L45CD,pcr
-                    lbra      L38D0
+                    leax      L45CC,pcr
+                    lbra      L38CF
 
-L36E4               ldd       #$0064
+L36E3               ldd       #$0064
                     pshs      d
                     ldd       $04,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     std       ,s
-                    lbsr      L39BF
+                    lbsr      L39BE
                     leas      $04,s
                     ldd       ,s
-                    lbeq      L39D6
+                    lbeq      L39D5
                     ldd       ,s
                     pshs      d
                     ldd       #$0036
@@ -6127,176 +6118,176 @@ L36E4               ldd       #$0064
                     pshs      d
                     ldd       #$0050
                     pshs      d
-                    lbsr      L3293
-                    lbra      L38D9
+                    lbsr      L3292
+                    lbra      L38D8
 
-L3716               ldd       $0e,s
+L3715               ldd       $0e,s
                     cmpd      #$0070
-                    lbeq      L39D6
+                    lbeq      L39D5
                     ldd       $06,s
                     pshs      d
                     ldd       #$0064
-                    lbra      L37FB
+                    lbra      L37FA
 
-L372A               ldd       $08,u
+L3729               ldd       $08,u
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L44A6
-                    lbra      L3800
+                    lbsr      L44A5
+                    lbra      L37FF
 
-L3738               ldd       #$0036
+L3737               ldd       #$0036
                     std       $10,s
                     ldu       ,s
-                    bra       L3766
+                    bra       L3765
 
-L3742               cmpx      #$0071
-                    lbeq      L36BF
+L3741               cmpx      #$0071
+                    lbeq      L36BE
                     cmpx      #$0076
-                    lbeq      L36BF
+                    lbeq      L36BE
                     cmpx      #$006F
-                    lbeq      L36BF
+                    lbeq      L36BE
                     cmpx      #$0070
-                    beq       L3716
+                    beq       L3715
                     cmpx      #$0037
-                    beq       L372A
+                    beq       L3729
                     cmpx      #$0036
-                    beq       L3738
-L3766               ldd       $0e,s
+                    beq       L3737
+L3765               ldd       $0e,s
                     cmpd      #$0070
-                    bne       L378B
+                    bne       L378A
                     ldd       $10,s
                     cmpd      #$0036
-                    bne       L378B
+                    bne       L378A
                     cmpu      #$0000
-                    bne       L378B
-                    leax      $45D4,pcr
+                    bne       L378A
+                    leax      $45D3,pcr
                     pshs      x
-L3783               lbsr      L43D2
-L3786               leas      $02,s
-                    lbra      L39D6
+L3782               lbsr      L43D1
+L3785               leas      $02,s
+                    lbra      L39D5
 
-L378B               leax      L45DF,pcr
-                    lbra      L380F
+L378A               leax      L45DE,pcr
+                    lbra      L380E
 
-L3792               ldd       $10,s
+L3791               ldd       $10,s
                     cmpd      #$0036
-                    bne       L37B7
+                    bne       L37B6
                     cmpu      #$0000
-                    bne       L37B7
+                    bne       L37B6
                     ldd       $06,s
                     pshs      d
-                    leax      $45E2,pcr
-L37A9               pshs      x
+                    leax      $45E1,pcr
+L37A8               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    lbra      L39D6
+                    lbra      L39D5
 
-L37B7               leax      L45EE,pcr
+L37B6               leax      L45ED,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $06,s
                     cmpd      #$0062
-                    bne       L3816
+                    bne       L3815
                     ldd       #$0064
                     std       $06,s
-                    bra       L3816
+                    bra       L3815
 
-L37D1               ldd       $10,s
+L37D0               ldd       $10,s
                     cmpd      #$0077
-                    bne       L3805
+                    bne       L3804
                     ldd       $06,u
                     std       $02,s
                     pshs      d
-                    lbsr      L1EB4
+                    lbsr      L1EB3
                     std       ,s++
-                    beq       L3805
+                    beq       L3804
                     ldd       $02,s
                     cmpd      $0e,s
-                    lbeq      L39D6
+                    lbeq      L39D5
                     ldd       $02,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     std       ,s
                     ldd       $08,s
-L37FB               pshs      d
-                    lbsr      L39BF
-L3800               leas      $04,s
-                    lbra      L39D6
+L37FA               pshs      d
+                    lbsr      L39BE
+L37FF               leas      $04,s
+                    lbra      L39D5
 
-L3805               leax      $45F2,pcr
-                    bra       L380F
+L3804               leax      $45F1,pcr
+                    bra       L380E
 
-L380B               leax      $45F5,pcr
-L380F               pshs      x
-                    lbsr      L43B9
+L380A               leax      $45F4,pcr
+L380E               pshs      x
+                    lbsr      L43B8
                     leas      $02,s
-L3816               leax      $08,s
-                    bra       L382B
+L3815               leax      $08,s
+                    bra       L382A
 
-L381A               ldd       #$0043
+L3819               ldd       #$0043
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $02,s
-L3824               leax      $45F9,pcr
-                    lbra      L38A3
+L3823               leax      $45F8,pcr
+                    lbra      L38A2
 
-L382B               leas      -$08,x
-                    lbra      L38AA
+L382A               leas      -$08,x
+                    lbra      L38A9
 
-L3830               ldd       $10,s
+L382F               ldd       $10,s
                     cmpd      #$0077
-                    lbne      L389F
+                    lbne      L389E
                     ldd       [$08,u]
                     std       $02,s
                     tfr       d,x
-                    bra       L388C
+                    bra       L388B
 
-L3844               ldd       $06,s
+L3843               ldd       $06,s
                     pshs      d
-                    lbsr      L448F
+                    lbsr      L448E
                     leas      $02,s
                     ldd       #$003E
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
                     ldd       $02,s
                     cmpd      #$0023
-                    bne       L386A
+                    bne       L3869
                     ldx       $08,u
                     ldd       $04,x
                     pshs      d
-                    lbsr      L4420
-                    bra       L3874
+                    lbsr      L441F
+                    bra       L3873
 
-L386A               ldd       $08,u
+L3869               ldd       $08,u
                     addd      #$0004
                     pshs      d
-                    lbsr      L4433
-L3874               leas      $02,s
+                    lbsr      L4432
+L3873               leas      $02,s
                     ldd       $14,u
                     pshs      d
-                    lbsr      L40B0
+                    lbsr      L40AF
                     leas      $02,s
                     ldd       >$004d,y
                     pshs      d
-                    lbsr      L43F7
-                    lbra      L3917
+                    lbsr      L43F6
+                    lbra      L3916
 
-L388C               cmpx      #$0021
-                    beq       L3844
+L388B               cmpx      #$0021
+                    beq       L3843
                     cmpx      #$0022
-                    lbeq      L3844
+                    lbeq      L3843
                     cmpx      #$0023
-                    lbeq      L3844
-L389F               leax      $45FD,pcr
-L38A3               pshs      x
-                    lbsr      L43B9
+                    lbeq      L3843
+L389E               leax      $45FC,pcr
+L38A2               pshs      x
+                    lbsr      L43B8
                     leas      $02,s
-L38AA               clra
+L38A9               clra
                     clrb
                     pshs      d
                     pshs      u
@@ -6304,133 +6295,133 @@ L38AA               clra
                     pshs      d
                     ldd       $0C,s
                     pshs      d
-                    lbsr      L4086
-                    bra       L38D9
+                    lbsr      L4085
+                    bra       L38D8
 
-L38BE               ldd       $10,s
+L38BD               ldd       $10,s
                     pshs      d
-                    lbsr      L3988
+                    lbsr      L3987
                     std       ,s
                     ldd       $08,s
                     pshs      d
-                    leax      $4601,pcr
-L38D0               pshs      x
+                    leax      $4600,pcr
+L38CF               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
-L38D9               leas      $08,s
-                    lbra      L39D6
+                    lbsr      L2D54
+L38D8               leas      $08,s
+                    lbra      L39D5
 
-L38DE               ldd       $06,s
+L38DD               ldd       $06,s
                     pshs      d
-                    lbsr      L448F
+                    lbsr      L448E
                     leas      $02,s
                     ldx       $10,s
-                    bra       L392D
+                    bra       L392C
 
-L38EC               leax      $460D,pcr
+L38EB               leax      $460C,pcr
                     pshs      x
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
                     leax      $08,s
-                    bra       L390E
+                    bra       L390D
 
-L38FB               pshs      u
-                    lbsr      L4408
+L38FA               pshs      u
+                    lbsr      L4407
                     leas      $02,s
                     ldd       #$002C
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
-                    bra       L3910
+                    bra       L390F
 
-L390E               leas      -$08,x
-L3910               ldd       $06,s
+L390D               leas      -$08,x
+L390F               ldd       $06,s
                     pshs      d
-                    lbsr      L43E8
-L3917               leas      $02,s
-                    lbsr      L43DD
-                    lbra      L39D6
+                    lbsr      L43E7
+L3916               leas      $02,s
+                    lbsr      L43DC
+                    lbra      L39D5
 
-L391F               leax      L4610,pcr
+L391E               leax      L460F,pcr
                     pshs      x
-                    lbsr      L4824
+                    lbsr      L4823
                     leas      $02,s
-                    lbra      L39D6
+                    lbra      L39D5
 
-L392D               cmpx      #$0070
-                    beq       L38EC
+L392C               cmpx      #$0070
+                    beq       L38EB
                     cmpx      #$0036
-                    beq       L38FB
-                    bra       L391F
+                    beq       L38FA
+                    bra       L391E
 
-L3939               ldd       >$0057,y
+L3938               ldd       >$0057,y
                     pshs      d
-                    lbsr      L4824
+                    lbsr      L4823
                     leas      $02,s
-                    lbra      L39D6
+                    lbra      L39D5
 
-L3947               cmpx      #$0075
-                    lbeq      L36A7
+L3946               cmpx      #$0075
+                    lbeq      L36A6
                     cmpx      #$0081
-                    lbeq      L3792
+                    lbeq      L3791
                     cmpx      #$0079
-                    lbeq      L37D1
+                    lbeq      L37D0
                     cmpx      #$0051
-                    lbeq      L380B
+                    lbeq      L380A
                     cmpx      #$004F
-                    lbeq      L381A
+                    lbeq      L3819
                     cmpx      #$0050
-                    lbeq      L3824
+                    lbeq      L3823
                     cmpx      #$007F
-                    lbeq      L3830
+                    lbeq      L382F
                     cmpx      #$0073
-                    lbeq      L38BE
+                    lbeq      L38BD
                     cmpx      #$0074
-                    lbeq      L38DE
-                    bra       L3939
+                    lbeq      L38DD
+                    bra       L3938
 
-L3988               pshs      u
+L3987               pshs      u
                     ldx       $04,s
-                    bra       L39A7
+                    bra       L39A6
 
-L398E               ldd       #$0064
+L398D               ldd       #$0064
                     puls      pc,u
-L3993               ldd       #$0078
+L3992               ldd       #$0078
                     puls      pc,u
-L3998               ldd       #$0079
+L3997               ldd       #$0079
                     puls      pc,u
-L399D               ldd       #$0075
+L399C               ldd       #$0075
                     puls      pc,u
-L39A2               ldd       #$0020
+L39A1               ldd       #$0020
                     puls      pc,u
-L39A7               cmpx      #$0070
-                    beq       L398E
+L39A6               cmpx      #$0070
+                    beq       L398D
                     cmpx      #$0071
-                    beq       L3993
+                    beq       L3992
                     cmpx      #$0076
-                    beq       L3998
+                    beq       L3997
                     cmpx      #$006F
-                    beq       L399D
-                    bra       L39A2
+                    beq       L399C
+                    bra       L39A1
                     puls      pc,u
-L39BF               pshs      u
+L39BE               pshs      u
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      L4618,pcr
+                    leax      L4617,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
-L39D6               leas      $08,s
+                    lbsr      L2D54
+L39D5               leas      $08,s
                     puls      pc,u
-L39DA               pshs      u
+L39D9               pshs      u
                     ldx       $04,s
-                    lbra      L3AFA
+                    lbra      L3AF9
 
-L39E1               ldd       #$0002
+L39E0               ldd       #$0002
                     pshs      d
                     ldd       #$0093
                     pshs      d
@@ -6438,13 +6429,13 @@ L39E1               ldd       #$0002
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $04,s
                     clra
                     clrb
@@ -6455,467 +6446,467 @@ L39E1               ldd       #$0002
                     pshs      d
                     ldd       #$0075
                     pshs      d
-                    lbsr      L3293
+                    lbsr      L3292
                     leas      $08,s
                     ldd       #$0070
                     pshs      d
                     ldd       #$007A
                     pshs      d
-                    lbsr      L3293
-                    lbra      L3BD6
+                    lbsr      L3292
+                    lbra      L3BD5
 
-L3A31               leax      L4624,pcr
+L3A30               leax      L4623,pcr
                     pshs      x
-                    lbsr      L43D2
-                    lbra      L40CD
+                    lbsr      L43D1
+                    lbra      L40CC
 
-L3A3D               leax      L4647,pcr
-                    bra       L3A7D
+L3A3C               leax      L4646,pcr
+                    bra       L3A7C
 
-L3A43               leax      L464E,pcr
-                    bra       L3A90
+L3A42               leax      L464D,pcr
+                    bra       L3A8F
 
-L3A49               leax      L4654,pcr
-                    bra       L3A90
+L3A48               leax      L4653,pcr
+                    bra       L3A8F
 
-L3A4F               leax      L465A,pcr
-                    bra       L3A90
+L3A4E               leax      L4659,pcr
+                    bra       L3A8F
 
-L3A55               leax      L4660,pcr
-                    bra       L3A90
+L3A54               leax      L465F,pcr
+                    bra       L3A8F
 
-L3A5B               leax      L4666,pcr
-                    bra       L3A90
+L3A5A               leax      L4665,pcr
+                    bra       L3A8F
 
-L3A61               leax      L466C,pcr
-                    bra       L3A90
+L3A60               leax      L466B,pcr
+                    bra       L3A8F
 
-L3A67               leax      L4672,pcr
-                    bra       L3A90
+L3A66               leax      L4671,pcr
+                    bra       L3A8F
 
-L3A6D               leax      $4677,pcr
-                    bra       L3A90
+L3A6C               leax      $4676,pcr
+                    bra       L3A8F
 
-L3A73               leax      L467D,pcr
-                    bra       L3A7D
+L3A72               leax      L467C,pcr
+                    bra       L3A7C
 
-L3A79               leax      L4683,pcr
-L3A7D               pshs      x
-                    lbsr      L3E6F
+L3A78               leax      L4682,pcr
+L3A7C               pshs      x
+                    lbsr      L3E6E
                     leas      $02,s
                     ldd       $000D
                     subd      #$0002
-                    lbra      L3E8A
+                    lbra      L3E89
 
-L3A8C               leax      L4689,pcr
-L3A90               pshs      x
-                    lbsr      L3E6F
-                    lbra      L40CD
+L3A8B               leax      L4688,pcr
+L3A8F               pshs      x
+                    lbsr      L3E6E
+                    lbra      L40CC
 
-L3A98               leax      L4690,pcr
-                    bra       L3ABA
+L3A97               leax      L468F,pcr
+                    bra       L3AB9
 
-L3A9E               leax      L4696,pcr
-                    bra       L3ABA
+L3A9D               leax      L4695,pcr
+                    bra       L3AB9
 
-L3AA4               leax      L469E,pcr
-                    bra       L3ABA
+L3AA3               leax      L469D,pcr
+                    bra       L3AB9
 
-L3AAA               leax      L46A5,pcr
-                    bra       L3ABA
+L3AA9               leax      L46A4,pcr
+                    bra       L3AB9
 
-L3AB0               leax      L46AC,pcr
-                    bra       L3ABA
+L3AAF               leax      L46AB,pcr
+                    bra       L3AB9
 
-L3AB6               leax      L46B2,pcr
-L3ABA               pshs      x
-                    lbsr      L3E6F
+L3AB5               leax      L46B1,pcr
+L3AB9               pshs      x
+                    lbsr      L3E6E
                     leas      $02,s
                     ldd       $000D
                     subd      #$0004
-                    lbra      L3E8A
+                    lbra      L3E89
 
-L3AC9               ldd       #$0002
+L3AC8               ldd       #$0002
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbra      L3BD3
+                    lbra      L3BD2
 
-L3AD5               leax      L46B8,pcr
+L3AD4               leax      L46B7,pcr
                     pshs      x
-                    lbsr      L4824
+                    lbsr      L4823
                     leas      $02,s
                     ldd       >$0057,y
                     pshs      d
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
-                    lbsr      L43DD
-                    lbra      L3BC1
+                    lbsr      L43DC
+                    lbra      L3BC0
 
-L3AFA               cmpx      #$006E
-                    lbeq      L39E1
+L3AF9               cmpx      #$006E
+                    lbeq      L39E0
                     cmpx      #$008B
-                    lbeq      L3A31
+                    lbeq      L3A30
                     cmpx      #$0089
-                    lbeq      L3A3D
+                    lbeq      L3A3C
                     cmpx      #$0050
-                    lbeq      L3A43
+                    lbeq      L3A42
                     cmpx      #$0051
-                    lbeq      L3A49
+                    lbeq      L3A48
                     cmpx      #$0052
-                    lbeq      L3A4F
+                    lbeq      L3A4E
                     cmpx      #$0053
-                    lbeq      L3A55
+                    lbeq      L3A54
                     cmpx      #$0054
-                    lbeq      L3A5B
+                    lbeq      L3A5A
                     cmpx      #$0057
-                    lbeq      L3A61
+                    lbeq      L3A60
                     cmpx      #$0058
-                    lbeq      L3A67
+                    lbeq      L3A66
                     cmpx      #$0059
-                    lbeq      L3A6D
+                    lbeq      L3A6C
                     cmpx      #$0056
-                    lbeq      L3A73
+                    lbeq      L3A72
                     cmpx      #$0055
-                    lbeq      L3A79
+                    lbeq      L3A78
                     cmpx      #$005A
-                    lbeq      L3A8C
+                    lbeq      L3A8B
                     cmpx      #$005B
-                    lbeq      L3A8C
+                    lbeq      L3A8B
                     cmpx      #$005E
-                    lbeq      L3A8C
+                    lbeq      L3A8B
                     cmpx      #$005C
-                    lbeq      L3A8C
+                    lbeq      L3A8B
                     cmpx      #$005F
-                    lbeq      L3A8C
+                    lbeq      L3A8B
                     cmpx      #$005D
-                    lbeq      L3A8C
+                    lbeq      L3A8B
                     cmpx      #$0043
-                    lbeq      L3A98
+                    lbeq      L3A97
                     cmpx      #$0044
-                    lbeq      L3A9E
+                    lbeq      L3A9D
                     cmpx      #$0083
-                    lbeq      L3AA4
+                    lbeq      L3AA3
                     cmpx      #$0086
-                    lbeq      L3AAA
+                    lbeq      L3AA9
                     cmpx      #$003C
-                    lbeq      L3AB0
+                    lbeq      L3AAF
                     cmpx      #$003E
-                    lbeq      L3AB0
+                    lbeq      L3AAF
                     cmpx      #$003D
-                    lbeq      L3AB6
+                    lbeq      L3AB5
                     cmpx      #$003F
-                    lbeq      L3AB6
+                    lbeq      L3AB5
                     cmpx      #$004A
-                    lbeq      L3AC9
-                    lbra      L3AD5
+                    lbeq      L3AC8
+                    lbra      L3AD4
 
-L3BC1               puls      pc,u
-L3BC3               pshs      u
+L3BC0               puls      pc,u
+L3BC2               pshs      u
                     ldu       $06,s
                     ldx       $04,s
-                    lbra      L3CD6
+                    lbra      L3CD5
 
-L3BCC               ldd       #$0004
+L3BCB               ldd       #$0004
                     pshs      d
                     pshs      u
-L3BD3               lbsr      L3D91
-L3BD6               leas      $04,s
+L3BD2               lbsr      L3D90
+L3BD5               leas      $04,s
                     puls      pc,u
-L3BDA               leax      L46C7,pcr
+L3BD9               leax      L46C6,pcr
                     pshs      x
-                    lbsr      L3E8E
+                    lbsr      L3E8D
                     leas      $02,s
                     ldd       $000D
                     subd      #$0008
-                    lbra      L3E8A
+                    lbra      L3E89
 
-L3BED               cmpu      #$0005
-                    bne       L3BF8
+L3BEC               cmpu      #$0005
+                    bne       L3BF7
                     ldd       #$0033
-                    bra       L3BFB
+                    bra       L3BFA
 
-L3BF8               ldd       #$0037
-L3BFB               pshs      d
-                    leax      L46CF,pcr
+L3BF7               ldd       #$0037
+L3BFA               pshs      d
+                    leax      L46CE,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
                     puls      pc,u
-L3C0E               cmpu      #$0005
-                    bne       L3C1A
-                    leax      L46DA,pcr
-                    bra       L3C1E
+L3C0D               cmpu      #$0005
+                    bne       L3C19
+                    leax      L46D9,pcr
+                    bra       L3C1D
 
-L3C1A               leax      L46E1,pcr
-L3C1E               tfr       x,d
+L3C19               leax      L46E0,pcr
+L3C1D               tfr       x,d
                     pshs      d
-                    lbsr      L3E8E
-                    lbra      L3E66
+                    lbsr      L3E8D
+                    lbra      L3E65
 
-L3C28               leax      L46E8,pcr
-                    bra       L3C44
+L3C27               leax      L46E7,pcr
+                    bra       L3C43
 
-L3C2E               leax      L46EE,pcr
-                    bra       L3C44
+L3C2D               leax      L46ED,pcr
+                    bra       L3C43
 
-L3C34               leax      L46F4,pcr
-                    bra       L3C44
+L3C33               leax      L46F3,pcr
+                    bra       L3C43
 
-L3C3A               leax      L46FA,pcr
-                    bra       L3C44
+L3C39               leax      L46F9,pcr
+                    bra       L3C43
 
-L3C40               leax      L4700,pcr
-L3C44               pshs      x
-                    lbsr      L3E8E
+L3C3F               leax      L46FF,pcr
+L3C43               pshs      x
+                    lbsr      L3E8D
                     leas      $02,s
                     ldd       $000D
                     addd      #$0008
-                    lbra      L3E8A
+                    lbra      L3E89
 
-L3C53               leax      L4707,pcr
-                    bra       L3CA9
+L3C52               leax      L4706,pcr
+                    bra       L3CA8
 
-L3C59               cmpu      #$0005
-                    bne       L3C65
-                    leax      L470D,pcr
-                    bra       L3C7B
+L3C58               cmpu      #$0005
+                    bne       L3C64
+                    leax      L470C,pcr
+                    bra       L3C7A
 
-L3C65               leax      L4713,pcr
-                    bra       L3C7B
+L3C64               leax      L4712,pcr
+                    bra       L3C7A
 
-L3C6B               cmpu      #$0005
-                    bne       L3C77
-                    leax      L4719,pcr
-                    bra       L3C7B
+L3C6A               cmpu      #$0005
+                    bne       L3C76
+                    leax      L4718,pcr
+                    bra       L3C7A
 
-L3C77               leax      L471F,pcr
-L3C7B               tfr       x,d
+L3C76               leax      L471E,pcr
+L3C7A               tfr       x,d
                     pshs      d
-                    bra       L3CAB
+                    bra       L3CAA
 
-L3C81               leax      L4725,pcr
-                    bra       L3CA9
+L3C80               leax      L4724,pcr
+                    bra       L3CA8
 
-L3C87               leax      L472B,pcr
-                    bra       L3CA9
+L3C86               leax      L472A,pcr
+                    bra       L3CA8
 
-L3C8D               leax      L4731,pcr
-                    bra       L3CA9
+L3C8C               leax      L4730,pcr
+                    bra       L3CA8
 
-L3C93               leax      L4737,pcr
-                    bra       L3CA9
+L3C92               leax      L4736,pcr
+                    bra       L3CA8
 
-L3C99               leax      L473D,pcr
-                    bra       L3CA9
+L3C98               leax      L473C,pcr
+                    bra       L3CA8
 
-L3C9F               leax      L4743,pcr
-                    bra       L3CA9
+L3C9E               leax      L4742,pcr
+                    bra       L3CA8
 
-L3CA5               leax      L4749,pcr
-L3CA9               pshs      x
-L3CAB               lbsr      L3E8E
-                    lbra      L40CD
+L3CA4               leax      L4748,pcr
+L3CA8               pshs      x
+L3CAA               lbsr      L3E8D
+                    lbra      L40CC
 
-L3CB1               leax      L474F,pcr
+L3CB0               leax      L474E,pcr
                     pshs      x
-                    lbsr      L4824
+                    lbsr      L4823
                     leas      $02,s
                     ldd       >$0057,y
                     pshs      d
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
-                    lbsr      L43DD
-                    lbra      L3D8F
+                    lbsr      L43DC
+                    lbra      L3D8E
 
-L3CD6               cmpx      #$004B
-                    lbeq      L3BCC
+L3CD5               cmpx      #$004B
+                    lbeq      L3BCB
                     cmpx      #$006E
-                    lbeq      L3BDA
+                    lbeq      L3BD9
                     cmpx      #$008B
-                    lbeq      L3BED
+                    lbeq      L3BEC
                     cmpx      #$0089
-                    lbeq      L3C0E
+                    lbeq      L3C0D
                     cmpx      #$0050
-                    lbeq      L3C28
+                    lbeq      L3C27
                     cmpx      #$0051
-                    lbeq      L3C2E
+                    lbeq      L3C2D
                     cmpx      #$0052
-                    lbeq      L3C34
+                    lbeq      L3C33
                     cmpx      #$0053
-                    lbeq      L3C3A
+                    lbeq      L3C39
                     cmpx      #$005A
-                    lbeq      L3C40
+                    lbeq      L3C3F
                     cmpx      #$005B
-                    lbeq      L3C40
+                    lbeq      L3C3F
                     cmpx      #$005E
-                    lbeq      L3C40
+                    lbeq      L3C3F
                     cmpx      #$005C
-                    lbeq      L3C40
+                    lbeq      L3C3F
                     cmpx      #$005F
-                    lbeq      L3C40
+                    lbeq      L3C3F
                     cmpx      #$005D
-                    lbeq      L3C40
+                    lbeq      L3C3F
                     cmpx      #$0043
-                    lbeq      L3C53
+                    lbeq      L3C52
                     cmpx      #$003C
-                    lbeq      L3C59
+                    lbeq      L3C58
                     cmpx      #$003E
-                    lbeq      L3C59
+                    lbeq      L3C58
                     cmpx      #$003D
-                    lbeq      L3C6B
+                    lbeq      L3C6A
                     cmpx      #$003F
-                    lbeq      L3C6B
+                    lbeq      L3C6A
                     cmpx      #$008D
-                    lbeq      L3C81
+                    lbeq      L3C80
                     cmpx      #$008C
-                    lbeq      L3C87
+                    lbeq      L3C86
                     cmpx      #$0090
-                    lbeq      L3C8D
+                    lbeq      L3C8C
                     cmpx      #$008E
-                    lbeq      L3C93
+                    lbeq      L3C92
                     cmpx      #$0092
-                    lbeq      L3C99
+                    lbeq      L3C98
                     cmpx      #$0091
-                    lbeq      L3C9F
+                    lbeq      L3C9E
                     cmpx      #$008F
-                    lbeq      L3CA5
-                    lbra      L3CB1
+                    lbeq      L3CA4
+                    lbra      L3CB0
 
-L3D8F               puls      pc,u
-L3D91               pshs      u,d
-                    leax      L475F,pcr
+L3D8E               puls      pc,u
+L3D90               pshs      u,d
+                    leax      L475E,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $000B
                     addd      #$0001
                     std       $000B
                     std       ,s
                     pshs      d
-                    lbsr      L4415
+                    lbsr      L4414
                     leas      $02,s
                     ldd       $08,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    bsr       L3DD1
+                    bsr       L3DD0
                     leas      $04,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L4420
+                    lbsr      L441F
                     leas      $02,s
-                    leax      L4764,pcr
+                    leax      L4763,pcr
                     pshs      x
-                    lbsr      L43D2
+                    lbsr      L43D1
                     leas      $02,s
-                    lbra      L40CD
+                    lbra      L40CC
 
-L3DD1               pshs      u
+L3DD0               pshs      u
                     ldu       $04,s
                     leas      -$02,s
-                    lbsr      $4B89
+                    lbsr      $4B88
                     ldd       $08,s
                     cmpd      #$0001
-                    bne       L3DEC
+                    bne       L3DEB
                     pshs      u
-                    lbsr      L4408
-L3DE7               leas      $02,s
-                    lbra      L3E4C
+                    lbsr      L4407
+L3DE6               leas      $02,s
+                    lbra      L3E4B
 
-L3DEC               cmpu      #$0000
-                    bne       L3E1D
+L3DEB               cmpu      #$0000
+                    bne       L3E1C
                     ldd       #$0001
                     std       ,s
-                    bra       L3E04
+                    bra       L3E03
 
-L3DF9               leax      L476B,pcr
+L3DF8               leax      L476A,pcr
                     pshs      x
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
-L3E04               ldd       ,s
+L3E03               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      $08,s
-                    blt       L3DF9
+                    blt       L3DF8
                     ldd       #$0030
                     pshs      d
-                    lbsr      L43E8
-                    bra       L3DE7
+                    lbsr      L43E7
+                    bra       L3DE6
 
-L3E1D               clra
+L3E1C               clra
                     clrb
-                    bra       L3E43
+                    bra       L3E42
 
-L3E21               ldd       ,u++
+L3E20               ldd       ,u++
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
                     ldd       $08,s
                     addd      #$FFFF
                     cmpd      ,s
-                    beq       L3E3E
+                    beq       L3E3D
                     ldd       #$002C
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
-L3E3E               ldd       ,s
+L3E3D               ldd       ,s
                     addd      #$0001
-L3E43               std       ,s
+L3E42               std       ,s
                     ldd       ,s
                     cmpd      $08,s
-                    blt       L3E21
-L3E4C               lbsr      L43DD
-                    lbra      L40CD
+                    blt       L3E20
+L3E4B               lbsr      L43DC
+                    lbra      L40CC
 
-L3E52               pshs      u
+L3E51               pshs      u
                     ldd       >$0051,y
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L43D2
-L3E66               leas      $02,s
+                    lbsr      L43D1
+L3E65               leas      $02,s
                     ldd       $000D
                     addd      #$0002
-                    bra       L3E8A
+                    bra       L3E89
 
-L3E6F               pshs      u
+L3E6E               pshs      u
                     ldd       >$0051,y
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L43D2
+                    lbsr      L43D1
                     leas      $02,s
                     ldd       $000D
                     addd      #$0004
-L3E8A               std       $000D
+L3E89               std       $000D
                     puls      pc,u
-L3E8E               pshs      u
+L3E8D               pshs      u
                     ldd       >$0051,y
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L43D2
-                    lbra      L40CD
+                    lbsr      L43D1
+                    lbra      L40CC
 
-L3EA5               pshs      u
+L3EA4               pshs      u
                     ldu       $04,s
                     leas      -$06,s
                     clra
@@ -6923,63 +6914,63 @@ L3EA5               pshs      u
                     std       $02,s
                     ldd       $0C,s
                     cmpd      #$0077
-                    bne       L3ED5
+                    bne       L3ED4
                     ldd       [$0e,s]
                     cmpd      #$0002
-                    bne       L3EC5
+                    bne       L3EC4
                     ldd       #$0001
-                    bra       L3EC7
+                    bra       L3EC6
 
-L3EC5               clra
+L3EC4               clra
                     clrb
-L3EC7               std       $02,s
+L3EC6               std       $02,s
                     ldx       $0e,s
                     ldd       $06,x
                     std       $0C,s
                     ldx       $0e,s
                     ldd       $08,x
                     std       $0e,s
-L3ED5               leax      ,u
-                    bra       L3EED
+L3ED4               leax      ,u
+                    bra       L3EEC
 
-L3ED9               leax      $476E,pcr
-                    bra       L3EE9
+L3ED8               leax      $476D,pcr
+                    bra       L3EE8
 
-L3EDF               leax      $4772,pcr
-                    bra       L3EE9
+L3EDE               leax      $4771,pcr
+                    bra       L3EE8
 
-L3EE5               leax      $4775,pcr
-L3EE9               stx       $04,s
-                    bra       L3EFC
+L3EE4               leax      $4774,pcr
+L3EE8               stx       $04,s
+                    bra       L3EFB
 
-L3EED               cmpx      #$0057
-                    beq       L3ED9
+L3EEC               cmpx      #$0057
+                    beq       L3ED8
                     cmpx      #$0058
-                    beq       L3EDF
+                    beq       L3EDE
                     cmpx      #$0059
-                    beq       L3EE5
-L3EFC               ldx       $0C,s
-                    lbra      L405C
+                    beq       L3EE4
+L3EFB               ldx       $0C,s
+                    lbra      L405B
 
-L3F01               ldd       $02,s
-                    beq       L3F23
+L3F00               ldd       $02,s
+                    beq       L3F22
                     cmpu      #$0057
-                    bne       L3F16
+                    bne       L3F15
                     ldd       >$0055,y
                     pshs      d
-                    lbsr      L43D2
+                    lbsr      L43D1
                     leas      $02,s
-L3F16               ldd       $04,s
+L3F15               ldd       $04,s
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     clra
                     clrb
-                    bra       L3F50
+                    bra       L3F4F
 
-L3F23               ldd       $04,s
+L3F22               ldd       $04,s
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     clra
                     clrb
@@ -6990,52 +6981,52 @@ L3F23               ldd       $04,s
                     pshs      d
                     ldd       #$0061
                     pshs      d
-                    lbsr      L4086
+                    lbsr      L4085
                     leas      $08,s
                     ldd       $04,s
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       #$0001
-L3F50               pshs      d
+L3F4F               pshs      d
                     ldd       $10,s
                     pshs      d
                     ldd       $10,s
                     pshs      d
                     ldd       #$0062
                     pshs      d
-                    lbsr      L4086
+                    lbsr      L4085
                     leas      $08,s
-                    lbra      L44A2
+                    lbra      L44A1
 
-L3F69               ldd       $0e,s
+L3F68               ldd       $0e,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      $5FAE
+                    lbsr      L5FAD
                     clra
                     std       ,s
                     tfr       d,x
-                    bra       L3FC3
+                    bra       L3FC2
 
-L3F7A               cmpu      #$0057
-                    bne       L3FCE
+L3F79               cmpu      #$0057
+                    bne       L3FCD
                     ldd       >$0055,y
                     pshs      d
-                    bra       L3F9A
+                    bra       L3F99
 
-L3F88               cmpu      #$0057
-                    beq       L3FCE
+L3F87               cmpu      #$0057
+                    beq       L3FCD
                     cmpu      #$0059
-                    bne       L3FA1
-                    leax      $4779,pcr
+                    bne       L3FA0
+                    leax      $4778,pcr
                     pshs      x
-L3F9A               lbsr      L43D2
+L3F99               lbsr      L43D1
                     leas      $02,s
-                    bra       L3FCE
+                    bra       L3FCD
 
-L3FA1               ldd       $04,s
+L3FA0               ldd       $04,s
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     clra
                     clrb
@@ -7046,40 +7037,40 @@ L3FA1               ldd       $04,s
                     pshs      d
                     ldd       #$0061
                     pshs      d
-                    lbsr      L4086
+                    lbsr      L4085
                     leas      $08,s
-                    bra       L3FCE
+                    bra       L3FCD
 
-L3FC3               stx       -$02,s
-                    beq       L3F7A
+L3FC2               stx       -$02,s
+                    beq       L3F79
                     cmpx      #$00FF
-                    beq       L3F88
-                    bra       L3FA1
+                    beq       L3F87
+                    bra       L3FA0
 
-L3FCE               ldd       $0e,s
+L3FCD               ldd       $0e,s
                     clra
                     std       ,s
                     tfr       d,x
-                    bra       L4024
+                    bra       L4023
 
-L3FD7               cmpu      #$0057
-                    lbne      L44A2
-                    leax      L477E,pcr
-                    bra       L3FF7
+L3FD6               cmpu      #$0057
+                    lbne      L44A1
+                    leax      L477D,pcr
+                    bra       L3FF6
 
-L3FE5               cmpu      #$0057
-                    lbeq      L44A2
+L3FE4               cmpu      #$0057
+                    lbeq      L44A1
                     cmpu      #$0059
-                    bne       L4001
-                    leax      L4783,pcr
-L3FF7               pshs      x
-                    lbsr      L43D2
+                    bne       L4000
+                    leax      L4782,pcr
+L3FF6               pshs      x
+                    lbsr      L43D1
                     leas      $02,s
-                    lbra      L44A2
+                    lbra      L44A1
 
-L4001               ldd       $04,s
+L4000               ldd       $04,s
                     pshs      d
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     clra
                     clrb
@@ -7090,58 +7081,58 @@ L4001               ldd       $04,s
                     pshs      d
                     ldd       #$0062
                     pshs      d
-                    lbsr      L4086
+                    lbsr      L4085
                     leas      $08,s
-                    lbra      L44A2
+                    lbra      L44A1
 
-L4024               stx       -$02,s
-                    beq       L3FD7
+L4023               stx       -$02,s
+                    beq       L3FD6
                     cmpx      #$00FF
-                    beq       L3FE5
-                    bra       L4001
+                    beq       L3FE4
+                    bra       L4000
 
-L402F               ldd       $04,s
+L402E               ldd       $04,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    leax      L4788,pcr
+                    leax      L4787,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $08,s
                     ldd       $000D
                     addd      #$0002
                     std       $000D
-                    lbra      L44A2
+                    lbra      L44A1
 
-L4050               leax      $479B,pcr
+L404F               leax      $479A,pcr
                     pshs      x
-                    lbsr      L4824
-                    lbra      L432E
+                    lbsr      L4823
+                    lbra      L432D
 
-L405C               cmpx      #$0034
-                    lbeq      L3F01
+L405B               cmpx      #$0034
+                    lbeq      L3F00
                     cmpx      #$0094
-                    lbeq      L3F01
+                    lbeq      L3F00
                     cmpx      #$0095
-                    lbeq      L3F01
+                    lbeq      L3F00
                     cmpx      #$0093
-                    lbeq      L3F01
+                    lbeq      L3F00
                     cmpx      #$0036
-                    lbeq      L3F69
+                    lbeq      L3F68
                     cmpx      #$006E
-                    beq       L402F
-                    bra       L4050
+                    beq       L402E
+                    bra       L404F
 
-L4086               pshs      u
+L4085               pshs      u
                     ldd       $04,s
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
                     ldd       #$0020
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
@@ -7149,479 +7140,479 @@ L4086               pshs      u
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    bsr       L40D1
+                    bsr       L40D0
                     leas      $06,s
-                    lbsr      L43DD
+                    lbsr      L43DC
                     puls      pc,u
-L40B0               pshs      u
+L40AF               pshs      u
                     ldu       $04,s
                     stu       -$02,s
-                    beq       L40CF
+                    beq       L40CE
                     cmpu      #$0000
-                    ble       L40C8
+                    ble       L40C7
                     ldd       #$002B
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
-L40C8               pshs      u
-                    lbsr      L4408
-L40CD               leas      $02,s
-L40CF               puls      pc,u
-L40D1               pshs      u,y,x,d
+L40C7               pshs      u
+                    lbsr      L4407
+L40CC               leas      $02,s
+L40CE               puls      pc,u
+L40D0               pshs      u,y,x,d
                     ldd       $0a,s
                     anda      #$80
                     clrb
                     std       -$02,s
-                    beq       L40E6
+                    beq       L40E5
                     ldd       #$005B
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
-L40E6               ldd       $0a,s
+L40E5               ldd       $0a,s
                     anda      #$7f
                     tfr       d,x
-                    lbra      L42E3
+                    lbra      L42E2
 
-L40EF               ldu       $0C,s
+L40EE               ldu       $0C,s
                     ldd       $06,u
                     cmpd      #$0041
-                    bne       L4110
+                    bne       L410F
                     ldd       #$0023
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
                     ldd       $0e,s
                     pshs      d
                     ldd       $0a,u
                     pshs      d
                     ldd       #$0077
-                    bra       L411D
+                    bra       L411C
 
-L4110               ldd       $0e,s
+L410F               ldd       $0e,s
                     addd      $14,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
                     ldd       $06,u
-L411D               pshs      d
-                    bsr       L40D1
+L411C               pshs      d
+                    bsr       L40D0
                     leas      $06,s
-                    lbra      L44A2
+                    lbra      L44A1
 
-L4126               ldd       #$0023
+L4125               ldd       #$0023
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
                     ldd       $0C,s
-                    lbra      L4268
+                    lbra      L4267
 
-L4135               leax      L47AC,pcr
+L4134               leax      L47AB,pcr
                     pshs      x
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
                     ldd       $0e,s
                     pshs      d
-                    lbsr      L40B0
+                    lbsr      L40AF
                     leas      $02,s
                     ldd       >$004d,y
                     pshs      d
-                    lbsr      L43F7
-                    lbra      L42DF
+                    lbsr      L43F6
+                    lbra      L42DE
 
-L4155               ldd       $0C,s
+L4154               ldd       $0C,s
                     std       ,s
-                    lbeq      L4266
+                    lbeq      L4265
                     ldd       [,s]
                     std       $02,s
                     tfr       d,x
-                    lbra      L4233
+                    lbra      L4232
 
-L4166               ldx       ,s
+L4165               ldx       ,s
                     ldd       $04,x
                     subd      $000D
                     addd      $0e,s
                     std       $0C,s
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
                     ldd       >$004f,y
-                    lbra      L4224
+                    lbra      L4223
 
-L417E               ldd       L0023
-                    bne       L419A
+L417D               ldd       L0023
+                    bne       L4199
                     ldd       $0a,s
                     anda      #$80
                     clrb
                     std       -$02,s
-                    beq       L4190
+                    beq       L418F
                     ldd       #$003E
-                    bra       L4193
+                    bra       L4192
 
-L4190               ldd       #$003C
-L4193               pshs      d
-                    lbsr      L43E8
+L418F               ldd       #$003C
+L4192               pshs      d
+                    lbsr      L43E7
                     leas      $02,s
-L419A               ldx       ,s
+L4199               ldx       ,s
                     ldd       $04,x
                     pshs      d
-                    lbsr      L4420
+                    lbsr      L441F
                     leas      $02,s
                     leax      $06,s
-                    bra       L41D3
+                    bra       L41D2
 
-L41A9               ldd       L0023
-                    bne       L41C5
+L41A8               ldd       L0023
+                    bne       L41C4
                     ldd       $0a,s
                     anda      #$80
                     clrb
                     std       -$02,s
-                    beq       L41BB
+                    beq       L41BA
                     ldd       #$003E
-                    bra       L41BE
+                    bra       L41BD
 
-L41BB               ldd       #$003C
-L41BE               pshs      d
-                    lbsr      L43E8
+L41BA               ldd       #$003C
+L41BD               pshs      d
+                    lbsr      L43E7
                     leas      $02,s
-L41C5               ldd       ,s
+L41C4               ldd       ,s
                     addd      #$0004
                     pshs      d
-                    lbsr      L4433
+                    lbsr      L4432
                     leas      $02,s
-                    bra       L41D5
+                    bra       L41D4
 
-L41D3               leas      -$06,x
-L41D5               ldd       $0e,s
+L41D2               leas      -$06,x
+L41D4               ldd       $0e,s
                     pshs      d
-                    lbsr      L40B0
+                    lbsr      L40AF
                     leas      $02,s
                     ldd       $0a,s
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L420B
+                    bne       L420A
                     ldd       L0023
-                    lbne      L431B
+                    lbne      L431A
                     ldd       $02,s
                     cmpd      #$0021
-                    lbeq      L431B
+                    lbeq      L431A
                     ldd       $02,s
                     cmpd      #$0022
-                    lbeq      L431B
+                    lbeq      L431A
                     ldd       $02,s
                     cmpd      #$0023
-                    lbeq      L431B
-L420B               ldx       ,s
+                    lbeq      L431A
+L420A               ldx       ,s
                     ldd       $02,x
                     clra
                     andb      #$30
                     cmpd      #$0030
-                    bne       L4220
-                    leax      L47B3,pcr
+                    bne       L421F
+                    leax      L47B2,pcr
                     pshs      x
-                    bra       L4226
+                    bra       L4225
 
-L4220               ldd       >$004d,y
-L4224               pshs      d
-L4226               lbsr      L43F7
-                    lbra      L42DF
+L421F               ldd       >$004d,y
+L4223               pshs      d
+L4225               lbsr      L43F6
+                    lbra      L42DE
 
-L422C               leax      $47B8,pcr
-                    lbra      L42DA
+L422B               leax      $47B7,pcr
+                    lbra      L42D9
 
-L4233               cmpx      #$000D
-                    lbeq      L4166
+L4232               cmpx      #$000D
+                    lbeq      L4165
                     cmpx      #$0023
-                    lbeq      L417E
+                    lbeq      L417D
                     cmpx      #$000F
-                    lbeq      L419A
+                    lbeq      L4199
                     cmpx      #$0021
-                    lbeq      L41A9
+                    lbeq      L41A8
                     cmpx      #$0022
-                    lbeq      L41A9
+                    lbeq      L41A8
                     cmpx      #$000E
-                    lbeq      L41C5
+                    lbeq      L41C4
                     cmpx      #$000C
-                    lbeq      L41C5
-                    bra       L422C
+                    lbeq      L41C4
+                    bra       L422B
 
-L4266               ldd       $0e,s
-L4268               pshs      d
-                    lbsr      L4408
-                    lbra      L42DF
+L4265               ldd       $0e,s
+L4267               pshs      d
+                    lbsr      L4407
+                    lbra      L42DE
 
-L4270               ldd       $0C,s
+L426F               ldd       $0C,s
                     addd      $0e,s
                     std       $0C,s
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
                     ldd       #$002C
                     pshs      d
-                    lbsr      L43E8
+                    lbsr      L43E7
                     leas      $02,s
                     ldd       $0a,s
                     anda      #$7f
                     tfr       d,x
-                    bra       L42A6
+                    bra       L42A5
 
-L428F               ldd       #$0078
-                    bra       L429C
+L428E               ldd       #$0078
+                    bra       L429B
 
-L4294               ldd       #$0079
-                    bra       L429C
+L4293               ldd       #$0079
+                    bra       L429B
 
-L4299               ldd       #$0075
-L429C               pshs      d
-                    lbsr      L43E8
+L4298               ldd       #$0075
+L429B               pshs      d
+                    lbsr      L43E7
                     leas      $02,s
-                    lbra      L431B
+                    lbra      L431A
 
-L42A6               cmpx      #$0093
-                    beq       L428F
+L42A5               cmpx      #$0093
+                    beq       L428E
                     cmpx      #$0094
-                    beq       L4294
+                    beq       L4293
                     cmpx      #$0095
-                    beq       L4299
-                    bra       L431B
+                    beq       L4298
+                    bra       L431A
 
-L42B7               ldd       >$004f,y
+L42B6               ldd       >$004f,y
                     pshs      d
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
-                    leax      L47C6,pcr
+                    leax      L47C5,pcr
                     pshs      x
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
                     ldd       $000D
                     addd      #$0002
                     std       $000D
-                    bra       L431B
+                    bra       L431A
 
-L42D6               leax      $47C9,pcr
-L42DA               pshs      x
-                    lbsr      L4824
-L42DF               leas      $02,s
-                    bra       L431B
+L42D5               leax      $47C8,pcr
+L42D9               pshs      x
+                    lbsr      L4823
+L42DE               leas      $02,s
+                    bra       L431A
 
-L42E3               cmpx      #$0077
-                    lbeq      L40EF
+L42E2               cmpx      #$0077
+                    lbeq      L40EE
                     cmpx      #$0036
-                    lbeq      L4126
+                    lbeq      L4125
                     cmpx      #$0080
-                    lbeq      L4135
+                    lbeq      L4134
                     cmpx      #$0034
-                    lbeq      L4155
+                    lbeq      L4154
                     cmpx      #$0093
-                    lbeq      L4270
+                    lbeq      L426F
                     cmpx      #$0094
-                    lbeq      L4270
+                    lbeq      L426F
                     cmpx      #$0095
-                    lbeq      L4270
+                    lbeq      L426F
                     cmpx      #$006E
-                    beq       L42B7
-                    bra       L42D6
+                    beq       L42B6
+                    bra       L42D5
 
-L431B               ldd       $0a,s
+L431A               ldd       $0a,s
                     anda      #$80
                     clrb
                     std       -$02,s
-                    lbeq      L44A2
+                    lbeq      L44A1
                     ldd       #$005D
                     pshs      d
-                    lbsr      L43E8
-L432E               leas      $02,s
-                    lbra      L44A2
+                    lbsr      L43E7
+L432D               leas      $02,s
+                    lbra      L44A1
 
-L4333               pshs      u
+L4332               pshs      u
                     ldx       $04,s
-                    bra       L4382
+                    bra       L4381
 
-L4339               leax      L47D5,pcr
+L4338               leax      L47D4,pcr
                     pshs      x
-                    lbsr      L4824
+                    lbsr      L4823
                     leas      $02,s
-L4344               leax      L47DC,pcr
-                    bra       L437E
+L4343               leax      L47DB,pcr
+                    bra       L437D
 
-L434A               leax      L47E0,pcr
-                    bra       L437E
+L4349               leax      L47DF,pcr
+                    bra       L437D
 
-L4350               leax      L47E4,pcr
-                    bra       L437E
+L434F               leax      L47E3,pcr
+                    bra       L437D
 
-L4356               leax      L47E8,pcr
-                    bra       L437E
+L4355               leax      L47E7,pcr
+                    bra       L437D
 
-L435C               leax      L47EC,pcr
-                    bra       L437E
+L435B               leax      L47EB,pcr
+                    bra       L437D
 
-L4362               leax      L47F0,pcr
-                    bra       L437E
+L4361               leax      L47EF,pcr
+                    bra       L437D
 
-L4368               leax      L47F4,pcr
-                    bra       L437E
+L4367               leax      L47F3,pcr
+                    bra       L437D
 
-L436E               leax      L47F8,pcr
-                    bra       L437E
+L436D               leax      L47F7,pcr
+                    bra       L437D
 
-L4374               leax      L47FC,pcr
-                    bra       L437E
+L4373               leax      L47FB,pcr
+                    bra       L437D
 
-L437A               leax      L4800,pcr
-L437E               tfr       x,d
+L4379               leax      L47FF,pcr
+L437D               tfr       x,d
                     puls      pc,u
-L4382               cmpx      #$005A
-                    beq       L4344
+L4381               cmpx      #$005A
+                    beq       L4343
                     cmpx      #$005B
-                    beq       L434A
+                    beq       L4349
                     cmpx      #$005C
-                    beq       L4350
+                    beq       L434F
                     cmpx      #$005D
-                    beq       L4356
+                    beq       L4355
                     cmpx      #$005E
-                    beq       L435C
+                    beq       L435B
                     cmpx      #$005F
-                    beq       L4362
+                    beq       L4361
                     cmpx      #$0060
-                    beq       L4368
+                    beq       L4367
                     cmpx      #$0061
-                    beq       L436E
+                    beq       L436D
                     cmpx      #$0062
-                    beq       L4374
+                    beq       L4373
                     cmpx      #$0063
-                    beq       L437A
-                    lbra      L4339
+                    beq       L4379
+                    lbra      L4338
                     puls      pc,u
-L43B9               pshs      u
+L43B8               pshs      u
                     ldd       $0005
                     pshs      d
                     ldd       #$0020
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
                     ldd       $04,s
                     pshs      d
-                    bsr       L43F7
-                    lbra      L446E
+                    bsr       L43F6
+                    lbra      L446D
 
-L43D2               pshs      u
+L43D1               pshs      u
                     ldd       $04,s
                     pshs      d
-                    bsr       L43B9
-                    lbra      L4488
+                    bsr       L43B8
+                    lbra      L4487
 
-L43DD               pshs      u
+L43DC               pshs      u
                     ldd       $0005
                     pshs      d
                     ldd       #$000D
-                    bra       L43F0
+                    bra       L43EF
 
-L43E8               pshs      u
+L43E7               pshs      u
                     ldd       $0005
                     pshs      d
                     ldd       $06,s
-L43F0               pshs      d
-                    lbsr      L515F
-                    bra       L4404
+L43EF               pshs      d
+                    lbsr      L515E
+                    bra       L4403
 
-L43F7               pshs      u
+L43F6               pshs      u
                     ldd       $04,s
                     pshs      d
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
-L4404               leas      $04,s
+                    lbsr      L2D54
+L4403               leas      $04,s
                     puls      pc,u
-L4408               pshs      u
+L4407               pshs      u
                     ldd       $04,s
                     pshs      d
-                    leax      L4804,pcr
-                    lbra      L4499
+                    leax      L4803,pcr
+                    lbra      L4498
 
-L4415               pshs      u
+L4414               pshs      u
                     ldd       $04,s
                     pshs      d
-                    bsr       L4420
-                    lbra      L4488
+                    bsr       L441F
+                    lbra      L4487
 
-L4420               pshs      u
+L441F               pshs      u
                     ldd       #$005F
                     pshs      d
-                    bsr       L43E8
+                    bsr       L43E7
                     leas      $02,s
                     ldd       $04,s
                     pshs      d
-                    bsr       L4408
-                    bra       L446E
+                    bsr       L4407
+                    bra       L446D
 
-L4433               pshs      u
+L4432               pshs      u
                     ldd       $04,s
                     pshs      d
-                    leax      $4807,pcr
-                    lbra      L4499
+                    leax      $4806,pcr
+                    lbra      L4498
 
-L4440               pshs      u,d
+L443F               pshs      u,d
                     ldd       $06,s
                     subd      $000D
                     std       ,s
-                    beq       L446C
-                    leax      $480C,pcr
+                    beq       L446B
+                    leax      $480B,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       ,s
                     pshs      d
-                    lbsr      L4408
+                    lbsr      L4407
                     leas      $02,s
                     ldd       >$004f,y
                     pshs      d
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
-                    lbsr      L43DD
-L446C               ldd       $06,s
-L446E               leas      $02,s
+                    lbsr      L43DC
+L446B               ldd       $06,s
+L446D               leas      $02,s
                     puls      pc,u
-L4472               pshs      u
+L4471               pshs      u
                     ldd       $04,s
                     pshs      d
-                    bsr       L4433
+                    bsr       L4432
                     leas      $02,s
                     ldd       $06,s
-                    beq       L448A
+                    beq       L4489
                     ldd       #$003A
                     pshs      d
-                    lbsr      L43E8
-L4488               leas      $02,s
-L448A               lbsr      L43DD
+                    lbsr      L43E7
+L4487               leas      $02,s
+L4489               lbsr      L43DC
                     puls      pc,u
-L448F               pshs      u
+L448E               pshs      u
                     ldd       $04,s
                     pshs      d
-                    leax      L4812,pcr
-L4499               pshs      x
+                    leax      L4811,pcr
+L4498               pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
-L44A2               leas      $06,s
+                    lbsr      L2D54
+L44A1               leas      $06,s
                     puls      pc,u
-L44A6               pshs      u
+L44A5               pshs      u
                     ldd       $04,s
                     pshs      d
-                    bsr       L448F
+                    bsr       L448E
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       #$005F
                     pshs      d
-                    leax      L481A,pcr
+                    leax      L4819,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $08,s
                     puls      pc,u
-                    bge       $4545
+                    bge       $4544
                     neg       $002C
                     com       >$006C
                     fcc       /bsr /
@@ -7632,36 +7623,36 @@ L44A6               pshs      u
                     fcb       $00
                     fcc       /unknown operator : /
                     fcb       $00
-L44F5               bra       L4567
+L44F4               bra       L4566
                     com       $6873
-                    bra       L4521
+                    bra       L4520
                     com       $0d,x
                     neg       $006C
                     fcb       $62
                     neg       $0070
                     fcb       $75
                     inc       -$0d,s
-                    bra       $457D
-                    bge       $457A
+                    bra       $457C
+                    bge       $4579
                     com       $0d,x
                     neg       $0063
                     fcc       /cmult/
                     fcb       $00
-L4514               fcc       /ccudiv/
+L4513               fcc       /ccudiv/
                     fcb       $00
-L451B               fcc       /ccdiv/
+L451A               fcc       /ccdiv/
                     fcb       $00
-L4521               fcc       /ccasl/
+L4520               fcc       /ccasl/
                     fcb       $00
-L4527               fcc       /ccasr/
+L4526               fcc       /ccasr/
                     fcb       $00
-L452D               fcc       /cclsr/
+L452C               fcc       /cclsr/
                     fcb       $00
-L4533               fcc       /ccumod/
+L4532               fcc       /ccumod/
                     fcb       $00
-L453A               fcc       /ccmod/
+L4539               fcc       /ccmod/
                     fcb       $00
-L4540               jmp       $05,s
+L453F               jmp       $05,s
                     asr       $01,s
                     tst       L0020
                     jmp       $05,s
@@ -7669,78 +7660,78 @@ L4540               jmp       $05,s
                     tst       L0020
                     fcc       /sbca #0/
                     fcb       $00
-L4554               com       $0f,s
+L4553               com       $0f,s
                     tst       $01,s
                     tst       L0020
                     fcc       /comb/
                     fcb       $00
-L455F               fcc       /leax /
+L455E               fcc       /leax /
                     fcb       $00
-L4565               fcb       $6C,$65
-L4567               fcb       $61,$73,$20
+L4564               fcb       $6C,$65
+L4566               fcb       $61,$73,$20
                     fcb       $00
-L456B               bge       $45E5
+L456A               bge       $45E4
                     tst       $0000
-L456F               fcc       /jsr /
+L456E               fcc       /jsr /
                     fcb       $00
-L4574               com       $6578
+L4573               com       $6578
                     neg       $006C
                     lsr       0,x
-L457B               fcb       $61
+L457A               fcb       $61
                     com       $6C62
                     tst       L0020
                     fcc       /rola/
                     fcb       $00
-L4586               fcb       $61
+L4585               fcb       $61
                     com       $7261
                     tst       L0020
                     fcc       /rorb/
                     fcb       $00
-L4591               inc       -$0d,s
+L4590               inc       -$0d,s
                     fcb       $72,$61
                     tst       L0020
                     fcc       /rorb/
                     fcb       $00
-L459C               fcc       /ldy /
+L459B               fcc       /ldy /
                     fcb       $00
-L45A1               fcc       /ldu /
+L45A0               fcc       /ldu /
                     fcb       $00
-L45A6               fcc       /leax /
+L45A5               fcc       /leax /
                     fcb       $00
-L45AC               bcs       L4612
-                    bge       L45D5
+L45AB               bcs       L4611
+                    bge       L45D4
                     com       $0d,x
                     neg       L0064
-                    bge       L45DB
+                    bge       L45DA
                     com       $0d,x
                     neg       $0073
                     fcb       $65
                     asl       >$0061
                     fcc       /dca #0/
                     fcb       $00
-L45C5               fcc       /sbca #0/
+L45C4               fcc       /sbca #0/
                     fcb       $00
-L45CD               bcs       $4633
-                    bge       L45F6
+L45CC               bcs       $4632
+                    bge       L45F5
                     com       $0d,x
                     neg       $0063
-L45D5               inc       -$0e,s
+L45D4               inc       -$0e,s
                     fcb       $61
                     tst       L0020
                     fcb       $63
-L45DB               fcb       $6C,$72,$62
+L45DA               fcb       $6C,$72,$62
                     fcb       $00
-L45DF               inc       $04,s
+L45DE               inc       $04,s
                     neg       L0020
                     com       $7425
                     com       0,y
-                    blt       L461C
-                    bge       L465F
+                    blt       L461B
+                    bge       L465E
                     tst       $0000
-L45EE               com       $0d,s
+L45ED               com       $0d,s
                     neg       >$0073
                     lsr       >$0073
-L45F6               fcb       $75,$62
+L45F5               fcb       $75,$62
                     neg       $0061
                     lsr       $04,s
                     neg       $006C
@@ -7748,171 +7739,171 @@ L45F6               fcb       $75,$62
                     neg       L0020
                     fcb       $65
                     asl       $6720
-                    bcs       L466B
-                    bge       L462F
+                    bcs       L466A
+                    bge       L462E
                     com       $0d,x
                     neg       L0064
-                    bge       L4610
-L4610               fcb       $4C,$45
-L4612               fcc       /A arg/
+                    bge       L460F
+L460F               fcb       $4C,$45
+L4611               fcc       /A arg/
                     fcb       $00
-L4618               bra       L468E
+L4617               bra       L468D
                     ror       -$0e,s
-L461C               bra       L4643
+L461B               bra       L4642
                     com       $0C,y
-                    bcs       L4685
+                    bcs       L4684
                     tst       $0000
-L4624               inc       $04,s
+L4623               inc       $04,s
                     fcb       $61
-                    bra       L4659
-                    bge       L46A3
+                    bra       L4658
+                    bge       L46A2
                     tst       L0020
                     clr       -$0e,s
-L462F               fcb       $61
-                    bra       L4663
-                    bge       L46AC
+L462E               fcb       $61
+                    bra       L4662
+                    bge       L46AB
                     tst       L0020
                     clr       -$0e,s
                     fcb       $61
-                    bra       L466D
-                    bge       L46B5
+                    bra       L466C
+                    bge       L46B4
                     tst       L0020
                     fcc       /ora /
-L4643               fcb       $33,$2C,$78
+L4642               fcb       $33,$2C,$78
                     fcb       $00
-L4647               clrb
+L4646               clrb
                     fcc       /lmove/
                     fcb       $00
-L464E               clrb
+L464D               clrb
                     fcc       /ladd/
                     fcb       $00
-L4654               clrb
+L4653               clrb
                     fcc       /lsub/
-L4659               fcb       $00
-L465A               clrb
+L4658               fcb       $00
+L4659               clrb
                     fcc       /lmul/
-L465F               fcb       $00
-L4660               clrb
+L465E               fcb       $00
+L465F               clrb
                     fcb       $6C,$64
-L4663               fcb       $69,$76
+L4662               fcb       $69,$76
                     fcb       $00
-L4666               clrb
+L4665               clrb
                     fcc       /lmod/
-L466B               fcb       $00
-L466C               clrb
-L466D               fcc       /land/
+L466A               fcb       $00
+L466B               clrb
+L466C               fcc       /land/
                     fcb       $00
-L4672               clrb
+L4671               clrb
                     inc       $0f,s
                     fcb       $72
                     neg       $005F
                     fcc       /lxor/
                     fcb       $00
-L467D               clrb
+L467C               clrb
                     fcc       /lshl/
                     fcb       $00
-L4683               clrb
+L4682               clrb
                     fcb       $6C
-L4685               fcb       $73,$68,$72
+L4684               fcb       $73,$68,$72
                     fcb       $00
-L4689               clrb
+L4688               clrb
                     fcc       /lcmp/
-L468E               fcb       $72
+L468D               fcb       $72
                     fcb       $00
-L4690               clrb
+L468F               clrb
                     fcc       /lneg/
                     fcb       $00
-L4696               clrb
+L4695               clrb
                     fcc       /lcompl/
                     fcb       $00
-L469E               clrb
+L469D               clrb
                     fcc       /lito/
-L46A3               fcb       $6C
+L46A2               fcb       $6C
                     fcb       $00
-L46A5               clrb
+L46A4               clrb
                     fcc       /lutol/
                     fcb       $00
-L46AC               clrb
+L46AB               clrb
                     fcc       /linc/
                     fcb       $00
-L46B2               clrb
+L46B1               clrb
                     fcb       $6C,$64
-L46B5               fcb       $65,$63
+L46B4               fcb       $65,$63
                     fcb       $00
-L46B8               fcc       /codgen - longs/
+L46B7               fcc       /codgen - longs/
                     fcb       $00
-L46C7               clrb
+L46C6               clrb
                     fcc       /dstack/
                     fcb       $00
-L46CF               bra       L473D
+L46CE               bra       L473C
                     lsr       $01,s
-                    bra       L46FA
+                    bra       L46F9
                     com       $0C,y
-                    asl       $0D00
-L46DA               clrb
+                    asl       L0D00
+L46D9               clrb
                     fcc       /fmove/
                     fcb       $00
-L46E1               clrb
+L46E0               clrb
                     fcc       /dmove/
                     fcb       $00
-L46E8               clrb
+L46E7               clrb
                     fcc       /dadd/
                     fcb       $00
-L46EE               clrb
+L46ED               clrb
                     fcc       /dsub/
                     fcb       $00
-L46F4               clrb
+L46F3               clrb
                     fcc       /dmul/
                     fcb       $00
-L46FA               clrb
+L46F9               clrb
                     fcc       /ddiv/
                     fcb       $00
-L4700               clrb
+L46FF               clrb
                     fcc       /dcmpr/
                     fcb       $00
-L4707               clrb
+L4706               clrb
                     fcc       /dneg/
                     fcb       $00
-L470D               clrb
+L470C               clrb
                     fcc       /finc/
                     fcb       $00
-L4713               clrb
+L4712               clrb
                     fcc       /dinc/
                     fcb       $00
-L4719               clrb
+L4718               clrb
                     fcc       /fdec/
                     fcb       $00
-L471F               clrb
+L471E               clrb
                     fcc       /ddec/
                     fcb       $00
-L4725               clrb
+L4724               clrb
                     fcc       /dtof/
                     fcb       $00
-L472B               clrb
+L472A               clrb
                     fcc       /ftod/
                     fcb       $00
-L4731               clrb
+L4730               clrb
                     fcc       /ltod/
                     fcb       $00
-L4737               clrb
+L4736               clrb
                     fcc       /itod/
                     fcb       $00
-L473D               clrb
+L473C               clrb
                     fcc       /utod/
                     fcb       $00
-L4743               clrb
+L4742               clrb
                     fcc       /dtol/
                     fcb       $00
-L4749               clrb
+L4748               clrb
                     fcc       /dtoi/
                     fcb       $00
-L474F               fcc       /codgen - floats/
+L474E               fcc       /codgen - floats/
                     fcb       $00
-L475F               fcc       /bsr /
+L475E               fcc       /bsr /
                     fcb       $00
-L4764               fcc       /puls x/
+L4763               fcc       /puls x/
                     fcb       $00
-L476B               leax      $0C,y
+L476A               leax      $0C,y
                     neg       $0061
                     jmp       $04,s
                     neg       $006F
@@ -7922,151 +7913,151 @@ L476B               leax      $0C,y
                     neg       $0063
                     fcb       $6F,$6D,$61
                     fcb       $00
-L477E               fcc       /clrb/
+L477D               fcc       /clrb/
                     fcb       $00
-L4783               fcc       /comb/
+L4782               fcc       /comb/
                     fcb       $00
-L4788               bra       L47AF
-                    com       $6120
-                    bge       L4802
-                    bmi       L479E
-                    bra       $47B8
-                    com       $6220
-                    bge       $480B
-                    bmi       L47A7
+L4787               bra       L47AE
+                    com       L6120
+                    bge       L4801
+                    bmi       L479D
+                    bra       $47B7
+                    com       L6220
+                    bge       $480A
+                    bmi       L47A6
                     neg       $0063
                     fcb       $6F,$6D
-L479E               fcc       /piler tro/
-L47A7               fcc       /uble/
+L479D               fcc       /piler tro/
+L47A6               fcc       /uble/
                     fcb       $00
-L47AC               clrb
+L47AB               clrb
                     fcb       $66,$6C
-L47AF               fcb       $61,$63,$63
+L47AE               fcb       $61,$63,$63
                     fcb       $00
-L47B3               bge       $4825
+L47B2               bge       $4824
                     com       -$0e,s
                     neg       $0073
                     fcc       /torage error/
                     fcb       $00
-L47C6               bmi       $47F3
+L47C5               bmi       $47F2
                     neg       L0064
                     fcc       /ereference/
                     fcb       $00
-L47D5               fcc       /rel op/
+L47D4               fcc       /rel op/
                     fcb       $00
-L47DC               fcb       $65,$71
-                    bra       L47E0
+L47DB               fcb       $65,$71
+                    bra       L47DF
 
-L47E0               jmp       $05,s
-                    bra       L47E4
+L47DF               jmp       $05,s
+                    bra       L47E3
 
-L47E4               inc       $05,s
-                    bra       L47E8
+L47E3               inc       $05,s
+                    bra       L47E7
 
-L47E8               inc       -$0C,s
-                    bra       L47EC
+L47E7               inc       -$0C,s
+                    bra       L47EB
 
-L47EC               asr       $05,s
-                    bra       L47F0
+L47EB               asr       $05,s
+                    bra       L47EF
 
-L47F0               asr       -$0C,s
-                    bra       L47F4
+L47EF               asr       -$0C,s
+                    bra       L47F3
 
-L47F4               inc       -$0d,s
-                    bra       L47F8
+L47F3               inc       -$0d,s
+                    bra       L47F7
 
-L47F8               inc       $0f,s
-                    bra       L47FC
+L47F7               inc       $0f,s
+                    bra       L47FB
 
-L47FC               asl       -$0d,s
-                    bra       L4800
+L47FB               asl       -$0d,s
+                    bra       L47FF
 
-L4800               asl       $09,s
-L4802               bra       L4804
+L47FF               asl       $09,s
+L4801               bra       L4803
 
-L4804               bcs       $486A
+L4803               bcs       $4869
                     neg       $0025
-                    bgt       $4842
+                    bgt       $4841
                     com       >$006C
                     fcc       /eas /
                     fcb       $00
-L4812               bra       L4880
+L4811               bra       L487F
                     fcc       /ea%c /
                     fcb       $00
-L481A               bcs       $487F
-                    bcs       L4882
-                    bge       $4890
+L4819               bcs       $487E
+                    bcs       L4881
+                    bge       $488F
                     com       -$0e,s
                     tst       $0000
-L4824               pshs      u
+L4823               pshs      u
                     ldd       $04,s
                     pshs      d
                     ldd       $0282,y
                     pshs      d
-                    bsr       L484C
-                    lbra      L4ACA
+                    bsr       L484B
+                    lbra      L4AC9
 
-L4835               pshs      u
-                    leax      L4B2F,pcr
+L4834               pshs      u
+                    leax      L4B2E,pcr
                     pshs      x
                     ldd       $0282,y
                     pshs      d
-                    bsr       L4880
+                    bsr       L487F
                     leas      $04,s
-                    lbsr      L0AE0
+                    lbsr      L0ADF
                     puls      pc,u
-L484C               pshs      u
+L484B               pshs      u
                     leas      -$32,s
-                    leax      L4B3D,pcr
+                    leax      L4B3C,pcr
                     pshs      x
                     leax      $02,s
                     pshs      x
-                    lbsr      L5600
+                    lbsr      L55FF
                     leas      $04,s
                     ldd       $38,s
                     pshs      d
                     leax      $02,s
                     pshs      x
-                    lbsr      L5618
+                    lbsr      L5617
                     leas      $04,s
                     leax      ,s
                     pshs      x
                     ldd       $38,s
                     pshs      d
-                    bsr       L4880
+                    bsr       L487F
                     leas      $04,s
                     leas      $32,s
                     puls      pc,u
-L4880               pshs      u
-L4882               ldu       $04,s
+L487F               pshs      u
+L4881               ldu       $04,s
                     ldd       $0e,u
                     pshs      d
                     ldd       $08,s
                     pshs      d
                     ldd       $10,u
                     pshs      d
-                    lbsr      L4939
-                    lbra      L4ADF
+                    lbsr      L4938
+                    lbra      L4ADE
 
-L4897               pshs      u
+L4896               pshs      u
                     ldd       $02DA,y
                     addd      #$0001
                     pshs      d
                     ldd       #$000A
-                    lbsr      L5EF1
+                    lbsr      L5EF0
                     std       $02DA,y
                     cmpd      $02DC,y
-                    bne       L48C6
+                    bne       L48C5
                     ldd       $02DC,y
                     addd      #$0001
                     pshs      d
                     ldd       #$000A
-                    lbsr      L5EF1
+                    lbsr      L5EF0
                     std       $02DC,y
-L48C6               ldd       $02DA,y
+L48C5               ldd       $02DA,y
                     pshs      d
                     ldd       #$0006
-                    lbsr      $5E90
+                    lbsr      L5E8F
                     leax      $029e,y
                     leax      d,x
                     leau      ,x
@@ -8075,94 +8066,94 @@ L48C6               ldd       $02DA,y
                     leax      $02,u
                     pshs      x
                     leax      $08,s
-                    lbsr      $5E24
+                    lbsr      L5E23
                     puls      pc,u
-L48E9               pshs      u,d
+L48E8               pshs      u,d
                     ldd       $02DA,y
-                    bra       L491A
+                    bra       L4919
 
-L48F1               ldd       ,s
+L48F0               ldd       ,s
                     pshs      d
                     ldd       #$0006
-                    lbsr      $5E90
+                    lbsr      L5E8F
                     leax      $029e,y
                     leax      d,x
                     leau      ,x
                     ldd       ,u
                     cmpd      $06,s
-                    bne       L490E
+                    bne       L490D
                     leax      $02,u
-                    bra       L492D
+                    bra       L492C
 
-L490E               ldd       ,s
+L490D               ldd       ,s
                     addd      #$FFFF
                     std       ,s
-                    bge       L491C
+                    bge       L491B
                     ldd       #$0009
-L491A               std       ,s
-L491C               ldd       ,s
+L4919               std       ,s
+L491B               ldd       ,s
                     cmpd      $02DC,y
-                    bne       L48F1
-                    bsr       $492B
+                    bne       L48F0
+                    bsr       $492A
                     stu       $FFFF
-                    stu       L3510
-L492D               leau      $0254,y
+                    stu       $3510
+L492C               leau      $0254,y
                     pshs      u
-                    lbsr      $5E24
-                    lbra      L4A87
+                    lbsr      L5E23
+                    lbra      L4A86
 
-L4939               pshs      u
+L4938               pshs      u
                     leas      -$05,s
                     leax      $0262,y
                     pshs      x
-                    leax      L4B4F,pcr
+                    leax      L4B4E,pcr
                     pshs      x
-                    lbsr      L2D40
+                    lbsr      L2D3F
                     leas      $04,s
                     ldd       $09,s
                     pshs      d
                     ldd       $0f,s
                     pshs      d
-                    leax      L4B54,pcr
+                    leax      L4B53,pcr
                     pshs      x
-                    lbsr      L2D40
+                    lbsr      L2D3F
                     leas      $06,s
                     ldd       $0b,s
                     pshs      d
-                    leax      L4B5E,pcr
+                    leax      L4B5D,pcr
                     pshs      x
-                    lbsr      L2D40
+                    lbsr      L2D3F
                     leas      $04,s
                     ldd       $02DE,y
-                    bne       L498D
-                    leax      L4B6E,pcr
+                    bne       L498C
+                    leax      L4B6D,pcr
                     pshs      x
                     ldd       $0280,y
                     pshs      d
-                    lbsr      L4F07
+                    lbsr      L4F06
                     leas      $04,s
                     std       $02DE,y
-                    beq       L49B2
-L498D               leax      $01,s
+                    beq       L49B1
+L498C               leax      $01,s
                     pshs      x
                     ldd       $0f,s
                     pshs      d
-                    lbsr      L48E9
+                    lbsr      L48E8
                     leas      $02,s
-                    lbsr      $5E24
+                    lbsr      L5E23
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $49AB
+                    bsr       $49AA
                     stu       $FFFF
-                    stu       L3510
-                    lbsr      $5DC0
-                    bne       L49B7
-L49B2               leax      $05,s
-                    lbra      L4A31
+                    stu       $3510
+                    lbsr      L5DBF
+                    bne       L49B6
+L49B1               leax      $05,s
+                    lbra      L4A30
 
-L49B7               clra
+L49B6               clra
                     clrb
                     pshs      d
                     leax      $03,s
@@ -8172,129 +8163,129 @@ L49B7               clra
                     pshs      d
                     ldd       $02DE,y
                     pshs      d
-                    lbsr      L4F9F
+                    lbsr      L4F9E
                     leas      $08,s
-L49D0               leax      $00CE,y
+L49CF               leax      $00CE,y
                     pshs      x
                     ldd       $02DE,y
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     stb       $02,s
                     sex
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
                     ldb       ,s
                     cmpb      #$0d
-                    bne       L49D0
-                    bra       L4A03
+                    bne       L49CF
+                    bra       L4A02
 
-L49F3               leax      $00CE,y
+L49F2               leax      $00CE,y
                     pshs      x
                     ldd       #$0020
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
-L4A03               ldd       $09,s
+L4A02               ldd       $09,s
                     addd      #$FFFF
                     std       $09,s
                     subd      #$FFFF
-                    bgt       L49F3
+                    bgt       L49F2
                     leax      $00CE,y
                     pshs      x
                     ldd       #$005E
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
                     leax      $00CE,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
-                    bra       L4A33
+                    bra       L4A32
 
-L4A31               leas      -$05,x
-L4A33               ldd       $0009
+L4A30               leas      -$05,x
+L4A32               ldd       $0009
                     addd      #$0001
                     std       $0009
-                    cmpd      #_start
-                    ble       L4A66
+                    cmpd      #start
+                    ble       L4A65
                     leax      $00CE,y
                     pshs      x
-                    lbsr      L528A
+                    lbsr      L5289
                     leas      $02,s
-                    leax      $4B70,pcr
+                    leax      $4B6F,pcr
                     pshs      x
                     leax      $00DB,y
                     pshs      x
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      exit
+                    lbsr      L6229
                     leas      $02,s
-L4A66               leas      $05,s
+L4A65               leas      $05,s
                     puls      pc,u
-L4A6A               pshs      u
+L4A69               pshs      u
                     ldu       $04,s
                     stu       -$02,s
-                    beq       L4A89
+                    beq       L4A88
                     ldd       $0a,u
                     pshs      d
-                    bsr       L4A6A
+                    bsr       L4A69
                     leas      $02,s
                     ldd       $0C,u
                     pshs      d
-                    lbsr      L4A6A
+                    lbsr      L4A69
                     leas      $02,s
                     pshs      u
-                    bsr       L4A8B
-L4A87               leas      $02,s
-L4A89               puls      pc,u
-L4A8B               pshs      u
+                    bsr       L4A8A
+L4A86               leas      $02,s
+L4A88               puls      pc,u
+L4A8A               pshs      u
                     ldu       $04,s
                     stu       -$02,s
-                    beq       L4ACC
+                    beq       L4ACB
                     ldx       $06,u
-                    bra       L4AB1
+                    bra       L4AB0
 
-L4A97               ldd       #$000D
-                    bra       L4AA4
+L4A96               ldd       #$000D
+                    bra       L4AA3
 
-L4A9C               ldd       #$0008
-                    bra       L4AA4
+L4A9B               ldd       #$0008
+                    bra       L4AA3
 
-L4AA1               ldd       #$0004
-L4AA4               pshs      d
+L4AA0               ldd       #$0004
+L4AA3               pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L3204
+                    lbsr      L3203
                     leas      $04,s
-                    bra       L4AC0
+                    bra       L4ABF
 
-L4AB1               cmpx      #$0034
-                    beq       L4A97
+L4AB0               cmpx      #$0034
+                    beq       L4A96
                     cmpx      #$004B
-                    beq       L4A9C
+                    beq       L4A9B
                     cmpx      #$004A
-                    beq       L4AA1
-L4AC0               ldd       #$0016
+                    beq       L4AA0
+L4ABF               ldd       #$0016
                     pshs      d
                     pshs      u
-                    lbsr      L3204
-L4ACA               leas      $04,s
-L4ACC               puls      pc,u
-L4ACE               pshs      u
+                    lbsr      L3203
+L4AC9               leas      $04,s
+L4ACB               puls      pc,u
+L4ACD               pshs      u
                     ldd       #$0016
                     pshs      d
                     ldd       $08,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    bsr       L4B11
-L4ADF               leas      $06,s
+                    bsr       L4B10
+L4ADE               leas      $06,s
                     puls      pc,u
                     pshs      u
                     ldd       $04,s
@@ -8309,237 +8300,237 @@ L4ADF               leas      $06,s
                     andb      #$0f
                     addd      ,s++
                     puls      pc,u
-L4AF8               pshs      u
+L4AF7               pshs      u
                     ldu       $04,s
                     cmpu      #$004C
-                    blt       L4B0D
+                    blt       L4B0C
                     cmpu      #$0063
-                    bgt       L4B0D
+                    bgt       L4B0C
                     ldd       #$0001
-                    bra       L4B0F
+                    bra       L4B0E
 
-L4B0D               clra
+L4B0C               clra
                     clrb
-L4B0F               puls      pc,u
-L4B11               pshs      u
+L4B0E               puls      pc,u
+L4B10               pshs      u
                     ldu       $04,s
-                    bra       L4B21
+                    bra       L4B20
 
-L4B17               ldb       ,u+
+L4B16               ldb       ,u+
                     ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     stb       -$01,x
-L4B21               ldd       $08,s
+L4B20               ldd       $08,s
                     addd      #$FFFF
                     std       $08,s
                     subd      #$FFFF
-                    bne       L4B17
+                    bne       L4B16
                     puls      pc,u
-L4B2F               fcc       /out of memory/
+L4B2E               fcc       /out of memory/
                     fcb       $00
-L4B3D               fcc       /compiler error - /
+L4B3C               fcc       /compiler error - /
                     fcb       $00
-L4B4F               bcs       $4BC4
+L4B4E               bcs       $4BC3
                     abx
-                    bra       L4B54
-L4B54               fcc       /line %d  /
+                    bra       L4B53
+L4B53               fcc       /line %d  /
                     fcb       $00
-L4B5E               bpl       L4B8A
-                    bpl       $4B8C
-                    bra       L4B84
-                    bcs       $4BD9
-                    bra       L4B88
-                    bpl       L4B94
-                    bpl       $4B96
+L4B5D               bpl       L4B89
+                    bpl       $4B8B
+                    bra       L4B83
+                    bcs       $4BD8
+                    bra       L4B87
+                    bpl       L4B93
+                    bpl       $4B95
                     tst       $0000
-L4B6E               fcb       $72
+L4B6D               fcb       $72
                     neg       $0074
                     fcc       /oo many errors - AB/
-L4B84               fcb       $4F,$52,$54
+L4B83               fcb       $4F,$52,$54
                     fcb       $0D
-L4B88               neg       $0034
-L4B8A               nega
-                    leax      L4D07,pcr
+L4B87               neg       $0034
+L4B89               nega
+                    leax      L4D06,pcr
                     pshs      x
-                    lbsr      L43B9
-L4B94               lbra      L4C8F
+                    lbsr      L43B8
+L4B93               lbra      L4C8E
 
-L4B97               pshs      u
+L4B96               pshs      u
                     ldu       $04,s
                     pshs      u
-                    leax      L4D0C,pcr
+                    leax      L4D0B,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      L4472
+                    lbsr      L4471
                     leas      $04,s
                     clra
                     clrb
                     std       $000D
                     std       $000F
                     std       L0017
-                    leax      L4D17,pcr
+                    leax      L4D16,pcr
                     pshs      x
-                    lbsr      L43D2
+                    lbsr      L43D1
                     leas      $02,s
                     ldd       $0011
-                    bne       L4BE3
+                    bne       L4BE2
                     ldd       $08,s
                     std       $0025
                     pshs      d
-                    leax      L4D1E,pcr
+                    leax      L4D1D,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-L4BE3               ldd       $0013
-                    lbeq      L4C91
-                    leax      L4D39,pcr
+L4BE2               ldd       $0013
+                    lbeq      L4C90
+                    leax      L4D38,pcr
                     pshs      x
-                    lbsr      L43B9
+                    lbsr      L43B8
                     leas      $02,s
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L4420
+                    lbsr      L441F
                     leas      $02,s
-                    leax      L4D3F,pcr
+                    leax      L4D3E,pcr
                     pshs      x
-                    lbsr      L43F7
+                    lbsr      L43F6
                     leas      $02,s
                     pshs      u
-                    lbsr      L4433
+                    lbsr      L4432
                     leas      $02,s
-                    leax      L4D53,pcr
+                    leax      L4D52,pcr
                     pshs      x
-                    lbsr      L43F7
-                    lbra      L4C8F
+                    lbsr      L43F6
+                    lbra      L4C8E
 
-L4C1B               pshs      u
+L4C1A               pshs      u
                     ldd       $0011
-                    bne       L4C3D
+                    bne       L4C3C
                     ldd       L0017
                     subd      $000F
                     addd      #$FFC0
                     pshs      d
                     ldd       $0025
                     pshs      d
-                    leax      L4D77,pcr
+                    leax      L4D76,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $08,s
-L4C3D               puls      pc,u
-L4C3F               pshs      u
+L4C3C               puls      pc,u
+L4C3E               pshs      u
                     ldd       $04,s
-                    beq       L4C4B
-                    leax      L4D84,pcr
-                    bra       L4C4F
+                    beq       L4C4A
+                    leax      L4D83,pcr
+                    bra       L4C4E
 
-L4C4B               leax      L4D8D,pcr
-L4C4F               tfr       x,d
+L4C4A               leax      L4D8C,pcr
+L4C4E               tfr       x,d
                     pshs      d
-                    bra       L4C5D
+                    bra       L4C5C
 
-L4C55               pshs      u
-                    leax      L4D93,pcr
+L4C54               pshs      u
+                    leax      L4D92,pcr
                     pshs      x
-L4C5D               lbsr      L43D2
-                    bra       L4C8F
+L4C5C               lbsr      L43D1
+                    bra       L4C8E
 
-L4C62               pshs      u,d
+L4C61               pshs      u,d
                     ldd       $0003
                     pshs      d
-                    lbsr      L53D8
+                    lbsr      L53D7
                     std       ,s
-                    lbsr      L4420
-                    bra       L4C78
+                    lbsr      L441F
+                    bra       L4C77
 
-L4C72               ldd       ,s
+L4C71               ldd       ,s
                     pshs      d
-                    bsr       L4C93
-L4C78               leas      $02,s
+                    bsr       L4C92
+L4C77               leas      $02,s
                     ldd       $0003
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       ,s
-                    bne       L4C72
+                    bne       L4C71
                     clra
                     clrb
                     pshs      d
-                    bsr       L4C93
+                    bsr       L4C92
                     leas      $02,s
-L4C8F               leas      $02,s
-L4C91               puls      pc,u
-L4C93               pshs      u
+L4C8E               leas      $02,s
+L4C90               puls      pc,u
+L4C92               pshs      u
                     ldd       $02E0,y
-                    bne       L4CAA
-                    leax      L4D9B,pcr
+                    bne       L4CA9
+                    leax      L4D9A,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $04,s
-L4CAA               ldd       $04,s
+L4CA9               ldd       $04,s
                     cmpd      #$0020
-                    blt       L4CBA
+                    blt       L4CB9
                     ldd       $04,s
                     cmpd      #$0022
-                    bne       L4CCF
-L4CBA               ldd       $04,s
+                    bne       L4CCE
+L4CB9               ldd       $04,s
                     pshs      d
-                    leax      L4DA2,pcr
+                    leax      L4DA1,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $06,s
-                    bra       L4CFF
+                    bra       L4CFE
 
-L4CCF               ldd       $0005
+L4CCE               ldd       $0005
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
                     ldd       $02E0,y
                     addd      #$0001
                     std       $02E0,y
                     subd      #$0001
                     cmpd      #$004B
-                    blt       L4D05
-                    leax      L4DAE,pcr
+                    blt       L4D04
+                    leax      L4DAD,pcr
                     pshs      x
                     ldd       $0005
                     pshs      d
-                    lbsr      L2D55
+                    lbsr      L2D54
                     leas      $04,s
-L4CFF               clra
+L4CFE               clra
                     clrb
                     std       $02E0,y
-L4D05               puls      pc,u
-L4D07               fcc       /fdb /
+L4D04               puls      pc,u
+L4D06               fcc       /fdb /
                     fcb       $00
-L4D0C               bra       L4D82
+L4D0B               bra       L4D81
                     lsr       $6C20
-                    bcs       L4D41
+                    bcs       L4D40
                     fcb       $38
-                    com       $0D00
-L4D17               fcc       /pshs u/
+                    com       L0D00
+L4D16               fcc       /pshs u/
                     fcb       $00
-L4D1E               bra       L4D8C
+L4D1D               bra       L4D8B
                     lsr       $04,s
-                    bra       $4D47
+                    bra       $4D46
                     clrb
-                    bcs       L4D8B
+                    bcs       L4D8A
                     tst       L0020
                     inc       $02,s
                     com       $7220
@@ -8549,17 +8540,17 @@ L4D1E               bra       L4D8C
                     fcb       $65
                     com       $0b,s
                     tst       $0000
-L4D39               fcc       /leax /
+L4D38               fcc       /leax /
                     fcb       $00
-L4D3F               bge       $4DB1
-L4D41               com       -$0e,s
+L4D3E               bge       $4DB0
+L4D40               com       -$0e,s
                     tst       L0020
                     neg       $7368
                     com       $2078
                     tst       L0020
                     fcc       /leax /
                     fcb       $00
-L4D53               bge       $4DC5
+L4D52               bge       $4DC4
                     com       -$0e,s
                     tst       L0020
                     neg       $7368
@@ -8570,97 +8561,97 @@ L4D53               bge       $4DC5
                     clrb
                     neg       $726F
                     ror       $0d,x
-                    bra       L4DDA
+                    bra       L4DD9
                     fcb       $65,$61
-                    com       $2034
-                    bge       L4DE8
+                    com       L2034
+                    bge       L4DE7
                     tst       $0000
-L4D77               clrb
-                    bcs       L4DDE
-                    bra       $4DE1
+L4D76               clrb
+                    bcs       L4DDD
+                    bra       $4DE0
                     fcb       $71,$75
-                    bra       $4DA5
+                    bra       $4DA4
                     lsr       $0d,x
-L4D82               tst       $0000
-L4D84               fcc       /vsect d/
-L4D8B               fcb       $70
-L4D8C               fcb       $00
-L4D8D               fcc       /vsect/
+L4D81               tst       $0000
+L4D83               fcc       /vsect d/
+L4D8A               fcb       $70
+L4D8B               fcb       $00
+L4D8C               fcc       /vsect/
                     fcb       $00
-L4D93               fcc       /endsect/
+L4D92               fcc       /endsect/
                     fcb       $00
-L4D9B               bra       $4E03
+L4D9A               bra       $4E02
                     fcc       /cc "/
                     fcb       $00
-L4DA2               bhi       $4DB1
-                    bra       $4E0C
+L4DA1               bhi       $4DB0
+                    bra       $4E0B
                     com       $02,s
-                    bra       $4DCE
-                    bcs       L4E24
+                    bra       $4DCD
+                    bcs       L4E23
                     tst       $0000
-L4DAE               bhi       $4DBD
+L4DAD               bhi       $4DBC
                     neg       $0034
                     nega
                     leau      $00C1,y
-L4DB7               ldd       $06,u
+L4DB6               ldd       $06,u
                     clra
                     andb      #$03
-                    lbeq      L4E28
+                    lbeq      L4E27
                     leau      $0d,u
                     pshs      u
                     leax      $0191,y
                     cmpx      ,s++
-                    bhi       L4DB7
+                    bhi       L4DB6
                     ldd       #$00C8
                     std       $0260,y
-                    lbra      L4E2C
+                    lbra      L4E2B
                     puls      pc,u
-L4DD8               pshs      u
-L4DDA               ldu       $08,s
-                    bne       L4DE2
-L4DDE               bsr       $4DB1
+L4DD7               pshs      u
+L4DD9               ldu       $08,s
+                    bne       L4DE1
+L4DDD               bsr       $4DB0
                     tfr       d,u
-L4DE2               stu       -$02,s
-                    beq       L4E2C
+L4DE1               stu       -$02,s
+                    beq       L4E2B
                     ldd       $04,s
-L4DE8               std       $08,u
+L4DE7               std       $08,u
                     ldx       $06,s
                     ldb       $01,x
                     cmpb      #$2b
-                    beq       L4DFA
+                    beq       L4DF9
                     ldx       $06,s
                     ldb       $02,x
                     cmpb      #$2b
-                    bne       L4E00
-L4DFA               ldd       $06,u
+                    bne       L4DFF
+L4DF9               ldd       $06,u
                     orb       #$03
-                    bra       L4E1E
+                    bra       L4E1D
 
-L4E00               ldd       $06,u
+L4DFF               ldd       $06,u
                     pshs      d
                     ldb       [$08,s]
                     cmpb      #$72
-                    beq       L4E12
+                    beq       L4E11
                     ldb       [$08,s]
                     cmpb      #$64
-                    bne       L4E17
-L4E12               ldd       #$0001
-                    bra       L4E1A
+                    bne       L4E16
+L4E11               ldd       #$0001
+                    bra       L4E19
 
-L4E17               ldd       #$0002
-L4E1A               ora       ,s+
+L4E16               ldd       #$0002
+L4E19               ora       ,s+
                     orb       ,s+
-L4E1E               std       $06,u
+L4E1D               std       $06,u
                     ldd       $02,u
                     addd      $0b,u
-L4E24               std       $04,u
+L4E23               std       $04,u
                     std       ,u
-L4E28               tfr       u,d
+L4E27               tfr       u,d
                     puls      pc,u
-L4E2C               clra
+L4E2B               clra
                     clrb
                     puls      pc,u
-L4E30               pshs      u
+L4E2F               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     clra
@@ -8670,51 +8661,51 @@ L4E30               pshs      u
                     ldb       $01,x
                     sex
                     tfr       d,x
-                    bra       L4E61
+                    bra       L4E60
 
-L4E43               ldx       $0a,s
+L4E42               ldx       $0a,s
                     ldb       $02,x
                     cmpb      #$2b
-                    bne       L4E50
+                    bne       L4E4F
                     ldd       #$0007
-                    bra       L4E58
+                    bra       L4E57
 
-L4E50               ldd       #$0004
-                    bra       L4E58
+L4E4F               ldd       #$0004
+                    bra       L4E57
 
-L4E55               ldd       #$0003
-L4E58               std       ,s
-                    bra       L4E71
+L4E54               ldd       #$0003
+L4E57               std       ,s
+                    bra       L4E70
 
-L4E5C               leax      $04,s
-                    lbra      L4EC9
+L4E5B               leax      $04,s
+                    lbra      L4EC8
 
-L4E61               stx       -$02,s
-                    beq       L4E71
+L4E60               stx       -$02,s
+                    beq       L4E70
                     cmpx      #$0078
-                    beq       L4E43
+                    beq       L4E42
                     cmpx      #$002B
-                    beq       L4E55
-                    bra       L4E5C
+                    beq       L4E54
+                    bra       L4E5B
 
-L4E71               ldb       [$0a,s]
+L4E70               ldb       [$0a,s]
                     sex
                     tfr       d,x
-                    lbra      L4ED6
+                    lbra      L4ED5
 
-L4E7A               ldd       ,s
+L4E79               ldd       ,s
                     orb       #$01
-                    bra       L4EBC
+                    bra       L4EBB
 
-L4E80               ldd       ,s
+L4E7F               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      $605B
+                    lbsr      L605A
                     leas      $04,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L4EAB
+                    beq       L4EAA
                     ldd       #$0002
                     pshs      d
                     clra
@@ -8723,45 +8714,45 @@ L4E80               ldd       ,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbsr      L6131
+                    lbsr      L6130
                     leas      $08,s
-                    bra       L4EF0
+                    bra       L4EEF
 
-L4EAB               ldd       ,s
+L4EAA               ldd       ,s
                     orb       #$02
                     pshs      d
                     pshs      u
-                    lbsr      $607C
-                    bra       L4EC3
+                    lbsr      L607B
+                    bra       L4EC2
 
-L4EB8               ldd       ,s
+L4EB7               ldd       ,s
                     orb       #$81
-L4EBC               pshs      d
+L4EBB               pshs      d
                     pshs      u
-                    lbsr      $605B
-L4EC3               leas      $04,s
+                    lbsr      L605A
+L4EC2               leas      $04,s
                     std       $02,s
-                    bra       L4EF0
+                    bra       L4EEF
 
-L4EC9               leas      -$04,x
-L4ECB               ldd       #$00CB
+L4EC8               leas      -$04,x
+L4ECA               ldd       #$00CB
                     std       $0260,y
                     clra
                     clrb
-                    bra       L4EF2
+                    bra       L4EF1
 
-L4ED6               cmpx      #$0072
-                    lbeq      L4E7A
+L4ED5               cmpx      #$0072
+                    lbeq      L4E79
                     cmpx      #$0061
-                    lbeq      L4E80
+                    lbeq      L4E7F
                     cmpx      #$0077
-                    beq       L4EAB
+                    beq       L4EAA
                     cmpx      #$0064
-                    beq       L4EB8
-                    bra       L4ECB
+                    beq       L4EB7
+                    bra       L4ECA
 
-L4EF0               ldd       $02,s
-L4EF2               leas      $04,s
+L4EEF               ldd       $02,s
+L4EF1               leas      $04,s
                     puls      pc,u
                     pshs      u
                     clra
@@ -8771,114 +8762,114 @@ L4EF2               leas      $04,s
                     pshs      d
                     ldd       $08,s
                     pshs      d
-                    lbra      L4F52
+                    lbra      L4F51
 
-L4F07               pshs      u
+L4F06               pshs      u
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L4E30
+                    lbsr      L4E2F
                     leas      $04,s
                     tfr       d,u
                     cmpu      #$FFFF
-                    bne       L4F22
+                    bne       L4F21
                     clra
                     clrb
-                    bra       L4F57
+                    bra       L4F56
 
-L4F22               clra
+L4F21               clra
                     clrb
-                    bra       L4F4A
+                    bra       L4F49
                     pshs      u
                     ldd       $08,s
                     pshs      d
-                    lbsr      L5250
+                    lbsr      L524F
                     leas      $02,s
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      L4E30
+                    lbsr      L4E2F
                     leas      $04,s
                     tfr       d,u
                     stu       -$02,s
-                    bge       L4F48
+                    bge       L4F47
                     clra
                     clrb
-                    bra       L4F57
+                    bra       L4F56
 
-L4F48               ldd       $08,s
-L4F4A               pshs      d
+L4F47               ldd       $08,s
+L4F49               pshs      d
                     ldd       $08,s
                     pshs      d
                     pshs      u
-L4F52               lbsr      L4DD8
+L4F51               lbsr      L4DD7
                     leas      $06,s
-L4F57               puls      pc,u
-L4F59               pshs      u
+L4F56               puls      pc,u
+L4F58               pshs      u
                     ldu       $04,s
                     leas      -$06,s
                     clra
                     clrb
-                    bra       L4F90
+                    bra       L4F8F
 
-L4F63               ldd       $0C,s
+L4F62               ldd       $0C,s
                     std       $04,s
-                    bra       L4F7F
+                    bra       L4F7E
 
-L4F69               ldd       $10,s
+L4F68               ldd       $10,s
                     pshs      d
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    beq       L4F99
+                    beq       L4F98
                     ldd       ,s
                     stb       ,u+
-L4F7F               ldd       $04,s
+L4F7E               ldd       $04,s
                     addd      #$FFFF
                     std       $04,s
                     subd      #$FFFF
-                    bgt       L4F69
+                    bgt       L4F68
                     ldd       $02,s
                     addd      #$0001
-L4F90               std       $02,s
+L4F8F               std       $02,s
                     ldd       $02,s
                     cmpd      $0e,s
-                    blt       L4F63
-L4F99               ldd       $02,s
+                    blt       L4F62
+L4F98               ldd       $02,s
                     leas      $06,s
                     puls      pc,u
-L4F9F               pshs      u
+L4F9E               pshs      u
                     ldu       $04,s
                     leas      -$06,s
                     cmpu      #$0000
-                    beq       L4FB2
+                    beq       L4FB1
                     ldd       $06,u
                     clra
                     andb      #$03
-                    bne       L4FB8
-L4FB2               ldd       #$FFFF
-                    lbra      L50DB
+                    bne       L4FB7
+L4FB1               ldd       #$FFFF
+                    lbra      L50DA
 
-L4FB8               ldd       $06,u
+L4FB7               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L4FCB
+                    bne       L4FCA
                     pshs      u
-                    lbsr      L54CA
+                    lbsr      L54C9
                     leas      $02,s
-                    lbra      L50A1
+                    lbra      L50A0
 
-L4FCB               ldd       $06,u
+L4FCA               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    beq       L4FEA
+                    beq       L4FE9
                     pshs      u
-                    lbsr      L528A
+                    lbsr      L5289
                     leas      $02,s
                     ldd       $06,u
                     anda      #$FE
@@ -8886,31 +8877,31 @@ L4FCB               ldd       $06,u
                     ldd       $02,u
                     addd      $0b,u
                     std       $04,u
-                    lbra      L509F
+                    lbra      L509E
 
-L4FEA               ldd       ,u
+L4FE9               ldd       ,u
                     cmpd      $04,u
-                    lbcc      L50A1
+                    lbcc      L50A0
                     leax      $02,s
                     pshs      x
                     leax      $0e,s
-                    lbsr      $5E24
+                    lbsr      L5E23
                     ldx       $10,s
-                    lbra      L506E
+                    lbra      L506D
 
-L5002               leax      $02,s
+L5001               leax      $02,s
                     pshs      x
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
                     pshs      u
-                    lbsr      L50F6
+                    lbsr      L50F5
                     leas      $02,s
-                    lbsr      $5DAB
-                    lbsr      $5E24
-L501B               ldd       $0b,u
-                    lbsr      $5E0B
+                    lbsr      L5DAA
+                    lbsr      L5E23
+L501A               ldd       $0b,u
+                    lbsr      L5E0A
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
@@ -8920,42 +8911,42 @@ L501B               ldd       $0b,u
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       L5038
+                    bsr       L5037
                     neg       $0000
                     neg       $0000
-L5038               puls      x
-                    lbsr      $5DC0
-                    bge       L5046
+L5037               puls      x
+                    lbsr      L5DBF
+                    bge       L5045
                     leax      $06,s
-                    lbsr      $5DE4
-                    bra       L5048
+                    lbsr      L5DE3
+                    bra       L5047
 
-L5046               leax      $06,s
-L5048               lbsr      $5DC0
-                    blt       L507B
+L5045               leax      $06,s
+L5047               lbsr      L5DBF
+                    blt       L507A
                     ldd       $04,s
                     addd      ,u
                     std       ,s
                     cmpd      $02,u
-                    bcs       L507B
+                    bcs       L507A
                     ldd       ,s
                     cmpd      $04,u
-                    bcc       L507B
+                    bcc       L507A
                     ldd       ,s
                     std       ,u
                     ldd       $06,u
                     andb      #$EF
                     std       $06,u
-                    lbra      L50D9
-                    bra       L507B
+                    lbra      L50D8
+                    bra       L507A
 
-L506E               stx       -$02,s
-                    lbeq      L5002
+L506D               stx       -$02,s
+                    lbeq      L5001
                     cmpx      #$0001
-                    lbeq      L501B
-L507B               ldd       $10,s
+                    lbeq      L501A
+L507A               ldd       $10,s
                     cmpd      #$0001
-                    bne       L509D
+                    bne       L509C
                     leax      $0C,s
                     pshs      x
                     ldd       $02,x
@@ -8964,12 +8955,12 @@ L507B               ldd       $10,s
                     pshs      d
                     ldd       $04,u
                     subd      ,u
-                    lbsr      $5E0B
-                    lbsr      $5DAB
-                    lbsr      $5E24
-L509D               ldd       $04,u
-L509F               std       ,u
-L50A1               ldd       $06,u
+                    lbsr      L5E0A
+                    lbsr      L5DAA
+                    lbsr      L5E23
+L509C               ldd       $04,u
+L509E               std       ,u
+L50A0               ldd       $06,u
                     andb      #$EF
                     std       $06,u
                     ldd       $10,s
@@ -8981,23 +8972,23 @@ L50A1               ldd       $06,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L6131
+                    lbsr      L6130
                     leas      $08,s
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $50CD
+                    bsr       $50CC
                     stu       $FFFF
-                    stu       L3510
-                    lbsr      $5DC0
-                    bne       L50D9
+                    stu       $3510
+                    lbsr      L5DBF
+                    bne       L50D8
                     ldd       #$FFFF
-                    bra       L50DB
+                    bra       L50DA
 
-L50D9               clra
+L50D8               clra
                     clrb
-L50DB               leas      $06,s
+L50DA               leas      $06,s
                     puls      pc,u
                     pshs      u
                     clra
@@ -9009,32 +9000,32 @@ L50DB               leas      $06,s
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    lbsr      L4F9F
+                    lbsr      L4F9E
                     leas      $08,s
                     puls      pc,u
-L50F6               pshs      u
+L50F5               pshs      u
                     ldu       $04,s
-                    beq       L5103
+                    beq       L5102
                     ldd       $06,u
                     clra
                     andb      #$03
-                    bne       L5116
-L5103               bsr       $5109
+                    bne       L5115
+L5102               bsr       $5108
                     stu       $FFFF
-                    stu       L3510
+                    stu       $3510
                     leau      $0254,y
                     pshs      u
-                    lbsr      $5E24
+                    lbsr      L5E23
                     puls      pc,u
-L5116               ldd       $06,u
+L5115               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L5126
+                    bne       L5125
                     pshs      u
-                    lbsr      L54CA
+                    lbsr      L54C9
                     leas      $02,s
-L5126               ldd       #$0001
+L5125               ldd       #$0001
                     pshs      d
                     clra
                     clrb
@@ -9042,7 +9033,7 @@ L5126               ldd       #$0001
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L6131
+                    lbsr      L6130
                     leas      $08,s
                     ldd       $02,x
                     pshs      d
@@ -9052,36 +9043,36 @@ L5126               ldd       #$0001
                     anda      #$01
                     clrb
                     std       -$02,s
-                    beq       L514F
+                    beq       L514E
                     ldd       $02,u
-                    bra       L5151
+                    bra       L5150
 
-L514F               ldd       $04,u
-L5151               pshs      d
+L514E               ldd       $04,u
+L5150               pshs      d
                     ldd       ,u
                     subd      ,s++
-                    lbsr      $5E0B
-                    lbsr      $5D96
+                    lbsr      L5E0A
+                    lbsr      L5D95
                     puls      pc,u
-L515F               pshs      u
+L515E               pshs      u
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$22
                     cmpd      #$8002
-                    beq       L5183
+                    beq       L5182
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    lbne      L529B
+                    lbne      L529A
                     pshs      u
-                    lbsr      L54CA
+                    lbsr      L54C9
                     leas      $02,s
-L5183               ldd       $06,u
+L5182               ldd       $06,u
                     clra
                     andb      #$04
-                    beq       L51BF
+                    beq       L51BE
                     ldd       #$0001
                     pshs      d
                     leax      $07,s
@@ -9091,31 +9082,31 @@ L5183               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L51A4
-                    leax      L6121,pcr
-                    bra       L51A8
+                    beq       L51A3
+                    leax      L6120,pcr
+                    bra       L51A7
 
-L51A4               leax      L6108,pcr
-L51A8               tfr       x,d
+L51A3               leax      L6107,pcr
+L51A7               tfr       x,d
                     tfr       d,x
                     jsr       ,x
                     leas      $06,s
                     cmpd      #$FFFF
-                    bne       L5200
+                    bne       L51FF
                     ldd       $06,u
                     orb       #$20
                     std       $06,u
-                    lbra      L529B
+                    lbra      L529A
 
-L51BF               ldd       $06,u
+L51BE               ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L51CF
+                    bne       L51CE
                     pshs      u
-                    lbsr      L52B8
+                    lbsr      L52B7
                     leas      $02,s
-L51CF               ldd       ,u
+L51CE               ldd       ,u
                     addd      #$0001
                     std       ,u
                     subd      #$0001
@@ -9124,19 +9115,19 @@ L51CF               ldd       ,u
                     stb       ,x
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L51F5
+                    bcc       L51F4
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L5200
+                    beq       L51FF
                     ldd       $04,s
                     cmpd      #$000D
-                    bne       L5200
-L51F5               pshs      u
-                    lbsr      L52B8
+                    bne       L51FF
+L51F4               pshs      u
+                    lbsr      L52B7
                     std       ,s++
-                    lbne      L529B
-L5200               ldd       $04,s
+                    lbne      L529A
+L51FF               ldd       $04,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
@@ -9144,105 +9135,106 @@ L5200               ldd       $04,s
                     pshs      d
                     pshs      u
                     ldd       #$0008
-                    lbsr      L5FBA
+                    lbsr      L5FB9
                     pshs      d
-                    lbsr      L515F
+                    lbsr      L515E
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      L515F
-                    lbra      L5372
-                    pshs      u,d
-L5229               leau      $00C1,y
+                    lbsr      L515E
+                    lbra      L5371
+
+L5226               pshs      u,d
+                    leau      $00C1,y
                     clra
                     clrb
                     std       ,s
-                    bra       L523D
+                    bra       L523C
 
-L5233               tfr       u,d
+L5232               tfr       u,d
                     leau      $0d,u
                     pshs      d
-                    bsr       L5250
+                    bsr       L524F
                     leas      $02,s
-L523D               ldd       ,s
+L523C               ldd       ,s
                     addd      #$0001
                     std       ,s
                     subd      #$0001
                     cmpd      #$0010
-                    blt       L5233
-                    lbra      L52B4
+                    blt       L5232
+                    lbra      L52B3
 
-L5250               pshs      u
+L524F               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     cmpu      #$0000
-                    beq       L5260
+                    beq       L525F
                     ldd       $06,u
-                    bne       L5266
-L5260               ldd       #$FFFF
-                    lbra      L52B4
+                    bne       L5265
+L525F               ldd       #$FFFF
+                    lbra      L52B3
 
-L5266               ldd       $06,u
+L5265               ldd       $06,u
                     clra
                     andb      #$02
-                    beq       L5275
+                    beq       L5274
                     pshs      u
-                    bsr       L528A
+                    bsr       L5289
                     leas      $02,s
-                    bra       L5277
+                    bra       L5276
 
-L5275               clra
+L5274               clra
                     clrb
-L5277               std       ,s
+L5276               std       ,s
                     ldd       $08,u
                     pshs      d
-                    lbsr      L606A
+                    lbsr      L6069
                     leas      $02,s
                     clra
                     clrb
                     std       $06,u
                     ldd       ,s
-                    bra       L52B4
+                    bra       L52B3
 
-L528A               pshs      u
+L5289               pshs      u
                     ldu       $04,s
-                    beq       L529B
+                    beq       L529A
                     ldd       $06,u
                     clra
                     andb      #$22
                     cmpd      #$0002
-                    beq       L52A0
-L529B               ldd       #$FFFF
+                    beq       L529F
+L529A               ldd       #$FFFF
                     puls      pc,u
-L52A0               ldd       $06,u
+L529F               ldd       $06,u
                     anda      #$80
                     clrb
                     std       -$02,s
-                    bne       L52B0
+                    bne       L52AF
                     pshs      u
-                    lbsr      L54CA
+                    lbsr      L54C9
                     leas      $02,s
-L52B0               pshs      u
-                    bsr       L52B8
-L52B4               leas      $02,s
+L52AF               pshs      u
+                    bsr       L52B7
+L52B3               leas      $02,s
                     puls      pc,u
-L52B8               pshs      u
+L52B7               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L52EA
+                    bne       L52E9
                     ldd       ,u
                     cmpd      $04,u
-                    beq       L52EA
+                    beq       L52E9
                     clra
                     clrb
                     pshs      d
                     pshs      u
-                    lbsr      L50F6
+                    lbsr      L50F5
                     leas      $02,s
                     ldd       $02,x
                     pshs      d
@@ -9250,70 +9242,70 @@ L52B8               pshs      u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L6131
+                    lbsr      L6130
                     leas      $08,s
-L52EA               ldd       ,u
+L52E9               ldd       ,u
                     subd      $02,u
                     std       $02,s
-                    lbeq      L5362
+                    lbeq      L5361
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    lbeq      L5362
+                    lbeq      L5361
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L5339
+                    beq       L5338
                     ldd       $02,u
-                    bra       L5331
+                    bra       L5330
 
-L530A               ldd       $02,s
+L5309               ldd       $02,s
                     pshs      d
                     ldd       ,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L6121
+                    lbsr      L6120
                     leas      $06,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L5327
+                    bne       L5326
                     leax      $04,s
-                    bra       L5351
+                    bra       L5350
 
-L5327               ldd       $02,s
+L5326               ldd       $02,s
                     subd      ,s
                     std       $02,s
                     ldd       ,u
                     addd      ,s
-L5331               std       ,u
+L5330               std       ,u
                     ldd       $02,s
-                    bne       L530A
-                    bra       L5362
+                    bne       L5309
+                    bra       L5361
 
-L5339               ldd       $02,s
+L5338               ldd       $02,s
                     pshs      d
                     ldd       $02,u
                     pshs      d
                     ldd       $08,u
                     pshs      d
-                    lbsr      L6108
+                    lbsr      L6107
                     leas      $06,s
                     cmpd      $02,s
-                    beq       L5362
-                    bra       L5353
+                    beq       L5361
+                    bra       L5352
 
-L5351               leas      -$04,x
-L5353               ldd       $06,u
+L5350               leas      -$04,x
+L5352               ldd       $06,u
                     orb       #$20
                     std       $06,u
                     ldd       $04,u
                     std       ,u
                     ldd       #$FFFF
-                    bra       L5372
+                    bra       L5371
 
-L5362               ldd       $06,u
+L5361               ldd       $06,u
                     ora       #$01
                     std       $06,u
                     ldd       $02,u
@@ -9322,19 +9314,19 @@ L5362               ldd       $06,u
                     std       $04,u
                     clra
                     clrb
-L5372               leas      $04,s
+L5371               leas      $04,s
                     puls      pc,u
-L5376               pshs      u
+L5375               pshs      u
                     ldu       $04,s
-                    beq       L53C2
+                    beq       L53C1
                     ldd       $06,u
                     anda      #$01
                     clrb
                     std       -$02,s
-                    bne       L53C2
+                    bne       L53C1
                     ldd       ,u
                     cmpd      $04,u
-                    bcc       L539E
+                    bcc       L539D
                     ldd       ,u
                     addd      #$0001
                     std       ,u
@@ -9342,27 +9334,27 @@ L5376               pshs      u
                     tfr       d,x
                     ldb       ,x
                     clra
-                    lbra      L54C8
+                    lbra      L54C7
 
-L539E               pshs      u
-                    lbsr      L5411
-                    lbra      L54C6
+L539D               pshs      u
+                    lbsr      L5410
+                    lbra      L54C5
                     pshs      u
                     ldu       $06,s
-                    beq       L53C2
+                    beq       L53C1
                     ldd       $06,u
                     clra
                     andb      #$01
-                    beq       L53C2
+                    beq       L53C1
                     ldd       $04,s
                     cmpd      #$FFFF
-                    beq       L53C2
+                    beq       L53C1
                     ldd       ,u
                     cmpd      $02,u
-                    bhi       L53C7
-L53C2               ldd       #$FFFF
+                    bhi       L53C6
+L53C1               ldd       #$FFFF
                     puls      pc,u
-L53C7               ldd       ,u
+L53C6               ldd       ,u
                     addd      #$FFFF
                     std       ,u
                     tfr       d,x
@@ -9370,63 +9362,63 @@ L53C7               ldd       ,u
                     stb       ,x
                     ldd       $04,s
                     puls      pc,u
-L53D8               pshs      u
+L53D7               pshs      u
                     ldu       $04,s
                     leas      -$04,s
                     pshs      u
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
-                    beq       L53FC
+                    beq       L53FB
                     pshs      u
-                    lbsr      L5376
+                    lbsr      L5375
                     leas      $02,s
                     std       ,s
                     cmpd      #$FFFF
-                    bne       L5401
-L53FC               ldd       #$FFFF
-                    bra       L540D
+                    bne       L5400
+L53FB               ldd       #$FFFF
+                    bra       L540C
 
-L5401               ldd       $02,s
+L5400               ldd       $02,s
                     pshs      d
                     ldd       #$0008
-                    lbsr      $5FD1
+                    lbsr      L5FD0
                     addd      ,s
-L540D               leas      $04,s
+L540C               leas      $04,s
                     puls      pc,u
-L5411               pshs      u
+L5410               pshs      u
                     ldu       $04,s
                     leas      -$02,s
                     ldd       $06,u
                     anda      #$80
                     andb      #$31
                     cmpd      #$8001
-                    beq       L5437
+                    beq       L5436
                     ldd       $06,u
                     clra
                     andb      #$31
                     cmpd      #$0001
-                    lbne      L54B0
+                    lbne      L54AF
                     pshs      u
-                    lbsr      L54CA
+                    lbsr      L54C9
                     leas      $02,s
-L5437               leax      $00C1,y
+L5436               leax      $00C1,y
                     pshs      x
                     cmpu      ,s++
-                    bne       L5454
+                    bne       L5453
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L5454
+                    beq       L5453
                     leax      $00CE,y
                     pshs      x
-                    lbsr      L528A
+                    lbsr      L5289
                     leas      $02,s
-L5454               ldd       $06,u
+L5453               ldd       $06,u
                     clra
                     andb      #$08
-                    beq       L5480
+                    beq       L547F
                     ldd       $0b,u
                     pshs      d
                     ldd       $02,u
@@ -9436,43 +9428,43 @@ L5454               ldd       $06,u
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L5474
-                    leax      L60F8,pcr
-                    bra       L5478
+                    beq       L5473
+                    leax      L60F7,pcr
+                    bra       L5477
 
-L5474               leax      L60D7,pcr
-L5478               tfr       x,d
+L5473               leax      L60D6,pcr
+L5477               tfr       x,d
                     tfr       d,x
                     jsr       ,x
-                    bra       L5492
+                    bra       L5491
 
-L5480               ldd       #$0001
+L547F               ldd       #$0001
                     pshs      d
                     leax      $0a,u
                     stx       $02,u
                     pshs      x
                     ldd       $08,u
                     pshs      d
-                    lbsr      L60D7
-L5492               leas      $06,s
+                    lbsr      L60D6
+L5491               leas      $06,s
                     std       ,s
                     ldd       ,s
-                    bgt       L54B5
+                    bgt       L54B4
                     ldd       $06,u
                     pshs      d
                     ldd       $02,s
-                    beq       L54A7
+                    beq       L54A6
                     ldd       #$0020
-                    bra       L54AA
+                    bra       L54A9
 
-L54A7               ldd       #$0010
-L54AA               ora       ,s+
+L54A6               ldd       #$0010
+L54A9               ora       ,s+
                     orb       ,s+
                     std       $06,u
-L54B0               ldd       #$FFFF
-                    bra       L54C6
+L54AF               ldd       #$FFFF
+                    bra       L54C5
 
-L54B5               ldd       $02,u
+L54B4               ldd       $02,u
                     addd      #$0001
                     std       ,u
                     ldd       $02,u
@@ -9480,14 +9472,14 @@ L54B5               ldd       $02,u
                     std       $04,u
                     ldb       [$02,u]
                     clra
-L54C6               leas      $02,s
-L54C8               puls      pc,u
-L54CA               pshs      u
+L54C5               leas      $02,s
+L54C7               puls      pc,u
+L54C9               pshs      u
                     ldu       $04,s
                     ldd       $06,u
                     clra
                     andb      #$C0
-                    bne       L5502
+                    bne       L5501
                     leas      -$20,s
                     leax      ,s
                     pshs      x
@@ -9496,71 +9488,71 @@ L54CA               pshs      u
                     clra
                     clrb
                     pshs      d
-                    lbsr      $5FEC
+                    lbsr      L5FEB
                     leas      $06,s
                     ldd       $06,u
                     pshs      d
                     ldb       $02,s
-                    bne       L54F6
+                    bne       L54F5
                     ldd       #$0040
-                    bra       L54F9
+                    bra       L54F8
 
-L54F6               ldd       #$0080
-L54F9               ora       ,s+
+L54F5               ldd       #$0080
+L54F8               ora       ,s+
                     orb       ,s+
                     std       $06,u
                     leas      $20,s
-L5502               ldd       $06,u
+L5501               ldd       $06,u
                     ora       #$80
                     std       $06,u
                     clra
                     andb      #$0C
-                    beq       L550F
+                    beq       L550E
                     puls      pc,u
-L550F               ldd       $0b,u
-                    bne       L5524
+L550E               ldd       $0b,u
+                    bne       L5523
                     ldd       $06,u
                     clra
                     andb      #$40
-                    beq       L551F
+                    beq       L551E
                     ldd       #$0080
-                    bra       L5522
+                    bra       L5521
 
-L551F               ldd       #$0100
-L5522               std       $0b,u
-L5524               ldd       $02,u
-                    bne       L5539
+L551E               ldd       #$0100
+L5521               std       $0b,u
+L5523               ldd       $02,u
+                    bne       L5538
                     ldd       $0b,u
                     pshs      d
-                    lbsr      L61EF
+                    lbsr      L61EE
                     leas      $02,s
                     std       $02,u
                     cmpd      #$FFFF
-                    beq       L5541
-L5539               ldd       $06,u
+                    beq       L5540
+L5538               ldd       $06,u
                     orb       #$08
                     std       $06,u
-                    bra       L5550
+                    bra       L554F
 
-L5541               ldd       $06,u
+L5540               ldd       $06,u
                     orb       #$04
                     std       $06,u
                     leax      $0a,u
                     stx       $02,u
                     ldd       #$0001
                     std       $0b,u
-L5550               ldd       $02,u
+L554F               ldd       $02,u
                     addd      $0b,u
                     std       $04,u
                     std       ,u
                     puls      pc,u
-L555A               pshs      u
+L5559               pshs      u
                     ldd       $0C,s
-                    beq       L5596
+                    beq       L5595
                     ldd       $0e,s
-                    beq       L557D
+                    beq       L557C
                     leax      $04,s
-                    lbsr      $5D52
+                    lbsr      L5D51
                     ldd       $14,s
                     aslb
                     rola
@@ -9570,11 +9562,11 @@ L555A               pshs      u
                     rola
                     leax      >$0059,y
                     leax      d,x
-                    lbsr      L56AA
-                    bra       L5598
+                    lbsr      L56A9
+                    bra       L5597
 
-L557D               leax      $04,s
-                    lbsr      $5D52
+L557C               leax      $04,s
+                    lbsr      L5D51
                     ldd       $14,s
                     aslb
                     rola
@@ -9584,18 +9576,18 @@ L557D               leax      $04,s
                     rola
                     leax      >$0059,y
                     leax      d,x
-                    lbsr      L56B2
-                    bra       L5598
+                    lbsr      L56B1
+                    bra       L5597
 
-L5596               leax      $04,s
-L5598               leau      $0254,y
+L5595               leax      $04,s
+L5597               leau      $0254,y
                     pshs      u
-                    lbsr      L5D79
+                    lbsr      L5D78
                     puls      pc,u
-L55A3               pshs      u
+L55A2               pshs      u
                     ldd       $0C,s
                     cmpd      #$0009
-                    ble       L55D3
+                    ble       L55D2
                     leax      $04,s
                     pshs      x
                     ldd       $10,s
@@ -9603,89 +9595,89 @@ L55A3               pshs      u
                     ldd       $10,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      $5F44
+                    lbsr      L5F43
                     addd      #$0009
                     pshs      d
                     leax      $0a,s
-                    lbsr      $5D52
-                    lbsr      L555A
+                    lbsr      L5D51
+                    lbsr      L5559
                     leas      $0C,s
-                    lbsr      L5D79
-L55D3               ldd       $0e,s
+                    lbsr      L5D78
+L55D2               ldd       $0e,s
                     pshs      d
                     ldd       $0e,s
                     pshs      d
                     ldd       #$000A
-                    lbsr      L5EF1
+                    lbsr      L5EF0
                     pshs      d
                     leax      $08,s
-                    lbsr      $5D52
-                    lbsr      L555A
+                    lbsr      L5D51
+                    lbsr      L5559
                     leas      $0C,s
                     puls      pc,u
-L55EF               pshs      u
+L55EE               pshs      u
                     ldu       $04,s
-L55F3               ldb       ,u+
-                    bne       L55F3
+L55F2               ldb       ,u+
+                    bne       L55F2
                     tfr       u,d
                     subd      $04,s
                     addd      #$FFFF
                     puls      pc,u
-L5600               pshs      u
+L55FF               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L560A               ldb       ,u+
+L5609               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L560A
-                    bra       L563F
+                    bne       L5609
+                    bra       L563E
 
-L5618               pshs      u
+L5617               pshs      u
                     ldu       $06,s
                     leas      -$02,s
                     ldd       $06,s
                     std       ,s
-L5622               ldx       ,s
+L5621               ldx       ,s
                     leax      $01,x
                     stx       ,s
                     ldb       -$01,x
-                    bne       L5622
+                    bne       L5621
                     ldd       ,s
                     addd      #$FFFF
                     std       ,s
-L5633               ldb       ,u+
+L5632               ldb       ,u+
                     ldx       ,s
                     leax      $01,x
                     stx       ,s
                     stb       -$01,x
-                    bne       L5633
-L563F               ldd       $06,s
+                    bne       L5632
+L563E               ldd       $06,s
                     leas      $02,s
                     puls      pc,u
                     pshs      u
                     ldu       $04,s
-                    bra       L565B
+                    bra       L565A
 
-L564B               ldx       $06,s
+L564A               ldx       $06,s
                     leax      $01,x
                     stx       $06,s
                     ldb       -$01,x
-                    bne       L5659
+                    bne       L5658
                     clra
                     clrb
                     puls      pc,u
-L5659               leau      $01,u
-L565B               ldb       ,u
+L5658               leau      $01,u
+L565A               ldb       ,u
                     sex
                     pshs      d
                     ldb       [$08,s]
                     sex
                     cmpd      ,s++
-                    beq       L564B
+                    beq       L564A
                     ldb       [$06,s]
                     sex
                     pshs      d
@@ -9693,40 +9685,40 @@ L565B               ldb       ,u
                     sex
                     subd      ,s++
                     puls      pc,u
-L5676               ldx       $02,s
-                    lbsr      $5D52
-                    bsr       L567E
+L5675               ldx       $02,s
+                    lbsr      L5D51
+                    bsr       L567D
                     rts
 
-L567E               pshs      u
+L567D               pshs      u
                     leas      -$1e,s
                     tfr       s,u
                     clr       $1d,u
                     clr       $19,u
-                    lbsr      $58F8
-                    lbra      L571D
+                    lbsr      L58F7
+                    lbra      L571C
 
-L5691               ldd       ,x
+L5690               ldd       ,x
                     eora      #$80
-                    lbra      $5CB6
-                    lbsr      L5B10
-                    lbsr      L57F2
-                    lbra      L571D
-                    lbsr      L5B10
-                    lbsr      L57C8
-                    lbra      L571D
+                    lbra      L5CB5
+                    lbsr      L5B0F
+                    lbsr      L57F1
+                    lbra      L571C
+                    lbsr      L5B0F
+                    lbsr      L57C7
+                    lbra      L571C
 
-L56AA               lbsr      L5B10
-                    lbsr      $596B
-                    bra       L571D
+L56A9               lbsr      L5B0F
+                    lbsr      L596A
+                    bra       L571C
 
-L56B2               lbsr      L5B10
-                    lbsr      $5997
-                    bra       L571D
+L56B1               lbsr      L5B0F
+                    lbsr      L5996
+                    bra       L571C
 
-L56BA               lbsr      $5CB4
-                    lbra      $5BB4
-                    bsr       L56BA
+L56B9               lbsr      L5CB3
+                    lbra      L5BB3
+                    bsr       L56B9
                     ldd       $02,x
                     rts
                     ldd       ,x
@@ -9734,21 +9726,21 @@ L56BA               lbsr      $5CB4
                     ldd       $02,x
                     leax      $0254,y
                     std       $02,x
-                    lbra      $5B54
+                    lbra      L5B53
                     leax      $0254,y
                     std       $02,x
                     tfr       a,b
                     sex
                     tfr       a,b
                     std       ,x
-                    lbra      $5B54
+                    lbra      L5B53
                     leax      $0254,y
                     std       $02,x
                     clr       ,x
                     clr       $01,x
-                    lbra      $5B54
+                    lbra      L5B53
 
-L56F3               ldd       ,x
+L56F2               ldd       ,x
                     std       $0254,y
                     lda       $02,x
                     ldb       $07,x
@@ -9767,7 +9759,7 @@ L56F3               ldd       ,x
                     clr       $06,x
                     rts
 
-L571D               leax      $0254,y
+L571C               leax      $0254,y
                     ldd       $22,u
                     std       ,x
                     ldd       $24,u
@@ -9784,121 +9776,122 @@ L571D               leax      $0254,y
                     rts
                     lda       $02,s
                     eora      ,x
-                    bmi       L57B0
+                    bmi       L57AF
                     lda       $02,s
-                    bmi       L5783
+                    bmi       L5782
                     lda       $09,s
-                    beq       L577C
+                    beq       L577B
                     ldb       $07,x
-                    beq       L57B4
+                    beq       L57B3
                     cmpa      $07,x
-                    bne       L5787
+                    bne       L5786
                     ldd       $02,s
                     cmpd      ,x
-                    bne       L5787
+                    bne       L5786
                     ldd       $04,s
                     cmpd      $02,x
-                    bne       L5787
+                    bne       L5786
                     ldd       $06,s
                     cmpd      $04,x
-                    bne       L5787
+                    bne       L5786
                     lda       $08,s
                     anda      #$FE
                     pshs      a
                     ldb       $06,x
                     andb      #$FE
                     cmpa      ,s+
-                    bne       L5787
-                    bra       L57B8
+                    bne       L5786
+                    bra       L57B7
 
-L577C               lda       $07,x
-                    bne       L57C3
+L577B               lda       $07,x
+                    bne       L57C2
                     clra
-                    bra       L57B8
+                    bra       L57B7
 
-L5783               lda       $07,x
+L5782               lda       $07,x
                     cmpa      $09,s
-L5787               bhi       L57B4
-                    bcs       L57C3
+L5786               bhi       L57B3
+                    bcs       L57C2
                     ldd       ,x
                     cmpd      $02,s
-                    bne       L5787
+                    bne       L5786
                     ldd       $02,x
                     cmpd      $04,s
-                    bne       L5787
+                    bne       L5786
                     ldd       $04,x
                     cmpd      $06,s
-                    bne       L5787
+                    bne       L5786
                     lda       $06,x
                     anda      #$FE
                     pshs      a
                     lda       $08,s
                     anda      #$FE
                     cmpa      ,s+
-                    bne       L5787
-                    bra       L57B8
+                    bne       L5786
+                    bra       L57B7
 
-L57B0               lda       ,x
-                    bpl       L57C3
-L57B4               lda       #$01
+L57AF               lda       ,x
+                    bpl       L57C2
+L57B3               lda       #$01
                     andcc     #$FE
-L57B8               pshs      cc
+L57B7               pshs      cc
                     ldd       $01,s
                     std       $09,s
                     puls      cc
                     leas      $08,s
                     rts
 
-L57C3               clra
+L57C2               clra
                     cmpa      #$01
-                    bra       L57B8
+                    bra       L57B7
 
-L57C8               lda       $17,u
-                    beq       L57E9
+L57C7               lda       $17,u
+                    beq       L57E8
                     ldb       $1C,u
                     eorb      #$80
                     stb       $1C,u
                     eorb      $18,u
                     stb       $19,u
                     ldb       $29,u
-                    bne       L57FB
-                    lbsr      $5C84
+                    bne       L57FA
+                    lbsr      L5C83
                     lda       $22,u
-                    lbra      $593B
+                    lbra      L593A
 
-L57E9               lda       $22,u
+L57E8               lda       $22,u
                     ldb       $18,u
-                    lbra      $593E
+                    lbra      L593D
 
-L57F2               lbeq      $5C84
+L57F1               lbeq      L5C83
                     lda       $17,u
-                    beq       L57E9
-L57FB               suba      $29,u
-                    beq       $582C
+                    beq       L57E8
+L57FA               suba      $29,u
+                    beq       L582B
                     sta       ,u
-                    bcs       $5832
+                    bcs       L5831
                     ldb       $17,u
                     stb       $29,u
                     ldd       $22,u
-                    lsra
-L580E               rorb
+L580C               lsra
+                    rorb
                     ror       $24,u
                     ror       $25,u
                     ror       $26,u
-                    ror       $0f,x
-                    eorb      #$27
+                    ror       $27,u
                     ror       $28,u
                     dec       ,u
-                    bne       L580E
+                    bne       L580C
                     std       $22,u
-L5826               lda       $19,u
-                    bmi       L58A2
-                    bra       L5853
-                    inc       ,u
+L5824               lda       $19,u
+                    bmi       L58A0
+                    bra       L5851
+
+L582B               inc       ,u
                     orcc      #$01
-                    bra       L5826
-                    ldd       $10,u
-L5836               lsra
+                    bra       L5824
+
+L5831               ldd       $10,u
+L5834               lsra
                     rorb
                     ror       $12,u
                     ror       $13,u
@@ -9906,11 +9899,11 @@ L5836               lsra
                     ror       $15,u
                     ror       $16,u
                     inc       ,u
-                    bne       L5836
+                    bne       L5834
                     std       $10,u
                     lda       $19,u
-                    bmi       L58A5
-L5853               ldd       $27,u
+                    bmi       L58A3
+L5851               ldd       $27,u
                     adcb      $16,u
                     adca      $15,u
                     std       $27,u
@@ -9925,7 +9918,7 @@ L5853               ldd       $27,u
                     adcb      $11,u
                     adca      $10,u
                     std       $22,u
-                    bcc       L589A
+                    bcc       L5898
                     inc       $29,u
                     ror       $22,u
                     ror       $23,u
@@ -9934,14 +9927,14 @@ L5853               ldd       $27,u
                     ror       $26,u
                     ror       $27,u
                     ror       $28,u
-L589A               lda       $1C,u
+L5898               lda       $1C,u
                     sta       $19,u
-                    bra       L58F9
+                    bra       L58F7
 
-L58A2               rola
+L58A0               rola
                     coma
                     asra
-L58A5               ldd       $27,u
+L58A3               ldd       $27,u
                     sbcb      $16,u
                     sbca      $15,u
                     std       $27,u
@@ -9957,7 +9950,7 @@ L58A5               ldd       $27,u
                     sbca      $10,u
                     sta       $22,u
                     lda       $18,u
-                    bcc       L58F6
+                    bcc       L58F4
                     com       $22,u
                     com       $23,u
                     com       $24,u
@@ -9966,25 +9959,25 @@ L58A5               ldd       $27,u
                     com       $27,u
                     com       $28,u
                     lda       ,u
-                    beq       L58F3
-                    lbsr      L5C42
-L58F3               lda       $1C,u
-L58F6               sta       $19,u
-L58F9               clr       ,u
-L58FB               lda       $22,u
-                    bmi       L593C
+                    beq       L58F1
+                    lbsr      L5C40
+L58F1               lda       $1C,u
+L58F4               sta       $19,u
+L58F7               clr       ,u
+L58F9               lda       $22,u
+                    bmi       L593A
                     ora       $23,u
                     ora       $24,u
                     ora       $25,u
                     ora       $26,u
                     ora       $27,u
                     ora       $28,u
-                    beq       L5950
+                    beq       L594E
                     ldd       $22,u
-L5917               dec       $29,u
-                    bne       L591F
+L5915               dec       $29,u
+                    bne       L591D
                     dec       $1d,u
-L591F               asl       ,u
+L591D               asl       ,u
                     rol       $28,u
                     rol       $27,u
                     rol       $26,u
@@ -9992,37 +9985,38 @@ L591F               asl       ,u
                     rol       $24,u
                     rolb
                     rola
-                    bpl       L5917
+                    bpl       L5915
                     stb       $23,u
                     ldb       $29,u
-                    beq       L5954
-L593C               ldb       $19,u
-                    anda      #$7f
+                    beq       L5952
+L593A               ldb       $19,u
+L593D               anda      #$7f
                     andb      #$80
                     pshs      b
                     adda      ,s+
                     sta       $22,u
                     tst       $1d,u
-                    bne       L5954
-L594F               rts
+                    bne       L5952
+L594D               rts
 
-L5950               sta       $29,u
+L594E               sta       $29,u
                     rts
 
-L5954               lda       $1d,u
+L5952               lda       $1d,u
                     ldb       $29,u
                     subd      #$0000
-                    beq       L5967
-                    bmi       L5967
-L5961               ldd       #$0028
-                    lbra      $5FDE
+                    beq       L5965
+                    bmi       L5965
+L595F               ldd       #$0028
+                    lbra      L5FDC
 
-L5967               lbsr      L5992
-                    bra       L5961
-                    beq       L5992
+L5965               lbsr      L5990
+                    bra       L595F
+
+L596A               beq       L5990
                     lda       $17,u
-                    beq       L5992
-                    lbsr      L5A0E
+                    beq       L5990
+                    lbsr      L5A0C
                     clra
                     ldb       $29,u
                     addb      $17,u
@@ -10030,22 +10024,23 @@ L5967               lbsr      L5992
                     subd      #$0080
                     stb       $29,u
                     sta       $1d,u
-                    lbsr      L58FB
+                    lbsr      L58F9
                     lda       ,u
-                    bpl       L594F
-                    lbra      L5C42
+                    bpl       L594D
+                    lbra      L5C40
 
-L5992               clra
+L5990               clra
                     sta       $29,u
-                    bra       L59F8
-                    ldb       $17,u
-                    bne       L59A3
-                    ldd       #$0029
-                    lbra      $5FDE
+                    bra       L59F6
 
-L59A3               tsta
-                    beq       L5992
-                    lbsr      L5A6C
+L5996               ldb       $17,u
+                    bne       L59A1
+                    ldd       #$0029
+                    lbra      L5FDC
+
+L59A1               tsta
+                    beq       L5990
+                    lbsr      L5A6A
                     clra
                     ldb       $29,u
                     subb      $17,u
@@ -10064,12 +10059,12 @@ L59A3               tsta
                     ror       $27,u
                     ror       $28,u
                     ror       ,u
-                    lbsr      L58FB
+                    lbsr      L58F9
                     lda       ,u
-                    bpl       L5A0D
-                    lbra      L5C42
+                    bpl       L5A0B
+                    lbra      L5C40
 
-L59E0               pshs      a
+L59DE               pshs      a
                     ldd       $22,u
                     std       ,u
                     ldd       $24,u
@@ -10079,22 +10074,22 @@ L59E0               pshs      a
                     ldb       $28,u
                     stb       $06,u
                     puls      a
-L59F8               sta       $22,u
+L59F6               sta       $22,u
                     sta       $23,u
                     sta       $24,u
                     sta       $25,u
                     sta       $26,u
                     sta       $27,u
                     sta       $28,u
-L5A0D               rts
+L5A0B               rts
 
-L5A0E               clra
-                    bsr       L59E0
+L5A0C               clra
+                    bsr       L59DE
                     ldb       #$38
                     stb       $08,u
-L5A15               lda       $06,u
+L5A13               lda       $06,u
                     lsra
-                    bcc       L5A44
+                    bcc       L5A42
                     ldd       $27,u
                     addd      $15,u
                     std       $27,u
@@ -10109,7 +10104,7 @@ L5A15               lda       $06,u
                     lda       $22,u
                     adca      $10,u
                     sta       $22,u
-L5A44               ror       $22,u
+L5A42               ror       $22,u
                     ror       $23,u
                     ror       $24,u
                     ror       $25,u
@@ -10124,16 +10119,16 @@ L5A44               ror       $22,u
                     ror       $05,u
                     ror       $06,u
                     dec       $08,u
-                    bne       L5A15
+                    bne       L5A13
                     rts
 
-L5A6C               clra
-                    lbsr      L59E0
+L5A6A               clra
+                    lbsr      L59DE
                     ldb       #$39
                     stb       $08,u
-L5A74               ldb       ,u
+L5A72               ldb       ,u
                     cmpb      $10,u
-                    bcs       L5AAB
+                    bcs       L5AA9
                     ldd       $05,u
                     subd      $15,u
                     std       $0d,u
@@ -10147,7 +10142,7 @@ L5A74               ldb       ,u
                     ldd       ,u
                     sbcb      $11,u
                     sbca      $10,u
-                    bcs       L5AAB
+                    bcs       L5AA9
                     std       ,u
                     lda       $0a,u
                     sta       $02,u
@@ -10155,7 +10150,7 @@ L5A74               ldb       ,u
                     std       $03,u
                     ldd       $0d,u
                     std       $05,u
-L5AAB               rol       $28,u
+L5AA9               rol       $28,u
                     rol       $27,u
                     rol       $26,u
                     rol       $25,u
@@ -10170,8 +10165,8 @@ L5AAB               rol       $28,u
                     rol       $01,u
                     rol       ,u
                     dec       $08,u
-                    bhi       L5A74
-                    beq       L5AF9
+                    bhi       L5A72
+                    beq       L5AF7
                     ldd       $05,u
                     subd      $15,u
                     std       $05,u
@@ -10187,9 +10182,9 @@ L5AAB               rol       $28,u
                     sbca      $10,u
                     sta       ,u
                     clra
-                    bra       L5AAB
+                    bra       L5AA9
 
-L5AF9               ror       ,u
+L5AF7               ror       ,u
                     com       $22,u
                     com       $23,u
                     com       $24,u
@@ -10197,9 +10192,9 @@ L5AF9               ror       ,u
                     com       $26,u
                     com       $27,u
                     com       $28,u
-L5B10               rts
+                    rts
 
-L5B11               puls      d
+L5B0F               puls      d
                     pshs      u
                     leas      -$1e,s
                     tfr       s,u
@@ -10226,7 +10221,7 @@ L5B11               puls      d
                     lda       $29,u
                     rts
                     leax      $22,u
-                    lda       #$A0
+L5B53               lda       #$A0
                     sta       $07,x
                     clr       $04,x
                     clr       $05,x
@@ -10236,10 +10231,10 @@ L5B11               puls      d
                     orb       $01,x
                     orb       $02,x
                     orb       $03,x
-                    beq       L5BA1
+                    beq       L5B9F
                     ldb       $01,x
                     tsta
-                    bpl       L5B83
+                    bpl       L5B81
                     pshs      d
                     clra
                     clrb
@@ -10249,92 +10244,92 @@ L5B11               puls      d
                     sbcb      $01,s
                     sbca      ,s
                     leas      $02,s
-                    bvs       L5B8D
-L5B83               dec       $07,x
+                    bvs       L5B8B
+L5B81               dec       $07,x
                     asl       $03,x
                     rol       $02,x
                     rolb
                     rola
-                    bpl       L5B83
-L5B8D               anda      #$7f
+                    bpl       L5B81
+L5B8B               anda      #$7f
                     tst       ,x
-                    bpl       L5B95
+                    bpl       L5B93
                     ora       #$80
-L5B95               std       ,x
+L5B93               std       ,x
                     rts
                     leax      $22,u
                     clr       $04,x
                     clr       $05,x
                     clr       $06,x
-L5BA1               clr       $07,x
-L5BA3               clr       ,x
+L5B9F               clr       $07,x
+L5BA1               clr       ,x
                     clr       $01,x
                     clr       $02,x
                     clr       $03,x
                     rts
 
-L5BAC               ldd       #$002A
-                    lbra      $5FDE
+L5BAA               ldd       #$002A
+                    lbra      L5FDC
                     leax      $22,u
-                    ldb       $07,x
-                    beq       L5BA3
+L5BB3               ldb       $07,x
+                    beq       L5BA1
                     subb      #$81
-                    bcs       L5C34
+                    bcs       L5C32
                     negb
                     addb      #$1f
-                    bmi       L5BAC
-                    bne       L5BD9
+                    bmi       L5BAA
+                    bne       L5BD7
                     ldd       ,x
                     cmpd      #$8000
-                    bne       L5BAC
+                    bne       L5BAA
                     lda       $02,x
                     ora       $03,x
                     ora       $04,x
                     ora       $05,x
                     ora       $06,x
-                    bne       L5BAC
+                    bne       L5BAA
                     rts
 
-L5BD9               pshs      b
+L5BD7               pshs      b
                     ldd       ,x
-                    bmi       L5BEF
+                    bmi       L5BED
                     ora       #$80
-L5BE1               lsra
+L5BDF               lsra
                     rorb
                     ror       $02,x
                     ror       $03,x
                     dec       ,s
-                    bne       L5BE1
+                    bne       L5BDF
                     std       ,x
                     puls      pc,b
-L5BEF               clr       ,-s
-L5BF1               lsra
+L5BED               clr       ,-s
+L5BEF               lsra
                     rorb
                     ror       $02,x
                     ror       $03,x
                     ror       $04,x
                     ror       $05,x
                     ror       $06,x
-                    bcc       L5C01
+                    bcc       L5BFF
                     inc       ,s
-L5C01               dec       $01,s
-                    bne       L5BF1
+L5BFF               dec       $01,s
+                    bne       L5BEF
                     std       ,x
                     ldd       ,s++
-                    bne       L5C13
+                    bne       L5C11
                     lda       $04,x
                     ora       $05,x
                     ora       $06,x
-                    beq       L5C24
-L5C13               ldd       $02,x
+                    beq       L5C22
+L5C11               ldd       $02,x
                     addd      #$0001
                     std       $02,x
                     ldd       ,x
                     adcb      #$00
                     adca      #$00
-                    bcs       L5BAC
+                    bcs       L5BAA
                     std       ,x
-L5C24               clra
+L5C22               clra
                     clrb
                     subd      $02,x
                     std       $02,x
@@ -10344,44 +10339,44 @@ L5C24               clra
                     std       ,x
                     rts
 
-L5C34               lda       ,x
-                    lbpl      L5BA3
+L5C32               lda       ,x
+                    lbpl      L5BA1
                     ldd       #$FFFF
                     std       $02,x
                     std       ,x
                     rts
 
-L5C42               inc       $28,u
-                    bne       L5C78
+L5C40               inc       $28,u
+                    bne       L5C76
                     inc       $27,u
-                    bne       L5C78
+                    bne       L5C76
                     inc       $26,u
-                    bne       L5C78
+                    bne       L5C76
                     inc       $25,u
-                    bne       L5C78
+                    bne       L5C76
                     inc       $24,u
-                    bne       L5C78
+                    bne       L5C76
                     inc       $23,u
-                    bne       L5C78
+                    bne       L5C76
                     ldb       $22,u
                     tfr       b,a
                     anda      #$7f
                     inca
-                    bpl       L5C6F
+                    bpl       L5C6D
                     inc       $29,u
                     anda      #$7f
-L5C6F               andb      #$80
+L5C6D               andb      #$80
                     pshs      b
                     adda      ,s+
                     sta       $22,u
-L5C78               rts
+L5C76               rts
 
-L5C79               neg       $0000
+L5C77               neg       $0000
                     neg       $0000
                     neg       $0000
                     neg       L0081
-                    leax      >L5C79,pcr
-                    pshs      a
+                    leax      >L5C77,pcr
+L5C83               pshs      a
                     ldd       ,x
                     std       $22,u
                     ldd       $02,x
@@ -10391,7 +10386,7 @@ L5C79               neg       $0000
                     ldd       $06,x
                     std       $28,u
                     puls      pc,a
-L5C9D               pshs      a
+L5C9B               pshs      a
                     ldd       $22,u
                     std       ,x
                     ldd       $24,u
@@ -10401,8 +10396,8 @@ L5C9D               pshs      a
                     ldd       $28,u
                     std       $06,x
                     puls      pc,a
-                    ldd       ,x
-                    std       $0254,y
+L5CB3               ldd       ,x
+L5CB5               std       $0254,y
                     ldd       $02,x
                     std       $0256,y
                     ldd       $04,x
@@ -10412,50 +10407,49 @@ L5C9D               pshs      a
                     std       $06,x
                     rts
                     pshs      x
-                    bsr       L5D53
-                    leax      L5C79,pcr
+                    bsr       L5D51
+                    leax      L5C77,pcr
                     pshs      x
-                    lbsr      L5B11
-                    lbsr      $57F3
-L5CDF               ldx       $2a,u
-                    bsr       L5C9D
+                    lbsr      L5B0F
+                    lbsr      L57F1
+L5CDD               ldx       $2a,u
+                    bsr       L5C9B
                     ldx       $1e,u
                     leas      $2a,u
                     tfr       x,u
                     puls      pc,x
                     pshs      x
-                    bsr       L5D53
-                    leax      >L5C79,pcr
+                    bsr       L5D51
+                    leax      >L5C77,pcr
                     pshs      x
-                    lbsr      L5B11
-                    lbsr      $57C9
-                    bra       L5CDF
+                    lbsr      L5B0F
+                    lbsr      L57C7
+                    bra       L5CDD
                     pshs      x
-                    bsr       $5D3C
-                    leax      L5C79,pcr
+                    bsr       L5D3A
+                    leax      L5C77,pcr
                     pshs      x
-                    lbsr      L5B11
-                    lbsr      $57F3
-                    ldx       $2a,u
+                    lbsr      L5B0F
+                    lbsr      L57F1
+L5D0E               ldx       $2a,u
                     ldd       $22,u
                     std       ,x
                     lda       $24,u
                     ldb       $29,u
                     std       $02,x
-                    ldx       $0f,u
-                    exg       u,y
-                    eorb      #$2a
+                    ldx       $1e,u
+                    leas      $2a,u
                     tfr       x,u
                     puls      pc,x
                     pshs      x
-                    bsr       L5D3D
-                    leax      $5C7A,pcr
+                    bsr       L5D3A
+                    leax      L5C77,pcr
                     pshs      x
-                    lbsr      $5B12
-                    lbsr      $57CA
-                    bra       $5D11
+                    lbsr      L5B0F
+                    lbsr      L57C7
+                    bra       L5D0E
 
-L5D3D               leas      -$08,s
+L5D3A               leas      -$08,s
                     ldd       $08,s
                     std       ,s
                     clra
@@ -10467,8 +10461,9 @@ L5D3D               leas      -$08,s
                     ldd       $02,x
                     sta       $04,s
                     stb       $09,s
-L5D53               rts
-                    leas      -$08,s
+                    rts
+
+L5D51               leas      -$08,s
                     ldd       $08,s
                     std       ,s
                     ldd       ,x
@@ -10480,15 +10475,17 @@ L5D53               rts
                     ldd       $06,x
                     std       $08,s
                     rts
-                    pshs      u
+
+L5D68               pshs      u
                     ldu       $04,s
                     exg       x,u
                     ldd       ,u
                     std       ,x
                     ldd       $02,u
                     std       $02,x
-L5D79               bra       L5D91
-                    pshs      u
+                    bra       L5D8E
+
+L5D78               pshs      u
                     ldu       $04,s
                     exg       x,u
                     ldd       ,u
@@ -10499,46 +10496,50 @@ L5D79               bra       L5D91
                     std       $04,x
                     ldd       $06,u
                     std       $06,x
-L5D91               puls      u
+L5D8E               puls      u
                     puls      d
                     std       ,s
                     rts
-                    ldd       $04,s
+
+L5D95               ldd       $04,s
                     addd      $02,x
                     std       $0256,y
                     ldd       $02,s
                     adcb      $01,x
                     adca      ,x
                     std       $0254,y
-                    lbra      L5E74
-                    ldd       $04,s
+                    lbra      L5E71
+
+L5DAA               ldd       $04,s
                     subd      $02,x
                     std       $0256,y
                     ldd       $02,s
                     sbcb      $01,x
                     sbca      ,x
                     std       $0254,y
-                    lbra      L5E74
-                    ldd       $02,s
+                    lbra      L5E71
+
+L5DBF               ldd       $02,s
                     cmpd      ,x
-                    bne       L5DDB
+                    bne       L5DD8
                     ldd       $04,s
                     cmpd      $02,x
-                    beq       L5DDB
-                    bcs       L5DD8
+                    beq       L5DD8
+                    bcs       L5DD5
                     lda       #$01
                     andcc     #$FE
-                    bra       L5DDB
+                    bra       L5DD8
 
-L5DD8               clra
+L5DD5               clra
                     cmpa      #$01
-L5DDB               pshs      cc
+L5DD8               pshs      cc
                     ldd       $01,s
                     std       $05,s
                     puls      cc
                     leas      $04,s
                     rts
-                    lbsr      L5E83
+
+L5DE3               lbsr      L5E80
                     ldd       #$0000
                     subd      $02,x
                     std       $02,x
@@ -10557,7 +10558,8 @@ L5DDB               pshs      cc
                     leax      $0254,y
                     std       $02,x
                     rts
-                    leax      $0254,y
+
+L5E0A               leax      $0254,y
                     std       $02,x
                     tfr       a,b
                     sex
@@ -10569,7 +10571,8 @@ L5DDB               pshs      cc
                     clr       ,x
                     clr       $01,x
                     rts
-                    pshs      y
+
+L5E23               pshs      y
                     ldy       $04,s
                     ldd       ,x
                     std       ,y
@@ -10580,38 +10583,39 @@ L5DDB               pshs      cc
                     puls      d
                     std       ,s
                     rts
-                    ldx       $02,s
+
+L5E39               ldx       $02,s
                     pshs      b
-                    lbsr      L5E83
+                    lbsr      L5E80
                     puls      b
                     tstb
-                    beq       L5E53
-L5E48               asl       $03,x
+                    beq       L5E50
+L5E45               asl       $03,x
                     rol       $02,x
                     rol       $01,x
                     rol       ,x
                     decb
-                    bne       L5E48
-L5E53               puls      d
+                    bne       L5E45
+L5E50               puls      d
                     std       ,s
                     rts
                     ldx       $02,s
                     pshs      b
-                    lbsr      L5E83
+                    lbsr      L5E80
                     puls      b
                     tstb
-                    beq       L5E6F
-L5E64               asr       ,x
+                    beq       L5E6C
+L5E61               asr       ,x
                     ror       $01,x
                     ror       $02,x
                     ror       $03,x
                     decb
-                    bne       L5E64
-L5E6F               puls      d
+                    bne       L5E61
+L5E6C               puls      d
                     std       ,s
                     rts
 
-L5E74               tfr       cc,a
+L5E71               tfr       cc,a
                     puls      x
                     stx       $02,s
                     leas      $02,s
@@ -10619,16 +10623,17 @@ L5E74               tfr       cc,a
                     tfr       a,cc
                     rts
 
-L5E83               ldd       ,x
+L5E80               ldd       ,x
                     std       $0254,y
                     ldd       $02,x
                     leax      $0254,y
                     std       $02,x
                     rts
-                    tsta
-                    bne       L5EA7
+
+L5E8F               tsta
+                    bne       L5EA4
                     tst       $02,s
-                    bne       L5EA7
+                    bne       L5EA4
                     lda       $03,s
                     mul
                     ldx       ,s
@@ -10636,7 +10641,7 @@ L5E83               ldd       ,x
                     ldx       #$0000
                     std       ,s
                     puls      pc,d
-L5EA7               pshs      d
+L5EA4               pshs      d
                     ldd       #$0000
                     pshs      d
                     pshs      d
@@ -10649,16 +10654,16 @@ L5EA7               pshs      d
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L5EC4
+                    bcc       L5EC1
                     inc       ,s
-L5EC4               lda       $04,s
+L5EC1               lda       $04,s
                     ldb       $09,s
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L5ED1
+                    bcc       L5ECE
                     inc       ,s
-L5ED1               lda       $04,s
+L5ECE               lda       $04,s
                     ldb       $08,s
                     mul
                     addd      ,s
@@ -10670,99 +10675,100 @@ L5ED1               lda       $04,s
                     leas      $08,s
                     rts
                     clr       $02E2,y
-                    leax      >L5F2D,pcr
+                    leax      >L5F2A,pcr
                     stx       $02E3,y
-L5EF1               bra       L5F07
-                    leax      >L5F46,pcr
+                    bra       L5F04
+
+L5EF0               leax      >L5F43,pcr
                     stx       $02E3,y
                     clr       $02E2,y
                     tst       $02,s
-                    bpl       L5F07
+                    bpl       L5F04
                     inc       $02E2,y
-L5F07               subd      #$0000
-                    bne       L5F12
+L5F04               subd      #$0000
+                    bne       L5F0F
                     puls      x
                     ldd       ,s++
                     jmp       ,x
 
-L5F12               ldx       $02,s
+L5F0F               ldx       $02,s
                     pshs      x
                     jsr       [$02E3,y]
                     ldd       ,s
                     std       $02,s
                     tfr       x,d
                     tst       $02E2,y
-                    beq       L5F2A
+                    beq       L5F27
                     nega
                     negb
                     sbca      #$00
-L5F2A               std       ,s++
+L5F27               std       ,s++
                     rts
 
-L5F2D               subd      #$0000
-                    beq       L5F3C
+L5F2A               subd      #$0000
+                    beq       L5F39
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
-                    bra       L5F6A
+                    bra       L5F67
 
-L5F3C               puls      d
+L5F39               puls      d
                     std       ,s
                     ldd       #$002D
-                    lbra      L5FDF
+                    lbra      L5FDC
 
-L5F46               subd      #$0000
-                    beq       L5F3C
+L5F43               subd      #$0000
+                    beq       L5F39
                     pshs      d
                     leas      -$02,s
                     clr       ,s
                     clr       $01,s
                     tsta
-                    bpl       L5F5E
+                    bpl       L5F5B
                     nega
                     negb
                     sbca      #$00
                     inc       $01,s
                     std       $02,s
-L5F5E               ldd       $06,s
-                    bpl       L5F6A
+L5F5B               ldd       $06,s
+                    bpl       L5F67
                     nega
                     negb
                     sbca      #$00
                     com       $01,s
                     std       $06,s
-L5F6A               lda       #$01
-L5F6C               inca
+L5F67               lda       #$01
+L5F69               inca
                     asl       $03,s
                     rol       $02,s
-                    bpl       L5F6C
+                    bpl       L5F69
                     sta       ,s
                     ldd       $06,s
                     clr       $06,s
                     clr       $07,s
-L5F7B               subd      $02,s
-                    bcc       L5F85
+L5F78               subd      $02,s
+                    bcc       L5F82
                     addd      $02,s
                     andcc     #$FE
-                    bra       L5F87
+                    bra       L5F84
 
-L5F85               orcc      #$01
-L5F87               rol       $07,s
+L5F82               orcc      #$01
+L5F84               rol       $07,s
                     rol       $06,s
                     lsr       $02,s
                     ror       $03,s
                     dec       ,s
-                    bne       L5F7B
+                    bne       L5F78
                     std       $02,s
                     tst       $01,s
-                    beq       L5FA1
+                    beq       L5F9E
                     ldd       $06,s
                     nega
                     negb
                     sbca      #$00
                     std       $06,s
-L5FA1               ldx       $04,s
+L5F9E               ldx       $04,s
                     ldd       $06,s
                     std       $04,s
                     stx       $06,s
@@ -10770,61 +10776,65 @@ L5FA1               ldx       $04,s
                     ldd       $04,s
                     leas      $06,s
                     rts
-                    tstb
-                    beq       L5FC6
-L5FB3               asr       $02,s
+
+L5FAD               tstb
+                    beq       L5FC3
+L5FB0               asr       $02,s
                     ror       $03,s
                     decb
-                    bne       L5FB3
-L5FBA               bra       L5FC6
-                    tstb
-                    beq       L5FC6
-L5FBF               lsr       $02,s
+                    bne       L5FB0
+                    bra       L5FC3
+
+L5FB9               tstb
+                    beq       L5FC3
+L5FBC               lsr       $02,s
                     ror       $03,s
                     decb
-                    bne       L5FBF
-L5FC6               ldd       $02,s
+                    bne       L5FBC
+L5FC3               ldd       $02,s
                     pshs      d
                     ldd       $02,s
                     std       $04,s
                     ldd       ,s
                     leas      $04,s
                     rts
-                    tstb
-                    beq       L5FC6
-L5FD6               asl       $03,s
+
+L5FD0               tstb
+                    beq       L5FC3
+L5FD3               asl       $03,s
                     rol       $02,s
                     decb
-                    bne       L5FD6
-                    bra       L5FC6
+                    bne       L5FD3
+                    bra       L5FC3
 
-L5FDF               std       $0260,y
+L5FDC               std       $0260,y
                     pshs      y,b
                     os9       F$ID
                     puls      y,b
                     os9       F$Send
                     rts
-                    lda       $05,s
+
+L5FEB               lda       $05,s
                     ldb       $03,s
-                    beq       L6021
+                    beq       L601E
                     cmpb      #$01
-                    beq       L6023
+                    beq       L6020
                     cmpb      #$06
-                    beq       L6023
+                    beq       L6020
                     cmpb      #$02
-                    beq       L6009
+                    beq       L6006
                     cmpb      #$05
-                    beq       L6009
+                    beq       L6006
                     ldb       #$D0
-                    lbra      L621E
+                    lbra      L621B
 
-L6009               pshs      u
+L6006               pshs      u
                     os9       I$GetStt
-                    bcc       L6015
+                    bcc       L6012
                     puls      u
-                    lbra      L621E
+                    lbra      L621B
 
-L6015               stx       [$08,s]
+L6012               stx       [$08,s]
                     ldx       $08,s
                     stu       $02,x
                     puls      u
@@ -10832,195 +10842,202 @@ L6015               stx       [$08,s]
                     clrb
                     rts
 
-L6021               ldx       $06,s
-L6023               os9       I$GetStt
-                    lbra      L6227
+L601E               ldx       $06,s
+L6020               os9       I$GetStt
+                    lbra      L6224
                     lda       $05,s
                     ldb       $03,s
-                    beq       L6038
+                    beq       L6035
                     cmpb      #$02
-                    beq       L6040
+                    beq       L603D
                     ldb       #$D0
-                    lbra      L621E
+                    lbra      L621B
 
-L6038               ldx       $06,s
+L6035               ldx       $06,s
                     os9       I$SetStt
-                    lbra      L6227
+                    lbra      L6224
 
-L6040               pshs      u
+L603D               pshs      u
                     ldx       $08,s
                     ldu       $0a,s
                     os9       I$SetStt
                     puls      u
-                    lbra      L6227
+                    lbra      L6224
                     ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    bcs       L605A
+                    bcs       L6057
                     os9       I$Close
-L605A               lbra      L6227
-                    ldx       $02,s
+L6057               lbra      L6224
+
+L605A               ldx       $02,s
                     lda       $05,s
                     os9       I$Open
-                    lbcs      L621E
+                    lbcs      L621B
                     tfr       a,b
-L606A               clra
+                    clra
                     rts
-                    lda       $03,s
+
+L6069               lda       $03,s
                     os9       I$Close
-                    lbra      L6227
+                    lbra      L6224
                     ldx       $02,s
                     ldb       $05,s
                     os9       I$MakDir
-                    lbra      L6227
-                    ldx       $02,s
+                    lbra      L6224
+
+L607B               ldx       $02,s
                     lda       $05,s
                     tfr       a,b
                     andb      #$24
                     orb       #$0b
                     os9       I$Create
-                    bcs       L6091
-L608D               tfr       a,b
+                    bcs       L608E
+L608A               tfr       a,b
                     clra
                     rts
 
-L6091               cmpb      #$DA
-                    lbne      L621E
+L608E               cmpb      #$DA
+                    lbne      L621B
                     lda       $05,s
                     bita      #$80
-                    lbne      L621E
+                    lbne      L621B
                     anda      #$07
                     ldx       $02,s
                     os9       I$Open
-                    lbcs      L621E
+                    lbcs      L621B
                     pshs      u,a
                     ldx       #$0000
                     leau      ,x
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-                    bcc       L608D
+                    bcc       L608A
                     pshs      b
                     os9       I$Close
                     puls      b
-                    lbra      L621E
-                    ldx       $02,s
+                    lbra      L621B
+
+L60C1               ldx       $02,s
                     os9       I$Delete
-                    lbra      L6227
+                    lbra      L6224
                     lda       $03,s
                     os9       I$Dup
-                    lbcs      L621E
+                    lbcs      L621B
                     tfr       a,b
-L60D7               clra
+                    clra
                     rts
-                    pshs      y
+
+L60D6               pshs      y
                     ldx       $06,s
                     lda       $05,s
                     ldy       $08,s
                     pshs      y
                     os9       I$Read
-L60E7               bcc       L60F6
+L60E4               bcc       L60F3
                     cmpb      #$D3
-                    bne       L60F1
+                    bne       L60EE
                     clra
                     clrb
                     puls      pc,y,x
-L60F1               puls      y,x
-                    lbra      L621E
+L60EE               puls      y,x
+                    lbra      L621B
 
-L60F6               tfr       y,d
-L60F8               puls      pc,y,x
-                    pshs      y
+L60F3               tfr       y,d
+                    puls      pc,y,x
+L60F7               pshs      y
                     lda       $05,s
                     ldx       $06,s
                     ldy       $08,s
                     pshs      y
                     os9       I$ReadLn
-L6108               bra       L60E7
-                    pshs      y
+                    bra       L60E4
+
+L6107               pshs      y
                     ldy       $08,s
-                    beq       L611F
+                    beq       L611C
                     lda       $05,s
                     ldx       $06,s
                     os9       I$Write
-L6118               bcc       L611F
+L6115               bcc       L611C
                     puls      y
-                    lbra      L621E
+                    lbra      L621B
 
-L611F               tfr       y,d
-L6121               puls      pc,y
-                    pshs      y
+L611C               tfr       y,d
+                    puls      pc,y
+L6120               pshs      y
                     ldy       $08,s
-                    beq       L611F
+                    beq       L611C
                     lda       $05,s
                     ldx       $06,s
                     os9       I$WritLn
-L6131               bra       L6118
-                    pshs      u
+                    bra       L6115
+
+L6130               pshs      u
                     ldd       $0a,s
-                    bne       L6141
+                    bne       L613E
                     ldu       #$0000
                     ldx       #$0000
-                    bra       L6175
+                    bra       L6172
 
-L6141               cmpd      #$0001
-                    beq       L616C
+L613E               cmpd      #$0001
+                    beq       L6169
                     cmpd      #$0002
-                    beq       L6161
+                    beq       L615E
                     ldb       #$F7
-L614F               clra
+L614C               clra
                     std       $0260,y
                     ldd       #$FFFF
                     leax      $0254,y
                     std       ,x
                     std       $02,x
                     puls      pc,u
-L6161               lda       $05,s
+L615E               lda       $05,s
                     ldb       #$02
                     os9       I$GetStt
-                    bcs       L614F
-                    bra       L6175
+                    bcs       L614C
+                    bra       L6172
 
-L616C               lda       $05,s
+L6169               lda       $05,s
                     ldb       #$05
                     os9       I$GetStt
-L6173               bcs       L614F
-L6175               tfr       u,d
+                    bcs       L614C
+L6172               tfr       u,d
                     addd      $08,s
                     std       $0256,y
                     tfr       d,u
                     tfr       x,d
                     adcb      $07,s
                     adca      $06,s
-                    bmi       L614F
+                    bmi       L614C
                     tfr       d,x
                     std       $0254,y
                     lda       $05,s
                     os9       I$Seek
-                    bcs       L614F
+                    bcs       L614C
                     leax      $0254,y
-L6198               puls      pc,u
-                    ldd       $0252,y
+                    puls      pc,u
+L6197               ldd       $0252,y
                     pshs      d
                     ldd       $04,s
                     cmpd      $02E5,y
-                    bcs       L61CE
+                    bcs       L61CB
                     addd      $0252,y
                     pshs      y
                     subd      ,s
                     os9       F$Mem
                     tfr       y,d
                     puls      y
-                    bcc       L61C0
+                    bcc       L61BD
                     ldd       #$FFFF
                     leas      $02,s
                     rts
 
-L61C0               std       $0252,y
+L61BD               std       $0252,y
                     addd      $02E5,y
                     subd      ,s
                     std       $02E5,y
-L61CE               leas      $02,s
+L61CB               leas      $02,s
                     ldd       $02E5,y
                     pshs      d
                     subd      $04,s
@@ -11030,161 +11047,304 @@ L61CE               leas      $02,s
                     pshs      d
                     clra
                     ldx       ,s
-L61E7               sta       ,x+
+L61E4               sta       ,x+
                     cmpx      $0252,y
-                    bcs       L61E7
-L61EF               puls      pc,d
-                    ldd       $02,s
+                    bcs       L61E4
+                    puls      pc,d
+L61EE               ldd       $02,s
                     addd      $025C,y
-                    bcs       L621A
+                    bcs       L6217
                     cmpd      $025e,y
-                    bcc       L621A
+                    bcc       L6217
                     pshs      d
                     ldx       $025C,y
                     clra
-L6207               cmpx      ,s
-                    bcc       L620F
+L6204               cmpx      ,s
+                    bcc       L620C
                     sta       ,x+
-                    bra       L6207
+                    bra       L6204
 
-L620F               ldd       $025C,y
+L620C               ldd       $025C,y
                     puls      x
                     stx       $025C,y
                     rts
 
-L621A               ldd       #$FFFF
+L6217               ldd       #$FFFF
                     rts
 
-L621E               clra
+L621B               clra
                     std       $0260,y
-                    ldd       #$FFFF
+L6220               ldd       #$FFFF
                     rts
 
-L6227               bcs       L621E
+L6224               bcs       L621B
                     clra
-exit                clrb
+                    clrb
                     rts
-                    lbsr      L6237
-                    lbsr      L5229
-                    ldd       $02,s
+
+L6229               lbsr      L6234
+                    lbsr      L5226
+L622F               ldd       $02,s
                     os9       F$Exit
-* ------------------------------------------------------------------
-* L6237 - cc1-style init image for the work block (see _start);
-* pure data: rts stub + count/block table + reloc dirs + module name.
-* ------------------------------------------------------------------
-L6237               fcb       $39       init table / work-block image
-                    fcb       $00,$03,$00,$00
+L6234               rts
+
+L6235               neg       $0003
+                    neg       $0000
                     fcb       $4B
-                    fcb       $01,$EB,$00,$02,$00,$04,$00,$08
-                    fcb       $00,$10,$00
-                    fcb       $20
-                    fcb       $00
-                    fcb       $40
-                    fcb       $00,$80,$01,$00,$02,$00,$04,$00
-                    fcb       $08,$00,$10,$00
-                    fcb       $20
-                    fcb       $00
-                    fcb       $40
-                    fcb       $00
-                    fcb       $27
-                    fcb       $10,$03,$E8,$00
-                    fcb       $64
-                    fcb       $00,$0A,$00,$00
-                    fcb       $44
-                    fcb       $C9
-                    fcb       $44
-                    fcb       $CC
-                    fcb       $44
-                    fcb       $CF
-                    fcb       $44
-                    fcb       $D5
-                    fcb       $44
-                    fcb       $DB
-                    fcb       $44
-                    fcb       $E0,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $80
-                    fcb       $20
-                    fcb       $00,$00,$00,$00,$00,$00,$84
-                    fcb       $48
-                    fcb       $00,$00,$00,$00,$00,$00,$87
-                    fcb       $7A
-                    fcb       $00,$00,$00,$00,$00,$00,$8A,$1C
-                    fcb       $40
-                    fcb       $00,$00,$00,$00,$00,$8E
-                    fcb       $43,$50
-                    fcb       $00,$00,$00,$00,$00,$91
-                    fcb       $74,$24
-                    fcb       $00,$00,$00,$00,$00,$94,$18,$96
-                    fcb       $80,$00,$00,$00,$00,$98
-                    fcb       $3E
-                    fcb       $BC
-                    fcb       $20
-                    fcb       $00,$00,$00,$00,$9B
-                    fcb       $6E,$6B,$28
-                    fcb       $00,$00,$00,$00,$9E,$15,$02,$F9
-                    fcb       $00,$00,$00,$00,$A2
-                    fcb       $2D,$78
-                    fcb       $EB,$C5,$AC
-                    fcb       $62
-                    fcb       $00,$C3
-                    fcb       $49
-                    fcb       $F2,$C9,$CD,$04
-                    fcb       $67,$4F
-                    fcb       $E4,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $01,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$02,$00,$01
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00
+                    fcb       $01
+                    addb      0,x
+                    fcb       $02
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       L0020
+                    neg       $0040
+                    neg       $0080
+                    fcb       $01
+                    neg       $0002
+                    neg       $0004
+                    neg       $0008
+                    neg       $0010
+                    neg       L0020
+                    neg       $0040
+                    neg       L0027
+                    fcb       $10
+                    com       $00E8
+                    neg       L0064
+                    neg       $000A
+                    neg       $0000
+                    lsra
+                    adcb      #$44
+                    ldd       #$44CF
+                    lsra
+                    bitb      $0044
+                    addb      $0044
+                    subb      0,x
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    suba      #$20
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    anda      #$48
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $87
+                    dec       >$0000
+                    neg       $0000
+                    neg       $0000
+                    ora       #$1C
+                    nega
+                    neg       $0000
+                    neg       $0000
+                    neg       $008E
+                    coma
+                    negb
+                    neg       $0000
+                    neg       $0000
+                    neg       L0091
+                    lsr       L2400
+                    neg       $0000
+                    neg       $0000
+                    anda      $0018
+                    lda       $0080
+                    neg       $0000
+                    neg       $0000
+                    eora      $003E
+                    cmpx      L2000
+                    neg       $0000
+                    neg       L009B
+                    jmp       $0b,s
+                    bvc       L62BA
+L62BA               neg       $0000
+                    neg       $009E
+                    fcb       $15,$02
+                    adcb      >$0000
+                    neg       $0000
+                    sbca      $0d,y
+                    asl       $EBC5
+                    cmpx      $02,s
+                    neg       L00C3
+                    rola
+                    sbcb      $C9CD
+                    lsr       $0067
+                    clra
+                    andb      0,x
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
                     fcb       $42
-                    fcb       $00,$02,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$00
-                    fcb       $00,$00,$00,$00,$00,$00,$00,$01
-                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
-                    fcb       $11,$11,$01,$11,$11,$01,$01,$01
-                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
-                    fcb       $01,$01,$01,$01,$01,$01,$01
-                    fcc       /0               HHHHHHHHHH       BBBBBB/
-                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
-                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
-                    fcb       $02,$02,$02,$02
-                    fcc       /      DDDDDD/
-                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
-                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
-                    fcb       $04,$04,$04,$04
-                    fcc       /    /
-                    fcb       $01,$00,$06,$00
-                    fcb       $57
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01,$11,$11,$01,$11,$11,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01
+                    leax      0,y
+                    bra       L63EB
+                    bra       L63ED
+                    bra       L63EF
+                    bra       L63F1
+                    bra       L63F3
+                    bra       L63F5
+                    bra       L63F7
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    bra       $6403
+                    bra       $6405
+                    bra       $6407
+                    bra       L642B
+                    fcb       $42,$42
+L63EB               fcb       $42,$42
+L63ED               fcb       $42
+                    fcb       $02
+L63EF               fcb       $02,$02
+L63F1               fcb       $02,$02
+L63F3               fcb       $02,$02
+L63F5               fcb       $02,$02
+L63F7               fcb       $02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02
+                    bra       L6424
+                    bra       L6426
+                    bra       $6428
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    bra       $6444
+
+L6424               bra       $6446
+L6426               fcb       $01
+                    neg       $0006
+                    neg       L0057
+L642B               neg       L0055
+                    neg       L0053
+                    neg       L0051
+                    neg       L004F
+                    neg       L004D
+                    neg       $0001
+                    neg       $0001
+                    fcc       /c.pass2/
                     fcb       $00
-                    fcb       $55
-                    fcb       $00
-                    fcb       $53
-                    fcb       $00
-                    fcb       $51
-                    fcb       $00
-                    fcb       $4F
-                    fcb       $00
-                    fcb       $4D
-                    fcb       $00,$01,$00,$01
-                    fcc       /c.pas/
+
                     emod
 eom                 equ       *
                     end

--- a/3rdparty/packages/ccompiler/cc1_dis.asm
+++ b/3rdparty/packages/ccompiler/cc1_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $04
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       2401
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /cc1/
                     fcb       edition
 
-L0011               lda       ,y+
+copybytes           lda       ,y+
 L0013               sta       ,u+
 L0015               leax      -$01,x
-L0017               bne       L0011
+L0017               bne       copybytes
 L0019               rts
 
-start               pshs      y
+_start              pshs      y
                     pshs      u
                     clra
 L001F               clrb
@@ -37,12 +37,12 @@ L002D               pshs      x
 L002F               leay      L1DAC,pcr
                     ldx       ,y++
                     beq       L003B
-                    bsr       L0011
+                    bsr       copybytes
                     ldu       $02,s
 L003B               leau      >$002d,u
                     ldx       ,y++
 L0041               beq       L0046
-L0043               bsr       L0011
+L0043               bsr       copybytes
 L0045               clra
 L0046               cmpu      ,s
                     beq       L004F
@@ -119,27 +119,25 @@ L00DD               leax      $01BF,u
                     ldd       $01FB,u
                     pshs      d
                     leay      ,u
-                    bsr       L00F7
-                    lbsr      L0179
+                    bsr       stkinit
+                    lbsr      main
                     clr       ,-s
                     clr       ,-s
-                    lbsr      L1DA0
-L00F7               leax      $05E1,y
+                    lbsr      exit
+stkinit             leax      $05E1,y
                     stx       $0209,y
                     sts       $01FD,y
                     sts       $020b,y
                     ldd       #$FF82
-L010C               leax      d,s
+stkcheck            leax      d,s
                     cmpx      $020b,y
                     bcc       L011E
                     cmpx      $0209,y
                     bcs       L0138
                     stx       $020b,y
 L011E               rts
-L011F               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+L011F               fcc       /**** STACK OVERFLOW ****/
+                    fcb       $0d       carriage return terminator
 L0138               leax      L011F,pcr
                     ldb       #$CF
                     pshs      b
@@ -147,7 +145,7 @@ L0138               leax      L011F,pcr
                     ldy       #$0064
                     os9       I$WritLn
                     clr       ,-s
-                    lbsr      L1DA6
+                    lbsr      _exit
                     ldd       $01FD,y
                     subd      $020b,y
                     rts
@@ -169,9 +167,9 @@ L0167               ldd       ,y++
                     leas      $04,s
                     rts
 
-L0179               pshs      u
+main                pshs      u
                     ldd       #$FFA1
-                    lbsr      L010C
+                    lbsr      stkcheck
                     leas      -$0f,s
                     leax      L0D1A,pcr
                     pshs      x
@@ -179,7 +177,7 @@ L0179               pshs      u
                     pshs      d
                     leax      $0088,y
                     pshs      x
-                    lbsr      L119C
+                    lbsr      fprintf
                     leas      $06,s
                     clra
                     clrb
@@ -265,7 +263,7 @@ L0249               ldd       #$0001
                     lbra      L03B6
 
 L0251               ldd       #$0001
-                    std       L0011
+                    std       copybytes
                     lbra      L03B6
 
 L0259               ldd       #$0001
@@ -486,12 +484,12 @@ L0458               ldd       L0025
                     pshs      x
                     leax      $0088,y
                     pshs      x
-                    lbsr      L119C
+                    lbsr      fprintf
                     leas      $04,s
                     clra
                     clrb
                     pshs      d
-                    lbsr      L1DA0
+                    lbsr      exit
                     leas      $02,s
 L0476               ldd       $000D
                     addd      $000B
@@ -893,7 +891,7 @@ L0853               leax      $04FB,y
                     pshs      x
                     lbsr      L1991
                     leas      $04,s
-                    ldd       L0011
+                    ldd       copybytes
                     lbne      L08FD
                     leax      $0E8D,pcr
                     pshs      x
@@ -1222,7 +1220,7 @@ L0B76               clra
                     pshs      x
                     leax      $040b,y
                     pshs      x
-                    lbsr      $1980
+                    lbsr      L1980
                     std       ,s
                     leax      L0F37,pcr
                     pshs      x
@@ -1232,7 +1230,7 @@ L0BA0               leas      $0f,s
                     puls      pc,u
                     pshs      u
                     ldd       #$FFB4
-                    lbsr      L010C
+                    lbsr      stkcheck
                     leas      -$02,s
                     clra
                     clrb
@@ -1246,7 +1244,7 @@ L0BA0               leas      $0f,s
                     tfr       d,u
                     cmpu      #$FFFF
                     bne       L0BCF
-                    lbsr      $0F48
+                    lbsr      L0F48
                     bra       L0BF1
 
 L0BCF               pshs      u
@@ -1267,7 +1265,7 @@ L0BF1               puls      pc,u,x
                     puls      pc,u,x
 L0BF5               pshs      u
                     ldd       #$FFBA
-                    lbsr      L010C
+                    lbsr      stkcheck
                     ldd       $04,s
                     beq       L0C15
                     ldd       $04,s
@@ -1281,28 +1279,28 @@ L0BF5               pshs      u
 L0C15               puls      pc,u
 L0C17               pshs      u
                     ldd       #$FFB6
-                    lbsr      L010C
+                    lbsr      stkcheck
                     ldd       $06,s
                     pshs      d
                     ldd       $06,s
                     pshs      d
                     leax      $0088,y
                     pshs      x
-                    lbsr      L119C
+                    lbsr      fprintf
                     leas      $06,s
                     leax      $0088,y
                     pshs      x
                     ldd       #$000D
                     pshs      d
-                    lbsr      $1690
+                    lbsr      fputc
                     leas      $04,s
                     ldd       #$0001
                     pshs      d
-                    lbsr      L1DA0
+                    lbsr      exit
                     puls      pc,u,x
 L0C4C               pshs      u
                     ldd       #$FFC0
-                    lbsr      L010C
+                    lbsr      stkcheck
                     ldu       $04,s
 L0C56               ldb       ,u+
                     bne       L0C56
@@ -1322,7 +1320,7 @@ L0C6C               ldb       $07,s
 L0C70               puls      pc,u
 L0C72               pshs      u
                     ldd       #$FFBD
-                    lbsr      L010C
+                    lbsr      stkcheck
                     ldu       $04,s
                     leas      -$03,s
 L0C7E               clra
@@ -1358,341 +1356,159 @@ L0CB4               leas      $03,s
                     puls      pc,u
 L0CB8               pshs      u
                     ldd       #$FFB8
-                    lbsr      L010C
+                    lbsr      stkcheck
                     ldd       $04,s
                     pshs      d
                     ldd       $002B
                     pshs      d
-                    lbsr      L119C
+                    lbsr      fprintf
                     leas      $04,s
                     puls      pc,u
-                    coma
-                    coma
-                    leay      0,y
-                    rorb
-                    fcb       $45
-                    fcb       $52
-                    comb
-                    rola
-                    clra
-                    fcb       $4e
-                    bra       L0D01
-                    com       $0D43
-                    fcb       $4f,$50,$59,$52,$49,$47,$48,$54
-                    fcb       $20,$31,$39,$38,$33,$20,$4d,$49
-                    fcb       $43,$52,$4f,$57,$41,$52,$45
-                    fcb       $0d,$52,$45,$50,$52,$4f,$44
-                    fcb       $55,$43,$45
-L0D00               fcb       $44
-L0D01               fcb       $20,$55,$4e,$44,$45,$52,$20,$4C
-                    fcb       $49,$43,$45,$4e,$53,$45,$0d
-                    lsrb
-                    clra
-                    bra       L0D68
-                    fcb       $41
-                    fcb       $4e
-                    lsra
-                    rolb
-                    tst       $0000
-L0D1A               fcb       $52
-                    comb
-                    bra       L0D4E
-                    leay      $0e,y
-                    leax      -$10,y
-                    bgt       L0D54
-                    leax      0,x
-L0D26               asr       >$0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $206F
-                    neg       $656E
-                    bra       L0DA7
-                    asl       $05,s
-                    inc       $0C,s
-                    bra       L0D9D
-                    clr       $0d,s
-                    tst       $01,s
-                    jmp       $04,s
-                    bra       $0DA8
-                    rol       $0C,s
-                    fcb       $65
-                    neg       L0053
-                    fcb       $75
-                    ror       $06,s
-                    rol       -$08,s
-                    bra       $0D75
-
-L0D4E               bgt       $0D75
-                    com       $07,y
-                    bra       L0DC2
-
-L0D54               clr       -$0C,s
-                    bra       L0DB9
-                    inc       $0C,s
-                    clr       -$09,s
-                    fcb       $65
-                    lsr       0,y
-                    ror       $0f,s
-                    fcb       $72
-                    bra       L0DD3
-                    fcb       $75
-L0D65               lsr       $7075
-L0D68               lsr       >$0054
-                    clr       $0f,s
-                    bra       $0DDC
-                    fcb       $61
-                    jmp       -$07,s
-                    bra       $0DE0
-                    rol       $02,s
-                    fcb       $72
-                    fcb       $61
-                    fcb       $72
-                    rol       $05,s
-                    com       >L0075
-                    fcb       $6e,$6b,$6e,$6f,$77,$6e,$20,$66
-                    fcb       $6C,$61,$67,$20,$3a,$20,$2d,$25
-                    fcb       $63,$0d,$00
-L0D91               bcs       $0E06
-                    bra       $0DCF
-                    bra       $0E05
-                    clr       0,y
-                    fcb       $72
-                    fcb       $65
-                    com       $0f,s
-L0D9D               asr       $0e,s
-                    rol       -$06,s
-                    fcb       $65
-                    lsr       0,y
-                    com       $7566
-L0DA7               ror       $09,s
-                    asl       >$006E
-                    clr       0,y
-                    ror       $09,s
-                    inc       $05,s
-                    com       $210D
-                    neg       L0069
-                    jmp       $03,s
-
-L0DB9               clr       $0d,s
-                    neg       $6174
-                    rol       $02,s
-                    inc       $05,s
-L0DC2               bra       L0E2A
-                    inc       $01,s
-                    asr       -$0d,s
-                    neg       L0025
-                    com       $203A
-                    bra       L0E3E
-                    fcb       $75
-                    lsr       $7075
-L0DD3               lsr       $206E
-                    fcb       $61
-                    tst       $05,s
-                    bra       $0E49
-                    clr       -$0C,s
-                    bra       L0E40
-                    neg       $706C
-                    rol       $03,s
-                    fcb       $61
-                    fcb       $62
-                    inc       $05,s
-                    neg       $006F
-                    fcb       $75
-                    lsr       $7075
-                    lsr       >$002E
-                    tst       0,x
-L0DF3               bgt       L0E67
-                    neg       L0065
-                    com       $08,s
-                    clr       0,y
-                    beq       L0DFD
-L0DFD               beq       $0E0C
-                    neg       L002D
-                    asl       L0D65
-                    com       $08,s
-                    clr       0,y
-                    com       $0e,y
-                    neg       $7265
-                    neg       $3A0D
-                    neg       L0043
-                    bgt       L0E64
-                    fcb       $52
-                    fcb       $45
-                    negb
-                    bra       L0E19
-
-L0E19               blt       $0E87
-                    bra       L0E1D
-
-L0E1D               bra       L0E1F
-
-L0E1F               bra       L0E21
-
-L0E21               bra       L0E61
-                    neg       $000D
-                    asl       L0D65
-                    com       $08,s
-L0E2A               clr       0,y
-                    com       $0e,y
-                    neg       $6173
-                    com       $313A
-                    tst       $0000
-L0E36               coma
-                    bgt       $0E89
-                    fcb       $41
-                    comb
-                    comb
-                    leay      0,y
-L0E3E               neg       L002D
-L0E40               fcb       $65
-                    bra       L0E43
-
-L0E43               bra       $0E72
-                    com       $2000
-L0E48               bra       L0E77
-                    neg       $2000
-L0E4D               bra       L0E7C
-                    clr       -$03,y
-                    neg       $000D
-                    lsr       $05,s
-                    inc       0,y
-                    neg       $000D
-                    neg       L0065
-                    com       $08,s
-                    clr       0,y
-                    com       $0e,y
-L0E61               neg       $6173
-L0E64               com       $323A
-L0E67               tst       $0000
-L0E69               coma
-                    bgt       L0EBC
-                    fcb       $41
-                    comb
-                    comb
-                    leas      0,y
-                    neg       L0020
-                    blt       L0EE8
-                    bra       L0E77
-
-L0E77               bra       $0EA6
-                    neg       $2000
-L0E7C               bra       L0E7E
-
-L0E7E               bra       L0EAD
-                    clr       -$03,y
-                    neg       $000D
-                    lsr       $05,s
-                    inc       0,y
-                    neg       L0020
-                    neg       $000D
-                    neg       L0065
-                    com       $08,s
-                    clr       0,y
-                    com       $0e,y
-                    clr       -$10,s
-                    lsr       $3A0D
-                    neg       L0043
-                    bgt       L0EEC
-                    negb
-                    lsrb
-                    bra       L0EA1
-
-L0EA1               bra       L0EA3
-
-L0EA3               tst       $0000
-L0EA5               lsr       $05,s
-                    inc       0,y
-                    neg       $000D
-                    neg       L0065
-L0EAD               com       $08,s
-                    clr       0,y
-                    com       $0e,y
-                    fcb       $61
-                    com       $6D3A
-                    tst       $0000
-L0EB9               coma
-                    bgt       L0EFD
-L0EBC               comb
-                    tsta
-                    bra       L0EC0
-
-L0EC0               bra       $0EEF
-                    clr       -$03,y
-                    neg       $000D
-                    neg       $0064
-                    fcb       $65
-                    inc       0,y
-                    neg       $000D
-                    neg       L0065
-                    com       $08,s
-                    clr       0,y
-                    com       $0e,y
-                    inc       $09,s
-                    jmp       $0b,s
-                    abx
-                    tst       $0000
-L0EDC               coma
-                    bgt       $0F2B
-                    rola
-                    fcb       $4e
-                    fcb       $4b
-                    bra       L0EE4
-
-L0EE4               ble       L0F4A
-                    lsr       0,x
-L0EE8               ble       $0F56
-                    rol       $02,s
-L0EEC               ble       $0F51
-                    com       $7461
-                    fcb       $72
-                    lsr       $2E72
-                    neg       L0020
-                    neg       L0020
-                    neg       L0020
-                    blt       L0F6C
-L0EFD               mul
-                    neg       L0020
-                    neg       L0020
-                    blt       $0F70
-                    mul
-                    neg       L002F
-                    inc       $09,s
-                    fcb       $62
-                    ble       L0F6F
-                    inc       $09,s
-                    fcb       $62
-                    bgt       L0F7D
-                    bra       L0F13
-
-L0F13               tst       $0000
-L0F15               lsr       $05,s
-                    inc       0,y
-                    neg       $000D
-                    neg       L002D
-                    lsr       $202D
-                    neg       L0D00
-L0F23               fcb       $72
-                    neg       $0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $2072
-                    fcb       $65
-                    clr       -$10,s
-                    fcb       $65
-                    jmp       0,y
-                    beq       L0F59
-                    com       $2700
-L0F37               com       $6865
-                    inc       $0C,s
-                    neg       $0063
-                    com       $04,s
-                    fcb       $65
-                    ror       $6963
-                    fcb       $65
-                    neg       L0020
-                    neg       $0034
-                    nega
-L0F4A               leas      -$07,s
+* ------------------------------------------------------------------
+* String pool for the cc1 compiler driver: the sign-on banner, error
+* messages, and the shell command-line fragments used to build the
+* pass invocations (c.prep, c.pass1, ... c.link).  Referenced by the
+* driver code via leax <label>,pcr; the banner (L0CCF) is reached
+* indirectly through the relocated work-block pointer at base+$5f.
+* ------------------------------------------------------------------
+L0CCF               fcc       /CC1 VERSION %s/    sign-on banner, %s = version string
+                    fcb       $0D
+                    fcc       /COPYRIGHT 1983 MICROWARE/
+                    fcb       $0D
+                    fcc       /REPRODUCED UNDER LICENSE/
+                    fcb       $0D
+                    fcc       /TO TANDY/
+                    fcb       $0D,$00
+L0D1A               fcc       /RS 01.00.00/
+                    fcb       $00
+L0D26               fcc       /w/
+                    fcb       $00
+                    fcc       /can't open shell command file/
+                    fcb       $00
+                    fcc       /Suffix '.%c' not allowed for output/
+                    fcb       $00
+                    fcc       /Too many libraries/
+                    fcb       $00
+                    fcc       /unknown flag : -%c/
+                    fcb       $0D,$00
+L0D91               fcc       /%s : no recognized suffix/
+                    fcb       $00
+                    fcc       /no files!/
+                    fcb       $0D,$00
+                    fcc       /incompatible flags/
+                    fcb       $00
+                    fcc       /%s : output name not applicable/
+                    fcb       $00
+                    fcc       /output/
+                    fcb       $00
+                    fcc       /.m/
+                    fcb       $00
+L0DF3               fcc       /.r/
+                    fcb       $00
+                    fcc       /echo '/
+                    fcb       $00
+L0DFD               fcc       /'/
+                    fcb       $0D,$00
+                    fcc       /-x/
+                    fcb       $0D
+                    fcc       /echo c.prep:/
+                    fcb       $0D,$00
+                    fcc       /C.PREP /
+                    fcb       $00
+L0E19               fcc       /-l /
+                    fcb       $00
+L0E1D               fcc       / /
+                    fcb       $00
+L0E1F               fcc       / /
+                    fcb       $00
+L0E21               fcc       / >/
+                    fcb       $00,$0D
+                    fcc       /x/
+                    fcb       $0D
+                    fcc       /echo c.pass1:/
+                    fcb       $0D,$00
+L0E36               fcc       /C.PASS1 /
+                    fcb       $00
+                    fcc       /-e /
+                    fcb       $00
+L0E43               fcc       / -s /
+                    fcb       $00
+L0E48               fcc       / -p /
+                    fcb       $00
+L0E4D               fcc       / -o=/
+                    fcb       $00,$0D
+                    fcc       /del /
+                    fcb       $00,$0D,$00
+                    fcc       /echo c.pass2:/
+                    fcb       $0D,$00
+L0E69               fcc       /C.PASS2 /
+                    fcb       $00
+                    fcc       / -s /
+                    fcb       $00
+L0E77               fcc       / -p /
+                    fcb       $00
+L0E7C               fcc       / /
+                    fcb       $00
+L0E7E               fcc       / -o=/
+                    fcb       $00,$0D
+                    fcc       /del /
+                    fcb       $00
+                    fcc       / /
+                    fcb       $00,$0D,$00
+                    fcc       /echo c.opt:/
+                    fcb       $0D,$00
+                    fcc       /C.OPT /
+                    fcb       $00
+L0EA1               fcc       / /
+                    fcb       $00
+L0EA3               fcb       $0D,$00
+L0EA5               fcc       /del /
+                    fcb       $00,$0D,$00
+                    fcc       /echo c.asm:/
+                    fcb       $0D,$00
+L0EB9               fcc       /C.ASM /
+                    fcb       $00
+L0EC0               fcc       / -o=/
+                    fcb       $00,$0D,$00
+                    fcc       /del /
+                    fcb       $00,$0D,$00
+                    fcc       /echo c.link:/
+                    fcb       $0D,$00
+L0EDC               fcc       /C.LINK /
+                    fcb       $00
+L0EE4               fcc       |/dd|
+                    fcb       $00
+L0EE8               fcc       |/lib/cstart.r|
+                    fcb       $00
+                    fcc       / /
+                    fcb       $00
+                    fcc       / /
+                    fcb       $00
+                    fcc       / -o=/
+                    fcb       $00
+                    fcc       / /
+                    fcb       $00
+                    fcc       / -l=/
+                    fcb       $00
+                    fcc       |/lib/clib.l |
+                    fcb       $00
+L0F13               fcb       $0D,$00
+L0F15               fcc       /del /
+                    fcb       $00,$0D,$00
+                    fcc       /-t -p/
+                    fcb       $0D,$00
+L0F23               fcc       /r/
+                    fcb       $00
+                    fcc       /can't reopen '%s'/
+                    fcb       $00
+L0F37               fcc       /shell/
+                    fcb       $00
+                    fcc       /ccdevice/
+                    fcb       $00
+                    fcc       / /
+                    fcb       $00
+L0F48               pshs      u
+                    leas      -$07,s
                     clra
                     clrb
                     pshs      d
@@ -1739,10 +1555,9 @@ L0FA3               clra
                     clrb
 L0FA5               leas      $07,s
                     puls      pc,u
-L0FA9               rola
-                    jmp       $09,s
-                    lsr       >$0034
-                    nega
+L0FA9               fcc       /Init/              "Init" string constant
+                    fcb       $00
+L0FAE               pshs      u
                     leau      >$006e,y
 L0FB4               ldd       $06,u
                     clra
@@ -1760,7 +1575,7 @@ L0FB4               ldd       $06,u
 L0FD5               pshs      u
                     ldu       $08,s
                     bne       L0FDF
-                    bsr       $0FAE
+                    bsr       L0FAE
                     tfr       d,u
 L0FDF               stu       -$02,s
                     beq       L1029
@@ -1978,13 +1793,13 @@ L116D               ldd       ,s
                     leax      >L1187,pcr
                     pshs      x
                     pshs      u
-                    lbsr      L11B8
+                    lbsr      sprintf
                     leas      $06,s
 L1183               ldd       $06,s
                     puls      pc,u,x
-L1187               bcs       L11ED
-                    neg       $0034
-                    nega
+L1187               fcc       /%d/                integer format string
+                    fcb       $00
+L118A               pshs      u
                     leax      >$007b,y
                     stx       $05C5,y
                     leax      $06,s
@@ -1992,7 +1807,7 @@ L1187               bcs       L11ED
                     ldd       $06,s
                     bra       L11AA
 
-L119C               pshs      u
+fprintf             pshs      u
                     ldd       $04,s
                     std       $05C5,y
                     leax      $08,s
@@ -2001,10 +1816,10 @@ L119C               pshs      u
 L11AA               pshs      d
                     leax      L1664,pcr
                     pshs      x
-                    bsr       L11DC
+                    bsr       doprnt
                     leas      $06,s
                     puls      pc,u
-L11B8               pshs      u
+sprintf             pshs      u
                     ldd       $04,s
                     std       $05C5,y
                     leax      $08,s
@@ -2013,14 +1828,14 @@ L11B8               pshs      u
                     pshs      d
                     leax      L1677,pcr
                     pshs      x
-                    bsr       L11DC
+                    bsr       doprnt
                     leas      $06,s
                     clra
                     clrb
                     stb       [>$05C5,y]
                     ldd       $04,s
                     puls      pc,u
-L11DC               pshs      u
+doprnt              pshs      u
                     ldu       $06,s
                     leas      -$0b,s
                     bra       L11F4
@@ -2185,7 +2000,7 @@ L131A               ldd       $06,s
                     ldb       $0e,s
                     sex
                     pshs      d
-                    lbsr      $1975
+                    lbsr      L1975
                     leas      $06,s
                     lbra      L13AC
 
@@ -2522,7 +2337,7 @@ L15FD               pshs      u
                     ldd       $08,s
                     pshs      d
                     pshs      u
-                    lbsr      $1980
+                    lbsr      L1980
                     leas      $02,s
                     nega
                     negb
@@ -2570,7 +2385,7 @@ L1664               pshs      u
                     pshs      d
                     ldd       $06,s
                     pshs      d
-                    lbsr      $1690
+                    lbsr      fputc
 L1673               leas      $04,s
                     puls      pc,u
 L1677               pshs      u
@@ -2580,11 +2395,9 @@ L1677               pshs      u
                     stx       $05C5,y
                     stb       -$01,x
                     puls      pc,u
-L1689               blt       L16BE
-                    leas      -$09,y
-                    pshu      y,x,dp
-                    neg       $0034
-                    nega
+L1689               fcc       /-32768/            INT_MIN literal, special-cased by itoa
+                    fcb       $00
+fputc               pshs      u         stream putc: write char to FILE at work+$5c5
                     ldu       $06,s
                     ldd       $06,u
                     anda      #$80
@@ -2667,12 +2480,12 @@ L1731               ldd       $04,s
                     ldd       #$0008
                     lbsr      L1A66
                     pshs      d
-                    lbsr      $1690
+                    lbsr      fputc
                     leas      $04,s
                     ldd       $06,s
                     pshs      d
                     pshs      u
-                    lbsr      $1690
+                    lbsr      fputc
                     lbra      L189F
 
 L1758               pshs      u,d
@@ -2941,13 +2754,13 @@ L195D               cmpx      #$0064
                     lbeq      L1940
                     bra       L194F
                     puls      pc,u
-L1974               neg       $0034
-                    nega
+L1974               fcb       $00       empty string
+L1975               pshs      u
                     leax      >L197F,pcr
                     tfr       x,d
                     puls      pc,u
-L197F               neg       $0034
-                    nega
+L197F               fcb       $00       empty string
+L1980               pshs      u
                     ldu       $04,s
 L1984               ldb       ,u+
                     bne       L1984
@@ -3464,263 +3277,64 @@ L1D9B               bcs       L1D92
                     clrb
                     rts
 
-L1DA0               lbsr      L1DAB
+exit                lbsr      L1DAB
                     lbsr      L1758
-L1DA6               ldd       $02,s
+_exit               ldd       $02,s
                     os9       F$Exit
 L1DAB               rts
 
-L1DAC               neg       $0001
-                    neg       $0001
-                    sbca      $0063
-                    lsr       $6D70
-                    bgt       L1E0F
-                    aslb
-                    aslb
-                    aslb
-                    aslb
-                    aslb
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0063
-                    bgt       $1E2B
-                    clr       $0d,s
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $000C
-                    fcb       $CF
-                    beq       L1DF7
-                    com       $00E8
-                    neg       $0064
-                    neg       $000A
-                    neg       L0069
-                    inc       -$08,s
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-L1DF7               neg       $0000
-                    fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-L1E0F               neg       $0000
-                    neg       $0000
-                    fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    leax      0,y
-                    bra       L1F07
-                    bra       L1F09
-                    bra       L1F0B
-                    bra       L1F0D
-                    bra       L1F0F
-                    bra       L1F11
-                    bra       L1F13
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    bra       $1F1F
-                    bra       $1F21
-                    bra       $1F23
-                    bra       L1F47
-                    fcb       $42
-                    fcb       $42
-L1F07               fcb       $42
-                    fcb       $42
-L1F09               fcb       $42
-                    fcb       $02
-L1F0B               fcb       $02
-                    fcb       $02
-L1F0D               fcb       $02
-                    fcb       $02
-L1F0F               fcb       $02
-                    fcb       $02
-L1F11               fcb       $02
-                    fcb       $02
-L1F13               fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    bra       L1F40
-                    bra       L1F42
-                    bra       $1F44
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    bra       $1F60
+* ------------------------------------------------------------------
+* L1DAC - initialisation image for the cc1 work block, walked once by
+* the _start routine: count1 word + count1 bytes copied to base, then
+* count2 word + count2 bytes copied to base+$2d, then two relocation
+* directories that fix up embedded pointers (see _start at $001A).
+* ------------------------------------------------------------------
+L1DAC               fdb       $0001     count1 - bytes copied to base
+                    fcb       $00       block1 image (-> base+$00)
+                    fdb       $0192     count2 - bytes copied to base+$2d
 
-L1F40               bra       $1F62
-L1F42               fcb       $01
-                    neg       $0001
-                    neg       $005F
-L1F47               neg       $0001
-                    neg       L0069
-                    com       $03,s
-                    leay      0,x
+* block2 - work block template ($192 bytes) copied to base+$2d
+                    fcc       /ctmp.XXXXXX/       base+$2d temporary file name template
+                    zmb       9         pad
+                    fcc       /c.com/             base+$41 compiler command name
+                    zmb       25        pad
+                    fdb       L0CCF     base+$5f reloc ptr (+module base) -> banner
+                    fdb       $2710,$03E8,$0064,$000A base+$61 powers of ten 10000,1000,100,10
+                    fdb       $0069     base+$69 relocatable pointer, +work base
+                    fcb       $6C,$78,$00 base+$6b
+                    zmb       7         work block default fields
+                    fcb       $01
+                    zmb       12
+                    fcb       $02,$00,$01
+                    zmb       10
+                    fcb       $42,$00,$02
+                    zmb       173
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01 character classification table
+                    fcb       $01,$11,$11,$01,$11,$11,$01,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
+                    fcb       $01,$01,$01,$01,$01,$01,$01,$01
+                    fcb       $30,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $48,$48,$48,$48,$48,$48,$48,$48
+                    fcb       $48,$48,$20,$20,$20,$20,$20,$20
+                    fcb       $20,$42,$42,$42,$42,$42,$42,$02
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02
+                    fcb       $02,$02,$02,$20,$20,$20,$20,$20
+                    fcb       $20,$44,$44,$44,$44,$44,$44,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04
+                    fcb       $04,$04,$04,$20,$20,$20,$20,$01
+
+* relocation directory
+                    fdb       $0001     nreloc1
+                    fdb       $005F     relocate word at work+$5f by module base
+                    fdb       $0001     nreloc2
+                    fdb       $0069     relocate word at work+$69 by work base
+
+* trailing module name string
+                    fcc       /cc1/
+                    fcb       $00
 
                     emod
 eom                 equ       *

--- a/3rdparty/packages/ccompiler/cc1_dis.asm
+++ b/3rdparty/packages/ccompiler/cc1_dis.asm
@@ -1,0 +1,3727 @@
+                    nam       cc1
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $04
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       2401
+size                equ       .
+
+name                equ       *
+                    fcs       /cc1/
+                    fcb       edition
+
+L0011               lda       ,y+
+L0013               sta       ,u+
+L0015               leax      -$01,x
+L0017               bne       L0011
+L0019               rts
+
+start               pshs      y
+                    pshs      u
+                    clra
+L001F               clrb
+L0020               sta       ,u+
+                    decb
+L0023               bne       L0020
+L0025               ldx       ,s
+L0027               leau      ,x
+L0029               leax      $05E1,x
+L002D               pshs      x
+L002F               leay      L1DAC,pcr
+                    ldx       ,y++
+                    beq       L003B
+                    bsr       L0011
+                    ldu       $02,s
+L003B               leau      >$002d,u
+                    ldx       ,y++
+L0041               beq       L0046
+L0043               bsr       L0011
+L0045               clra
+L0046               cmpu      ,s
+                    beq       L004F
+L004B               sta       ,u+
+L004D               bra       L0046
+
+L004F               ldu       $02,s
+                    ldd       ,y++
+L0053               beq       L005C
+                    leax      >$0000,pcr
+                    lbsr      L015F
+L005C               ldd       ,y++
+                    beq       L0065
+                    leax      ,u
+                    lbsr      L015F
+L0065               leas      $04,s
+L0067               puls      x
+L0069               stx       $01FF,u
+L006D               sty       $01BF,u
+L0072               ldd       #$0001
+L0075               std       $01FB,u
+                    leay      $01C1,u
+                    leax      ,s
+                    lda       ,x+
+L0081               ldb       $01FC,u
+                    cmpb      #$1d
+                    beq       L00DD
+L0089               cmpa      #$0d
+                    beq       L00DD
+                    cmpa      #$20
+                    beq       L0095
+                    cmpa      #$2C
+                    bne       L0099
+L0095               lda       ,x+
+                    bra       L0089
+
+L0099               cmpa      #$22
+                    beq       L00A1
+                    cmpa      #$27
+                    bne       L00BF
+L00A1               stx       ,y++
+                    inc       $01FC,u
+                    pshs      a
+L00A9               lda       ,x+
+                    cmpa      #$0d
+                    beq       L00B3
+                    cmpa      ,s
+                    bne       L00A9
+L00B3               puls      b
+                    clr       -$01,x
+                    cmpa      #$0d
+                    beq       L00DD
+                    lda       ,x+
+                    bra       L0081
+
+L00BF               leax      -$01,x
+                    stx       ,y++
+                    leax      $01,x
+                    inc       $01FC,u
+L00C9               cmpa      #$0d
+L00CB               beq       L00D9
+                    cmpa      #$20
+                    beq       L00D9
+                    cmpa      #$2C
+                    beq       L00D9
+                    lda       ,x+
+                    bra       L00C9
+
+L00D9               clr       -$01,x
+                    bra       L0081
+
+L00DD               leax      $01BF,u
+                    pshs      x
+                    ldd       $01FB,u
+                    pshs      d
+                    leay      ,u
+                    bsr       L00F7
+                    lbsr      L0179
+                    clr       ,-s
+                    clr       ,-s
+                    lbsr      L1DA0
+L00F7               leax      $05E1,y
+                    stx       $0209,y
+                    sts       $01FD,y
+                    sts       $020b,y
+                    ldd       #$FF82
+L010C               leax      d,s
+                    cmpx      $020b,y
+                    bcc       L011E
+                    cmpx      $0209,y
+                    bcs       L0138
+                    stx       $020b,y
+L011E               rts
+L011F               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L0138               leax      L011F,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clr       ,-s
+                    lbsr      L1DA6
+                    ldd       $01FD,y
+                    subd      $020b,y
+                    rts
+                    ldd       $020b,y
+                    subd      $0209,y
+                    rts
+
+L015F               pshs      x
+                    leax      d,y
+                    leax      d,x
+                    pshs      x
+L0167               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+                    std       ,x
+                    cmpy      ,s
+                    bne       L0167
+                    leas      $04,s
+                    rts
+
+L0179               pshs      u
+                    ldd       #$FFA1
+                    lbsr      L010C
+                    leas      -$0f,s
+                    leax      L0D1A,pcr
+                    pshs      x
+                    ldd       >$005f,y
+                    pshs      d
+                    leax      $0088,y
+                    pshs      x
+                    lbsr      L119C
+                    leas      $06,s
+                    clra
+                    clrb
+                    std       $08,s
+                    leax      >$002d,y
+                    pshs      x
+                    lbsr      L1156
+                    leas      $02,s
+                    leax      L0D26,pcr
+                    pshs      x
+                    leax      >$0041,y
+                    pshs      x
+                    lbsr      L1104
+                    leas      $04,s
+                    std       $002B
+                    lbne      L043E
+                    leax      $0D28,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $02,s
+                    lbra      L043E
+
+L01CE               ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       ,x
+                    std       $0C,s
+                    tfr       d,x
+                    ldb       ,x
+                    cmpb      #$2d
+                    lbne      L03CA
+                    lbra      L03B6
+
+L01E7               ldb       [$0C,s]
+                    clra
+                    andb      #$DF
+                    tfr       d,x
+                    lbra      L0359
+
+L01F2               ldx       $0C,s
+                    ldb       $01,x
+                    lbeq      L0341
+                    ldd       #$002D
+                    ldx       $0C,s
+                    leax      -$01,x
+                    stx       $0C,s
+                    stb       ,x
+                    ldd       #$0044
+                    ldx       $0C,s
+                    stb       $01,x
+                    ldd       L0027
+                    addd      #$0001
+                    std       L0027
+                    subd      #$0001
+                    aslb
+                    rola
+                    leax      $0343,y
+                    lbra      L033B
+
+L021F               ldd       #$002D
+                    ldx       $0C,s
+                    leax      -$01,x
+                    stx       $0C,s
+                    stb       ,x
+                    ldd       $0C,s
+                    std       L0023
+                    lbra      L0341
+
+L0231               ldd       #$0001
+                    std       L0019
+                    lbra      L03B6
+
+L0239               ldd       #$0001
+                    std       $0007
+                    lbra      L03B6
+
+L0241               ldd       #$0001
+                    std       $0001
+                    lbra      L03B6
+
+L0249               ldd       #$0001
+                    std       L0015
+                    lbra      L03B6
+
+L0251               ldd       #$0001
+                    std       L0011
+                    lbra      L03B6
+
+L0259               ldd       #$0001
+                    std       $000B
+                    lbra      L03B6
+
+L0261               ldd       #$0001
+                    std       $000D
+                    lbra      L03B6
+
+L0269               leax      >$0021,y
+                    stx       $0a,s
+                    leax      $0f,s
+                    bra       L027B
+
+L0273               leax      >$001f,y
+                    stx       $0a,s
+                    bra       L027D
+
+L027B               leas      -$0f,x
+L027D               ldb       [$0C,s]
+                    clra
+                    andb      #$5f
+                    stb       [$0C,s]
+                    ldx       $0C,s
+                    ldb       $01,x
+                    lbeq      L0341
+                    ldd       #$002D
+                    ldx       $0C,s
+                    leax      -$01,x
+                    stx       $0C,s
+                    stb       ,x
+                    ldd       $0C,s
+                    std       [$0a,s]
+                    lbra      L0341
+
+L02A1               ldx       $0C,s
+                    leax      $01,x
+                    stx       $0C,s
+                    ldb       ,x
+                    cmpb      #$3d
+                    lbne      L0341
+                    ldd       $0C,s
+                    addd      #$0001
+                    pshs      d
+                    leax      $0537,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    ldb       $0537,y
+                    lbeq      L0341
+                    ldd       $0003
+                    addd      #$0001
+                    std       $0003
+                    leax      $0537,y
+                    pshs      x
+                    lbsr      L0C72
+                    leas      $02,s
+                    stb       $0e,s
+                    cmpb      #$63
+                    beq       L02F3
+                    ldb       $0e,s
+                    cmpb      #$72
+                    beq       L02F3
+                    ldb       $0e,s
+                    cmpb      #$43
+                    beq       L02F3
+                    ldb       $0e,s
+                    cmpb      #$52
+                    bne       L0341
+L02F3               ldb       $0e,s
+                    sex
+                    pshs      d
+                    leax      $0D46,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $04,s
+                    bra       L0341
+
+L0305               ldx       $0C,s
+                    ldb       $01,x
+                    cmpb      #$3d
+                    bne       L0341
+                    ldd       L0017
+                    cmpd      #$0004
+                    bne       L0320
+                    leax      $0D6A,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $02,s
+L0320               ldd       #$002D
+                    ldx       $0C,s
+                    leax      -$01,x
+                    stx       $0C,s
+                    stb       ,x
+                    ldd       L0017
+                    addd      #$0001
+                    std       L0017
+                    subd      #$0001
+                    aslb
+                    rola
+                    leax      $020f,y
+L033B               leax      d,x
+                    ldd       $0C,s
+                    std       ,x
+L0341               leax      $0f,s
+                    lbra      L03C5
+
+L0346               ldb       [$0C,s]
+                    sex
+                    pshs      d
+                    leax      $0D7D,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $04,s
+                    bra       L03B6
+
+L0359               cmpx      #$0044
+                    lbeq      L01F2
+                    cmpx      #$004E
+                    lbeq      L021F
+                    cmpx      #$0058
+                    lbeq      L0231
+                    cmpx      #$0053
+                    lbeq      L0239
+                    cmpx      #$0043
+                    lbeq      L0241
+                    cmpx      #$0050
+                    lbeq      L0249
+                    cmpx      #$004F
+                    lbeq      L0251
+                    cmpx      #$0052
+                    lbeq      L0259
+                    cmpx      #$0041
+                    lbeq      L0261
+                    cmpx      #$0045
+                    lbeq      L0269
+                    cmpx      #$004D
+                    lbeq      L0273
+                    cmpx      #$0046
+                    lbeq      L02A1
+                    cmpx      #$004C
+                    lbeq      L0305
+                    bra       L0346
+
+L03B6               ldx       $0C,s
+                    leax      $01,x
+                    stx       $0C,s
+                    ldb       ,x
+                    lbne      L01E7
+                    lbra      L043E
+
+L03C5               leas      -$0f,x
+                    lbra      L043E
+
+L03CA               ldd       [$15,s]
+                    pshs      d
+                    lbsr      L0C72
+                    leas      $02,s
+                    stb       $0e,s
+                    sex
+                    tfr       d,x
+                    bra       L0416
+
+L03DB               ldd       #$0001
+                    std       L0029
+L03E0               ldd       L0025
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       $0e,s
+                    stb       ,x
+                    ldd       L0025
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       [$15,s]
+                    std       ,x
+                    ldd       L0025
+                    addd      #$0001
+                    std       L0025
+                    bra       L043E
+
+L0404               ldd       [$15,s]
+                    pshs      d
+                    leax      L0D91,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $04,s
+                    bra       L043E
+
+L0416               cmpx      #$0052
+                    beq       L03DB
+                    cmpx      #$0072
+                    lbeq      L03DB
+                    cmpx      #$0041
+                    beq       L03E0
+                    cmpx      #$0043
+                    lbeq      L03E0
+                    cmpx      #$0061
+                    lbeq      L03E0
+                    cmpx      #$0063
+                    lbeq      L03E0
+                    bra       L0404
+
+L043E               ldd       $13,s
+                    addd      #$FFFF
+                    std       $13,s
+                    ble       L0458
+                    ldd       $08,s
+                    addd      #$0001
+                    std       $08,s
+                    cmpd      #$0064
+                    lblt      L01CE
+L0458               ldd       L0025
+                    bne       L0476
+                    leax      $0DAB,pcr
+                    pshs      x
+                    leax      $0088,y
+                    pshs      x
+                    lbsr      L119C
+                    leas      $04,s
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L1DA0
+                    leas      $02,s
+L0476               ldd       $000D
+                    addd      $000B
+                    cmpd      #$0001
+                    ble       L048F
+                    clra
+                    clrb
+                    pshs      d
+                    leax      $0DB6,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $04,s
+L048F               ldd       $0003
+                    beq       L04B4
+                    ldd       L0025
+                    cmpd      #$0001
+                    ble       L04B4
+                    ldd       $000D
+                    bne       L04A3
+                    ldd       $000B
+                    beq       L04B4
+L04A3               leax      $0537,y
+                    pshs      x
+                    leax      $0DC9,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $04,s
+L04B4               ldd       $0003
+                    bne       L04D9
+                    ldd       L0025
+                    cmpd      #$0001
+                    bne       L04C8
+                    ldd       $0217,y
+                    pshs      d
+                    bra       L04CE
+
+L04C8               leax      $0DE9,pcr
+                    pshs      x
+L04CE               leax      $0537,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+L04D9               leax      >$002d,y
+                    pshs      x
+                    leax      $0447,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    leax      $0DF0,pcr
+                    pshs      x
+                    leax      $0447,y
+                    pshs      x
+                    lbsr      L19AB
+                    leas      $04,s
+                    leax      >$002d,y
+                    pshs      x
+                    leax      $0483,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    leax      L0DF3,pcr
+                    pshs      x
+                    leax      $0483,y
+                    pshs      x
+                    lbsr      L19AB
+                    leas      $04,s
+                    clra
+                    clrb
+                    std       $08,s
+                    lbra      L09BE
+
+L0524               leax      $0DF6,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $08,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0DFD,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $08,s
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$43
+                    beq       L056B
+                    ldd       $08,s
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$63
+                    lbne      L07F7
+L056B               ldd       #$0001
+                    std       ,s
+                    leax      $0447,y
+                    pshs      x
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    ldd       #$006D
+                    pshs      d
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0C4C
+                    leas      $04,s
+                    leax      $0E00,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0E11,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $0001
+                    beq       L05B6
+                    leax      L0E19,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L05B6               ldd       $0021
+                    beq       L05CE
+                    ldd       $0021
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0E1D,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L05CE               clra
+                    clrb
+                    std       $04,s
+                    bra       L05FA
+
+L05D4               ldd       $04,s
+                    addd      #$0001
+                    std       $04,s
+                    subd      #$0001
+                    aslb
+                    rola
+                    leax      $0343,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0E1F,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L05FA               ldd       $04,s
+                    cmpd      L0027
+                    blt       L05D4
+                    ldd       $08,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0E21,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    leax      $0E24,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0E36,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       L0013
+                    beq       L066B
+                    leax      $0E3F,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L066B               ldd       $0007
+                    beq       L067A
+                    leax      L0E43,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L067A               ldd       L0015
+                    beq       L0689
+                    leax      L0E48,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L0689               leax      $0447,y
+                    pshs      x
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    ldd       #$0069
+                    pshs      d
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0C4C
+                    leas      $04,s
+                    leax      L0E4D,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       L0013
+                    bne       L06E7
+                    leax      $0E52,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0E58,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    bra       L06F8
+
+L06E7               leax      $04FB,y
+                    pshs      x
+                    leax      $0573,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+L06F8               leax      $0E5A,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0E69,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $0007
+                    beq       L0739
+                    leax      $0E72,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L0739               ldd       L0015
+                    beq       L0748
+                    leax      L0E77,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L0748               ldd       L0013
+                    beq       L0762
+                    leax      L0E7C,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0573,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L0762               ldd       $000D
+                    beq       L0794
+                    ldd       $0003
+                    beq       L077B
+                    leax      $0537,y
+                    pshs      x
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L1991
+                    bra       L07A2
+
+L077B               ldd       $08,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+L0794               ldd       #$0061
+                    pshs      d
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0C4C
+L07A2               leas      $04,s
+                    leax      L0E7E,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0E83,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       L0013
+                    beq       L07EA
+                    leax      $0E89,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0573,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L07EA               leax      $0E8B,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    bra       L07FB
+
+L07F7               clra
+                    clrb
+                    std       ,s
+L07FB               ldd       $000D
+                    lbne      L09B7
+                    ldd       $08,s
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$52
+                    lbeq      L09B7
+                    ldd       $08,s
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$72
+                    lbeq      L09B7
+                    ldd       $08,s
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$41
+                    beq       L083D
+                    ldd       $08,s
+                    leax      $02DF,y
+                    leax      d,x
+                    ldb       ,x
+                    cmpb      #$61
+                    bne       L084D
+L083D               ldd       $08,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    bra       L0853
+
+L084D               leax      $04BF,y
+                    pshs      x
+L0853               leax      $04FB,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    ldd       L0011
+                    lbne      L08FD
+                    leax      $0E8D,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0E9A,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0447,y
+                    pshs      x
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    ldd       #$006F
+                    pshs      d
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0C4C
+                    leas      $04,s
+                    leax      L0EA1,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0EA3,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       ,s
+                    beq       L08EC
+                    leax      L0EA5,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0EAA,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L08EC               leax      $04BF,y
+                    pshs      x
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+L08FD               leax      $0EAC,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0EB9,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       L0025
+                    cmpd      #$0001
+                    bne       L0932
+                    ldd       $000B
+                    bne       L0932
+                    leax      $0483,y
+L092E               pshs      x
+                    bra       L0966
+
+L0932               ldd       $0003
+                    beq       L0940
+                    ldd       $000B
+                    beq       L0940
+                    leax      $0537,y
+                    bra       L092E
+
+L0940               ldd       #$0072
+                    pshs      d
+                    ldd       $0a,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    lbsr      L0C4C
+                    leas      $04,s
+                    ldd       $08,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+L0966               leax      $04BF,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    leax      L0EC0,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0EC5,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       ,s
+                    beq       L09B7
+                    leax      $0EC7,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04FB,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0ECC,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L09B7               ldd       $08,s
+                    addd      #$0001
+                    std       $08,s
+L09BE               ldd       $08,s
+                    cmpd      L0025
+                    lblt      L0524
+                    ldd       $000D
+                    lbne      L0B2A
+                    ldd       $000B
+                    lbne      L0B2A
+                    ldd       $0003
+                    bne       L09E6
+                    clra
+                    clrb
+                    pshs      d
+                    leax      $0537,y
+                    pshs      x
+                    lbsr      L0C4C
+                    leas      $04,s
+L09E6               leax      $0ECE,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0EDC,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0EE4,pcr
+                    stx       $0C,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      L0EE8,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       L0025
+                    cmpd      #$0001
+                    bne       L0A48
+                    ldb       $02DF,y
+                    cmpb      #$52
+                    beq       L0A48
+                    ldb       $02DF,y
+                    cmpb      #$72
+                    beq       L0A48
+                    leax      $0EF6,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $04BF,y
+                    stx       $001D
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    bra       L0A7C
+
+L0A48               clra
+                    clrb
+                    bra       L0A6F
+
+L0A4C               leax      $0EF8,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $08,s
+                    aslb
+                    rola
+                    leax      $0217,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $08,s
+                    addd      #$0001
+L0A6F               std       $08,s
+                    ldd       $08,s
+                    cmpd      L0025
+                    blt       L0A4C
+                    clra
+                    clrb
+                    std       $001D
+L0A7C               leax      $0EFA,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0537,y
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    clra
+                    clrb
+                    bra       L0AB9
+
+L0A96               leax      $0EFF,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $06,s
+                    aslb
+                    rola
+                    leax      $020f,y
+                    leax      d,x
+                    ldd       ,x
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $06,s
+                    addd      #$0001
+L0AB9               std       $06,s
+                    ldd       $06,s
+                    cmpd      L0017
+                    blt       L0A96
+                    leax      $0F01,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $0C,s
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0F06,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       L0023
+                    pshs      d
+                    lbsr      L0BF5
+                    leas      $02,s
+                    ldd       $0021
+                    pshs      d
+                    lbsr      L0BF5
+                    leas      $02,s
+                    ldd       L001F
+                    pshs      d
+                    lbsr      L0BF5
+                    leas      $02,s
+                    leax      L0F13,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $001D
+                    beq       L0B2A
+                    leax      L0F15,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+                    ldd       $001D
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0F1A,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L0B2A               ldd       $002B
+                    pshs      d
+                    lbsr      L1780
+                    leas      $02,s
+                    ldd       L0019
+                    lbne      L0BA0
+                    leax      $0F1C,pcr
+                    pshs      x
+                    leax      $040b,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    leax      >$006e,y
+                    pshs      x
+                    leax      L0F23,pcr
+                    pshs      x
+                    leax      >$0041,y
+                    pshs      x
+                    lbsr      L1123
+                    leas      $06,s
+                    std       -$02,s
+                    bne       L0B76
+                    leax      >$0041,y
+                    pshs      x
+                    leax      $0F25,pcr
+                    pshs      x
+                    lbsr      L0C17
+                    leas      $04,s
+L0B76               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    leax      $040b,y
+                    pshs      x
+                    leax      $040b,y
+                    pshs      x
+                    lbsr      $1980
+                    std       ,s
+                    leax      L0F37,pcr
+                    pshs      x
+                    lbsr      L1D13
+                    leas      $0C,s
+L0BA0               leas      $0f,s
+                    puls      pc,u
+                    pshs      u
+                    ldd       #$FFB4
+                    lbsr      L010C
+                    leas      -$02,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$0004
+                    pshs      d
+                    leax      $0F3D,pcr
+                    pshs      x
+                    lbsr      L1C31
+                    leas      $06,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L0BCF
+                    lbsr      $0F48
+                    bra       L0BF1
+
+L0BCF               pshs      u
+                    ldd       $09,u
+                    addd      ,s++
+                    std       ,s
+                    pshs      d
+                    leax      $05A5,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    pshs      u
+                    lbsr      L1C5A
+                    leas      $02,s
+                    leax      $05A5,y
+                    tfr       x,d
+L0BF1               puls      pc,u,x
+                    puls      pc,u,x
+L0BF5               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L010C
+                    ldd       $04,s
+                    beq       L0C15
+                    ldd       $04,s
+                    pshs      d
+                    lbsr      L0CB8
+                    leas      $02,s
+                    leax      $0F46,pcr
+                    pshs      x
+                    lbsr      L0CB8
+                    leas      $02,s
+L0C15               puls      pc,u
+L0C17               pshs      u
+                    ldd       #$FFB6
+                    lbsr      L010C
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    leax      $0088,y
+                    pshs      x
+                    lbsr      L119C
+                    leas      $06,s
+                    leax      $0088,y
+                    pshs      x
+                    ldd       #$000D
+                    pshs      d
+                    lbsr      $1690
+                    leas      $04,s
+                    ldd       #$0001
+                    pshs      d
+                    lbsr      L1DA0
+                    puls      pc,u,x
+L0C4C               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L010C
+                    ldu       $04,s
+L0C56               ldb       ,u+
+                    bne       L0C56
+                    ldb       -$03,u
+                    cmpb      #$2e
+                    beq       L0C62
+                    puls      pc,u
+L0C62               ldb       $07,s
+                    bne       L0C6C
+                    clra
+                    clrb
+                    stb       -$03,u
+                    bra       L0C70
+
+L0C6C               ldb       $07,s
+                    stb       -$02,u
+L0C70               puls      pc,u
+L0C72               pshs      u
+                    ldd       #$FFBD
+                    lbsr      L010C
+                    ldu       $04,s
+                    leas      -$03,s
+L0C7E               clra
+                    clrb
+                    bra       L0C8D
+
+L0C82               ldb       ,s
+                    cmpb      #$2f
+                    beq       L0C7E
+                    ldd       $01,s
+                    addd      #$0001
+L0C8D               std       $01,s
+                    ldb       ,u+
+                    stb       ,s
+                    bne       L0C82
+                    ldd       $01,s
+                    cmpd      #$001D
+                    bgt       L0CB2
+                    ldd       $01,s
+                    cmpd      #$0002
+                    ble       L0CB2
+                    ldb       -$03,u
+                    cmpb      #$2e
+                    bne       L0CB2
+                    ldb       -$02,u
+                    sex
+                    orb       #$40
+                    bra       L0CB4
+
+L0CB2               clra
+                    clrb
+L0CB4               leas      $03,s
+                    puls      pc,u
+L0CB8               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L010C
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $002B
+                    pshs      d
+                    lbsr      L119C
+                    leas      $04,s
+                    puls      pc,u
+                    coma
+                    coma
+                    leay      0,y
+                    rorb
+                    fcb       $45
+                    fcb       $52
+                    comb
+                    rola
+                    clra
+                    fcb       $4e
+                    bra       L0D01
+                    com       $0D43
+                    fcb       $4f,$50,$59,$52,$49,$47,$48,$54
+                    fcb       $20,$31,$39,$38,$33,$20,$4d,$49
+                    fcb       $43,$52,$4f,$57,$41,$52,$45
+                    fcb       $0d,$52,$45,$50,$52,$4f,$44
+                    fcb       $55,$43,$45
+L0D00               fcb       $44
+L0D01               fcb       $20,$55,$4e,$44,$45,$52,$20,$4C
+                    fcb       $49,$43,$45,$4e,$53,$45,$0d
+                    lsrb
+                    clra
+                    bra       L0D68
+                    fcb       $41
+                    fcb       $4e
+                    lsra
+                    rolb
+                    tst       $0000
+L0D1A               fcb       $52
+                    comb
+                    bra       L0D4E
+                    leay      $0e,y
+                    leax      -$10,y
+                    bgt       L0D54
+                    leax      0,x
+L0D26               asr       >$0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $206F
+                    neg       $656E
+                    bra       L0DA7
+                    asl       $05,s
+                    inc       $0C,s
+                    bra       L0D9D
+                    clr       $0d,s
+                    tst       $01,s
+                    jmp       $04,s
+                    bra       $0DA8
+                    rol       $0C,s
+                    fcb       $65
+                    neg       L0053
+                    fcb       $75
+                    ror       $06,s
+                    rol       -$08,s
+                    bra       $0D75
+
+L0D4E               bgt       $0D75
+                    com       $07,y
+                    bra       L0DC2
+
+L0D54               clr       -$0C,s
+                    bra       L0DB9
+                    inc       $0C,s
+                    clr       -$09,s
+                    fcb       $65
+                    lsr       0,y
+                    ror       $0f,s
+                    fcb       $72
+                    bra       L0DD3
+                    fcb       $75
+L0D65               lsr       $7075
+L0D68               lsr       >$0054
+                    clr       $0f,s
+                    bra       $0DDC
+                    fcb       $61
+                    jmp       -$07,s
+                    bra       $0DE0
+                    rol       $02,s
+                    fcb       $72
+                    fcb       $61
+                    fcb       $72
+                    rol       $05,s
+                    com       >L0075
+                    fcb       $6e,$6b,$6e,$6f,$77,$6e,$20,$66
+                    fcb       $6C,$61,$67,$20,$3a,$20,$2d,$25
+                    fcb       $63,$0d,$00
+L0D91               bcs       $0E06
+                    bra       $0DCF
+                    bra       $0E05
+                    clr       0,y
+                    fcb       $72
+                    fcb       $65
+                    com       $0f,s
+L0D9D               asr       $0e,s
+                    rol       -$06,s
+                    fcb       $65
+                    lsr       0,y
+                    com       $7566
+L0DA7               ror       $09,s
+                    asl       >$006E
+                    clr       0,y
+                    ror       $09,s
+                    inc       $05,s
+                    com       $210D
+                    neg       L0069
+                    jmp       $03,s
+
+L0DB9               clr       $0d,s
+                    neg       $6174
+                    rol       $02,s
+                    inc       $05,s
+L0DC2               bra       L0E2A
+                    inc       $01,s
+                    asr       -$0d,s
+                    neg       L0025
+                    com       $203A
+                    bra       L0E3E
+                    fcb       $75
+                    lsr       $7075
+L0DD3               lsr       $206E
+                    fcb       $61
+                    tst       $05,s
+                    bra       $0E49
+                    clr       -$0C,s
+                    bra       L0E40
+                    neg       $706C
+                    rol       $03,s
+                    fcb       $61
+                    fcb       $62
+                    inc       $05,s
+                    neg       $006F
+                    fcb       $75
+                    lsr       $7075
+                    lsr       >$002E
+                    tst       0,x
+L0DF3               bgt       L0E67
+                    neg       L0065
+                    com       $08,s
+                    clr       0,y
+                    beq       L0DFD
+L0DFD               beq       $0E0C
+                    neg       L002D
+                    asl       L0D65
+                    com       $08,s
+                    clr       0,y
+                    com       $0e,y
+                    neg       $7265
+                    neg       $3A0D
+                    neg       L0043
+                    bgt       L0E64
+                    fcb       $52
+                    fcb       $45
+                    negb
+                    bra       L0E19
+
+L0E19               blt       $0E87
+                    bra       L0E1D
+
+L0E1D               bra       L0E1F
+
+L0E1F               bra       L0E21
+
+L0E21               bra       L0E61
+                    neg       $000D
+                    asl       L0D65
+                    com       $08,s
+L0E2A               clr       0,y
+                    com       $0e,y
+                    neg       $6173
+                    com       $313A
+                    tst       $0000
+L0E36               coma
+                    bgt       $0E89
+                    fcb       $41
+                    comb
+                    comb
+                    leay      0,y
+L0E3E               neg       L002D
+L0E40               fcb       $65
+                    bra       L0E43
+
+L0E43               bra       $0E72
+                    com       $2000
+L0E48               bra       L0E77
+                    neg       $2000
+L0E4D               bra       L0E7C
+                    clr       -$03,y
+                    neg       $000D
+                    lsr       $05,s
+                    inc       0,y
+                    neg       $000D
+                    neg       L0065
+                    com       $08,s
+                    clr       0,y
+                    com       $0e,y
+L0E61               neg       $6173
+L0E64               com       $323A
+L0E67               tst       $0000
+L0E69               coma
+                    bgt       L0EBC
+                    fcb       $41
+                    comb
+                    comb
+                    leas      0,y
+                    neg       L0020
+                    blt       L0EE8
+                    bra       L0E77
+
+L0E77               bra       $0EA6
+                    neg       $2000
+L0E7C               bra       L0E7E
+
+L0E7E               bra       L0EAD
+                    clr       -$03,y
+                    neg       $000D
+                    lsr       $05,s
+                    inc       0,y
+                    neg       L0020
+                    neg       $000D
+                    neg       L0065
+                    com       $08,s
+                    clr       0,y
+                    com       $0e,y
+                    clr       -$10,s
+                    lsr       $3A0D
+                    neg       L0043
+                    bgt       L0EEC
+                    negb
+                    lsrb
+                    bra       L0EA1
+
+L0EA1               bra       L0EA3
+
+L0EA3               tst       $0000
+L0EA5               lsr       $05,s
+                    inc       0,y
+                    neg       $000D
+                    neg       L0065
+L0EAD               com       $08,s
+                    clr       0,y
+                    com       $0e,y
+                    fcb       $61
+                    com       $6D3A
+                    tst       $0000
+L0EB9               coma
+                    bgt       L0EFD
+L0EBC               comb
+                    tsta
+                    bra       L0EC0
+
+L0EC0               bra       $0EEF
+                    clr       -$03,y
+                    neg       $000D
+                    neg       $0064
+                    fcb       $65
+                    inc       0,y
+                    neg       $000D
+                    neg       L0065
+                    com       $08,s
+                    clr       0,y
+                    com       $0e,y
+                    inc       $09,s
+                    jmp       $0b,s
+                    abx
+                    tst       $0000
+L0EDC               coma
+                    bgt       $0F2B
+                    rola
+                    fcb       $4e
+                    fcb       $4b
+                    bra       L0EE4
+
+L0EE4               ble       L0F4A
+                    lsr       0,x
+L0EE8               ble       $0F56
+                    rol       $02,s
+L0EEC               ble       $0F51
+                    com       $7461
+                    fcb       $72
+                    lsr       $2E72
+                    neg       L0020
+                    neg       L0020
+                    neg       L0020
+                    blt       L0F6C
+L0EFD               mul
+                    neg       L0020
+                    neg       L0020
+                    blt       $0F70
+                    mul
+                    neg       L002F
+                    inc       $09,s
+                    fcb       $62
+                    ble       L0F6F
+                    inc       $09,s
+                    fcb       $62
+                    bgt       L0F7D
+                    bra       L0F13
+
+L0F13               tst       $0000
+L0F15               lsr       $05,s
+                    inc       0,y
+                    neg       $000D
+                    neg       L002D
+                    lsr       $202D
+                    neg       L0D00
+L0F23               fcb       $72
+                    neg       $0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $2072
+                    fcb       $65
+                    clr       -$10,s
+                    fcb       $65
+                    jmp       0,y
+                    beq       L0F59
+                    com       $2700
+L0F37               com       $6865
+                    inc       $0C,s
+                    neg       $0063
+                    com       $04,s
+                    fcb       $65
+                    ror       $6963
+                    fcb       $65
+                    neg       L0020
+                    neg       $0034
+                    nega
+L0F4A               leas      -$07,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       #$000C
+                    pshs      d
+                    leax      >L0FA9,pcr
+L0F59               pshs      x
+                    lbsr      L1C31
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    beq       L0FA3
+                    ldd       ,s
+                    ldx       ,s
+L0F6C               addd      $10,x
+L0F6F               std       $05,s
+                    leau      $05B9,y
+                    bra       L0F7B
+
+L0F77               ldb       $04,s
+                    stb       ,u+
+L0F7B               ldx       $05,s
+L0F7D               leax      $01,x
+                    stx       $05,s
+                    ldb       -$01,x
+                    stb       $04,s
+                    bgt       L0F77
+                    ldb       $04,s
+                    clra
+                    andb      #$7f
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       ,s
+                    pshs      d
+                    lbsr      L1C5A
+                    leas      $02,s
+                    leax      $05B9,y
+                    tfr       x,d
+                    bra       L0FA5
+
+L0FA3               clra
+                    clrb
+L0FA5               leas      $07,s
+                    puls      pc,u
+L0FA9               rola
+                    jmp       $09,s
+                    lsr       >$0034
+                    nega
+                    leau      >$006e,y
+L0FB4               ldd       $06,u
+                    clra
+                    andb      #$03
+                    lbeq      L1025
+                    leau      $0d,u
+                    pshs      u
+                    leax      $013e,y
+                    cmpx      ,s++
+                    bhi       L0FB4
+                    ldd       #$00C8
+                    std       $020d,y
+                    lbra      L1029
+                    puls      pc,u
+L0FD5               pshs      u
+                    ldu       $08,s
+                    bne       L0FDF
+                    bsr       $0FAE
+                    tfr       d,u
+L0FDF               stu       -$02,s
+                    beq       L1029
+                    ldd       $04,s
+                    std       $08,u
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$2b
+                    beq       L0FF7
+                    ldx       $06,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L0FFD
+L0FF7               ldd       $06,u
+                    orb       #$03
+                    bra       L101B
+
+L0FFD               ldd       $06,u
+                    pshs      d
+                    ldb       [$08,s]
+                    cmpb      #$72
+                    beq       L100F
+                    ldb       [$08,s]
+                    cmpb      #$64
+                    bne       L1014
+L100F               ldd       #$0001
+                    bra       L1017
+
+L1014               ldd       #$0002
+L1017               ora       ,s+
+                    orb       ,s+
+L101B               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+L1025               tfr       u,d
+                    puls      pc,u
+L1029               clra
+                    clrb
+                    puls      pc,u
+L102D               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $0a,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L105E
+
+L1040               ldx       $0a,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L104D
+                    ldd       #$0007
+                    bra       L1055
+
+L104D               ldd       #$0004
+                    bra       L1055
+
+L1052               ldd       #$0003
+L1055               std       ,s
+                    bra       L106E
+
+L1059               leax      $04,s
+                    lbra      L10C6
+
+L105E               stx       -$02,s
+                    beq       L106E
+                    cmpx      #$0078
+                    beq       L1040
+                    cmpx      #$002B
+                    beq       L1052
+                    bra       L1059
+
+L106E               ldb       [$0a,s]
+                    sex
+                    tfr       d,x
+                    lbra      L10D3
+
+L1077               ldd       ,s
+                    orb       #$01
+                    bra       L10B9
+
+L107D               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      L1AF8
+                    leas      $04,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L10A8
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L1BCA
+                    leas      $08,s
+                    bra       L10ED
+
+L10A8               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    pshs      u
+                    lbsr      L1B19
+                    bra       L10C0
+
+L10B5               ldd       ,s
+                    orb       #$81
+L10B9               pshs      d
+                    pshs      u
+                    lbsr      L1AF8
+L10C0               leas      $04,s
+                    std       $02,s
+                    bra       L10ED
+
+L10C6               leas      -$04,x
+L10C8               ldd       #$00CB
+                    std       $020d,y
+                    clra
+                    clrb
+                    bra       L10EF
+
+L10D3               cmpx      #$0072
+                    lbeq      L1077
+                    cmpx      #$0061
+                    lbeq      L107D
+                    cmpx      #$0077
+                    beq       L10A8
+                    cmpx      #$0064
+                    beq       L10B5
+                    bra       L10C8
+
+L10ED               ldd       $02,s
+L10EF               leas      $04,s
+                    puls      pc,u
+                    pshs      u
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    lbra      L114F
+
+L1104               pshs      u
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L102D
+                    leas      $04,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L111F
+                    clra
+                    clrb
+                    bra       L1154
+
+L111F               clra
+                    clrb
+                    bra       L1147
+
+L1123               pshs      u
+                    ldd       $08,s
+                    pshs      d
+                    lbsr      L1780
+                    leas      $02,s
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      L102D
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L1145
+                    clra
+                    clrb
+                    bra       L1154
+
+L1145               ldd       $08,s
+L1147               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+L114F               lbsr      L0FD5
+                    leas      $06,s
+L1154               puls      pc,u
+L1156               pshs      u,d
+                    ldu       $06,s
+                    bra       L115E
+
+L115C               leau      $01,u
+L115E               ldb       ,u
+                    sex
+                    std       ,s
+                    beq       L116D
+                    ldd       ,s
+                    cmpd      #$0058
+                    bne       L115C
+L116D               ldd       ,s
+                    beq       L1183
+                    lbsr      L1D4D
+                    pshs      d
+                    leax      >L1187,pcr
+                    pshs      x
+                    pshs      u
+                    lbsr      L11B8
+                    leas      $06,s
+L1183               ldd       $06,s
+                    puls      pc,u,x
+L1187               bcs       L11ED
+                    neg       $0034
+                    nega
+                    leax      >$007b,y
+                    stx       $05C5,y
+                    leax      $06,s
+                    pshs      x
+                    ldd       $06,s
+                    bra       L11AA
+
+L119C               pshs      u
+                    ldd       $04,s
+                    std       $05C5,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L11AA               pshs      d
+                    leax      L1664,pcr
+                    pshs      x
+                    bsr       L11DC
+                    leas      $06,s
+                    puls      pc,u
+L11B8               pshs      u
+                    ldd       $04,s
+                    std       $05C5,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    leax      L1677,pcr
+                    pshs      x
+                    bsr       L11DC
+                    leas      $06,s
+                    clra
+                    clrb
+                    stb       [>$05C5,y]
+                    ldd       $04,s
+                    puls      pc,u
+L11DC               pshs      u
+                    ldu       $06,s
+                    leas      -$0b,s
+                    bra       L11F4
+
+L11E4               ldb       $08,s
+                    lbeq      L1425
+                    ldb       $08,s
+                    sex
+L11ED               pshs      d
+                    jsr       [$11,s]
+                    leas      $02,s
+L11F4               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    bne       L11E4
+                    ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L1219
+                    ldd       #$0001
+                    std       $05DB,y
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L121F
+
+L1219               clra
+                    clrb
+                    std       $05DB,y
+L121F               ldb       $08,s
+                    cmpb      #$30
+                    bne       L122A
+                    ldd       #$0030
+                    bra       L122D
+
+L122A               ldd       #$0020
+L122D               std       $05DD,y
+                    bra       L124D
+
+L1233               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L1A07
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+L124D               ldb       $08,s
+                    sex
+                    leax      $013f,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L1233
+                    ldb       $08,s
+                    cmpb      #$2e
+                    bne       L1296
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L1280
+
+L126A               ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L1A07
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+L1280               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $013f,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L126A
+                    bra       L129A
+
+L1296               clra
+                    clrb
+                    std       $04,s
+L129A               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L13C8
+
+L12A2               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L1429
+                    bra       L12CA
+
+L12B7               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L14EA
+L12CA               std       ,s
+                    lbra      L13AE
+
+L12CF               ldd       $06,s
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    leax      $013f,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$02
+                    pshs      d
+                    ldx       $17,s
+                    leax      $02,x
+                    stx       $17,s
+                    ldd       -$02,x
+                    pshs      d
+                    lbsr      L1530
+                    lbra      L13AA
+
+L12F5               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    leax      $05C7,y
+                    pshs      x
+                    lbsr      L1471
+                    lbra      L13AA
+
+L1311               ldd       $04,s
+                    bne       L131A
+                    ldd       #$0006
+                    std       $02,s
+L131A               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    ldb       $0e,s
+                    sex
+                    pshs      d
+                    lbsr      $1975
+                    leas      $06,s
+                    lbra      L13AC
+
+L1334               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    lbra      L13BE
+
+L1341               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L1389
+                    ldd       $09,s
+                    std       $04,s
+                    bra       L1363
+
+L1357               ldb       [$09,s]
+                    beq       L136F
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+L1363               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L1357
+L136F               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $15,s
+                    pshs      d
+                    lbsr      L159B
+                    leas      $08,s
+                    bra       L13B8
+
+L1389               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    bra       L13AC
+
+L1391               ldb       ,u+
+                    stb       $08,s
+                    bra       L1399
+                    leas      -$0b,x
+L1399               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldb       $0C,s
+                    sex
+                    pshs      d
+                    lbsr      L1937
+L13AA               leas      $04,s
+L13AC               pshs      d
+L13AE               ldd       $13,s
+                    pshs      d
+                    lbsr      L15FD
+                    leas      $06,s
+L13B8               lbra      L11F4
+
+L13BB               ldb       $08,s
+                    sex
+L13BE               pshs      d
+                    jsr       [$11,s]
+                    leas      $02,s
+                    lbra      L11F4
+
+L13C8               cmpx      #$0064
+                    lbeq      L12A2
+                    cmpx      #$006F
+                    lbeq      L12B7
+                    cmpx      #$0078
+                    lbeq      L12CF
+                    cmpx      #$0058
+                    lbeq      L12CF
+                    cmpx      #$0075
+                    lbeq      L12F5
+                    cmpx      #$0066
+                    lbeq      L1311
+                    cmpx      #$0065
+                    lbeq      L1311
+                    cmpx      #$0067
+                    lbeq      L1311
+                    cmpx      #$0045
+                    lbeq      L1311
+                    cmpx      #$0047
+                    lbeq      L1311
+                    cmpx      #$0063
+                    lbeq      L1334
+                    cmpx      #$0073
+                    lbeq      L1341
+                    cmpx      #$006C
+                    lbeq      L1391
+                    bra       L13BB
+
+L1425               leas      $0b,s
+                    puls      pc,u
+L1429               pshs      u,d
+                    leax      $05C7,y
+                    stx       ,s
+                    ldd       $06,s
+                    bge       L145D
+                    ldd       $06,s
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $06,s
+                    bge       L1452
+                    leax      L1689,pcr
+                    pshs      x
+                    leax      $05C7,y
+                    pshs      x
+                    lbsr      L1991
+                    leas      $04,s
+                    puls      pc,u,x
+L1452               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L145D               ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    pshs      d
+                    bsr       L1471
+                    leas      $04,s
+                    leax      $05C7,y
+                    tfr       x,d
+                    puls      pc,u,x
+L1471               pshs      u,y,x,d
+                    ldu       $0a,s
+                    clra
+                    clrb
+                    std       $02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L148E
+
+L147F               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      >$0061,y
+                    std       $0C,s
+L148E               ldd       $0C,s
+                    blt       L147F
+                    leax      >$0061,y
+                    stx       $04,s
+                    bra       L14D0
+
+L149A               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L14A1               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    bge       L149A
+                    ldd       $0C,s
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L14BA
+                    ldd       #$0001
+                    std       $02,s
+L14BA               ldd       $02,s
+                    beq       L14C5
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L14C5               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+L14D0               ldd       $04,s
+                    cmpd      >$0069,y
+                    bne       L14A1
+                    ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $0a,s
+                    leas      $06,s
+                    puls      pc,u
+L14EA               pshs      u,d
+                    leax      $05C7,y
+                    stx       ,s
+                    leau      $05D1,y
+L14F6               ldd       $06,s
+                    clra
+                    andb      #$07
+                    addd      #$0030
+                    stb       ,u+
+                    ldd       $06,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    std       $06,s
+                    bne       L14F6
+                    bra       L1518
+
+L150E               ldb       ,u
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L1518               leau      -$01,u
+                    pshs      u
+                    leax      $05D1,y
+                    cmpx      ,s++
+                    bls       L150E
+                    clra
+                    clrb
+                    stb       [,s]
+                    leax      $05C7,y
+                    tfr       x,d
+                    puls      pc,u,x
+L1530               pshs      u,x,d
+                    leax      $05C7,y
+                    stx       $02,s
+                    leau      $05D1,y
+L153C               ldd       $08,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L155E
+                    ldd       $0C,s
+                    beq       L1556
+                    ldd       #$0041
+                    bra       L1559
+
+L1556               ldd       #$0061
+L1559               addd      #$FFF6
+                    bra       L1561
+
+L155E               ldd       #$0030
+L1561               addd      ,s++
+                    stb       ,u+
+                    ldd       $08,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $08,s
+                    bne       L153C
+                    bra       L1581
+
+L1577               ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+L1581               leau      -$01,u
+                    pshs      u
+                    leax      $05D1,y
+                    cmpx      ,s++
+                    bls       L1577
+                    clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $05C7,y
+                    tfr       x,d
+                    lbra      L1673
+
+L159B               pshs      u
+                    ldu       $06,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       $0a,s
+                    ldd       $05DB,y
+                    bne       L15D0
+                    bra       L15B8
+
+L15AD               ldd       $05DD,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L15B8               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L15AD
+                    bra       L15D0
+
+L15C6               ldb       ,u+
+                    sex
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L15D0               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L15C6
+                    ldd       $05DB,y
+                    beq       L15FB
+                    bra       L15EF
+
+L15E4               ldd       $05DD,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L15EF               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L15E4
+L15FB               puls      pc,u
+L15FD               pshs      u
+                    ldu       $06,s
+                    ldd       $08,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $1980
+                    leas      $02,s
+                    nega
+                    negb
+                    sbca      #$00
+                    addd      ,s++
+                    std       $08,s
+                    ldd       $05DB,y
+                    bne       L163F
+                    bra       L1627
+
+L161C               ldd       $05DD,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L1627               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L161C
+                    bra       L163F
+
+L1635               ldb       ,u+
+                    sex
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L163F               ldb       ,u
+                    bne       L1635
+                    ldd       $05DB,y
+                    beq       L1662
+                    bra       L1656
+
+L164B               ldd       $05DD,y
+                    pshs      d
+                    jsr       [$06,s]
+                    leas      $02,s
+L1656               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L164B
+L1662               puls      pc,u
+L1664               pshs      u
+                    ldd       $05C5,y
+                    pshs      d
+                    ldd       $06,s
+                    pshs      d
+                    lbsr      $1690
+L1673               leas      $04,s
+                    puls      pc,u
+L1677               pshs      u
+                    ldd       $04,s
+                    ldx       $05C5,y
+                    leax      $01,x
+                    stx       $05C5,y
+                    stb       -$01,x
+                    puls      pc,u
+L1689               blt       L16BE
+                    leas      -$09,y
+                    pshu      y,x,dp
+                    neg       $0034
+                    nega
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       L16B4
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    lbne      L17CA
+                    pshs      u
+                    lbsr      L18A7
+                    leas      $02,s
+L16B4               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       L16F0
+                    ldd       #$0001
+L16BE               pshs      d
+                    leax      $07,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L16D5
+                    leax      L1BBA,pcr
+                    bra       L16D9
+
+L16D5               leax      L1BA1,pcr
+L16D9               tfr       x,d
+                    tfr       d,x
+                    jsr       ,x
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       L1731
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      L17CA
+
+L16F0               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L1700
+                    pshs      u
+                    lbsr      L17E5
+                    leas      $02,s
+L1700               ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       $04,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L1726
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L1731
+                    ldd       $04,s
+                    cmpd      #$000D
+                    bne       L1731
+L1726               pshs      u
+                    lbsr      L17E5
+                    std       ,s++
+                    lbne      L17CA
+L1731               ldd       $04,s
+                    puls      pc,u
+                    pshs      u
+                    ldu       $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      L1A66
+                    pshs      d
+                    lbsr      $1690
+                    leas      $04,s
+                    ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    lbsr      $1690
+                    lbra      L189F
+
+L1758               pshs      u,d
+                    leau      >$006e,y
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L176E
+
+L1764               tfr       u,d
+                    leau      $0d,u
+                    pshs      d
+                    bsr       L1780
+                    leas      $02,s
+L176E               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    blt       L1764
+                    puls      pc,u,x
+L1780               pshs      u
+                    ldu       $04,s
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       L1790
+                    ldd       $06,u
+                    bne       L1795
+L1790               ldd       #$FFFF
+                    puls      pc,u,x
+L1795               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       L17A4
+                    pshs      u
+                    bsr       L17B9
+                    leas      $02,s
+                    bra       L17A6
+
+L17A4               clra
+                    clrb
+L17A6               std       ,s
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L1B07
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $06,u
+                    ldd       ,s
+                    puls      pc,u,x
+L17B9               pshs      u
+                    ldu       $04,s
+                    beq       L17CA
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       L17CF
+L17CA               ldd       #$FFFF
+                    puls      pc,u
+L17CF               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L17DF
+                    pshs      u
+                    lbsr      L18A7
+                    leas      $02,s
+L17DF               pshs      u
+                    bsr       L17E5
+                    puls      pc,u,x
+L17E5               pshs      u
+                    ldu       $04,s
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L1817
+                    ldd       ,u
+                    cmpd      $04,u
+                    beq       L1817
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      u
+                    lbsr      L18A3
+                    leas      $02,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L1BCA
+                    leas      $08,s
+L1817               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      L188F
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L188F
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L1866
+                    ldd       $02,u
+                    bra       L185E
+
+L1837               ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L1BBA
+                    leas      $06,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L1854
+                    leax      $04,s
+                    bra       L187E
+
+L1854               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+L185E               std       ,u
+                    ldd       $02,s
+                    bne       L1837
+                    bra       L188F
+
+L1866               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    pshs      d
+                    lbsr      L1BA1
+                    leas      $06,s
+                    cmpd      $02,s
+                    beq       L188F
+                    bra       L1880
+
+L187E               leas      -$04,x
+L1880               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       L189F
+
+L188F               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+L189F               leas      $04,s
+                    puls      pc,u
+L18A3               pshs      u
+                    puls      pc,u
+L18A7               pshs      u
+                    ldu       $04,s
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       L18DF
+                    leas      -$20,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    lbsr      L1A89
+                    leas      $06,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       L18D3
+                    ldd       #$0040
+                    bra       L18D6
+
+L18D3               ldd       #$0080
+L18D6               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $20,s
+L18DF               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       L18EC
+                    puls      pc,u
+L18EC               ldd       $0b,u
+                    bne       L1901
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L18FC
+                    ldd       #$0080
+                    bra       L18FF
+
+L18FC               ldd       #$0100
+L18FF               std       $0b,u
+L1901               ldd       $02,u
+                    bne       L1916
+                    ldd       $0b,u
+                    pshs      d
+                    lbsr      L1CBD
+                    leas      $02,s
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       L191E
+L1916               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       L192D
+
+L191E               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+L192D               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    puls      pc,u
+L1937               pshs      u
+                    ldb       $05,s
+                    sex
+                    tfr       d,x
+                    bra       L195D
+
+L1940               ldd       [$06,s]
+                    addd      #$0004
+                    std       [$06,s]
+                    leax      >L1974,pcr
+                    bra       L1959
+
+L194F               ldb       $05,s
+                    stb       >$006C,y
+                    leax      >$006b,y
+L1959               tfr       x,d
+                    puls      pc,u
+L195D               cmpx      #$0064
+                    beq       L1940
+                    cmpx      #$006F
+                    lbeq      L1940
+                    cmpx      #$0078
+                    lbeq      L1940
+                    bra       L194F
+                    puls      pc,u
+L1974               neg       $0034
+                    nega
+                    leax      >L197F,pcr
+                    tfr       x,d
+                    puls      pc,u
+L197F               neg       $0034
+                    nega
+                    ldu       $04,s
+L1984               ldb       ,u+
+                    bne       L1984
+                    tfr       u,d
+                    subd      $04,s
+                    addd      #$FFFF
+                    puls      pc,u
+L1991               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L199B               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L199B
+                    ldd       $06,s
+                    puls      pc,u,x
+L19AB               pshs      u
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $06,s
+                    std       ,s
+L19B5               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L19B5
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L19C6               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L19C6
+                    ldd       $06,s
+                    puls      pc,u,x
+                    pshs      u
+                    ldu       $04,s
+                    bra       L19EC
+
+L19DC               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    bne       L19EA
+                    clra
+                    clrb
+                    puls      pc,u
+L19EA               leau      $01,u
+L19EC               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L19DC
+                    ldb       [$06,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+                    puls      pc,u
+L1A07               tsta
+                    bne       L1A1C
+                    tst       $02,s
+                    bne       L1A1C
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+L1A1C               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L1A39
+                    inc       ,s
+L1A39               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L1A46
+                    inc       ,s
+L1A46               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+                    rts
+                    tstb
+                    beq       L1A70
+L1A5D               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L1A5D
+                    bra       L1A70
+
+L1A66               tstb
+                    beq       L1A70
+L1A69               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L1A69
+L1A70               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+                    leas      $04,s
+                    rts
+                    tstb
+                    beq       L1A70
+L1A80               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       L1A80
+                    bra       L1A70
+
+L1A89               lda       $05,s
+                    ldb       $03,s
+                    beq       L1ABC
+                    cmpb      #$01
+                    beq       L1ABE
+                    cmpb      #$06
+                    beq       L1ABE
+                    cmpb      #$02
+                    beq       L1AA4
+                    cmpb      #$05
+                    beq       L1AA4
+                    ldb       #$D0
+                    lbra      L1D92
+
+L1AA4               pshs      u
+                    os9       I$GetStt
+                    bcc       L1AB0
+                    puls      u
+                    lbra      L1D92
+
+L1AB0               stx       [$08,s]
+                    ldx       $08,s
+                    stu       $02,x
+                    puls      u
+                    clra
+                    clrb
+                    rts
+
+L1ABC               ldx       $06,s
+L1ABE               os9       I$GetStt
+                    lbra      L1D9B
+                    lda       $05,s
+                    ldb       $03,s
+                    beq       L1AD3
+                    cmpb      #$02
+                    beq       L1ADB
+                    ldb       #$D0
+                    lbra      L1D92
+
+L1AD3               ldx       $06,s
+                    os9       I$SetStt
+                    lbra      L1D9B
+
+L1ADB               pshs      u
+                    ldx       $08,s
+                    ldu       $0a,s
+                    os9       I$SetStt
+                    puls      u
+                    lbra      L1D9B
+                    ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    bcs       L1AF5
+                    os9       I$Close
+L1AF5               lbra      L1D9B
+
+L1AF8               ldx       $02,s
+                    lda       $05,s
+                    os9       I$Open
+                    lbcs      L1D92
+                    tfr       a,b
+                    clra
+                    rts
+
+L1B07               lda       $03,s
+                    os9       I$Close
+                    lbra      L1D9B
+                    ldx       $02,s
+                    ldb       $05,s
+                    os9       I$MakDir
+                    lbra      L1D9B
+
+L1B19               ldx       $02,s
+                    lda       $05,s
+                    ldb       #$0b
+                    os9       I$Create
+                    bcs       L1B28
+L1B24               tfr       a,b
+                    clra
+                    rts
+
+L1B28               cmpb      #$DA
+                    lbne      L1D92
+                    lda       $05,s
+                    bita      #$80
+                    lbne      L1D92
+                    anda      #$07
+                    ldx       $02,s
+                    os9       I$Open
+                    lbcs      L1D92
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+                    bcc       L1B24
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+                    lbra      L1D92
+                    ldx       $02,s
+                    os9       I$Delete
+                    lbra      L1D9B
+                    lda       $03,s
+                    os9       I$Dup
+                    lbcs      L1D92
+                    tfr       a,b
+                    clra
+                    rts
+                    pshs      y
+                    ldx       $06,s
+                    lda       $05,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$Read
+L1B7E               bcc       L1B8D
+                    cmpb      #$D3
+                    bne       L1B88
+                    clra
+                    clrb
+                    puls      pc,y,x
+L1B88               puls      y,x
+                    lbra      L1D92
+
+L1B8D               tfr       y,d
+                    puls      pc,y,x
+                    pshs      y
+                    lda       $05,s
+                    ldx       $06,s
+                    ldy       $08,s
+                    pshs      y
+                    os9       I$ReadLn
+                    bra       L1B7E
+
+L1BA1               pshs      y
+                    ldy       $08,s
+                    beq       L1BB6
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$Write
+L1BAF               bcc       L1BB6
+                    puls      y
+                    lbra      L1D92
+
+L1BB6               tfr       y,d
+                    puls      pc,y
+L1BBA               pshs      y
+                    ldy       $08,s
+                    beq       L1BB6
+                    lda       $05,s
+                    ldx       $06,s
+                    os9       I$WritLn
+                    bra       L1BAF
+
+L1BCA               pshs      u
+                    ldd       $0a,s
+                    bne       L1BD8
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       L1C0C
+
+L1BD8               cmpd      #$0001
+                    beq       L1C03
+                    cmpd      #$0002
+                    beq       L1BF8
+                    ldb       #$F7
+L1BE6               clra
+                    std       $020d,y
+                    ldd       #$FFFF
+                    leax      $0201,y
+                    std       ,x
+                    std       $02,x
+                    puls      pc,u
+L1BF8               lda       $05,s
+                    ldb       #$02
+                    os9       I$GetStt
+                    bcs       L1BE6
+                    bra       L1C0C
+
+L1C03               lda       $05,s
+                    ldb       #$05
+                    os9       I$GetStt
+                    bcs       L1BE6
+L1C0C               tfr       u,d
+                    addd      $08,s
+                    std       $0203,y
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       L1BE6
+                    tfr       d,x
+                    std       $0201,y
+                    lda       $05,s
+                    os9       I$Seek
+                    bcs       L1BE6
+                    leax      $0201,y
+                    puls      pc,u
+L1C31               pshs      u,y
+                    ldx       $06,s
+                    lda       $09,s
+                    asla
+                    asla
+                    asla
+                    asla
+                    ora       $0b,s
+                    os9       F$Link
+L1C40               tfr       u,d
+                    puls      u,y
+                    lbcs      L1D92
+                    rts
+                    pshs      u,y
+                    ldx       $06,s
+                    lda       $09,s
+                    asla
+                    asla
+                    asla
+                    asla
+                    ora       $0b,s
+                    os9       F$Load
+                    bra       L1C40
+
+L1C5A               pshs      u
+                    ldu       $04,s
+                    os9       F$UnLink
+                    puls      u
+                    lbra      L1D9B
+                    ldd       $01FF,y
+                    pshs      d
+                    ldd       $04,s
+                    cmpd      $05DF,y
+                    bcs       L1C9A
+                    addd      $01FF,y
+                    pshs      y
+                    subd      ,s
+                    os9       F$Mem
+                    tfr       y,d
+                    puls      y
+                    bcc       L1C8C
+                    ldd       #$FFFF
+                    leas      $02,s
+                    rts
+
+L1C8C               std       $01FF,y
+                    addd      $05DF,y
+                    subd      ,s
+                    std       $05DF,y
+L1C9A               leas      $02,s
+                    ldd       $05DF,y
+                    pshs      d
+                    subd      $04,s
+                    std       $05DF,y
+                    ldd       $01FF,y
+                    subd      ,s++
+                    pshs      d
+                    clra
+                    ldx       ,s
+L1CB3               sta       ,x+
+                    cmpx      $01FF,y
+                    bcs       L1CB3
+                    puls      pc,d
+L1CBD               ldd       $02,s
+                    addd      $0209,y
+                    bcs       L1CE6
+                    cmpd      $020b,y
+                    bcc       L1CE6
+                    pshs      d
+                    ldx       $0209,y
+                    clra
+L1CD3               cmpx      ,s
+                    bcc       L1CDB
+                    sta       ,x+
+                    bra       L1CD3
+
+L1CDB               ldd       $0209,y
+                    puls      x
+                    stx       $0209,y
+                    rts
+
+L1CE6               ldd       #$FFFF
+                    rts
+                    lda       $03,s
+                    ldb       $05,s
+                    os9       F$Send
+                    lbra      L1D9B
+                    clra
+                    clrb
+                    os9       F$Wait
+                    lbcs      L1D92
+                    ldx       $02,s
+                    beq       L1D05
+                    stb       $01,x
+                    clr       ,x
+L1D05               tfr       a,b
+                    clra
+                    rts
+                    lda       $03,s
+                    ldb       $05,s
+                    os9       F$SPrior
+                    lbra      L1D9B
+
+L1D13               leau      ,s
+                    leas      $00FF,y
+                    ldx       $02,u
+                    ldy       $04,u
+                    lda       $09,u
+                    asla
+                    asla
+                    asla
+                    asla
+                    ora       $0b,u
+                    ldb       $0d,u
+                    ldu       $06,u
+                    os9       F$Chain
+                    os9       F$Exit
+                    pshs      u,y
+                    ldx       $06,s
+                    ldy       $08,s
+                    ldu       $0a,s
+                    lda       $0d,s
+                    ora       $0f,s
+                    ldb       $11,s
+                    os9       F$Fork
+                    puls      u,y
+                    lbcs      L1D92
+                    tfr       a,b
+                    clra
+                    rts
+
+L1D4D               pshs      y
+                    os9       F$ID
+                    puls      y
+                    bcc       L1D5A
+                    lbcs      L1D92
+L1D5A               tfr       a,b
+                    clra
+                    rts
+
+L1D5E               pshs      y
+                    os9       F$ID
+                    bcc       L1D6A
+L1D65               puls      y
+                    lbra      L1D92
+
+L1D6A               tfr       y,d
+                    puls      pc,y
+                    pshs      y
+                    bsr       L1D5E
+                    std       -$02,s
+                    beq       L1D7A
+                    ldb       #$D6
+                    bra       L1D65
+
+L1D7A               ldy       $04,s
+                    os9       F$SUser
+                    bcc       L1D8E
+                    cmpb      #$D0
+                    bne       L1D65
+                    tfr       y,d
+                    ldy       >L004B
+                    std       $09,y
+L1D8E               clra
+                    clrb
+                    puls      pc,y
+L1D92               clra
+                    std       $020d,y
+                    ldd       #$FFFF
+                    rts
+
+L1D9B               bcs       L1D92
+                    clra
+                    clrb
+                    rts
+
+L1DA0               lbsr      L1DAB
+                    lbsr      L1758
+L1DA6               ldd       $02,s
+                    os9       F$Exit
+L1DAB               rts
+
+L1DAC               neg       $0001
+                    neg       $0001
+                    sbca      $0063
+                    lsr       $6D70
+                    bgt       L1E0F
+                    aslb
+                    aslb
+                    aslb
+                    aslb
+                    aslb
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0063
+                    bgt       $1E2B
+                    clr       $0d,s
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $000C
+                    fcb       $CF
+                    beq       L1DF7
+                    com       $00E8
+                    neg       $0064
+                    neg       $000A
+                    neg       L0069
+                    inc       -$08,s
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L1DF7               neg       $0000
+                    fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+L1E0F               neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    leax      0,y
+                    bra       L1F07
+                    bra       L1F09
+                    bra       L1F0B
+                    bra       L1F0D
+                    bra       L1F0F
+                    bra       L1F11
+                    bra       L1F13
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    bra       $1F1F
+                    bra       $1F21
+                    bra       $1F23
+                    bra       L1F47
+                    fcb       $42
+                    fcb       $42
+L1F07               fcb       $42
+                    fcb       $42
+L1F09               fcb       $42
+                    fcb       $02
+L1F0B               fcb       $02
+                    fcb       $02
+L1F0D               fcb       $02
+                    fcb       $02
+L1F0F               fcb       $02
+                    fcb       $02
+L1F11               fcb       $02
+                    fcb       $02
+L1F13               fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    bra       L1F40
+                    bra       L1F42
+                    bra       $1F44
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    bra       $1F60
+
+L1F40               bra       $1F62
+L1F42               fcb       $01
+                    neg       $0001
+                    neg       $005F
+L1F47               neg       $0001
+                    neg       L0069
+                    com       $03,s
+                    leay      0,x
+
+                    emod
+eom                 equ       *
+                    end

--- a/3rdparty/packages/ccompiler/defsfile
+++ b/3rdparty/packages/ccompiler/defsfile
@@ -1,2 +1,3 @@
+Level     set    2
           use    os9.d
           use    scf.d

--- a/3rdparty/packages/ccompiler/make_dis.asm
+++ b/3rdparty/packages/ccompiler/make_dis.asm
@@ -8,7 +8,7 @@ atrv                set       ReEnt+rev
 rev                 set       $01
 edition             set       $12
 
-                    mod       eom,name,tylg,atrv,start,size
+                    mod       eom,name,tylg,atrv,_start,size
 
 u0000               rmb       6775
 size                equ       .
@@ -17,13 +17,13 @@ name                equ       *
                     fcs       /make/
                     fcb       edition
 
-L0012               lda       ,y+
+copybytes           lda       ,y+
 L0014               sta       ,u+
                     leax      -$01,x
-                    bne       L0012
+                    bne       copybytes
                     rts
 
-start               pshs      y
+_start              pshs      y
 L001D               pshs      u
 L001F               clra
 L0020               clrb
@@ -34,23 +34,23 @@ L0024               bne       L0021
                     leau      ,x
 L002A               leax      $16F7,x
 L002E               pshs      x
-L0030               leay      $3A9B,pcr
+L0030               leay      L3A9B,pcr
 L0034               ldx       ,y++
                     beq       L003C
-                    bsr       L0012
+                    bsr       copybytes
 L003A               ldu       $02,s
 L003C               leau      >$0029,u
 L0040               ldx       ,y++
                     beq       L0047
-                    bsr       L0012
-L0046               clra
+                    bsr       copybytes
+                    clra
 L0047               cmpu      ,s
                     beq       L0050
-L004C               sta       ,u+
+                    sta       ,u+
                     bra       L0047
 
 L0050               ldu       $02,s
-L0052               ldd       ,y++
+                    ldd       ,y++
                     beq       L005D
                     leax      >$0000,pcr
                     lbsr      L014F
@@ -74,7 +74,7 @@ L0080               cmpa      #$2C
                     cmpa      #$22
                     beq       L00A4
                     cmpa      #$27
-L008A               beq       L00A4
+                    beq       L00A4
                     leax      -$01,x
                     pshs      x
                     leay      $01,y
@@ -109,7 +109,7 @@ L00BA               tfr       y,d
                     bra       L00D0
 
 L00C8               ldd       ,x
-L00CA               ldu       ,y
+                    ldu       ,y
                     std       ,y
                     stu       ,x++
 L00D0               leay      -$02,y
@@ -135,19 +135,33 @@ L00FB               leax      d,s
                     bcs       L0127
                     stx       $01FB,y
 L010D               rts
-L010E               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
-                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
-                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
-                    fcb       $0d
+
+L010E               bpl       L013A
+                    bpl       $013C
+                    bra       $0167
+                    lsrb
+                    fcb       $41
+                    coma
+                    fcb       $4B
+                    bra       L0169
+                    rorb
+                    fcb       $45,$52
+                    rora
+                    inca
+                    clra
+                    asrb
+                    bra       $014D
+                    bpl       L014F
+                    bpl       L0134
 L0127               leax      L010E,pcr
                     ldb       #$CF
                     pshs      b
                     lda       #$02
                     ldy       #$0064
-                    os9       I$WritLn
+L0134               os9       I$WritLn
                     clra
                     puls      b
-                    lbsr      $3953
+L013A               lbsr      L3953
                     ldd       $01ED,y
                     subd      $01FB,y
                     rts
@@ -307,11 +321,11 @@ L0285               lbsr      L0406
 L0290               pshs      u
                     ldd       #$FFC0
                     lbsr      L00FB
-                    leax      $09E9,pcr
+                    leax      L09E9,pcr
                     stx       $020b,y
                     leax      L09EC,pcr
                     stx       $020f,y
-                    leax      $09EF,pcr
+                    leax      L09EF,pcr
                     stx       $020d,y
                     puls      pc,u
 L02B2               pshs      u
@@ -566,7 +580,7 @@ L050A               ldx       $10,s
                     clrb
                     std       $0019
 L0521               leax      >$0019,y
-                    stx       start
+                    stx       _start
                     clra
                     clrb
                     std       ,s
@@ -737,11 +751,11 @@ L0656               ldd       $0011
 L0677               ldd       #$0004
                     lbsr      L357F
                     std       $10,s
-                    std       [start,y]
+                    std       [_start,y]
                     beq       L069B
                     ldd       $10,s
                     addd      #$0002
-                    std       start
+                    std       _start
                     ldd       $16,s
                     std       [$10,s]
                     clra
@@ -799,7 +813,7 @@ L070A               pshs      u,d
                     ldd       #$FFB4
                     lbsr      L00FB
                     leas      -$02,s
-                    leax      $0CB0,pcr
+                    leax      L0CB0,pcr
                     pshs      x
                     ldd       $04,s
                     lbsr      L279E
@@ -831,7 +845,7 @@ L0741               pshs      u
                     addd      ,s++
                     cmpd      #$1000
                     ble       L076F
-                    leax      $0CB2,pcr
+                    leax      L0CB2,pcr
                     pshs      x
                     ldd       #$0001
                     lbra      L09B8
@@ -1111,177 +1125,60 @@ L09B8               lbsr      L2227
                     lbsr      L3949
 L09C0               leas      $02,s
                     puls      pc,u
-                    com       $01,s
-                    jmp       $07,y
-                    lsr       L206F
-                    neg       $656E
-                    bra       L09F2
-                    bcs       L0A45
-                    bhi       L0A02
-                    bra       L09D6
-
-L09D6               bgt       L09D8
-L09D8               bgt       L09DA
-L09DA               bcs       L0A4F
-                    bra       L0A53
-                    neg       $2074
-                    clr       0,y
-                    lsr       $01,s
-                    lsr       $650D
-                    neg       L0063
-                    com       0,x
-L09EC               com       $03,s
-                    neg       $0072
-                    tst       $01,s
-L09F2               neg       $0053
-                    fcb       $79,$6e,$74,$61,$78,$3a,$20,$6d
-                    fcb       $61,$6b,$65,$20,$7b,$5b
-L0A02               fcb       $3C,$2d,$6f,$70,$74,$73,$3e,$5d
-                    fcb       $20,$5b,$3C,$20,$74,$61,$72,$67
-                    fcb       $65,$74,$20,$66,$69,$6C,$65,$20
-                    fcb       $3e,$5d,$20,$5b,$3C,$20,$6d,$61
-                    fcb       $63,$72,$6f,$73,$20,$3e,$5d,$7d
-                    fcb       $0d,$00
-L0A2C               fcb       $46,$75,$6e,$63,$74,$69,$6f,$6e
-                    fcb       $3a,$20,$6b,$65,$65,$70,$20,$74
-                    fcb       $72,$61,$63,$6b,$20,$6f,$66,$20
-                    fcb       $6d
-L0A45               fcb       $6f,$64,$75,$6C,$65,$73,$20,$66
-                    fcb       $6f,$72
-L0A4F               fcb       $20,$61,$20,$66
-L0A53               fcb       $69,$6C,$65,$0d,$00
-                    clra
-                    neg       $7469
-                    clr       $0e,s
-                    com       L3A0D
-                    neg       L0020
-                    bra       L0A85
-                    bra       L0A94
-                    fcb       $62,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $20,$64,$6f,$6e,$27,$74,$20,$75
-                    fcb       $73,$65,$20,$62,$75,$69,$6C,$74
-                    fcb       $2d,$69,$6e,$20,$72,$75
-L0A85               fcb       $6C,$65,$73,$0d,$00
-                    bra       $0AAC
-                    bra       $0AAE
-                    blt       %0000101011110100
-                    fcb       $20,$20,$20,$20
-L0A94               fcb       $20,$20,$20,$20,$64,$65,$62,$75
-                    fcb       $67,$20,$6d,$6f,$64,$65,$2C,$20
-                    fcb       $70,$72,$69,$6e,$74,$20,$6f,$75
-                    fcb       $74
-L0AAD               fcb       $20,$74,$68,$65,$20,$66,$69,$6C
-                    fcb       $65,$20,$64,$61,$74,$65,$73
-L0ABC               fcb       $20,$69,$6e,$20,$6d,$61,$6b,$65
-                    fcb       $66,$69,$6C,$65,$0d,$00
-                    bra       $0AEC
-                    bra       $0AEE
-                    blt       %0000101100110110
-                    fcb       $3d,$3C,$78,$78,$78,$3e,$20,$20
-                    fcb       $75,$73,$65,$20,$3C,$78,$78,$78
-                    fcb       $3e,$20,$61,$73,$20,$74,$68,$65
-                    fcb       $20,$6d,$61,$6b,$65
-L0AED               fcb       $66,$69,$6C,$65,$20,$20,$28,$64
-                    fcb       $65,$66,$61,$75,$6C,$74,$3a
-L0AFC               fcb       $20,$6d,$61,$6b,$65,$66,$69,$6C
-                    fcb       $65,$29,$0d,$00
-                    bra       $0B2A
-                    bra       $0B2C
-                    blt       %0000101101110111
-                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $69,$67,$6e,$6f,$72,$65,$20,$65
-                    fcb       $72,$72,$6f,$72,$73,$20,$6f,$6e
-                    fcb       $20,$63,$6f,$6d,$6d
-L0B2B               fcb       $61,$6e,$64,$73,$20,$61,$6e,$64
-                    fcb       $20,$6b,$65,$65,$70,$20,$67
-L0B3A               fcb       $6f,$69,$6e,$67,$0d,$00
-                    bra       $0B62
-                    bra       $0B64
-                    blt       %0000101110110100
-                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $64,$6f,$6e,$27,$74,$20,$65,$78
-                    fcb       $65,$63,$75,$74,$65,$20,$63,$6f
-                    fcb       $6d,$6d,$61,$6e,$64
-L0B63               fcb       $73,$2C,$20,$6a,$75,$73,$74,$20
-                    fcb       $70,$72,$69,$6e,$74,$20,$74
-L0B72               fcb       $68,$65,$6d,$20,$6f,$75,$74
-                    fcb       $0d,$00
-                    bra       $0B9D
-                    bra       $0B9F
-                    blt       %0000101111110100
-                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $73,$69,$6C,$65,$6e,$74,$20,$6d
-                    fcb       $6f,$64,$65,$2C,$20,$65,$78,$65
-                    fcb       $63,$75,$74,$65,$20
-L0B9E               fcb       $63,$6f,$6d,$6d,$61,$6e,$64,$73
-                    fcb       $20,$77,$69,$74,$68,$6f,$75
-L0BAD               fcb       $74,$20,$65,$63,$68,$6f,$69,$6e
-                    fcb       $67,$20,$74,$68,$65,$6d,$0d
-                    neg       L0020
-                    bra       L0BE0
-                    bra       L0BEF
-                    fcb       $74,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $20,$75,$70,$64,$61,$74,$65,$20
-                    fcb       $74,$68,$65,$20,$64,$61,$74,$65
-                    fcb       $73,$20,$77,$69,$74,$68
-L0BE0               fcb       $6f,$75,$74,$20,$65,$78,$65,$63
-                    fcb       $75,$74,$69,$6e,$67,$20,$74
-L0BEF               fcb       $68,$65,$20,$63,$6f,$6d,$6d,$61
-                    fcb       $6e,$64,$73,$0d,$00
-L0BFC               bra       $0C1E
-                    bra       $0C20
-                    blt       %0000110001110111
-                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
-                    fcb       $64,$6f,$20,$74,$68,$65,$20,$6d
-                    fcb       $61,$6b,$65,$20,$77,$68,$65,$74
-                    fcb       $68,$65,$72,$20,$69
-L0C1F               fcb       $74,$20,$6e,$65,$65,$64,$73,$20
-                    fcb       $69,$74,$20,$6f,$72,$20,$6e
-L0C2E               fcb       $6f,$74,$0d,$00
-                    bra       $0C54
-                    bra       $0C56
-                    blt       $0CB2
-                    fcb       $5b,$3d,$3C,$70,$61,$74,$68,$3e
-                    fcb       $5d,$20,$67,$65,$74,$20,$6C,$69
-                    fcb       $73,$74,$20,$6f,$66,$20,$66,$69
-                    fcb       $6C,$65,$73,$20,$74
-L0C55               fcb       $6f,$20,$6d,$61,$6b,$65,$20,$66
-                    fcb       $72,$6f,$6d,$20,$73,$74,$64
-L0C64               fcb       $69,$6e,$20,$6f,$72,$20,$70,$61
-                    fcb       $74,$68,$0d,$00
-L0C70               fcb       $6e,$6f,$20,$64,$65,$70,$65,$6e
-                    fcb       $64,$65,$6e,$63,$79,$20,$6C,$69
-                    fcb       $73,$74,$20,$66,$6f,$72,$20,$63
-                    fcb       $6f,$6d,$6d,$61,$6e,$64,$20,$6C
-                    fcb       $69,$6e,$65,$0d,$00
-L0C95               com       $796e
-                    lsr       $6178
-                    bra       $0D02
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    tst       $0022
-                    bcs       L0D18
-                    bhi       L0CA7
-L0CA7               tst       $01,s
-                    fcb       $6b
-                    fcb       $65
-                    ror       $09,s
-                    inc       $05,s
-                    neg       $0072
-                    neg       $0062
-                    fcb       $75,$66,$66,$65,$72,$20,$6f,$76
-                    fcb       $65,$72,$66,$6C,$6f,$77,$20,$2d
-                    fcb       $2d,$20,$6C,$69,$6e,$65,$20,$74
-                    fcb       $6f,$6f,$20,$6C,$6f,$6e,$67
-                    fcb       $0d,$00
-L0CD4               fcb       $75,$6e,$66,$69,$6e,$69,$73,$68
-                    fcb       $65,$64,$20,$63,$6f,$6e,$74,$69
-                    fcb       $6e,$75,$61,$74,$69,$6f,$6e,$20
-                    fcb       $6C,$69,$6e,$65,$0d,$00
-L0CF2               fcb       $6d,$61,$6b,$65,$20,$74,$65,$72
-                    fcb       $6d,$69,$6e,$61,$74,$65
-L0D00               fcb       $64,$0d,$00
+                    fcc       /can't open "%s". /
+                    fcb       $00
+L09D6               fcb       $2E
+                    fcb       $00
+L09D8               fcb       $2E
+                    fcb       $00
+L09DA               fcc       /%s up to date/
+                    fcb       $0D,$00
+L09E9               fcb       $63,$63
+                    fcb       $00
+L09EC               fcb       $63,$63
+                    fcb       $00
+L09EF               fcb       $72,$6D,$61
+                    fcb       $00
+                    fcc       /Syntax: make {[<-opts>] [< target file >] [< macros >]}/
+                    fcb       $0D,$00
+                    fcc       /Function: keep track of modules for a file/
+                    fcb       $0D,$00
+                    fcc       /Options:/
+                    fcb       $0D,$00
+                    fcc       /    -b        don't use built-in rules/
+                    fcb       $0D,$00
+                    fcc       /    -d        debug mode, print out the file dates in makefile/
+                    fcb       $0D,$00
+                    fcc       /    -f=<xxx>  use <xxx> as the makefile  (default: makefile)/
+                    fcb       $0D,$00
+                    fcc       /    -i        ignore errors on commands and keep going/
+                    fcb       $0D,$00
+                    fcc       /    -n        don't execute commands, just print them out/
+                    fcb       $0D,$00
+                    fcc       /    -s        silent mode, execute commands without echoing them/
+                    fcb       $0D,$00
+                    fcc       /    -t        update the dates without executing the commands/
+                    fcb       $0D,$00
+                    fcc       /    -u        do the make whether it needs it or not/
+                    fcb       $0D,$00
+                    fcc       /    -z[=<path>] get list of files to make from stdin or path/
+                    fcb       $0D,$00
+L0C70               fcc       /no dependency list for command line/
+                    fcb       $0D,$00
+L0C95               fcc       /syntax error/
+                    fcb       $0D
+                    fcc       /"%s"/
+                    fcb       $00
+L0CA7               fcc       /makefile/
+                    fcb       $00
+L0CB0               fcb       $72
+                    fcb       $00
+L0CB2               fcc       /buffer overflow -- line too long/
+                    fcb       $0D,$00
+L0CD4               fcc       /unfinished continuation line/
+                    fcb       $0D,$00
+L0CF2               fcc       /make terminated/
+                    fcb       $0D,$00
 L0D03               pshs      u
                     tfr       d,u
                     ldd       #$FFAE
@@ -1293,7 +1190,7 @@ L0D03               pshs      u
 
 L0D16               clra
                     clrb
-L0D18               std       $08,s
+                    std       $08,s
                     std       $0a,s
                     bra       L0D29
 
@@ -1555,7 +1452,7 @@ L0F3A               ldx       ,u
                     leax      >$0043,y
                     leax      d,x
                     pshs      x
-                    leax      $12E0,pcr
+                    leax      L12E0,pcr
                     tfr       x,d
                     lbsr      L209B
                     leas      $04,s
@@ -1616,7 +1513,7 @@ L0FBE               ldx       ,u
                     pshs      d
                     ldd       $0a,s
                     pshs      d
-                    leax      $130C,pcr
+                    leax      L130C,pcr
                     tfr       x,d
                     lbsr      L209B
                     leas      $04,s
@@ -1716,7 +1613,7 @@ L10AE               ldd       L0021
                     ldx       ,u
                     ldd       $02,x
                     pshs      d
-                    leax      $1341,pcr
+                    leax      L1341,pcr
                     pshs      x
                     ldd       #$0001
                     lbsr      L2227
@@ -1893,83 +1790,32 @@ L1239               ldx       ,s
 L1246               tfr       u,d
 L1248               leas      $02,s
                     puls      pc,u
-L124C               fcb       $63,$68,$65,$63,$6b,$69,$6e,$67
-                    fcb       $20,$66,$6f,$72,$20,$69,$6d,$70
-                    fcb       $6C,$69,$63,$69,$74,$20,$72,$65
-                    fcb       $6C,$6f,$63,$61,$74,$61,$62,$6C
-                    fcb       $65,$20,$66,$69,$6C,$65,$73
-                    fcb       $0d,$00
-L1275               fcb       $63,$68,$65,$63,$6b,$69,$6e,$67
-                    fcb       $20,$66,$6f,$72,$20,$69,$6d,$70
-                    fcb       $6C,$69,$63,$69,$74,$20,$73,$6f
-                    fcb       $75,$72,$63,$65,$20,$66,$69,$6C
-                    fcb       $65,$73,$0d,$00
-L1299               bcs       L130E
-                    ror       $09,s
-                    inc       $05,s
-                    abx
-                    bra       L12C7
-                    com       L0D00
-L12A5               fcb       $66,$6f,$75,$6e,$64,$20,$6f,$62
-                    fcb       $6a,$65,$63,$74,$20,$66,$69,$6C
-                    fcb       $65,$28,$6C,$65,$76,$65,$6C,$20
-                    fcb       $25,$64,$29,$3a,$20,$25,$73
-                    fcb       $0d,$00
-L12C6               fcb       $6e
-L12C7               fcb       $6f,$20,$65,$78,$70,$6C,$69,$63
-                    fcb       $69,$74,$20,$22,$2e,$72,$22,$20
-                    fcb       $66,$69,$6C,$65,$0d,$00
-L12DD               bgt       $1351
-                    neg       $0025
-                    com       $6669
-                    inc       $05,s
-                    abx
-                    bra       L130E
-                    com       L0D00
-L12EC               fcb       $6e,$6f,$20,$65,$78,$70,$6C,$69
-                    fcb       $63,$69,$74,$20,$73,$6f,$75,$72
-                    fcb       $63,$65,$20,$66,$69,$6C,$65,$20
-                    fcb       $6C,$69,$73,$74,$65,$64,$0d
-                    neg       L0066
-                    fcb       $6f
-L130E               fcb       $75,$6e,$64,$20,$64,$65,$70,$65
-                    fcb       $6e,$64,$65,$6e,$74,$20,$28,$6C
-                    fcb       $65,$76,$65,$6C,$20,$25,$64,$29
-                    fcb       $3a,$20,$25,$73,$0d,$00
-L132C               lsr       0,x
-L132E               com       $01,s
-                    jmp       $07,y
-                    lsr       L2072
-                    fcb       $65
-                    fcb       $61
-                    lsr       0,y
-                    bhi       $1360
-                    com       $222E
-                    bra       $1360
-                    neg       L0063
-                    fcb       $61
-                    jmp       $07,y
-                    lsr       $2066
-                    rol       $0e,s
-                    lsr       0,y
-                    com       $6F75
-                    fcb       $72
-                    com       $05,s
-                    bra       $13BA
-                    rol       $0C,s
-                    fcb       $65
-                    bra       $13CD
-                    clr       0,y
-                    tst       $01,s
-                    fcb       $6b
-                    fcb       $65
-                    bra       $1383
-                    bcs       $13D6
-                    bhi       L1365
-L1365               fcb       $66,$6f,$75,$6e,$64,$20,$22,$25
-                    fcb       $73,$22,$20,$74,$6f,$20,$6d,$61
-                    fcb       $6b,$65,$20,$22,$25,$73,$22
-                    fcb       $0d,$00
+L124C               fcc       /checking for implicit relocatable files/
+                    fcb       $0D,$00
+L1275               fcc       /checking for implicit source files/
+                    fcb       $0D,$00
+L1299               fcc       /%sfile: %s/
+                    fcb       $0D,$00
+L12A5               fcc       /found object file(level %d): %s/
+                    fcb       $0D,$00
+L12C6               fcc       /no explicit ".r" file/
+                    fcb       $0D,$00
+L12DD               fcb       $2E,$72
+                    fcb       $00
+L12E0               fcc       /%sfile: %s/
+                    fcb       $0D,$00
+L12EC               fcc       /no explicit source file listed/
+                    fcb       $0D,$00
+L130C               fcc       /found dependent (level %d): %s/
+                    fcb       $0D,$00
+L132C               fcb       $64
+                    fcb       $00
+L132E               fcc       /can't read "%s".  /
+                    fcb       $00
+L1341               fcc       /can't find source file to make "%s"/
+                    fcb       $00
+L1365               fcc       /found "%s" to make "%s"/
+                    fcb       $0D,$00
 L137E               pshs      u
                     tfr       d,u
                     ldd       #$FFAE
@@ -2208,14 +2054,14 @@ L1584               pshs      u,d
                     clrb
                     pshs      d
                     ldd       $1C,s
-                    lbsr      $36CC
+                    lbsr      L36CC
                     leas      $02,s
                     std       $12,s
                     bge       L15E5
                     ldd       #$0080
                     pshs      d
                     ldd       $1C,s
-                    lbsr      $36CC
+                    lbsr      L36CC
                     leas      $02,s
                     std       $12,s
                     bge       L15E5
@@ -2243,7 +2089,7 @@ L15E5               ldb       [,s]
                     leax      $04,s
                     pshs      x
                     ldd       $16,s
-                    lbsr      $3928
+                    lbsr      L3928
                     leas      $04,s
                     cmpd      #$FFFF
                     bne       L1617
@@ -2352,7 +2198,7 @@ L16C5               pshs      u,d
                     beq       L16F2
                     ldd       $04,x
                     pshs      d
-                    leax      $1E82,pcr
+                    leax      L1E82,pcr
                     tfr       x,d
                     lbsr      L209B
                     leas      $02,s
@@ -2603,7 +2449,7 @@ L18E2               clra
                     lbsr      $33CF
                     pshs      d
                     ldd       $0a,s
-                    lbsr      $38E4
+                    lbsr      L38E4
                     leas      $0a,s
                     std       $06,s
                     cmpd      #$FFFF
@@ -2616,7 +2462,7 @@ L18E2               clra
                     bne       L192F
                     ldd       $0a,s
                     bne       L192F
-                    leax      $1ED0,pcr
+                    leax      L1ED0,pcr
                     bra       L1921
 
 L191D               leax      L1EE7,pcr
@@ -2633,7 +2479,7 @@ L1933               pshs      u,d
                     leas      -$04,s
 L193D               leax      ,s
                     tfr       x,d
-                    lbsr      $38A6
+                    lbsr      L38A6
                     std       $02,s
                     cmpd      #$FFFF
                     beq       L1977
@@ -2806,7 +2652,7 @@ L1AAA               ldd       $28,s
                     leas      $02,s
 L1AD8               ldd       $0227,y
                     beq       L1B02
-                    leax      $1F26,pcr
+                    leax      L1F26,pcr
                     pshs      x
                     ldd       $0003
                     lbsr      L33FA
@@ -2822,7 +2668,7 @@ L1AD8               ldd       $0227,y
                     stb       -$01,x
                     bra       L1B0F
 
-L1B02               leax      $1F2B,pcr
+L1B02               leax      L1F2B,pcr
                     pshs      x
                     ldd       $0003
                     lbsr      L33FA
@@ -2863,7 +2709,7 @@ L1B52               leas      $02,s
                     leas      $02,s
                     lbsr      L33FA
                     leas      $02,s
-L1B6C               leax      $1F34,pcr
+L1B6C               leax      L1F34,pcr
                     pshs      x
                     ldd       $01FF,y
                     lbsr      L3427
@@ -2871,7 +2717,7 @@ L1B6C               leax      $1F34,pcr
                     beq       L1B9A
                     ldd       $1e,s
                     bne       L1B9A
-                    leax      $1F36,pcr
+                    leax      L1F36,pcr
                     pshs      x
                     ldd       $01FF,y
                     pshs      d
@@ -2880,7 +2726,7 @@ L1B6C               leax      $1F34,pcr
                     leas      $02,s
                     lbsr      L33FA
                     leas      $02,s
-L1B9A               leax      $1F38,pcr
+L1B9A               leax      L1F38,pcr
                     pshs      x
                     ldd       $2C,s
                     pshs      d
@@ -2921,7 +2767,7 @@ L1BFF               ldd       $1e,s
                     bne       L1C22
                     ldd       $0227,y
                     beq       L1C22
-                    leax      $1F3D,pcr
+                    leax      L1F3D,pcr
                     pshs      x
                     ldd       $0201,y
                     pshs      d
@@ -2930,7 +2776,7 @@ L1BFF               ldd       $1e,s
                     leas      $02,s
                     lbsr      L33FA
                     leas      $02,s
-L1C22               leax      $1F3F,pcr
+L1C22               leax      L1F3F,pcr
                     pshs      x
                     ldd       $2C,s
                     pshs      d
@@ -2943,7 +2789,7 @@ L1C22               leax      $1F3F,pcr
                     bne       L1C56
                     ldd       $0203,y
                     beq       L1C56
-                    leax      $1F44,pcr
+                    leax      L1F44,pcr
                     pshs      x,d
                     ldd       $0003
                     lbsr      L33FA
@@ -2955,7 +2801,7 @@ L1C56               ldd       $2C,s
                     ldd       $0003
                     lbsr      L33FA
 L1C60               leas      $02,s
-L1C62               leax      $1F46,pcr
+L1C62               leax      L1F46,pcr
                     pshs      x
                     ldd       $0003
                     lbsr      L33FA
@@ -2998,7 +2844,7 @@ L1CA7               ldd       $66,s
                     pshs      u
                     ldd       $0201,y
                     pshs      d
-                    leax      $1F48,pcr
+                    leax      L1F48,pcr
                     bra       L1D03
 
 L1CCB               ldd       $0225,y
@@ -3010,7 +2856,7 @@ L1CCB               ldd       $0225,y
                     pshs      u
                     ldd       $0203,y
                     pshs      d
-                    leax      $1F4E,pcr
+                    leax      L1F4E,pcr
                     bra       L1D03
 
 L1CE8               ldd       $0223,y
@@ -3022,7 +2868,7 @@ L1CE8               ldd       $0223,y
                     pshs      u
                     ldd       $01FF,y
                     pshs      d
-                    leax      $1F54,pcr
+                    leax      L1F54,pcr
 L1D03               pshs      x
                     leax      $08,s
                     tfr       x,d
@@ -3039,7 +2885,7 @@ L1D1B               ldd       #$0002
                     pshs      d
                     leax      $04,s
                     tfr       x,d
-                    lbsr      $36CC
+                    lbsr      L36CC
                     leas      $02,s
                     std       $68,s
                     bge       L1D44
@@ -3055,7 +2901,7 @@ L1D44               ldd       $0219,y
                     bne       L1D5F
                     leax      $02,s
                     pshs      x
-                    leax      $1F5A,pcr
+                    leax      L1F5A,pcr
                     pshs      x
                     leax      $00B4,y
                     tfr       x,d
@@ -3108,7 +2954,7 @@ L1D6A               pshs      u
                     leax      >$0078,y
                     leax      d,x
                     pshs      x
-                    leax      $1F69,pcr
+                    leax      L1F69,pcr
                     tfr       x,d
                     lbsr      L28EF
                     leas      $0e,s
@@ -3186,95 +3032,59 @@ L1E3E               pshs      u
                     lbsr      L33FA
                     leas      $02,s
                     puls      pc,u
-L1E64               ble       L1E66
-L1E66               ble       L1E68
-L1E68               ble       L1E6A
-L1E6A               asr       $05,s
-                    lsr       $7374
-                    fcb       $61
-                    lsr       L2065
-                    fcb       $72
-                    fcb       $72
-                    clr       -$0e,s
-                    bra       L1EA6
-                    bra       L1E9D
-                    bcs       L1EF0
-                    bhi       L1EAD
-                    bra       L1EA1
-                    neg       L0063
-                    clr       $0d,s
-                    tst       $01,s
-                    jmp       $04,s
-                    abx
-                    bra       L1EB1
-                    com       L0D00
-L1E8F               fcb       $6e,$6f,$20,$65,$78,$70,$6C,$69
-                    fcb       $63,$69,$74,$20,$63,$6f
-L1E9D               fcb       $6d,$6d,$61,$6e
-L1EA1               fcb       $64,$0d,$00
-L1EA4               fcb       $22,$25
-L1EA6               fcb       $73,$22,$20,$2d,$20,$75,$6e
-L1EAD               fcb       $6b,$6e,$6f,$77
-L1EB1               fcb       $6e,$20,$6d,$61,$63,$72,$6f,$20
-                    fcb       $6f,$6e,$20,$63,$6f,$6d,$6d,$61
-                    fcb       $6e,$64,$20,$6C,$69,$6e,$65
-                    fcb       $0d,$00
-L1ECA               com       $6865
-                    inc       $0C,s
-                    neg       L0061
-                    fcb       $62,$6f,$72,$74,$65,$64,$20,$64
-                    fcb       $75,$65,$20,$74,$6f,$20,$65,$72
-                    fcb       $72,$6f,$72,$73,$0d,$00
-L1EE7               fcb       $61,$62,$6f,$72,$74,$65,$64,$20
-                    fcb       $64
-L1EF0               fcb       $75,$65,$20,$74,$6f,$20,$65,$72
-                    fcb       $72,$6f,$72,$73,$0d,$00
-L1EFE               fcb       $64,$6f,$6e,$27,$74,$20,$6b,$6e
-                    fcb       $6f,$77,$20,$61,$62,$6f,$75,$74
-                    fcb       $20,$27,$66,$27,$20,$6f,$72,$20
-                    fcb       $27,$70,$27,$20,$63,$6f,$6d,$70
-                    fcb       $69,$6C,$65,$72,$73,$2e,$0d
-                    neg       L0020
-                    blt       $1F9B
-                    mul
-                    neg       L0020
-                    blt       $1FA0
-                    bra       L1F30
-L1F30               fcb       $72
-                    pshu      y,x,dp
-                    neg       L002E
-                    neg       $002F
-                    neg       L0020
-                    blt       L1FAA
-                    mul
-                    neg       $002F
-                    neg       L0020
-                    blt       $1FA8
-                    mul
-                    neg       $002F
-                    neg       $000D
-                    neg       $0025
-                    com       $2F25
-                    com       >$0025
-                    com       $2F25
-                    com       >$0025
-                    com       $2F25
-                    com       >$0075
-                    neg       $6461
-                    lsr       $6564
-                    abx
-                    bra       L1F86
-                    bcs       $1FD9
-                    bhi       L1F75
-                    neg       $0025
-                    fcb       $73,$25,$2d,$33,$32,$73,$20,$64
-                    fcb       $61,$74,$65
-L1F75               fcb       $3a,$20,$25,$30,$32,$64,$2f,$25
-                    fcb       $30,$32,$64,$2f,$25,$30,$32,$64
-                    fcb       $20
-L1F86               fcb       $25,$30,$32,$64,$3a,$25,$30,$32
-                    fcb       $64,$0d,$00
-L1F91               ble       L1F93
+L1E64               fcb       $2F
+                    fcb       $00
+L1E66               fcb       $2F
+                    fcb       $00
+L1E68               fcb       $2F
+                    fcb       $00
+L1E6A               fcc       /getstat error - "%s".  /
+                    fcb       $00
+L1E82               fcc       /command: %s/
+                    fcb       $0D,$00
+L1E8F               fcc       /no explicit command/
+                    fcb       $0D,$00
+L1EA4               fcc       /"%s" - unknown macro on command line/
+                    fcb       $0D,$00
+L1ECA               fcc       /shell/
+                    fcb       $00
+L1ED0               fcc       /aborted due to errors/
+                    fcb       $0D,$00
+L1EE7               fcc       /aborted due to errors/
+                    fcb       $0D,$00
+L1EFE               fcc       /don't know about 'f' or 'p' compilers./
+                    fcb       $0D,$00
+L1F26               fcc       / -r=/
+                    fcb       $00
+L1F2B               fcc       / -r /
+                    fcb       $00
+L1F30               fcb       $72,$36,$38
+                    fcb       $00
+L1F34               fcb       $2E
+                    fcb       $00
+L1F36               fcb       $2F
+                    fcb       $00
+L1F38               fcc       / -o=/
+                    fcb       $00
+L1F3D               fcb       $2F
+                    fcb       $00
+L1F3F               fcc       / -f=/
+                    fcb       $00
+L1F44               fcb       $2F
+                    fcb       $00
+L1F46               fcb       $0D,$00
+L1F48               fcc       |%s/%s|
+                    fcb       $00
+L1F4E               fcc       |%s/%s|
+                    fcb       $00
+L1F54               fcc       |%s/%s|
+                    fcb       $00
+L1F5A               fcc       /updated: "%s"/
+                    fcb       $0D,$00
+L1F69               fcc       |%s%-32s date: %02d/%02d/%02d %02d:%02d|
+                    fcb       $0D,$00
+L1F91               fcb       $2F
+                    fcb       $00
 L1F93               pshs      u
                     tfr       d,u
                     ldd       #$FFB8
@@ -3284,7 +3094,7 @@ L1F93               pshs      u
                     lbsr      $33CF
                     addd      #$000E
                     lbsr      L21FB
-L1FAA               std       ,s
+                    std       ,s
                     pshs      u
                     ldd       $02,s
                     lbsr      L2015
@@ -3378,16 +3188,14 @@ L2065               ldd       $02,s
                     pshs      d
                     leax      >L207E,pcr
                     pshs      x
-L206F               ldd       #$0001
-L2072               lbsr      L2227
+                    ldd       #$0001
+                    lbsr      L2227
                     leas      $04,s
                     lbsr      L3949
 L207A               leas      $04,s
                     puls      pc,u
-L207E               fcb       $63,$61,$6e,$27,$74,$20,$66,$69
-                    fcb       $6e,$64,$20,$74,$61,$72,$67,$65
-                    fcb       $74,$20,$66,$69,$6C,$65,$3a,$20
-                    fcb       $25,$73,$2e,$0d,$00
+L207E               fcc       /can't find target file: %s./
+                    fcb       $0D,$00
 L209B               pshs      u,d
                     ldd       #$FFB4
                     lbsr      L00FB
@@ -3559,7 +3367,7 @@ L21FB               pshs      u
                     lbsr      L00FB
                     leas      -$02,s
                     tfr       u,d
-                    lbsr      $380B
+                    lbsr      L380B
                     std       ,s
                     cmpd      #$FFFF
                     bne       L225C
@@ -3576,7 +3384,7 @@ L2227               pshs      u,d
                     lbsr      L00FB
                     leax      $00A7,y
                     pshs      x
-                    leax      >$2285,pcr
+                    leax      >L2285,pcr
                     tfr       x,d
                     lbsr      L280A
                     leas      $02,s
@@ -3594,33 +3402,11 @@ L2227               pshs      u,d
 L225C               ldd       ,s
 L225E               leas      $02,s
                     puls      pc,u
-L2262               bra       $2291
-                    bra       $22D9
-                    rol       $7374
-                    fcb       $65
-                    tst       0,y
-                    tst       $05,s
-                    tst       $0f,s
-                    fcb       $72
-                    rol       L2072
-                    fcb       $65
-                    fcb       $71
-                    fcb       $75
-                    fcb       $65
-                    com       $7420
-                    lsr       $05,s
-                    jmp       $09,s
-                    fcb       $65
-                    lsr       $0e,y
-                    bra       L22A4
-                    neg       $006D
-                    fcb       $61
-                    fcb       $6b
-                    fcb       $65
-                    abx
-                    bra       L228C
-
-L228C               tst       $0000
+L2262               fcc       / - system memory request denied.  /
+                    fcb       $00
+L2285               fcc       /make: /
+                    fcb       $00
+L228C               fcb       $0D,$00
 L228E               pshs      u
                     tfr       d,u
                     ldd       #$FFB2
@@ -3630,7 +3416,7 @@ L228E               pshs      u
                     ldd       $0213,y
                     beq       L22D3
                     tfr       u,d
-L22A4               lbsr      L27EA
+                    lbsr      L27EA
                     bra       L22D3
 
 L22A9               ldx       $04,s
@@ -3721,7 +3507,7 @@ L2310               tfr       u,d
                     std       $0223,y
                     lbra      L24A8
 
-L2372               leax      $2611,pcr
+L2372               leax      L2611,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3736,7 +3522,7 @@ L2372               leax      $2611,pcr
                     std       $0227,y
                     lbra      L24A8
 
-L239E               leax      $2616,pcr
+L239E               leax      L2616,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3751,7 +3537,7 @@ L239E               leax      $2616,pcr
                     std       $0225,y
                     lbra      L24A8
 
-L23CA               leax      $261B,pcr
+L23CA               leax      L261B,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3763,7 +3549,7 @@ L23CA               leax      $261B,pcr
                     std       $0207,y
                     lbra      L24A8
 
-L23EB               leax      $2622,pcr
+L23EB               leax      L2622,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3775,7 +3561,7 @@ L23EB               leax      $2622,pcr
                     std       $0209,y
                     lbra      L24A8
 
-L240C               leax      $2629,pcr
+L240C               leax      L2629,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3787,7 +3573,7 @@ L240C               leax      $2629,pcr
                     std       $0205,y
                     lbra      L24A8
 
-L242D               leax      $2630,pcr
+L242D               leax      L2630,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3802,7 +3588,7 @@ L242D               leax      $2630,pcr
                     std       $0229,y
                     bra       L24A8
 
-L2458               leax      $2633,pcr
+L2458               leax      L2633,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3817,7 +3603,7 @@ L2458               leax      $2633,pcr
                     std       $022b,y
                     bra       L24A8
 
-L2481               leax      $2636,pcr
+L2481               leax      L2636,pcr
                     pshs      x
                     tfr       u,d
                     lbsr      L3427
@@ -3950,7 +3736,7 @@ L25A0               ldb       [$08,s]
 
 L25A7               ldd       $06,s
                     pshs      d
-                    leax      $2639,pcr
+                    leax      L2639,pcr
                     pshs      x
                     ldd       #$0001
                     lbsr      L2227
@@ -3995,53 +3781,26 @@ L2606               clra
                     clrb
 L2608               leas      $02,s
                     puls      pc,u
-L260C               comb
-                    lsra
-                    rola
-                    fcb       $52
-                    neg       L0052
-                    lsra
-                    rola
-                    fcb       $52
-                    neg       $004F
-                    lsra
-                    rola
-                    fcb       $52
-                    neg       $0043
-                    rora
-                    inca
-                    fcb       $41
-                    asra
-                    comb
-                    neg       L0052
-                    rora
-                    inca
-                    fcb       $41
-                    asra
-                    comb
-                    neg       L004C
-                    rora
-                    inca
-                    fcb       $41
-                    asra
-                    comb
-                    neg       $0043
-                    coma
-                    neg       L0052
-                    coma
-                    neg       L004C
-                    coma
-                    neg       $0022
-                    bcs       L26AF
-                    bhi       $265E
-                    blt       $2660
-                    fcb       $75
-                    jmp       $0b,s
-                    jmp       $0f,s
-                    asr       $6E20
-                    tst       $01,s
-                    com       -$0e,s
-                    clr       0,x
+L260C               fcc       /SDIR/
+                    fcb       $00
+L2611               fcc       /RDIR/
+                    fcb       $00
+L2616               fcc       /ODIR/
+                    fcb       $00
+L261B               fcc       /CFLAGS/
+                    fcb       $00
+L2622               fcc       /RFLAGS/
+                    fcb       $00
+L2629               fcc       /LFLAGS/
+                    fcb       $00
+L2630               fcb       $43,$43
+                    fcb       $00
+L2633               fcb       $52,$43
+                    fcb       $00
+L2636               fcb       $4C,$43
+                    fcb       $00
+L2639               fcc       /"%s" - unknown macro/
+                    fcb       $00
 L264E               pshs      u
                     leau      $009a,y
 L2654               ldd       $06,u
@@ -4089,7 +3848,7 @@ L269E               ldd       $06,u
                     cmpb      #$64
                     bne       L26B1
 L26AC               ldd       #$0001
-L26AF               bra       L26B4
+                    bra       L26B4
 
 L26B1               ldd       #$0002
 L26B4               ora       ,s+
@@ -4156,7 +3915,7 @@ L271C               ldd       ,s
                     orb       #$02
                     pshs      d
                     tfr       u,d
-                    lbsr      $36CC
+                    lbsr      L36CC
                     leas      $02,s
                     std       $02,s
                     cmpd      #$FFFF
@@ -4168,7 +3927,7 @@ L271C               ldd       ,s
                     pshs      d
                     pshs      d
                     ldd       $08,s
-                    lbsr      $37A0
+                    lbsr      L37A0
                     leas      $06,s
                     bra       L278A
 
@@ -4176,14 +3935,14 @@ L2745               ldd       ,s
                     orb       #$02
                     pshs      d
                     tfr       u,d
-                    lbsr      $36EA
+                    lbsr      L36EA
                     bra       L275D
 
 L2752               ldd       ,s
                     orb       #$81
 L2756               pshs      d
                     tfr       u,d
-                    lbsr      $36CC
+                    lbsr      L36CC
 L275D               leas      $02,s
                     std       $02,s
                     bra       L278A
@@ -5019,7 +4778,7 @@ L2E1F               leax      $02,s
                     pshs      d
                     tfr       u,d
                     lbsr      L2F09
-                    lbsr      $396C
+                    lbsr      L396C
                     lbsr      L39E5
 L2E36               ldd       $0b,u
                     lbsr      L39CC
@@ -5033,17 +4792,16 @@ L2E36               ldd       $0b,u
                     ldd       ,x
                     pshs      d
                     bsr       L2E53
-                    neg       $0000
-                    neg       $0000
+                    fcb       $00,$00,$00,$00
 L2E53               puls      x
-                    lbsr      $3981
+                    lbsr      L3981
                     bge       L2E61
                     leax      $06,s
                     lbsr      L39A5
                     bra       L2E63
 
 L2E61               leax      $06,s
-L2E63               lbsr      $3981
+L2E63               lbsr      L3981
                     blt       L2E92
                     ldd       $04,s
                     addd      ,u
@@ -5075,7 +4833,7 @@ L2E92               ldd       $0e,s
                     ldd       $04,u
                     subd      ,u
                     lbsr      L39CC
-                    lbsr      $396C
+                    lbsr      L396C
                     lbsr      L39E5
 L2EB3               ldd       $04,u
 L2EB5               std       ,u
@@ -5090,16 +4848,16 @@ L2EB7               ldd       $06,u
                     ldd       ,x
                     pshs      d
                     ldd       $08,u
-                    lbsr      $37A0
+                    lbsr      L37A0
                     leas      $06,s
                     ldd       $02,x
                     pshs      d
                     ldd       ,x
                     pshs      d
-                    bsr       $2EE0
-                    stu       $FFFF
-                    stu       L3510
-                    lbsr      $3981
+                    bsr       L2EE0
+                    fcb       $FF,$FF,$FF,$FF
+L2EE0               puls      x
+                    lbsr      L3981
                     bne       L2EEC
                     ldd       #$FFFF
                     bra       L2EEE
@@ -5129,9 +4887,9 @@ L2F09               pshs      u
                     clra
                     andb      #$03
                     bne       L2F2D
-L2F1A               bsr       $2F20
-                    stu       $FFFF
-                    stu       L3510
+L2F1A               bsr       L2F20
+                    fcb       $FF,$FF,$FF,$FF
+L2F20               puls      x
                     leau      $01F1,y
                     pshs      u
                     lbsr      L39E5
@@ -5150,7 +4908,7 @@ L2F3B               ldd       #$0001
                     pshs      d
                     pshs      d
                     ldd       $08,u
-                    lbsr      $37A0
+                    lbsr      L37A0
                     leas      $06,s
                     ldd       $02,x
                     pshs      d
@@ -5197,10 +4955,10 @@ L2F94               ldd       $06,u
                     clra
                     andb      #$40
                     beq       L2FB1
-                    leax      $3787,pcr
+                    leax      L3787,pcr
                     bra       L2FB5
 
-L2FB1               leax      $3777,pcr
+L2FB1               leax      L3777,pcr
 L2FB5               tfr       x,d
                     tfr       d,x
                     ldd       $08,u
@@ -5248,7 +5006,7 @@ L3008               tfr       u,d
                     pshs      d
                     pshs      u
                     ldd       #$0008
-                    lbsr      $3A78
+                    lbsr      L3A78
                     lbsr      L2F72
                     leas      $02,s
                     ldd       $04,s
@@ -5256,7 +5014,8 @@ L3008               tfr       u,d
                     tfr       u,d
                     lbsr      L2F72
                     lbra      L308C
-                    pshs      u,d
+
+L3037               pshs      u,d
                     leau      $009a,y
                     clra
                     clrb
@@ -5345,7 +5104,7 @@ L30BE               pshs      u
                     ldd       ,x
                     pshs      d
                     ldd       $08,u
-                    lbsr      $37A0
+                    lbsr      L37A0
                     leas      $06,s
 L30EC               ldd       ,u
                     subd      $02,u
@@ -5368,7 +5127,7 @@ L310C               ldd       $02,s
                     ldd       ,u
                     pshs      d
                     ldd       $08,u
-                    lbsr      $3787
+                    lbsr      L3787
                     leas      $04,s
                     std       ,s
                     cmpd      #$FFFF
@@ -5391,7 +5150,7 @@ L3139               ldd       $02,s
                     ldd       $02,u
                     pshs      d
                     ldd       $08,u
-                    lbsr      $3777
+                    lbsr      L3777
                     leas      $04,s
                     cmpd      $02,s
                     beq       L3160
@@ -5551,7 +5310,7 @@ L3286               ldd       $06,u
                     clra
                     andb      #$40
                     beq       L32A2
-                    leax      $3761,pcr
+                    leax      L3761,pcr
                     bra       L32A6
 
 L32A2               leax      L3753,pcr
@@ -5643,7 +5402,7 @@ L3350               std       $0b,u
 L3352               ldd       $02,u
                     bne       L3363
                     ldd       $0b,u
-                    lbsr      $3871
+                    lbsr      L3871
                     std       $02,u
                     cmpd      #$FFFF
                     beq       L336B
@@ -5865,7 +5624,7 @@ L350A               ldd       $0a,s
                     bge       L3512
                     clra
                     clrb
-L3510               stb       [,s]
+                    stb       [,s]
 L3512               ldd       $02,s
                     leas      $04,s
                     puls      pc,u
@@ -5893,7 +5652,7 @@ L3539               pshs      u,d
                     addd      #$00FF
                     pshs      d
                     ldd       #$0008
-                    lbsr      $3A78
+                    lbsr      L3A78
                     pshs      d
                     ldd       #$0008
                     lbsr      L3A8F
@@ -5902,7 +5661,7 @@ L3539               pshs      u,d
                     rola
                     aslb
                     rola
-                    lbsr      $380B
+                    lbsr      L380B
                     tfr       d,u
                     cmpu      #$FFFF
                     bne       L3567
@@ -6046,158 +5805,164 @@ L3658               std       ,u
 L3677               stu       ,x
 L3679               tfr       x,d
                     std       $01EB,y
-                    bra       $36A5
+                    bra       L36A5
                     pshs      u,d
                     leas      -$02,s
                     ldd       $02,s
-                    pshs      u,dp,d,cc
-                    ror       $00EC
-                    dec       -$09,x
-                    com       $008B
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      L3A19
                     std       ,s
-                    lbsr      $3580
+                    lbsr      L357F
                     tfr       d,u
                     stu       -$02,s
-                    beq       L36A4
+                    beq       L36A3
                     ldd       ,s
                     pshs      d
                     tfr       u,d
-                    bsr       L36AA
+                    bsr       L36A9
                     leas      $02,s
-L36A4               tfr       u,d
-                    leas      $04,s
+L36A3               tfr       u,d
+L36A5               leas      $04,s
                     puls      pc,u
-L36AA               pshs      u
+L36A9               pshs      u
                     tfr       d,u
-                    bra       L36B4
+                    bra       L36B3
 
-L36B0               clra
+L36AF               clra
                     clrb
                     stb       ,u+
-L36B4               ldd       $04,s
+L36B3               ldd       $04,s
                     addd      #$FFFF
                     std       $04,s
                     subd      #$FFFF
-                    bne       L36B0
+                    bne       L36AF
                     puls      pc,u
                     tfr       d,x
                     lda       $03,s
                     os9       I$Open
-                    bcc       L36DC
-                    bra       L36DF
-                    tfr       d,x
+                    bcc       L36DB
+                    bra       L36DE
+
+L36CC               tfr       d,x
                     lda       $03,s
                     os9       I$Open
-                    bcs       L372E
+                    bcs       L372D
                     tfr       a,b
                     clra
-L36D9               rts
-                    tfr       b,a
-L36DC               os9       I$Close
-L36DF               lbra      L3945
+                    rts
+
+L36D9               tfr       b,a
+L36DB               os9       I$Close
+L36DE               lbra      L3944
                     tfr       d,x
                     ldb       $03,s
                     os9       I$MakDir
-                    bra       L36DF
-                    pshs      d
+                    bra       L36DE
+
+L36EA               pshs      d
                     ldx       ,s
                     lda       $05,s
                     tfr       a,b
                     andb      #$24
                     orb       #$0b
                     os9       I$Create
-                    bcs       L3702
-L36FC               leas      $02,s
+                    bcs       L3701
+L36FB               leas      $02,s
                     tfr       a,b
                     clra
                     rts
 
-L3702               cmpb      #$DA
-                    bne       L372C
+L3701               cmpb      #$DA
+                    bne       L372B
                     lda       $05,s
                     bita      #$80
-                    bne       L372C
+                    bne       L372B
                     anda      #$07
                     ldx       ,s
                     os9       I$Open
-                    bcs       L372C
+                    bcs       L372B
                     pshs      u,a
                     ldx       #$0000
                     leau      ,x
                     ldb       #$02
                     os9       I$SetStt
                     puls      u,a
-                    bcc       L36FC
+                    bcc       L36FB
                     pshs      b
                     os9       I$Close
                     puls      b
-L372C               leas      $02,s
-L372E               lbra      L393C
+L372B               leas      $02,s
+L372D               lbra      L393B
                     tfr       d,x
                     lda       $03,s
                     ldb       $05,s
                     os9       I$Create
-                    lbcs      L393C
+                    lbcs      L393B
                     tfr       a,b
                     clra
                     rts
                     tfr       d,x
                     os9       I$Delete
-                    bra       L36DF
+                    bra       L36DE
                     tfr       b,a
                     os9       I$Dup
-                    bcs       L372E
+                    bcs       L372D
                     tfr       a,b
                     clra
-L3753               rts
-                    pshs      y
+                    rts
+
+L3753               pshs      y
                     tfr       b,a
                     ldx       $04,s
                     ldy       $06,s
                     os9       I$Read
-                    bra       L376E
-                    pshs      y
+                    bra       L376D
+
+L3761               pshs      y
                     tfr       b,a
                     ldx       $04,s
                     ldy       $06,s
                     os9       I$ReadLn
-L376E               bcc       L3798
+L376D               bcc       L3797
                     cmpb      #$D3
-                    bne       L379C
+                    bne       L379B
                     clra
                     clrb
                     puls      pc,y
-                    pshs      y
+L3777               pshs      y
                     ldy       $06,s
-                    beq       L3798
+                    beq       L3797
                     tfr       b,a
                     ldx       $04,s
                     os9       I$Write
-                    bra       L3796
-                    pshs      y
+                    bra       L3795
+
+L3787               pshs      y
                     ldy       $06,s
-                    beq       L3798
+                    beq       L3797
                     tfr       b,a
                     ldx       $04,s
                     os9       I$WritLn
-L3796               bcs       L379C
-L3798               tfr       y,d
+L3795               bcs       L379B
+L3797               tfr       y,d
                     puls      pc,y
-L379C               puls      y
-                    lbra      L393C
-                    pshs      u,d
+L379B               puls      y
+                    lbra      L393B
+
+L37A0               pshs      u,d
                     ldd       $0a,s
-                    bne       L37AF
+                    bne       L37AE
                     ldu       #$0000
                     ldx       #$0000
-                    bra       L37E5
+                    bra       L37E4
 
-L37AF               cmpd      #$0001
-                    beq       L37DC
+L37AE               cmpd      #$0001
+                    beq       L37DB
                     cmpd      #$0002
-                    beq       L37D1
+                    beq       L37D0
                     ldb       #$F7
-L37BD               clra
+L37BC               clra
                     std       $01FD,y
                     ldd       #$FFFF
                     leax      $01F1,y
@@ -6205,53 +5970,53 @@ L37BD               clra
                     std       $02,x
                     leas      $02,s
                     puls      pc,u
-L37D1               lda       $01,s
+L37D0               lda       $01,s
                     ldb       #$02
                     os9       I$GetStt
-                    bcs       L37BD
-                    bra       L37E5
+                    bcs       L37BC
+                    bra       L37E4
 
-L37DC               lda       $01,s
+L37DB               lda       $01,s
                     ldb       #$05
                     os9       I$GetStt
-                    bcs       L37BD
-L37E5               tfr       u,d
+                    bcs       L37BC
+L37E4               tfr       u,d
                     addd      $08,s
                     tfr       d,u
                     tfr       x,d
                     adcb      $07,s
                     adca      $06,s
-                    bmi       L37BD
+                    bmi       L37BC
                     tfr       d,x
                     stx       $01F1,y
                     stu       $01F3,y
                     lda       $01,s
                     os9       I$Seek
-                    bcs       L37BD
+                    bcs       L37BC
                     leax      $01F1,y
                     leas      $02,s
                     puls      pc,u
-                    pshs      y,d
+L380B               pshs      y,d
                     cmpd      $16F3,y
-                    bls       L3843
+                    bls       L3842
                     subd      $16F3,y
                     addd      $01EF,y
                     subd      $02,s
                     os9       F$Mem
                     tfr       y,d
                     ldy       $02,s
-                    bcc       L382F
+                    bcc       L382E
                     ldd       #$FFFF
                     leas      $04,s
                     rts
 
-L382F               ldx       $01EF,y
+L382E               ldx       $01EF,y
                     std       $01EF,y
                     pshs      x
                     subd      ,s++
                     addd      $16F3,y
                     std       $16F3,y
-L3843               ldd       $01EF,y
+L3842               ldd       $01EF,y
                     subd      $16F3,y
                     tfr       d,x
                     ldd       $16F3,y
@@ -6260,57 +6025,59 @@ L3843               ldd       $01EF,y
                     ldd       ,s
                     stx       ,s
                     bitb      #$01
-                    beq       L3862
+                    beq       L3861
                     clr       ,x+
                     decb
-L3862               tfr       d,y
+L3861               tfr       d,y
                     leay      ,y
-                    beq       L3870
+                    beq       L386F
                     clra
                     clrb
-L386A               std       ,x++
+L3869               std       ,x++
                     leay      -$02,y
-                    bne       L386A
-L3870               puls      pc,y,d
-                    addd      $01F9,y
-                    bcs       L3899
+                    bne       L3869
+L386F               puls      pc,y,d
+L3871               addd      $01F9,y
+                    bcs       L3898
                     cmpd      $01FB,y
-                    bcc       L3899
+                    bcc       L3898
                     pshs      d
                     ldx       $01F9,y
                     clra
-                    bra       L388A
+                    bra       L3889
 
-L3888               sta       ,x+
-L388A               cmpx      ,s
-                    bcs       L3888
+L3887               sta       ,x+
+L3889               cmpx      ,s
+                    bcs       L3887
                     ldd       $01F9,y
                     puls      x
                     stx       $01F9,y
                     rts
 
-L3899               ldd       #$FFFF
-L389C               rts
-                    tfr       b,a
+L3898               ldd       #$FFFF
+                    rts
+
+L389C               tfr       b,a
                     ldb       $03,s
                     os9       F$Send
-                    lbra      L3945
-                    tfr       d,x
+                    lbra      L3944
+
+L38A6               tfr       d,x
                     clra
                     clrb
                     os9       F$Wait
-                    lbcs      L393C
+                    lbcs      L393B
                     stx       -$02,s
-                    beq       L38BA
+                    beq       L38B9
                     stb       $01,x
                     clr       ,x
-L38BA               tfr       a,b
+L38B9               tfr       a,b
                     clra
                     rts
                     tfr       b,a
                     ldb       $03,s
                     os9       F$SPrior
-                    lbra      L3945
+                    lbra      L3944
                     leau      $02,s
                     leas      $00FF,y
                     tfr       d,x
@@ -6325,7 +6092,7 @@ L38BA               tfr       a,b
                     ldu       $02,u
                     os9       F$Chain
                     os9       F$Exit
-                    pshs      u,y
+L38E4               pshs      u,y
                     tfr       d,x
                     ldy       $06,s
                     ldu       $08,s
@@ -6334,87 +6101,95 @@ L38BA               tfr       a,b
                     ldb       $0f,s
                     os9       F$Fork
                     puls      u,y
-                    lbcs      L393C
+                    lbcs      L393B
                     tfr       a,b
                     clra
-L3900               rts
-                    pshs      u
+                    rts
+
+L3900               pshs      u
                     tfr       y,u
                     std       $16F5,y
-                    leax      >L3915,pcr
+                    leax      >L3914,pcr
                     os9       F$Icpt
                     puls      u
-                    lbra      L3945
+                    lbra      L3944
 
-L3915               tfr       u,y
+L3914               tfr       u,y
                     clra
                     jsr       [$16F5,y]
-L391C               rti
-                    tfr       b,a
+                    rti
+
+L391C               tfr       b,a
                     ldb       #$00
                     ldx       $02,s
                     os9       I$GetStt
-                    lbra      L3945
-                    tfr       b,a
+                    lbra      L3944
+
+L3928               tfr       b,a
                     ldb       #$0f
                     ldx       $02,s
                     pshs      y
                     ldy       $06,s
                     os9       I$GetStt
                     puls      y
-                    lbra      L3945
+                    lbra      L3944
 
-L393C               clra
+L393B               clra
                     std       $01FD,y
                     ldd       #$FFFF
                     rts
 
-L3945               bcs       L393C
+L3944               bcs       L393B
                     clra
                     clrb
-L3949               rts
-                    pshs      d
-                    lbsr      L3957
-                    lbsr      $3038
+                    rts
+
+L3949               pshs      d
+                    lbsr      L3956
+                    lbsr      L3037
                     puls      d
-                    os9       F$Exit
-L3957               rts
-                    ldd       $04,s
+L3953               os9       F$Exit
+L3956               rts
+
+L3957               ldd       $04,s
                     addd      $02,x
                     std       $01F3,y
                     ldd       $02,s
                     adcb      $01,x
                     adca      ,x
                     std       $01F1,y
-                    lbra      L39FC
-                    ldd       $04,s
+                    lbra      L39FB
+
+L396C               ldd       $04,s
                     subd      $02,x
                     std       $01F3,y
                     ldd       $02,s
                     sbcb      $01,x
                     sbca      ,x
                     std       $01F1,y
-                    lbra      L39FC
-                    ldd       $02,s
+                    lbra      L39FB
+
+L3981               ldd       $02,s
                     cmpd      ,x
-                    bne       L399B
+                    bne       L399A
                     ldd       $04,s
                     cmpd      $02,x
-                    beq       L399B
-                    bcs       L3998
+                    beq       L399A
+                    bcs       L3997
                     lda       #$01
                     andcc     #$FE
-                    bra       L399B
+                    bra       L399A
 
-L3998               clra
+L3997               clra
                     cmpa      #$01
-L399B               pshs      cc
+L399A               pshs      cc
                     ldd       $01,s
                     std       $05,s
                     puls      cc
                     leas      $04,s
-L39A5               rts
-                    lbsr      L3A0B
+                    rts
+
+L39A5               lbsr      L3A0A
                     ldd       #$0000
                     subd      $02,x
                     std       $02,x
@@ -6432,8 +6207,9 @@ L39A5               rts
                     comb
                     leax      $01F1,y
                     std       $02,x
-L39CC               rts
-                    leax      $01F1,y
+                    rts
+
+L39CC               leax      $01F1,y
                     std       $02,x
                     tfr       a,b
                     sex
@@ -6444,8 +6220,9 @@ L39CC               rts
                     std       $02,x
                     clr       ,x
                     clr       $01,x
-L39E5               rts
-                    pshs      y
+                    rts
+
+L39E5               pshs      y
                     ldy       $04,s
                     ldd       ,x
                     std       ,y
@@ -6457,7 +6234,7 @@ L39E5               rts
                     std       ,s
                     rts
 
-L39FC               tfr       cc,a
+L39FB               tfr       cc,a
                     puls      x
                     stx       $02,s
                     leas      $02,s
@@ -6465,16 +6242,17 @@ L39FC               tfr       cc,a
                     tfr       a,cc
                     rts
 
-L3A0B               ldd       ,x
-L3A0D               std       $01F1,y
+L3A0A               ldd       ,x
+                    std       $01F1,y
                     ldd       $02,x
                     leax      $01F1,y
                     std       $02,x
-L3A19               rts
-                    tsta
-                    bne       L3A2F
+                    rts
+
+L3A19               tsta
+                    bne       L3A2E
                     tst       $02,s
-                    bne       L3A2F
+                    bne       L3A2E
                     lda       $03,s
                     mul
                     ldx       ,s
@@ -6482,7 +6260,7 @@ L3A19               rts
                     ldx       #$0000
                     std       ,s
                     puls      pc,d
-L3A2F               pshs      d
+L3A2E               pshs      d
                     ldd       #$0000
                     pshs      d
                     pshs      d
@@ -6495,16 +6273,16 @@ L3A2F               pshs      d
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L3A4C
+                    bcc       L3A4B
                     inc       ,s
-L3A4C               lda       $04,s
+L3A4B               lda       $04,s
                     ldb       $09,s
                     mul
                     addd      $01,s
                     std       $01,s
-                    bcc       L3A59
+                    bcc       L3A58
                     inc       ,s
-L3A59               lda       $04,s
+L3A58               lda       $04,s
                     ldb       $08,s
                     mul
                     addd      ,s
@@ -6516,327 +6294,110 @@ L3A59               lda       $04,s
                     leas      $08,s
                     rts
                     tstb
-                    beq       L3A83
-L3A70               asr       $02,s
+                    beq       L3A82
+L3A6F               asr       $02,s
                     ror       $03,s
                     decb
-                    bne       L3A70
-                    bra       L3A83
-                    tstb
-                    beq       L3A83
-L3A7C               lsr       $02,s
+                    bne       L3A6F
+                    bra       L3A82
+
+L3A78               tstb
+                    beq       L3A82
+L3A7B               lsr       $02,s
                     ror       $03,s
                     decb
-                    bne       L3A7C
-L3A83               ldd       $02,s
+                    bne       L3A7B
+L3A82               ldd       $02,s
                     pshs      d
                     ldd       $02,s
                     std       $04,s
                     ldd       ,s
                     leas      $04,s
-L3A8F               rts
-                    tstb
-                    beq       L3A83
-L3A93               asl       $03,s
+                    rts
+
+L3A8F               tstb
+                    beq       L3A82
+L3A92               asl       $03,s
                     rol       $02,s
                     decb
-                    bne       L3A93
-                    bra       L3A83
-                    neg       $0009
-                    neg       $0000
-                    coma
-                    ror       $00D3
-                    neg       $0025
-                    neg       $0027
-                    fcb       $01
-                    andb      #$09
-                    andb      #$09
-                    addd      L0A2C
-                    dec       $0058
-                    dec       $0062
-                    dec       L008A
-                    dec       L00CA
-                    fcb       $0b
-                    asl       $000B
-                    nega
-                    fcb       $0b
-                    fcb       $7b
-                    fcb       $0b
-                    jsr       L0BFC
-                    inc       $0032
-                    bra       L3AE5
-                    bra       L3AE7
-                    bra       L3AE9
-                    bra       L3AEB
-                    bra       L3AED
-                    bra       L3AEF
-                    bra       L3AF1
-                    bra       L3AF3
-                    bra       L3AF5
-                    bra       L3AF7
-                    neg       L0020
-                    neg       $0064
-                    fcb       $6f,$6e,$27,$74,$20,$6b,$6e,$6f
-                    fcb       $77,$20
-L3AE5               fcb       $68,$6f
-L3AE7               fcb       $77,$20
-L3AE9               fcb       $74,$6f
-L3AEB               fcb       $20,$6d
-L3AED               fcb       $61,$6b
-L3AEF               fcb       $65,$20
-L3AF1               fcb       $22,$25
-L3AF3               fcb       $73,$22
-L3AF5               fcb       $2e,$0d
-L3AF7               neg       L0020
-                    bra       L3B1B
-                    bra       L3B1D
-                    bra       L3B1F
-                    bra       L3B21
-                    bra       $3B23
-                    bra       $3B25
-                    bra       $3B27
-                    bra       $3B29
-                    bra       $3B2B
-                    bra       L3B0D
-
-L3B0D               beq       L3B1F
-                    com       $00E8
-                    neg       $0064
-                    neg       $000A
-                    neg       $0095
-                    inc       -$08,s
-                    neg       $0000
-L3B1B               neg       $0000
-L3B1D               neg       $0000
-L3B1F               neg       $0000
-L3B21               fcb       $01
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    fcb       $02
-                    neg       $0001
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
+                    bne       L3A92
+                    bra       L3A82
+* ------------------------------------------------------------------
+* L3A9B - cc1-style init image for the work block (see _start):
+* rts stub + count/block table + relocation dirs + module-name string.
+* ------------------------------------------------------------------
+L3A9B               fcb       $00,$09,$00,$00
+                    fcb       $43
+                    fcb       $06,$D3,$00
+                    fcb       $25
+                    fcb       $00
+                    fcb       $27
+                    fcb       $01,$C4,$09,$C4,$09,$F3,$0A
+                    fcb       $2C
+                    fcb       $0A
+                    fcb       $58
+                    fcb       $0A
+                    fcb       $62
+                    fcb       $0A,$8A,$0A,$CA,$0B,$08,$0B
+                    fcb       $40
+                    fcb       $0B
+                    fcb       $7B
+                    fcb       $0B,$BD,$0B,$FC,$0C
+                    fcc       /2                    /
+                    fcb       $00
+                    fcb       $20
+                    fcb       $00
+                    fcc       /don't know how to mak/
+                    fcc       /e /
+                    fcb       $22
+                    fcc       /%s/
+                    fcb       $22,$2E
+                    fcb       $0D,$00
+                    fcc       /                    /
+                    fcb       $00
+                    fcb       $27
+                    fcb       $10,$03,$E8,$00
+                    fcb       $64
+                    fcb       $00,$0A,$00,$95
+                    fcc       /lx/
+                    fcb       $00,$00,$00,$00,$00,$00,$00,$00,$01,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$02,$00,$01,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
                     fcb       $42
-                    neg       $0002
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0000
-                    neg       $0001
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $11
-                    fcb       $11
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    fcb       $01
-                    leax      0,y
-                    bra       L3C2F
-                    bra       L3C31
-                    bra       L3C33
-                    bra       L3C35
-                    bra       L3C37
-                    bra       L3C39
-                    bra       L3C3B
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    asla
-                    bra       $3C47
-                    bra       $3C49
-                    bra       $3C4B
-                    bra       L3C6F
-                    fcb       $42
-                    fcb       $42
-L3C2F               fcb       $42
-                    fcb       $42
-L3C31               fcb       $42
-                    fcb       $02
-L3C33               fcb       $02
-                    fcb       $02
-L3C35               fcb       $02
-                    fcb       $02
-L3C37               fcb       $02
-                    fcb       $02
-L3C39               fcb       $02
-                    fcb       $02
-L3C3B               fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    fcb       $02
-                    bra       L3C68
-                    bra       L3C6A
-                    bra       $3C6C
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsra
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    lsr       $0004
-                    bra       $3C88
-
-L3C68               bra       $3C8A
-L3C6A               fcb       $01
-                    neg       $0000
-                    neg       $000D
-L3C6F               neg       $0033
-                    neg       $0031
-                    neg       $002F
-                    neg       $002D
-                    neg       $002B
-                    neg       $0029
-                    neg       $0041
-                    neg       $003F
-                    neg       $003D
-                    neg       $003B
-                    neg       $0039
-                    neg       $0037
-                    neg       $0035
-                    neg       $0005
-                    neg       $0001
-                    neg       $0003
-                    neg       $0005
-                    neg       $0007
-                    neg       $0095
-                    tst       $01,s
-                    fcb       $6b
-                    fcb       $65
+                    fcb       $00,$02,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$01,$01,$01,$01,$01,$01,$01,$01,$01,$11,$11,$01,$11,$11,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01,$01
+                    fcc       /0               HHHHH/
+                    fcc       /HHHHH       BBBBBB/
+                    fcb       $02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02,$02
+                    fcc       /      DDDDDD/
+                    fcb       $04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04,$04
+                    fcc       /    /
+                    fcb       $01,$00,$00,$00,$0D,$00
+                    fcb       $33
+                    fcb       $00
+                    fcb       $31
+                    fcb       $00
+                    fcb       $2F
+                    fcb       $00
+                    fcb       $2D
+                    fcb       $00
+                    fcb       $2B
+                    fcb       $00
+                    fcb       $29
+                    fcb       $00
+                    fcb       $41
+                    fcb       $00
+                    fcb       $3F
+                    fcb       $00
+                    fcb       $3D
+                    fcb       $00
+                    fcb       $3B
+                    fcb       $00
+                    fcb       $39
+                    fcb       $00
+                    fcb       $37
+                    fcb       $00
+                    fcb       $35
+                    fcb       $00,$05,$00,$01,$00,$03,$00,$05,$00,$07,$00,$95
+                    fcc       /make/
+                    fcb       $00
 
                     emod
 eom                 equ       *

--- a/3rdparty/packages/ccompiler/make_dis.asm
+++ b/3rdparty/packages/ccompiler/make_dis.asm
@@ -1,0 +1,6843 @@
+                    nam       make
+                    ttl       program module
+
+                    use       defsfile
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $01
+edition             set       $12
+
+                    mod       eom,name,tylg,atrv,start,size
+
+u0000               rmb       6775
+size                equ       .
+
+name                equ       *
+                    fcs       /make/
+                    fcb       edition
+
+L0012               lda       ,y+
+L0014               sta       ,u+
+                    leax      -$01,x
+                    bne       L0012
+                    rts
+
+start               pshs      y
+L001D               pshs      u
+L001F               clra
+L0020               clrb
+L0021               sta       ,u+
+L0023               decb
+L0024               bne       L0021
+                    ldx       ,s
+                    leau      ,x
+L002A               leax      $16F7,x
+L002E               pshs      x
+L0030               leay      $3A9B,pcr
+L0034               ldx       ,y++
+                    beq       L003C
+                    bsr       L0012
+L003A               ldu       $02,s
+L003C               leau      >$0029,u
+L0040               ldx       ,y++
+                    beq       L0047
+                    bsr       L0012
+L0046               clra
+L0047               cmpu      ,s
+                    beq       L0050
+L004C               sta       ,u+
+                    bra       L0047
+
+L0050               ldu       $02,s
+L0052               ldd       ,y++
+                    beq       L005D
+                    leax      >$0000,pcr
+                    lbsr      L014F
+L005D               ldd       ,y++
+                    beq       L0066
+L0061               leax      ,u
+L0063               lbsr      L014F
+L0066               leas      $04,s
+                    puls      x
+                    stx       $01EF,u
+L006E               pshs      y
+L0070               ldy       #$0001
+L0074               leax      $02,s
+L0076               lda       ,x+
+L0078               cmpa      #$0d
+L007A               beq       L00BA
+                    cmpa      #$20
+                    beq       L0076
+L0080               cmpa      #$2C
+                    beq       L0076
+                    cmpa      #$22
+                    beq       L00A4
+                    cmpa      #$27
+L008A               beq       L00A4
+                    leax      -$01,x
+                    pshs      x
+                    leay      $01,y
+L0092               lda       ,x+
+                    beq       L00B4
+                    cmpa      #$0d
+                    beq       L00B4
+                    cmpa      #$20
+                    beq       L00B4
+                    cmpa      #$2C
+                    beq       L00B4
+                    bra       L0092
+
+L00A4               pshs      x,a
+                    leay      $01,y
+L00A8               lda       ,x+
+                    cmpa      #$0d
+                    beq       L00B2
+                    cmpa      ,s
+                    bne       L00A8
+L00B2               puls      b
+L00B4               clr       -$01,x
+                    cmpa      #$0d
+                    bne       L0076
+L00BA               tfr       y,d
+                    leax      ,s
+                    pshs      x,d
+                    aslb
+                    rola
+                    leay      d,x
+                    pshs      u
+                    bra       L00D0
+
+L00C8               ldd       ,x
+L00CA               ldu       ,y
+                    std       ,y
+                    stu       ,x++
+L00D0               leay      -$02,y
+                    pshs      y
+                    cmpx      ,s++
+                    bcs       L00C8
+                    puls      y
+                    bsr       L00E6
+                    puls      d
+                    lbsr      L0178
+                    clra
+                    clrb
+                    lbsr      L3949
+L00E6               leax      $16F7,y
+                    stx       $01F9,y
+                    sts       $01ED,y
+                    sts       $01FB,y
+                    ldd       #$FF82
+L00FB               leax      d,s
+                    cmpx      $01FB,y
+                    bcc       L010D
+                    cmpx      $01F9,y
+                    bcs       L0127
+                    stx       $01FB,y
+L010D               rts
+L010E               fcb       $2a,$2a,$2a,$2a,$20,$53,$54,$41
+                    fcb       $43,$4b,$20,$4f,$56,$45,$52,$46
+                    fcb       $4C,$4f,$57,$20,$2a,$2a,$2a,$2a
+                    fcb       $0d
+L0127               leax      L010E,pcr
+                    ldb       #$CF
+                    pshs      b
+                    lda       #$02
+                    ldy       #$0064
+                    os9       I$WritLn
+                    clra
+                    puls      b
+                    lbsr      $3953
+                    ldd       $01ED,y
+                    subd      $01FB,y
+                    rts
+                    ldd       $01FB,y
+                    subd      $01F9,y
+                    rts
+
+L014F               pshs      x
+                    leax      d,y
+                    leax      d,x
+                    pshs      x
+L0157               ldd       ,y++
+                    leax      d,u
+                    ldd       ,x
+                    addd      $02,s
+                    std       ,x
+                    cmpy      ,s
+                    bne       L0157
+                    leas      $04,s
+                    rts
+
+L0169               pshs      u,d
+                    ldd       #$FFBE
+                    lbsr      L00FB
+                    ldd       ,s
+                    std       $0017
+                    lbra      L03E0
+
+L0178               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB2
+                    lbsr      L00FB
+                    leas      -$08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    lbsr      L0290
+                    ldd       $0C,s
+                    std       $000D
+                    leax      -$01,u
+                    stx       $0013
+                    lbra      L0208
+
+L0196               ldx       $0C,s
+                    leax      $02,x
+                    stx       $0C,s
+                    ldd       ,x
+                    std       $04,s
+                    tfr       d,x
+                    ldb       ,x
+                    cmpb      #$2d
+                    bne       L01C0
+                    ldd       $04,s
+                    addd      #$0001
+                    std       $04,s
+                    lbsr      L02B2
+                    ldd       $0013
+                    addd      #$FFFF
+                    std       $0013
+                    clra
+                    clrb
+                    std       [$0C,s]
+                    bra       L0208
+
+L01C0               ldd       $04,s
+                    std       $06,s
+                    bra       L01F2
+
+L01C6               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    cmpb      #$3d
+                    bne       L01F2
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $06,s
+                    lbsr      L228E
+                    leas      $02,s
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+                    ldd       $0013
+                    addd      #$FFFF
+                    std       $0013
+                    clra
+                    clrb
+                    std       [$0C,s]
+                    bra       L01F7
+
+L01F2               ldb       [$06,s]
+                    bne       L01C6
+L01F7               ldd       $02,s
+                    beq       L0201
+                    clra
+                    clrb
+                    std       $02,s
+                    bra       L0208
+
+L0201               ldd       $0011
+                    addd      #$0001
+                    std       $0011
+L0208               leau      -$01,u
+                    stu       -$02,s
+                    lbgt      L0196
+                    lbsr      L04A4
+                    ldd       $01FF,y
+                    bne       L0221
+                    leax      L09D6,pcr
+                    stx       $01FF,y
+L0221               ldd       $0201,y
+                    lbne      L0285
+                    leax      L09D8,pcr
+                    stx       $0201,y
+                    bra       L0285
+
+L0233               ldd       $04,s
+                    lbsr      L2038
+                    std       ,s
+                    clra
+                    clrb
+                    lbsr      L3900
+                    ldd       $0211,y
+                    bne       L024A
+                    ldd       ,s
+                    lbsr      L0E04
+L024A               ldd       ,s
+                    lbsr      L1468
+                    leax      L0169,pcr
+                    tfr       x,d
+                    lbsr      L3900
+                    ldx       ,s
+                    ldd       $04,x
+                    beq       L0265
+                    tfr       x,d
+                    lbsr      L137E
+                    bra       L026A
+
+L0265               tfr       x,d
+                    lbsr      L16C5
+L026A               ldd       $022f,y
+                    bne       L0285
+                    ldd       $04,s
+                    pshs      d
+                    leax      L09DA,pcr
+                    tfr       x,d
+                    lbsr      L28EF
+                    leas      $02,s
+                    clra
+                    clrb
+                    std       $022f,y
+L0285               lbsr      L0406
+                    std       $04,s
+                    bne       L0233
+                    leas      $08,s
+                    puls      pc,u
+L0290               pshs      u
+                    ldd       #$FFC0
+                    lbsr      L00FB
+                    leax      $09E9,pcr
+                    stx       $020b,y
+                    leax      L09EC,pcr
+                    stx       $020f,y
+                    leax      $09EF,pcr
+                    stx       $020d,y
+                    puls      pc,u
+L02B2               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       ,s
+                    lbra      L03DA
+
+L02C5               ldb       ,u+
+                    sex
+                    lbsr      L318C
+                    tfr       d,x
+                    lbra      L0383
+
+L02D0               ldd       $0211,y
+                    addd      #$0001
+                    std       $0211,y
+                    lbra      L03DA
+
+L02DE               ldd       $0213,y
+                    addd      #$0001
+                    std       $0213,y
+                    lbra      L03DA
+
+L02EC               ldb       ,u
+                    cmpb      #$3d
+                    bne       L02F4
+                    leau      $01,u
+L02F4               tfr       u,d
+                    std       $0009
+                    lbra      L03E0
+
+L02FB               ldd       $0215,y
+                    addd      #$0001
+                    std       $0215,y
+                    lbra      L03DA
+
+L0309               ldd       $0217,y
+                    addd      #$0001
+                    std       $0217,y
+                    lbra      L03DA
+
+L0317               ldd       $0219,y
+                    addd      #$0001
+                    std       $0219,y
+                    lbra      L03DA
+
+L0325               ldd       $021b,y
+                    addd      #$0001
+                    std       $021b,y
+                    lbra      L03DA
+
+L0333               ldd       $021f,y
+                    addd      #$0001
+                    std       $021f,y
+                    lbra      L03DA
+
+L0341               ldd       $021d,y
+                    addd      #$0001
+                    std       $021d,y
+                    lbra      L03DA
+
+L034F               ldd       $0221,y
+                    addd      #$0001
+                    std       $0221,y
+                    ldb       ,u
+                    cmpb      #$3d
+                    lbne      L03DA
+                    ldb       $01,u
+                    lbeq      L03DA
+                    leax      $01,u
+                    stx       $000F
+                    lbra      L03E0
+                    bra       L03DA
+
+L0371               lbsr      L03E4
+                    clra
+                    clrb
+                    lbsr      L3949
+L0379               bsr       L03E4
+                    ldd       #$00D7
+                    lbsr      L3949
+                    bra       L03DA
+
+L0383               cmpx      #$0062
+                    lbeq      L02D0
+                    cmpx      #$0064
+                    lbeq      L02DE
+                    cmpx      #$0066
+                    lbeq      L02EC
+                    cmpx      #$0020
+                    beq       L03E0
+                    cmpx      #$000D
+                    beq       L03E0
+                    cmpx      #$0069
+                    lbeq      L02FB
+                    cmpx      #$006E
+                    lbeq      L0309
+                    cmpx      #$0073
+                    lbeq      L0317
+                    cmpx      #$0074
+                    lbeq      L0325
+                    cmpx      #$0078
+                    lbeq      L0333
+                    cmpx      #$0075
+                    lbeq      L0341
+                    cmpx      #$007A
+                    lbeq      L034F
+                    cmpx      #$003F
+                    beq       L0371
+                    bra       L0379
+
+L03DA               ldb       ,u
+                    lbne      L02C5
+L03E0               leas      $02,s
+                    puls      pc,u
+L03E4               pshs      u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leau      >$002b,y
+                    bra       L03FF
+
+L03F2               leax      $00A7,y
+                    pshs      x
+                    ldd       ,u++
+                    lbsr      L280A
+                    leas      $02,s
+L03FF               cmpu      $0001
+                    bcs       L03F2
+                    puls      pc,u
+L0406               pshs      u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    ldb       $0231,y
+                    beq       L0426
+                    ldd       $0015
+                    lbne      L04A0
+                    ldd       #$0001
+                    std       $0015
+                    leax      $0231,y
+                    lbra      L049C
+
+L0426               ldd       $0013
+                    beq       L043F
+                    addd      #$FFFF
+                    std       $0013
+L042F               ldx       $000D
+                    leax      $02,x
+                    stx       $000D
+                    ldd       ,x
+                    beq       L042F
+                    ldd       [$000D,y]
+                    puls      pc,u
+L043F               ldd       $0221,y
+                    beq       L04A0
+                    ldd       $0281,y
+                    bne       L0460
+                    ldd       $000F
+                    beq       L0458
+                    lbsr      L070A
+                    std       $0281,y
+                    bra       L0460
+
+L0458               leax      $009a,y
+                    stx       $0281,y
+L0460               ldd       $0281,y
+                    pshs      d
+                    ldd       #$0050
+                    pshs      d
+                    leax      $0283,y
+                    tfr       x,d
+                    lbsr      L2863
+                    leas      $04,s
+                    std       -$02,s
+                    beq       L04A0
+                    ldb       $0283,y
+                    cmpb      #$0d
+                    beq       L04A0
+                    leax      $0283,y
+                    tfr       x,d
+                    lbsr      $33CF
+                    addd      #$FFFF
+                    leax      $0283,y
+                    leax      d,x
+                    clra
+                    clrb
+                    stb       ,x
+                    leax      $0283,y
+L049C               tfr       x,d
+                    puls      pc,u
+L04A0               clra
+                    clrb
+                    puls      pc,u
+L04A4               pshs      u
+                    ldd       #$FFA0
+                    lbsr      L00FB
+                    leas      -$18,s
+                    clra
+                    clrb
+                    std       $0019
+                    lbsr      L06DE
+                    std       $000B
+                    lbra      L06C7
+
+L04BB               ldb       ,u
+                    cmpb      #$20
+                    bne       L0503
+                    leau      $01,u
+                    tfr       u,d
+                    lbsr      L0DDD
+                    std       $08,s
+                    ldd       $0019
+                    std       $10,s
+                    beq       L04EF
+L04D1               ldd       [$10,s]
+                    std       $16,s
+                    ldx       [$16,s]
+                    ldd       $04,x
+                    bne       L04E2
+                    ldd       $08,s
+                    std       $04,x
+L04E2               ldx       $10,s
+                    ldd       $02,x
+                    std       $10,s
+                    bne       L04D1
+                    lbra      L06C7
+
+L04EF               leax      L0C70,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $02,s
+                    lbsr      L3949
+                    lbra      L06C7
+
+L0503               ldd       $0019
+                    std       $10,s
+                    beq       L0521
+L050A               ldx       $10,s
+                    ldd       $02,x
+                    std       $0e,s
+                    tfr       x,d
+                    lbsr      L3602
+                    ldd       $0e,s
+                    std       $10,s
+                    bne       L050A
+                    clra
+                    clrb
+                    std       $0019
+L0521               leax      >$0019,y
+                    stx       start
+                    clra
+                    clrb
+                    std       ,s
+                    ldu       $06,s
+                    tfr       u,d
+                    std       $0C,s
+                    bra       L0573
+
+L0533               ldb       ,u+
+                    sex
+                    tfr       d,x
+                    bra       L0563
+
+L053A               pshs      u
+                    ldd       $08,s
+                    lbsr      L228E
+                    leas      $02,s
+                    ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    bra       L0577
+
+L054C               ldd       $0a,s
+                    pshs      d
+                    leax      L0C95,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+                    bra       L0573
+
+L0563               cmpx      #$003D
+                    beq       L053A
+                    cmpx      #$003A
+                    beq       L0577
+                    stx       -$02,s
+                    beq       L054C
+                    bra       L0573
+
+L0573               ldb       ,u
+                    bne       L0533
+L0577               ldd       ,s
+                    beq       L0584
+                    clra
+                    clrb
+                    std       ,s
+                    lbra      L06C7
+
+L0582               leau      $01,u
+L0584               ldb       ,u
+                    cmpb      #$20
+                    beq       L0582
+                    cmpb      #$09
+                    lbeq      L0582
+                    std       -$02,s
+                    beq       L05A4
+                    tfr       u,d
+                    lbsr      $33CF
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L0D03
+                    leas      $02,s
+                    bra       L05A6
+
+L05A4               clra
+                    clrb
+L05A6               std       $14,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       $0C,s
+                    std       $0a,s
+                    clra
+                    clrb
+                    std       $04,s
+                    lbra      L06C1
+
+L05B8               ldb       [$0C,s]
+                    sex
+                    tfr       d,x
+                    bra       L05D8
+
+L05C0               ldd       #$0001
+                    std       $02,s
+                    bra       L05E9
+
+L05C7               ldd       $04,s
+                    addd      #$0001
+                    std       $04,s
+                    ldd       $0C,s
+                    addd      #$0001
+                    std       $0C,s
+                    lbra      L06C1
+
+L05D8               cmpx      #$003A
+                    beq       L05C0
+                    cmpx      #$0020
+                    beq       L05E9
+                    cmpx      #$0009
+                    beq       L05E9
+                    bra       L05C7
+
+L05E9               ldd       $04,s
+                    lbeq      L06C7
+                    clra
+                    clrb
+                    std       $04,s
+                    ldx       $0C,s
+                    leax      $01,x
+                    stx       $0C,s
+                    stb       -$01,x
+                    ldd       $0a,s
+                    lbsr      L1FF8
+                    std       $16,s
+L0603               ldx       $16,s
+                    ldd       $04,x
+                    beq       L063C
+                    ldd       $04,x
+                    bra       L0613
+
+L060E               ldx       $12,s
+                    ldd       $02,x
+L0613               std       $12,s
+                    ldx       $12,s
+                    ldd       $02,x
+                    bne       L060E
+                    ldd       $02,s
+                    beq       L0628
+                    ldx       $16,s
+                    ldd       $06,x
+                    beq       L062D
+L0628               ldd       $14,s
+                    bne       L0632
+L062D               ldd       $14,s
+                    bra       L0635
+
+L0632               lbsr      L121F
+L0635               ldx       $12,s
+                    std       $02,x
+                    bra       L0656
+
+L063C               ldd       $02,s
+                    beq       L0644
+                    ldd       $06,x
+                    beq       L0649
+L0644               ldd       $14,s
+                    bne       L064E
+L0649               ldd       $14,s
+                    bra       L0651
+
+L064E               lbsr      L121F
+L0651               ldx       $16,s
+                    std       $04,x
+L0656               ldd       $0011
+                    bne       L0677
+                    ldd       $0221,y
+                    bne       L0677
+                    ldx       [$16,s]
+                    ldd       $02,x
+                    pshs      d
+                    leax      $0231,y
+                    tfr       x,d
+                    lbsr      L33E2
+                    leas      $02,s
+                    ldd       #$0001
+                    std       $0011
+L0677               ldd       #$0004
+                    lbsr      L357F
+                    std       $10,s
+                    std       [start,y]
+                    beq       L069B
+                    ldd       $10,s
+                    addd      #$0002
+                    std       start
+                    ldd       $16,s
+                    std       [$10,s]
+                    clra
+                    clrb
+                    ldx       $10,s
+                    std       $02,x
+L069B               ldx       $16,s
+                    ldd       $06,x
+                    std       $16,s
+                    lbne      L0603
+                    bra       L06B0
+
+L06A9               ldd       $0C,s
+                    addd      #$0001
+                    std       $0C,s
+L06B0               ldb       [$0C,s]
+                    cmpb      #$20
+                    beq       L06A9
+                    cmpb      #$09
+                    lbeq      L06A9
+                    ldd       $0C,s
+                    std       $0a,s
+L06C1               ldd       $02,s
+                    lbeq      L05B8
+L06C7               lbsr      L078C
+                    tfr       d,u
+                    tfr       u,d
+                    std       $06,s
+                    lbne      L04BB
+                    ldd       $000B
+                    lbsr      L305B
+                    leas      $18,s
+                    puls      pc,u
+L06DE               pshs      u
+                    ldd       #$FFBC
+                    lbsr      L00FB
+                    ldd       $0009
+                    bne       L06F2
+                    leax      L0CA7,pcr
+                    tfr       x,d
+                    bra       L0704
+
+L06F2               ldb       [$0009,y]
+                    cmpb      #$2d
+                    bne       L0702
+                    leax      $009a,y
+                    stx       $000B
+                    bra       L0708
+
+L0702               ldd       $0009
+L0704               bsr       L070A
+                    std       $000B
+L0708               puls      pc,u
+L070A               pshs      u,d
+                    ldd       #$FFB4
+                    lbsr      L00FB
+                    leas      -$02,s
+                    leax      $0CB0,pcr
+                    pshs      x
+                    ldd       $04,s
+                    lbsr      L279E
+                    leas      $02,s
+                    std       ,s
+                    bne       L073B
+                    ldd       $02,s
+                    pshs      d
+                    ldd       >$0029,y
+                    pshs      d
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L073B               ldd       ,s
+                    leas      $04,s
+                    puls      pc,u
+L0741               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    lbsr      $33CF
+                    std       ,s
+                    pshs      d
+                    ldd       $08,s
+                    lbsr      $33CF
+                    addd      ,s++
+                    cmpd      #$1000
+                    ble       L076F
+                    leax      $0CB2,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbra      L09B8
+
+L076F               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    leax      d,u
+                    pshs      x
+                    ldx       $08,s
+                    leax      $01,x
+                    stx       $08,s
+                    ldb       -$01,x
+                    stb       [,s++]
+                    bne       L076F
+                    lbra      L09C0
+
+L078C               pshs      u
+                    ldd       #$FFB0
+                    lbsr      L00FB
+                    leas      -$08,s
+                    clra
+                    clrb
+                    std       $04,s
+                    std       ,s
+                    leax      $06D3,y
+                    stx       $06,s
+                    leau      $02D3,y
+                    ldd       $16D3,y
+                    lbne      L096F
+L07AE               clra
+                    clrb
+                    std       $02,s
+                    ldb       ,u
+                    cmpb      #$20
+                    beq       L07BC
+                    cmpb      #$09
+                    bne       L07F1
+L07BC               leau      $01,u
+                    ldb       ,u
+                    cmpb      #$20
+                    beq       L07BC
+                    cmpb      #$09
+                    lbeq      L07BC
+                    tfr       u,d
+                    lbsr      L0975
+                    std       -$02,s
+                    bne       L080E
+                    ldd       $04,s
+                    beq       L07DB
+                    ldd       ,s
+                    beq       L07E6
+L07DB               ldd       #$0020
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    stb       -$01,x
+L07E6               ldd       ,s
+                    bne       L0813
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L0813
+
+L07F1               tfr       u,d
+                    lbsr      L0975
+                    std       -$02,s
+                    bne       L080E
+                    ldb       ,u
+                    cmpb      #$2d
+                    bne       L0813
+                    ldd       ,s
+                    bne       L0813
+                    pshs      u
+                    ldd       #$0001
+                    addd      ,s++
+                    lbsr      L02B2
+L080E               ldd       #$0001
+                    std       $02,s
+L0813               ldd       $02,s
+                    lbne      L08F8
+                    lbra      L08EF
+
+L081C               ldb       ,u
+                    sex
+                    tfr       d,x
+                    lbra      L08D8
+
+L0824               ldb       $01,u
+                    sex
+                    tfr       d,x
+                    bra       L083B
+
+L082B               ldd       $04,s
+                    beq       L084E
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    leau      $01,u
+                    lbra      L08EF
+
+L083B               cmpx      #$002A
+                    beq       L082B
+                    cmpx      #$0040
+                    lbeq      L082B
+                    cmpx      #$003F
+                    lbeq      L082B
+L084E               tfr       u,d
+                    lbsr      $33CF
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L24B7
+                    leas      $02,s
+                    tfr       d,u
+                    lbra      L08EF
+
+L0861               ldx       $06,s
+                    ldb       -$01,x
+                    cmpb      #$5C
+                    bne       L086E
+                    ldd       #$0001
+                    bra       L0870
+
+L086E               clra
+                    clrb
+L0870               std       ,s
+                    beq       L087E
+                    tfr       x,d
+                    addd      #$FFFF
+                    std       $06,s
+                    lbra      L08F8
+
+L087E               ldd       $04,s
+                    beq       L08C6
+                    tfr       x,d
+                    addd      #$0001
+                    std       $06,s
+                    bra       L08C6
+
+L088B               ldb       $01,u
+                    sex
+                    leax      $016b,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L08CD
+L089B               ldx       $06,s
+                    leax      -$01,x
+                    stx       $06,s
+                    ldb       ,x
+                    cmpb      #$20
+                    beq       L089B
+                    ldb       [$06,s]
+                    cmpb      #$09
+                    lbeq      L089B
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    ldd       $04,s
+                    beq       L08C6
+                    ldd       #$000D
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    stb       -$01,x
+L08C6               clra
+                    clrb
+                    stb       [$06,s]
+                    bra       L08F8
+
+L08CD               leau      $01,u
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    bra       L08EF
+
+L08D8               cmpx      #$0024
+                    lbeq      L0824
+                    cmpx      #$000D
+                    lbeq      L0861
+                    cmpx      #$0023
+                    lbeq      L088B
+                    bra       L08CD
+
+L08EF               ldb       ,u
+                    stb       [$06,s]
+                    lbne      L081C
+L08F8               ldd       $000B
+                    pshs      d
+                    ldd       #$0400
+                    pshs      d
+                    leax      $02D3,y
+                    tfr       x,d
+                    lbsr      L2863
+                    leas      $04,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L091F
+                    ldd       $16D3,y
+                    addd      #$0001
+                    std       $16D3,y
+                    bra       L093E
+
+L091F               ldd       $04,s
+                    beq       L093E
+                    ldb       ,u
+                    cmpb      #$20
+                    beq       L092D
+                    cmpb      #$09
+                    bne       L0934
+L092D               ldd       #$0001
+                    std       $02,s
+                    bra       L093E
+
+L0934               ldd       ,s
+                    bne       L093E
+                    clra
+                    clrb
+                    std       $04,s
+                    bra       L0967
+
+L093E               ldd       ,s
+                    bne       L0946
+                    ldd       $02,s
+                    beq       L094E
+L0946               ldd       $16D3,y
+                    lbeq      L07AE
+L094E               ldd       ,s
+                    beq       L0963
+                    leax      L0CD4,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $02,s
+                    lbsr      L3949
+L0963               ldd       $02,s
+                    bne       L096F
+L0967               leax      $06D3,y
+                    tfr       x,d
+                    bra       L0971
+
+L096F               clra
+                    clrb
+L0971               leas      $08,s
+                    puls      pc,u
+L0975               pshs      u
+                    tfr       d,u
+                    ldd       #$FFC0
+                    lbsr      L00FB
+                    ldb       ,u
+                    sex
+                    tfr       d,x
+                    bra       L098B
+
+L0986               ldd       #$0001
+                    puls      pc,u
+L098B               cmpx      #$0023
+                    beq       L0986
+                    cmpx      #$002A
+                    lbeq      L0986
+                    cmpx      #$000D
+                    lbeq      L0986
+                    stx       -$02,s
+                    lbeq      L0986
+                    clra
+                    clrb
+                    puls      pc,u
+L09A8               pshs      u,d
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leax      L0CF2,pcr
+                    pshs      x
+                    ldd       $02,s
+L09B8               lbsr      L2227
+                    leas      $02,s
+                    lbsr      L3949
+L09C0               leas      $02,s
+                    puls      pc,u
+                    com       $01,s
+                    jmp       $07,y
+                    lsr       L206F
+                    neg       $656E
+                    bra       L09F2
+                    bcs       L0A45
+                    bhi       L0A02
+                    bra       L09D6
+
+L09D6               bgt       L09D8
+L09D8               bgt       L09DA
+L09DA               bcs       L0A4F
+                    bra       L0A53
+                    neg       $2074
+                    clr       0,y
+                    lsr       $01,s
+                    lsr       $650D
+                    neg       L0063
+                    com       0,x
+L09EC               com       $03,s
+                    neg       $0072
+                    tst       $01,s
+L09F2               neg       $0053
+                    fcb       $79,$6e,$74,$61,$78,$3a,$20,$6d
+                    fcb       $61,$6b,$65,$20,$7b,$5b
+L0A02               fcb       $3C,$2d,$6f,$70,$74,$73,$3e,$5d
+                    fcb       $20,$5b,$3C,$20,$74,$61,$72,$67
+                    fcb       $65,$74,$20,$66,$69,$6C,$65,$20
+                    fcb       $3e,$5d,$20,$5b,$3C,$20,$6d,$61
+                    fcb       $63,$72,$6f,$73,$20,$3e,$5d,$7d
+                    fcb       $0d,$00
+L0A2C               fcb       $46,$75,$6e,$63,$74,$69,$6f,$6e
+                    fcb       $3a,$20,$6b,$65,$65,$70,$20,$74
+                    fcb       $72,$61,$63,$6b,$20,$6f,$66,$20
+                    fcb       $6d
+L0A45               fcb       $6f,$64,$75,$6C,$65,$73,$20,$66
+                    fcb       $6f,$72
+L0A4F               fcb       $20,$61,$20,$66
+L0A53               fcb       $69,$6C,$65,$0d,$00
+                    clra
+                    neg       $7469
+                    clr       $0e,s
+                    com       L3A0D
+                    neg       L0020
+                    bra       L0A85
+                    bra       L0A94
+                    fcb       $62,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $20,$64,$6f,$6e,$27,$74,$20,$75
+                    fcb       $73,$65,$20,$62,$75,$69,$6C,$74
+                    fcb       $2d,$69,$6e,$20,$72,$75
+L0A85               fcb       $6C,$65,$73,$0d,$00
+                    bra       $0AAC
+                    bra       $0AAE
+                    blt       %0000101011110100
+                    fcb       $20,$20,$20,$20
+L0A94               fcb       $20,$20,$20,$20,$64,$65,$62,$75
+                    fcb       $67,$20,$6d,$6f,$64,$65,$2C,$20
+                    fcb       $70,$72,$69,$6e,$74,$20,$6f,$75
+                    fcb       $74
+L0AAD               fcb       $20,$74,$68,$65,$20,$66,$69,$6C
+                    fcb       $65,$20,$64,$61,$74,$65,$73
+L0ABC               fcb       $20,$69,$6e,$20,$6d,$61,$6b,$65
+                    fcb       $66,$69,$6C,$65,$0d,$00
+                    bra       $0AEC
+                    bra       $0AEE
+                    blt       %0000101100110110
+                    fcb       $3d,$3C,$78,$78,$78,$3e,$20,$20
+                    fcb       $75,$73,$65,$20,$3C,$78,$78,$78
+                    fcb       $3e,$20,$61,$73,$20,$74,$68,$65
+                    fcb       $20,$6d,$61,$6b,$65
+L0AED               fcb       $66,$69,$6C,$65,$20,$20,$28,$64
+                    fcb       $65,$66,$61,$75,$6C,$74,$3a
+L0AFC               fcb       $20,$6d,$61,$6b,$65,$66,$69,$6C
+                    fcb       $65,$29,$0d,$00
+                    bra       $0B2A
+                    bra       $0B2C
+                    blt       %0000101101110111
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $69,$67,$6e,$6f,$72,$65,$20,$65
+                    fcb       $72,$72,$6f,$72,$73,$20,$6f,$6e
+                    fcb       $20,$63,$6f,$6d,$6d
+L0B2B               fcb       $61,$6e,$64,$73,$20,$61,$6e,$64
+                    fcb       $20,$6b,$65,$65,$70,$20,$67
+L0B3A               fcb       $6f,$69,$6e,$67,$0d,$00
+                    bra       $0B62
+                    bra       $0B64
+                    blt       %0000101110110100
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $64,$6f,$6e,$27,$74,$20,$65,$78
+                    fcb       $65,$63,$75,$74,$65,$20,$63,$6f
+                    fcb       $6d,$6d,$61,$6e,$64
+L0B63               fcb       $73,$2C,$20,$6a,$75,$73,$74,$20
+                    fcb       $70,$72,$69,$6e,$74,$20,$74
+L0B72               fcb       $68,$65,$6d,$20,$6f,$75,$74
+                    fcb       $0d,$00
+                    bra       $0B9D
+                    bra       $0B9F
+                    blt       %0000101111110100
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $73,$69,$6C,$65,$6e,$74,$20,$6d
+                    fcb       $6f,$64,$65,$2C,$20,$65,$78,$65
+                    fcb       $63,$75,$74,$65,$20
+L0B9E               fcb       $63,$6f,$6d,$6d,$61,$6e,$64,$73
+                    fcb       $20,$77,$69,$74,$68,$6f,$75
+L0BAD               fcb       $74,$20,$65,$63,$68,$6f,$69,$6e
+                    fcb       $67,$20,$74,$68,$65,$6d,$0d
+                    neg       L0020
+                    bra       L0BE0
+                    bra       L0BEF
+                    fcb       $74,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $20,$75,$70,$64,$61,$74,$65,$20
+                    fcb       $74,$68,$65,$20,$64,$61,$74,$65
+                    fcb       $73,$20,$77,$69,$74,$68
+L0BE0               fcb       $6f,$75,$74,$20,$65,$78,$65,$63
+                    fcb       $75,$74,$69,$6e,$67,$20,$74
+L0BEF               fcb       $68,$65,$20,$63,$6f,$6d,$6d,$61
+                    fcb       $6e,$64,$73,$0d,$00
+L0BFC               bra       $0C1E
+                    bra       $0C20
+                    blt       %0000110001110111
+                    fcb       $20,$20,$20,$20,$20,$20,$20,$20
+                    fcb       $64,$6f,$20,$74,$68,$65,$20,$6d
+                    fcb       $61,$6b,$65,$20,$77,$68,$65,$74
+                    fcb       $68,$65,$72,$20,$69
+L0C1F               fcb       $74,$20,$6e,$65,$65,$64,$73,$20
+                    fcb       $69,$74,$20,$6f,$72,$20,$6e
+L0C2E               fcb       $6f,$74,$0d,$00
+                    bra       $0C54
+                    bra       $0C56
+                    blt       $0CB2
+                    fcb       $5b,$3d,$3C,$70,$61,$74,$68,$3e
+                    fcb       $5d,$20,$67,$65,$74,$20,$6C,$69
+                    fcb       $73,$74,$20,$6f,$66,$20,$66,$69
+                    fcb       $6C,$65,$73,$20,$74
+L0C55               fcb       $6f,$20,$6d,$61,$6b,$65,$20,$66
+                    fcb       $72,$6f,$6d,$20,$73,$74,$64
+L0C64               fcb       $69,$6e,$20,$6f,$72,$20,$70,$61
+                    fcb       $74,$68,$0d,$00
+L0C70               fcb       $6e,$6f,$20,$64,$65,$70,$65,$6e
+                    fcb       $64,$65,$6e,$63,$79,$20,$6C,$69
+                    fcb       $73,$74,$20,$66,$6f,$72,$20,$63
+                    fcb       $6f,$6d,$6d,$61,$6e,$64,$20,$6C
+                    fcb       $69,$6e,$65,$0d,$00
+L0C95               com       $796e
+                    lsr       $6178
+                    bra       $0D02
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    tst       $0022
+                    bcs       L0D18
+                    bhi       L0CA7
+L0CA7               tst       $01,s
+                    fcb       $6b
+                    fcb       $65
+                    ror       $09,s
+                    inc       $05,s
+                    neg       $0072
+                    neg       $0062
+                    fcb       $75,$66,$66,$65,$72,$20,$6f,$76
+                    fcb       $65,$72,$66,$6C,$6f,$77,$20,$2d
+                    fcb       $2d,$20,$6C,$69,$6e,$65,$20,$74
+                    fcb       $6f,$6f,$20,$6C,$6f,$6e,$67
+                    fcb       $0d,$00
+L0CD4               fcb       $75,$6e,$66,$69,$6e,$69,$73,$68
+                    fcb       $65,$64,$20,$63,$6f,$6e,$74,$69
+                    fcb       $6e,$75,$61,$74,$69,$6f,$6e,$20
+                    fcb       $6C,$69,$6e,$65,$0d,$00
+L0CF2               fcb       $6d,$61,$6b,$65,$20,$74,$65,$72
+                    fcb       $6d,$69,$6e,$61,$74,$65
+L0D00               fcb       $64,$0d,$00
+L0D03               pshs      u
+                    tfr       d,u
+                    ldd       #$FFAE
+                    lbsr      L00FB
+                    leas      -$0C,s
+                    leax      $02,s
+                    stx       ,s
+                    lbra      L0D99
+
+L0D16               clra
+                    clrb
+L0D18               std       $08,s
+                    std       $0a,s
+                    bra       L0D29
+
+L0D1E               leau      $01,u
+                    ldd       $10,s
+                    addd      #$FFFF
+                    std       $10,s
+L0D29               ldb       ,u
+                    cmpb      #$20
+                    beq       L0D1E
+                    cmpb      #$09
+                    lbeq      L0D1E
+                    stu       $06,s
+                    ldb       ,u
+                    lbeq      L0DA0
+                    bra       L0D70
+
+L0D3F               ldb       ,u
+                    sex
+                    tfr       d,x
+                    bra       L0D5E
+
+L0D46               clra
+                    clrb
+                    stb       ,u+
+L0D4A               ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+                    bra       L0D70
+
+L0D53               leau      $01,u
+                    ldd       $08,s
+                    addd      #$0001
+                    std       $08,s
+                    bra       L0D70
+
+L0D5E               cmpx      #$0020
+                    beq       L0D46
+                    cmpx      #$0009
+                    lbeq      L0D46
+                    stx       -$02,s
+                    beq       L0D4A
+                    bra       L0D53
+
+L0D70               ldd       $0a,s
+                    beq       L0D3F
+                    ldd       $10,s
+                    pshs      d
+                    ldd       $0a,s
+                    addd      #$0001
+                    nega
+                    negb
+                    sbca      #$00
+                    addd      ,s++
+                    std       $10,s
+                    ldd       $06,s
+                    lbsr      L1FC2
+                    bsr       L0DA6
+                    std       $04,s
+                    std       [,s]
+                    ldd       $04,s
+                    addd      #$0002
+                    std       ,s
+L0D99               ldd       $10,s
+                    lbgt      L0D16
+L0DA0               ldd       $02,s
+                    leas      $0C,s
+                    puls      pc,u
+L0DA6               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      L21FB
+                    bsr       L0DBD
+                    lbra      L1248
+
+L0DBD               pshs      u
+                    tfr       d,u
+                    ldd       #$FFC0
+                    lbsr      L00FB
+                    clra
+                    clrb
+                    std       $04,u
+                    std       $02,u
+                    ldd       $04,s
+                    std       ,u
+                    ldd       [$04,s]
+                    std       $06,u
+                    stu       [$04,s]
+                    tfr       u,d
+                    puls      pc,u
+L0DDD               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    lbsr      $33CF
+                    addd      #$0001
+                    lbsr      L21FB
+                    std       ,s
+                    pshs      u
+                    ldd       $02,s
+                    lbsr      L33E2
+                    leas      $02,s
+                    ldd       ,s
+                    lbra      L1248
+
+L0E04               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    clra
+                    clrb
+                    std       L0021
+                    leax      >$001d,y
+                    stx       L001F
+                    leax      L124C,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    clra
+                    clrb
+                    pshs      d
+                    tfr       u,d
+                    bsr       L0E4B
+                    leas      $02,s
+                    leax      L1275,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    clra
+                    clrb
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L0F22
+                    leas      $02,s
+                    ldd       L0021
+                    beq       L0E49
+                    ldd       #$0001
+                    lbsr      L101B
+L0E49               puls      pc,u
+L0E4B               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB0
+                    lbsr      L00FB
+                    leas      -$08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       $0C,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    std       ,s
+L0E63               ldx       ,u
+                    ldd       $02,x
+                    std       $06,s
+                    pshs      d
+                    ldd       #$0014
+                    subd      $02,s
+                    leax      >$0043,y
+                    leax      d,x
+                    pshs      x
+                    leax      L1299,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    leas      $04,s
+                    ldd       $06,s
+                    lbsr      L162D
+                    std       -$02,s
+                    lbeq      L0F02
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $0e,s
+                    pshs      d
+                    leax      L12A5,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    leas      $04,s
+                    ldd       $04,u
+                    beq       L0EB8
+                    ldd       $0C,s
+                    pshs      d
+                    leax      L20F7,pcr
+                    pshs      x
+                    ldd       $04,u
+                    lbsr      L0FB4
+                    leas      $04,s
+                    std       $02,s
+L0EB8               ldd       $02,s
+                    bne       L0EFC
+                    leax      L12C6,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    ldd       $06,s
+                    lbsr      $33CF
+                    addd      #$0003
+                    lbsr      L357F
+                    std       $04,s
+                    ble       L0F14
+                    leax      L12DD,pcr
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    lbsr      L33E2
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L11A3
+                    leas      $02,s
+                    ldd       $04,s
+                    lbsr      L3602
+                    bra       L0F14
+
+L0EFC               clra
+                    clrb
+                    std       $02,s
+                    bra       L0F14
+
+L0F02               ldd       $04,u
+                    beq       L0F14
+                    ldd       $0C,s
+                    addd      #$0001
+                    pshs      d
+                    ldd       $04,u
+                    lbsr      L0E4B
+                    leas      $02,s
+L0F14               ldd       $0C,s
+                    beq       L0F1E
+                    ldu       $02,u
+                    lbne      L0E63
+L0F1E               leas      $08,s
+                    puls      pc,u
+L0F22               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB4
+                    lbsr      L00FB
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       $02,s
+                    ldd       $08,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    std       ,s
+L0F3A               ldx       ,u
+                    ldd       $02,x
+                    pshs      d
+                    ldd       #$0014
+                    subd      $02,s
+                    leax      >$0043,y
+                    leax      d,x
+                    pshs      x
+                    leax      $12E0,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    leas      $04,s
+                    ldx       ,u
+                    ldd       $02,x
+                    lbsr      L20F7
+                    std       -$02,s
+                    beq       L0F93
+                    ldd       $04,u
+                    beq       L0F79
+                    ldd       $08,s
+                    pshs      d
+                    leax      L20C1,pcr
+                    pshs      x
+                    ldd       $04,u
+                    bsr       L0FB4
+                    leas      $04,s
+                    std       $02,s
+L0F79               ldd       $02,s
+                    bne       L0F8D
+                    leax      L12EC,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    tfr       u,d
+                    lbsr      L0FF5
+                    bra       L0FA5
+
+L0F8D               clra
+                    clrb
+                    std       $02,s
+                    bra       L0FA5
+
+L0F93               ldd       $04,u
+                    beq       L0FA5
+                    ldd       $08,s
+                    addd      #$0001
+                    pshs      d
+                    ldd       $04,u
+                    lbsr      L0F22
+                    leas      $02,s
+L0FA5               ldd       $08,s
+                    lbeq      L121B
+                    ldu       $02,u
+                    lbne      L0F3A
+                    lbra      L121B
+
+L0FB4               pshs      u,d
+                    ldd       #$FFB6
+                    lbsr      L00FB
+L0FBC               ldu       ,s
+L0FBE               ldx       ,u
+                    ldd       $02,x
+                    jsr       [$06,s]
+                    std       -$02,s
+                    beq       L0FE4
+                    ldx       ,u
+                    ldd       $02,x
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    leax      $130C,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    leas      $04,s
+                    ldd       #$0001
+                    lbra      L1248
+
+L0FE4               ldu       $02,u
+                    bne       L0FBE
+                    ldx       ,s
+                    ldd       $04,x
+                    std       ,s
+                    bne       L0FBC
+                    clra
+                    clrb
+                    lbra      L1248
+
+L0FF5               pshs      u,d
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    ldd       #$0004
+L1000               lbsr      L21FB
+                    tfr       d,u
+                    stu       [L001F,y]
+                    ldd       ,s
+                    std       ,u
+                    leax      $02,u
+                    stx       L001F
+                    ldd       L0021
+                    addd      #$0001
+                    std       L0021
+                    lbra      L1248
+
+L101B               pshs      u
+                    ldd       #$FF94
+                    lbsr      L00FB
+                    leas      -$22,s
+                    leax      L132C,pcr
+                    pshs      x
+                    ldd       $01FF,y
+                    lbsr      L279E
+                    leas      $02,s
+                    std       ,s
+                    bne       L1051
+                    ldd       $01FF,y
+                    pshs      d
+                    ldd       >$0029,y
+                    pshs      d
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L1051               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0040
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $06,s
+                    lbsr      $2DC1
+                    leas      $06,s
+                    cmpd      #$FFFF
+                    bne       L1093
+                    ldd       $01FF,y
+                    pshs      d
+                    leax      L132E,pcr
+                    pshs      x
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+                    bra       L1093
+
+L1085               ldb       $02,s
+                    beq       L1093
+                    leax      $02,s
+                    tfr       x,d
+                    bsr       L10D7
+                    std       -$02,s
+                    beq       L10AE
+L1093               ldd       ,s
+                    pshs      d
+                    ldd       #$0020
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L28A8
+                    leas      $06,s
+                    std       -$02,s
+                    bne       L1085
+L10AE               ldd       L0021
+                    beq       L10CD
+                    ldu       [L001D,y]
+                    ldx       ,u
+                    ldd       $02,x
+                    pshs      d
+                    leax      $1341,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L10CD               ldd       ,s
+                    lbsr      L305B
+                    leas      $22,s
+                    puls      pc,u
+L10D7               pshs      u
+                    tfr       d,u
+                    ldd       #$FF90
+                    lbsr      L00FB
+                    leas      -$28,s
+                    clra
+                    clrb
+                    std       $20,s
+                    ldd       L001D
+                    std       $22,s
+                    pshs      u
+                    leax      $02,s
+                    tfr       x,d
+                    lbsr      L3518
+                    leas      $02,s
+L10F9               ldd       [$22,s]
+                    std       $24,s
+                    ldx       [$24,s]
+                    ldd       $02,x
+                    std       $26,s
+                    lbsr      $33CF
+                    std       $1e,s
+                    bra       L1135
+
+L110F               ldd       $1e,s
+                    addd      #$FFFF
+                    std       $1e,s
+                    addd      $26,s
+                    tfr       d,x
+                    ldb       ,x
+                    cmpb      #$2f
+                    bne       L1135
+                    ldd       $26,s
+                    pshs      d
+                    ldd       $20,s
+                    addd      #$0001
+                    addd      ,s++
+                    std       $26,s
+                    bra       L113A
+
+L1135               ldd       $1e,s
+                    bne       L110F
+L113A               leax      ,s
+                    pshs      x
+                    ldd       $28,s
+                    lbsr      L21A3
+                    std       ,s++
+                    beq       L118A
+                    ldd       $20,s
+                    beq       L1159
+                    ldx       $22,s
+                    ldd       $02,x
+                    ldx       $20,s
+                    std       $02,x
+                    bra       L1160
+
+L1159               ldx       $22,s
+                    ldd       $02,x
+                    std       L001D
+L1160               ldx       [$24,s]
+                    ldd       $02,x
+                    pshs      d
+                    leax      $02,s
+                    pshs      x
+                    leax      L1365,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    leas      $04,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $26,s
+                    bsr       L11C9
+                    leas      $02,s
+                    ldd       L0021
+                    addd      #$FFFF
+                    std       L0021
+                    bra       L1190
+
+L118A               ldd       $22,s
+                    std       $20,s
+L1190               ldx       $22,s
+                    ldd       $02,x
+                    std       $22,s
+                    lbne      L10F9
+                    ldd       L0021
+                    leas      $28,s
+                    puls      pc,u
+L11A3               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldd       $06,s
+                    lbsr      L1FF8
+                    lbsr      L121F
+                    bra       L11BD
+
+L11B9               ldx       ,s
+                    ldd       $02,x
+L11BD               std       ,s
+                    ldx       ,s
+                    ldd       $02,x
+                    bne       L11B9
+                    ldd       $04,u
+                    bra       L11E3
+
+L11C9               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldd       $06,s
+                    lbsr      L1FC2
+                    lbsr      L0DA6
+                    std       ,s
+                    ldd       $04,u
+                    ldx       ,s
+L11E3               std       $02,x
+                    tfr       x,d
+                    std       $04,u
+                    lbra      L1248
+
+L11EC               pshs      u,d
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldd       #$0008
+                    lbsr      L21FB
+                    std       ,s
+                    ldd       [$02,s]
+                    std       [,s]
+                    ldx       $02,s
+                    ldd       $06,x
+                    ldx       ,s
+                    std       $06,x
+                    tfr       x,d
+                    ldx       $02,s
+                    std       $06,x
+                    clra
+                    clrb
+                    ldx       ,s
+                    std       $04,x
+                    std       $02,x
+                    tfr       x,d
+L121B               leas      $04,s
+                    puls      pc,u
+L121F               pshs      u,d
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    ldd       ,s
+                    bsr       L11EC
+                    tfr       d,u
+                    ldx       ,s
+                    ldd       $04,x
+                    beq       L1239
+                    ldd       $04,x
+                    bsr       L121F
+                    std       $04,u
+L1239               ldx       ,s
+                    ldd       $02,x
+                    beq       L1246
+                    ldd       $02,x
+                    lbsr      L121F
+                    std       $02,u
+L1246               tfr       u,d
+L1248               leas      $02,s
+                    puls      pc,u
+L124C               fcb       $63,$68,$65,$63,$6b,$69,$6e,$67
+                    fcb       $20,$66,$6f,$72,$20,$69,$6d,$70
+                    fcb       $6C,$69,$63,$69,$74,$20,$72,$65
+                    fcb       $6C,$6f,$63,$61,$74,$61,$62,$6C
+                    fcb       $65,$20,$66,$69,$6C,$65,$73
+                    fcb       $0d,$00
+L1275               fcb       $63,$68,$65,$63,$6b,$69,$6e,$67
+                    fcb       $20,$66,$6f,$72,$20,$69,$6d,$70
+                    fcb       $6C,$69,$63,$69,$74,$20,$73,$6f
+                    fcb       $75,$72,$63,$65,$20,$66,$69,$6C
+                    fcb       $65,$73,$0d,$00
+L1299               bcs       L130E
+                    ror       $09,s
+                    inc       $05,s
+                    abx
+                    bra       L12C7
+                    com       L0D00
+L12A5               fcb       $66,$6f,$75,$6e,$64,$20,$6f,$62
+                    fcb       $6a,$65,$63,$74,$20,$66,$69,$6C
+                    fcb       $65,$28,$6C,$65,$76,$65,$6C,$20
+                    fcb       $25,$64,$29,$3a,$20,$25,$73
+                    fcb       $0d,$00
+L12C6               fcb       $6e
+L12C7               fcb       $6f,$20,$65,$78,$70,$6C,$69,$63
+                    fcb       $69,$74,$20,$22,$2e,$72,$22,$20
+                    fcb       $66,$69,$6C,$65,$0d,$00
+L12DD               bgt       $1351
+                    neg       $0025
+                    com       $6669
+                    inc       $05,s
+                    abx
+                    bra       L130E
+                    com       L0D00
+L12EC               fcb       $6e,$6f,$20,$65,$78,$70,$6C,$69
+                    fcb       $63,$69,$74,$20,$73,$6f,$75,$72
+                    fcb       $63,$65,$20,$66,$69,$6C,$65,$20
+                    fcb       $6C,$69,$73,$74,$65,$64,$0d
+                    neg       L0066
+                    fcb       $6f
+L130E               fcb       $75,$6e,$64,$20,$64,$65,$70,$65
+                    fcb       $6e,$64,$65,$6e,$74,$20,$28,$6C
+                    fcb       $65,$76,$65,$6C,$20,$25,$64,$29
+                    fcb       $3a,$20,$25,$73,$0d,$00
+L132C               lsr       0,x
+L132E               com       $01,s
+                    jmp       $07,y
+                    lsr       L2072
+                    fcb       $65
+                    fcb       $61
+                    lsr       0,y
+                    bhi       $1360
+                    com       $222E
+                    bra       $1360
+                    neg       L0063
+                    fcb       $61
+                    jmp       $07,y
+                    lsr       $2066
+                    rol       $0e,s
+                    lsr       0,y
+                    com       $6F75
+                    fcb       $72
+                    com       $05,s
+                    bra       $13BA
+                    rol       $0C,s
+                    fcb       $65
+                    bra       $13CD
+                    clr       0,y
+                    tst       $01,s
+                    fcb       $6b
+                    fcb       $65
+                    bra       $1383
+                    bcs       $13D6
+                    bhi       L1365
+L1365               fcb       $66,$6f,$75,$6e,$64,$20,$22,$25
+                    fcb       $73,$22,$20,$74,$6f,$20,$6d,$61
+                    fcb       $6b,$65,$20,$22,$25,$73,$22
+                    fcb       $0d,$00
+L137E               pshs      u
+                    tfr       d,u
+                    ldd       #$FFAE
+                    lbsr      L00FB
+                    leas      -$0C,s
+                    ldd       $04,u
+                    std       $0a,s
+                    ldd       [$0a,s]
+                    addd      #$0006
+                    std       $08,s
+                    ldd       ,u
+                    addd      #$0006
+                    std       $06,s
+                    clra
+                    clrb
+                    std       $02,s
+                    leax      $02,s
+                    stx       ,s
+                    lbra      L1427
+
+L13A8               ldd       $0017
+                    beq       L13AF
+                    lbsr      L09A8
+L13AF               ldd       $0a,s
+                    lbsr      L1468
+                    ldb       [$06,s]
+                    cmpb      #$FF
+                    beq       L13D2
+                    ldd       [$0a,s]
+                    addd      #$0006
+                    pshs      d
+                    ldd       $08,s
+                    lbsr      L1667
+                    std       ,s++
+                    bne       L13D2
+                    ldd       $021d,y
+                    beq       L13F1
+L13D2               ldd       #$0004
+                    lbsr      L21FB
+                    std       $04,s
+                    std       [,s]
+                    ldd       $04,s
+                    addd      #$0002
+                    std       ,s
+                    ldx       [$0a,s]
+                    ldd       $02,x
+                    std       [$04,s]
+                    clra
+                    clrb
+                    ldx       $04,s
+                    std       $02,x
+L13F1               ldx       $0a,s
+                    ldd       $04,x
+                    beq       L1403
+                    ldd       L0023
+                    addd      #$0001
+                    std       L0023
+                    ldd       $0a,s
+                    lbsr      L137E
+L1403               ldd       [$0a,s]
+                    addd      #$0006
+                    cmpd      $08,s
+                    beq       L1421
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      L1667
+                    std       ,s++
+                    beq       L1421
+                    ldd       [$0a,s]
+                    addd      #$0006
+                    std       $08,s
+L1421               ldx       $0a,s
+                    ldd       $02,x
+                    std       $0a,s
+L1427               ldd       $0a,s
+                    lbne      L13A8
+                    ldx       ,u
+                    ldb       $06,x
+                    cmpb      #$FF
+                    beq       L1452
+                    ldd       $08,s
+                    pshs      d
+                    tfr       x,d
+                    addd      #$0006
+                    lbsr      L1667
+                    std       ,s++
+                    bne       L144B
+                    ldd       $021d,y
+                    beq       L145D
+L144B               ldd       #$00FF
+                    ldx       ,u
+                    stb       $06,x
+L1452               ldd       $02,s
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L16C5
+                    leas      $02,s
+L145D               ldd       L0023
+                    addd      #$FFFF
+                    std       L0023
+                    leas      $0C,s
+                    puls      pc,u
+L1468               pshs      u
+                    tfr       d,u
+                    ldd       #$FF4C
+                    lbsr      L00FB
+                    leas      -$6C,s
+                    ldx       ,u
+                    ldd       $02,x
+                    std       $6a,s
+                    clra
+                    clrb
+                    std       $04,s
+                    std       $02,s
+                    ldd       $6a,s
+                    std       ,s
+                    bra       L149E
+
+L1489               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    cmpb      #$2f
+                    bne       L149E
+                    ldd       $04,s
+                    addd      #$0001
+                    std       $04,s
+                    bra       L14A2
+
+L149E               ldb       [,s]
+                    bne       L1489
+L14A2               clra
+                    clrb
+                    stb       $06,s
+                    ldd       $6a,s
+                    lbsr      L20F7
+                    std       -$02,s
+                    beq       L14E6
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+                    ldd       $04,s
+                    lbne      L1547
+                    ldd       $0227,y
+                    lbeq      L1547
+                    ldd       $0201,y
+                    pshs      d
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L33E2
+                    leas      $02,s
+                    leax      L1E64,pcr
+L14D8               pshs      x
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbra      L1547
+
+L14E6               ldd       $6a,s
+                    lbsr      L162D
+                    std       -$02,s
+                    beq       L1516
+                    ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+                    ldd       $04,s
+                    bne       L1547
+                    ldd       $0225,y
+                    beq       L1547
+                    ldd       $0203,y
+                    pshs      d
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L33E2
+                    leas      $02,s
+                    leax      L1E66,pcr
+                    bra       L14D8
+
+L1516               ldd       $6a,s
+                    lbsr      L20C1
+                    std       -$02,s
+                    beq       L1540
+                    ldd       $04,s
+                    bne       L1547
+                    ldd       $0223,y
+                    beq       L1547
+                    ldd       $01FF,y
+                    pshs      d
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L33E2
+                    leas      $02,s
+                    leax      L1E68,pcr
+                    lbra      L14D8
+
+L1540               ldd       $02,s
+                    addd      #$0001
+                    std       $02,s
+L1547               ldd       $6a,s
+                    pshs      d
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldx       ,u
+                    ldb       $06,x
+                    bne       L1569
+                    ldd       $02,s
+                    pshs      d
+                    leax      $08,s
+                    pshs      x
+                    tfr       u,d
+                    bsr       L1584
+                    leas      $04,s
+L1569               ldd       $0213,y
+                    beq       L157F
+                    ldd       ,u
+                    addd      #$0006
+                    pshs      d
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L1D6A
+                    leas      $02,s
+L157F               leas      $6C,s
+                    puls      pc,u
+L1584               pshs      u,d
+                    ldd       #$FFA2
+                    lbsr      L00FB
+                    ldu       $08,s
+                    leas      -$14,s
+                    ldd       [$14,s]
+                    addd      #$0006
+                    std       ,s
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $1C,s
+                    lbsr      $36CC
+                    leas      $02,s
+                    std       $12,s
+                    bge       L15E5
+                    ldd       #$0080
+                    pshs      d
+                    ldd       $1C,s
+                    lbsr      $36CC
+                    leas      $02,s
+                    std       $12,s
+                    bge       L15E5
+                    stu       -$02,s
+                    bne       L15C7
+                    ldx       $14,s
+                    ldd       $04,x
+                    beq       L15CE
+L15C7               ldd       #$00FF
+                    stb       [,s]
+                    bra       L15E5
+
+L15CE               ldd       $1a,s
+                    pshs      d
+                    ldd       >$0029,y
+                    pshs      d
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L15E5               ldb       [,s]
+                    bne       L1628
+                    ldd       #$0010
+                    pshs      d
+                    leax      $04,s
+                    pshs      x
+                    ldd       $16,s
+                    lbsr      $3928
+                    leas      $04,s
+                    cmpd      #$FFFF
+                    bne       L1617
+                    ldd       $1a,s
+                    pshs      d
+                    leax      L1E6A,pcr
+                    pshs      x
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L1617               leax      $05,s
+                    pshs      x
+                    ldd       $02,s
+                    lbsr      L212D
+                    leas      $02,s
+                    ldd       $12,s
+                    lbsr      L36D9
+L1628               leas      $16,s
+                    puls      pc,u
+L162D               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    pshs      u
+                    tfr       u,d
+                    lbsr      $33CF
+                    addd      ,s++
+                    std       ,s
+                    bra       L1656
+
+L1646               ldb       [,s]
+                    cmpb      #$2f
+                    lbeq      L16BE
+                    ldb       [,s]
+                    cmpb      #$2e
+                    lbeq      L16A2
+L1656               ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+                    pshs      d
+                    cmpu      ,s++
+                    bls       L1646
+                    lbra      L16BE
+
+L1667               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBC
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldb       ,u
+                    cmpb      #$FF
+                    beq       L16A2
+                    ldb       [$06,s]
+                    cmpb      #$FF
+                    beq       L16BE
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L16B6
+
+L1686               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L16A6
+                    ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$08,s]
+                    sex
+                    cmpd      ,s++
+                    bgt       L16BE
+L16A2               clra
+                    clrb
+                    bra       L16C1
+
+L16A6               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    leau      $01,u
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+L16B6               ldd       ,s
+                    cmpd      #$0005
+                    blt       L1686
+L16BE               ldd       #$0001
+L16C1               leas      $02,s
+                    puls      pc,u
+L16C5               pshs      u,d
+                    ldd       #$FFA8
+                    lbsr      L00FB
+                    leas      -$0C,s
+                    ldu       #$0000
+                    clra
+                    clrb
+                    std       $06,s
+                    ldd       $0003
+                    std       ,s
+                    ldx       [$0C,s]
+                    ldd       $04,x
+                    beq       L16F2
+                    ldd       $04,x
+                    pshs      d
+                    leax      $1E82,pcr
+                    tfr       x,d
+                    lbsr      L209B
+                    leas      $02,s
+                    bra       L16FB
+
+L16F2               leax      L1E8F,pcr
+                    tfr       x,d
+                    lbsr      L209B
+L16FB               ldd       #$0001
+                    std       $022f,y
+                    ldx       [$0C,s]
+                    ldd       $04,x
+                    std       $04,s
+                    bne       L1712
+                    ldd       $0C,s
+                    lbsr      L19BB
+                    std       $04,s
+L1712               ldb       [$04,s]
+                    cmpb      #$0d
+                    lbeq      L192F
+                    ldd       ,s
+                    cmpd      $04,s
+                    lbeq      L1851
+                    ldd       $021b,y
+                    lbne      L1851
+                    lbra      L1840
+
+L172F               ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       -$01,x
+                    sex
+                    tfr       d,x
+                    lbra      L1832
+
+L173D               ldx       [$0C,s]
+                    ldd       $02,x
+                    std       $02,s
+                    lbsr      $33CF
+                    std       $0a,s
+                    ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       -$01,x
+                    sex
+                    tfr       d,x
+                    lbra      L17F5
+
+L1757               clra
+                    clrb
+                    std       $06,s
+                    ldd       $0a,s
+                    bra       L17A2
+
+L175F               ldx       $02,s
+                    ldd       $08,s
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    tfr       d,x
+                    bra       L1794
+
+L176C               ldd       $06,s
+                    bne       L17A0
+                    ldd       $08,s
+                    std       $0a,s
+                    ldd       $06,s
+                    addd      #$0001
+                    std       $06,s
+                    bra       L17A0
+
+L177D               ldd       $02,s
+                    pshs      d
+                    ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+                    addd      ,s++
+                    std       $02,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       $0a,s
+                    bra       L17AB
+
+L1794               cmpx      #$002E
+                    beq       L176C
+                    cmpx      #$002F
+                    beq       L177D
+                    bra       L17A0
+
+L17A0               ldd       $08,s
+L17A2               addd      #$FFFF
+                    std       $08,s
+                    ldd       $08,s
+                    bgt       L175F
+L17AB               ldd       $0a,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    pshs      u
+                    ldd       $0003
+                    addd      ,s++
+                    lbsr      L3455
+                    leas      $04,s
+                    ldd       $0a,s
+                    bra       L17D6
+
+L17C2               ldd       $12,s
+                    lbeq      L1840
+                    pshs      d
+                    pshs      u
+                    ldd       $0003
+                    addd      ,s++
+                    lbsr      L197D
+                    leas      $02,s
+L17D6               leau      d,u
+                    lbra      L1840
+
+L17DB               ldd       $04,s
+                    addd      #$FFFE
+                    pshs      d
+                    leax      L1EA4,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+                    bra       L1840
+
+L17F5               cmpx      #$002A
+                    lbeq      L1757
+                    cmpx      #$0040
+                    beq       L17AB
+                    cmpx      #$003F
+                    beq       L17C2
+                    bra       L17DB
+
+L1808               pshs      u
+                    ldd       #$0001
+                    addd      ,s++
+                    addd      $0003
+                    tfr       d,x
+                    clra
+                    clrb
+                    stb       ,x
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $02,s
+                    bsr       L1861
+                    leas      $02,s
+                    ldd       $021b,y
+                    lbne      L192F
+                    ldu       #$0000
+                    bra       L1840
+
+L182E               leau      $01,u
+                    bra       L1840
+
+L1832               cmpx      #$0024
+                    lbeq      L173D
+                    cmpx      #$000D
+                    beq       L1808
+                    bra       L182E
+
+L1840               ldx       $0003
+                    tfr       u,d
+                    leax      d,x
+                    ldb       [$04,s]
+                    stb       ,x
+                    lbne      L172F
+                    bra       L185B
+
+L1851               ldd       $0C,s
+                    pshs      d
+                    ldd       $06,s
+                    bsr       L1861
+                    leas      $02,s
+L185B               ldd       #$0001
+                    lbra      L192F
+
+L1861               pshs      u
+                    tfr       d,u
+                    ldd       #$FFA4
+                    lbsr      L00FB
+                    leas      -$0e,s
+                    clra
+                    clrb
+                    std       $0C,s
+                    std       $0a,s
+                    ldb       ,u
+                    sex
+                    tfr       d,x
+                    bra       L188E
+
+L187A               ldd       $0C,s
+                    addd      #$0001
+                    std       $0C,s
+                    bra       L188A
+
+L1883               ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+L188A               leau      $01,u
+                    bra       L1898
+
+L188E               cmpx      #$0040
+                    beq       L187A
+                    cmpx      #$002D
+                    beq       L1883
+L1898               ldd       $0217,y
+                    beq       L18AE
+                    leax      $00A7,y
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L280A
+                    leas      $02,s
+                    lbra      L192F
+
+L18AE               ldd       $021b,y
+                    beq       L18BF
+                    ldx       [$12,s]
+                    ldd       $02,x
+                    lbsr      L1C76
+                    lbra      L192F
+
+L18BF               leax      L1ECA,pcr
+                    stx       ,s
+                    stu       $02,s
+                    clra
+                    clrb
+                    std       $04,s
+                    ldd       $0219,y
+                    bne       L18E2
+                    ldd       $0C,s
+                    bne       L18E2
+                    leax      $00A7,y
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L280A
+                    leas      $02,s
+L18E2               clra
+                    clrb
+                    pshs      d
+                    ldd       #$0001
+                    pshs      d
+                    pshs      d
+                    pshs      u
+                    tfr       u,d
+                    lbsr      $33CF
+                    pshs      d
+                    ldd       $0a,s
+                    lbsr      $38E4
+                    leas      $0a,s
+                    std       $06,s
+                    cmpd      #$FFFF
+                    beq       L191D
+                    ldd       $06,s
+                    bsr       L1933
+                    std       -$02,s
+                    beq       L192F
+                    ldd       $0215,y
+                    bne       L192F
+                    ldd       $0a,s
+                    bne       L192F
+                    leax      $1ED0,pcr
+                    bra       L1921
+
+L191D               leax      L1EE7,pcr
+L1921               pshs      x
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $02,s
+                    lbsr      L3949
+L192F               leas      $0e,s
+                    puls      pc,u
+L1933               pshs      u,d
+                    ldd       #$FFB4
+                    lbsr      L00FB
+                    leas      -$04,s
+L193D               leax      ,s
+                    tfr       x,d
+                    lbsr      $38A6
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L1977
+                    ldd       $02,s
+                    bne       L1963
+                    ldd       $0017
+                    pshs      d
+                    ldd       $06,s
+                    lbsr      L389C
+                    leas      $02,s
+                    cmpd      #$FFFF
+                    beq       L1972
+                    bra       L193D
+
+L1963               cmpd      $04,s
+                    lbne      L193D
+                    ldd       ,s
+                    beq       L1977
+                    std       $01FD,y
+L1972               ldd       #$FFFF
+                    bra       L1979
+
+L1977               clra
+                    clrb
+L1979               leas      $06,s
+                    puls      pc,u
+L197D               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    ldd       [$04,s]
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L33E2
+                    bra       L19AA
+
+L1993               leax      >$0058,y
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       [$04,s]
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L0741
+L19AA               leas      $02,s
+                    ldx       $04,s
+                    ldd       $02,x
+                    std       $04,s
+                    bne       L1993
+                    tfr       u,d
+                    lbsr      $33CF
+                    puls      pc,u
+L19BB               pshs      u
+                    tfr       d,u
+                    ldd       #$FF8A
+                    lbsr      L00FB
+                    leas      -$2e,s
+                    clra
+                    clrb
+                    std       $28,s
+                    std       $26,s
+                    std       $24,s
+                    ldx       ,u
+                    ldd       $02,x
+                    std       $2C,s
+                    lbsr      L20F7
+                    std       -$02,s
+                    beq       L19F4
+                    ldd       #$0073
+L19E4               pshs      d
+                    ldd       $04,u
+                    lbsr      L1DCF
+                    leas      $02,s
+                    std       $2a,s
+                    bne       L1A19
+                    bra       L1A03
+
+L19F4               ldd       $2C,s
+                    lbsr      L162D
+                    std       -$02,s
+                    beq       L1A03
+                    ldd       #$0072
+                    bra       L19E4
+
+L1A03               ldd       $2C,s
+                    pshs      d
+                    leax      >$005a,y
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L1A19               ldd       $2C,s
+                    lbsr      L1E1F
+                    std       $20,s
+                    ldd       $2a,s
+                    lbsr      L1E1F
+                    std       $1e,s
+                    ldd       $2a,s
+                    lbsr      $33CF
+                    addd      #$FFFF
+                    std       $22,s
+                    ldx       $2a,s
+                    leax      d,x
+                    ldb       ,x
+                    sex
+                    tfr       d,x
+                    bra       L1A8D
+
+L1A43               ldd       $28,s
+                    addd      #$0001
+                    std       $28,s
+                    bra       L1AAA
+
+L1A4E               ldd       $26,s
+                    addd      #$0001
+                    std       $26,s
+                    bra       L1AAA
+
+L1A59               ldd       $24,s
+                    addd      #$0001
+                    std       $24,s
+                    bra       L1AAA
+
+L1A64               leax      L1EFE,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $02,s
+                    lbsr      L3949
+L1A75               ldd       $2C,s
+                    pshs      d
+                    leax      >$005a,y
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+                    bra       L1AAA
+
+L1A8D               cmpx      #$0063
+                    beq       L1A43
+                    cmpx      #$0061
+                    beq       L1A4E
+                    cmpx      #$0072
+                    beq       L1A59
+                    cmpx      #$0066
+                    beq       L1A64
+                    cmpx      #$0070
+                    lbeq      L1A64
+                    bra       L1A75
+
+L1AAA               ldd       $28,s
+                    lbeq      L1B1C
+                    leax      >$0058,y
+                    pshs      x
+                    ldd       $020b,y
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33E2
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $0207,y
+                    beq       L1AD8
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+L1AD8               ldd       $0227,y
+                    beq       L1B02
+                    leax      $1F26,pcr
+                    pshs      x
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $0003
+                    lbsr      L1E3E
+                    ldd       $0003
+                    lbsr      $33CF
+                    tfr       d,x
+                    ldd       $0003
+                    leax      d,x
+                    ldd       #$0020
+                    stb       -$01,x
+                    bra       L1B0F
+
+L1B02               leax      $1F2B,pcr
+                    pshs      x
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+L1B0F               ldd       $2a,s
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L0741
+                    lbra      L1C60
+
+L1B1C               ldd       $26,s
+                    lbeq      L1BC8
+                    ldd       $022b,y
+                    bne       L1B3C
+                    ldd       $021f,y
+                    beq       L1B3C
+                    leax      L1F30,pcr
+                    pshs      x
+                    ldd       $0003
+                    lbsr      L33E2
+                    bra       L1B52
+
+L1B3C               leax      >$0058,y
+                    pshs      x
+                    ldd       $020d,y
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33E2
+                    leas      $02,s
+                    lbsr      L33FA
+L1B52               leas      $02,s
+                    ldd       $0209,y
+                    beq       L1B6C
+                    leax      >$0058,y
+                    pshs      x,d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+L1B6C               leax      $1F34,pcr
+                    pshs      x
+                    ldd       $01FF,y
+                    lbsr      L3427
+                    std       ,s++
+                    beq       L1B9A
+                    ldd       $1e,s
+                    bne       L1B9A
+                    leax      $1F36,pcr
+                    pshs      x
+                    ldd       $01FF,y
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+L1B9A               leax      $1F38,pcr
+                    pshs      x
+                    ldd       $2C,s
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $0227,y
+                    lbeq      L1C56
+                    ldd       $20,s
+                    lbne      L1C56
+                    ldd       $0003
+                    lbsr      L1E3E
+                    lbra      L1C56
+
+L1BC8               ldd       $24,s
+                    lbeq      L1C62
+                    leax      >$0058,y
+                    pshs      x
+                    ldd       $020f,y
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33E2
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $0205,y
+                    beq       L1BFF
+                    leax      >$0058,y
+                    pshs      x,d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+L1BFF               ldd       $1e,s
+                    bne       L1C22
+                    ldd       $0227,y
+                    beq       L1C22
+                    leax      $1F3D,pcr
+                    pshs      x
+                    ldd       $0201,y
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+L1C22               leax      $1F3F,pcr
+                    pshs      x
+                    ldd       $2C,s
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $20,s
+                    bne       L1C56
+                    ldd       $0203,y
+                    beq       L1C56
+                    leax      $1F44,pcr
+                    pshs      x,d
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    lbsr      L33FA
+                    leas      $02,s
+L1C56               ldd       $2C,s
+                    pshs      d
+                    ldd       $0003
+                    lbsr      L33FA
+L1C60               leas      $02,s
+L1C62               leax      $1F46,pcr
+                    pshs      x
+                    ldd       $0003
+                    lbsr      L33FA
+                    leas      $02,s
+                    ldd       $0003
+                    leas      $2e,s
+                    puls      pc,u
+L1C76               pshs      u
+                    tfr       d,u
+                    ldd       #$FF4C
+                    lbsr      L00FB
+                    leas      -$6a,s
+                    clra
+                    clrb
+                    std       $66,s
+                    stu       ,s
+                    bra       L1CA3
+
+L1C8C               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    cmpb      #$2f
+                    bne       L1CA3
+                    ldd       $66,s
+                    addd      #$0001
+                    std       $66,s
+                    bra       L1CA7
+
+L1CA3               ldb       [,s]
+                    bne       L1C8C
+L1CA7               ldd       $66,s
+                    lbne      L1D10
+                    ldd       $0227,y
+                    beq       L1CCB
+                    tfr       u,d
+                    lbsr      L20F7
+                    std       -$02,s
+                    beq       L1CCB
+                    pshs      u
+                    ldd       $0201,y
+                    pshs      d
+                    leax      $1F48,pcr
+                    bra       L1D03
+
+L1CCB               ldd       $0225,y
+                    beq       L1CE8
+                    tfr       u,d
+                    lbsr      L162D
+                    std       -$02,s
+                    beq       L1CE8
+                    pshs      u
+                    ldd       $0203,y
+                    pshs      d
+                    leax      $1F4E,pcr
+                    bra       L1D03
+
+L1CE8               ldd       $0223,y
+                    beq       L1D1B
+                    tfr       u,d
+                    lbsr      L20C1
+                    std       -$02,s
+                    beq       L1D1B
+                    pshs      u
+                    ldd       $01FF,y
+                    pshs      d
+                    leax      $1F54,pcr
+L1D03               pshs      x
+                    leax      $08,s
+                    tfr       x,d
+                    lbsr      L291D
+                    leas      $06,s
+                    bra       L1D1B
+
+L1D10               pshs      u
+                    leax      $04,s
+                    tfr       x,d
+                    lbsr      L33E2
+                    leas      $02,s
+L1D1B               ldd       #$0002
+                    pshs      d
+                    leax      $04,s
+                    tfr       x,d
+                    lbsr      $36CC
+                    leas      $02,s
+                    std       $68,s
+                    bge       L1D44
+                    leax      $02,s
+                    pshs      x
+                    ldd       >$0029,y
+                    pshs      d
+                    ldd       $01FD,y
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L1D44               ldd       $0219,y
+                    bne       L1D5F
+                    leax      $02,s
+                    pshs      x
+                    leax      $1F5A,pcr
+                    pshs      x
+                    leax      $00B4,y
+                    tfr       x,d
+                    lbsr      L2901
+                    leas      $04,s
+L1D5F               ldd       $68,s
+                    lbsr      L36D9
+                    leas      $6a,s
+                    puls      pc,u
+L1D6A               pshs      u
+                    tfr       d,u
+                    ldd       #$FFA2
+                    lbsr      L00FB
+                    leas      -$0C,s
+                    ldb       [$10,s]
+                    sex
+                    std       $08,s
+                    ldx       $10,s
+                    ldb       $01,x
+                    sex
+                    std       $06,s
+                    ldb       $02,x
+                    sex
+                    std       $04,s
+                    ldb       $03,x
+                    sex
+                    std       $02,s
+                    ldb       $04,x
+                    sex
+                    std       ,s
+                    ldd       L0023
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    std       $0a,s
+                    ldd       ,s
+                    pshs      d
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $10,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0014
+                    subd      $16,s
+                    leax      >$0078,y
+                    leax      d,x
+                    pshs      x
+                    leax      $1F69,pcr
+                    tfr       x,d
+                    lbsr      L28EF
+                    leas      $0e,s
+                    leas      $0C,s
+                    puls      pc,u
+L1DCF               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB2
+                    lbsr      L00FB
+                    leas      -$0a,s
+L1DDB               stu       $02,s
+L1DDD               ldd       $02,s
+                    std       ,s
+L1DE1               ldx       [,s]
+                    ldd       $02,x
+                    std       $04,s
+                    ldb       $0f,s
+                    cmpb      #$72
+                    bne       L1DF8
+                    ldd       $04,s
+                    lbsr      L20F7
+                    std       -$02,s
+                    bne       L1E01
+                    bra       L1E05
+
+L1DF8               ldd       $04,s
+                    lbsr      L20C1
+                    std       -$02,s
+                    beq       L1E05
+L1E01               ldd       $04,s
+                    bra       L1E1B
+
+L1E05               ldx       ,s
+                    ldd       $02,x
+                    std       ,s
+                    bne       L1DE1
+                    ldx       $02,s
+                    ldd       $04,x
+                    std       $02,s
+                    bne       L1DDD
+                    ldu       $02,u
+                    bne       L1DDB
+                    clra
+                    clrb
+L1E1B               leas      $0a,s
+                    puls      pc,u
+L1E1F               pshs      u
+                    tfr       d,u
+                    ldd       #$FFC0
+                    lbsr      L00FB
+                    bra       L1E36
+
+L1E2B               ldb       ,u+
+                    cmpb      #$2f
+                    bne       L1E36
+                    ldd       #$0001
+                    puls      pc,u
+L1E36               ldb       ,u
+                    bne       L1E2B
+                    clra
+                    clrb
+                    puls      pc,u
+L1E3E               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    ldd       $0201,y
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L0741
+                    leas      $02,s
+                    leax      L1F91,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L33FA
+                    leas      $02,s
+                    puls      pc,u
+L1E64               ble       L1E66
+L1E66               ble       L1E68
+L1E68               ble       L1E6A
+L1E6A               asr       $05,s
+                    lsr       $7374
+                    fcb       $61
+                    lsr       L2065
+                    fcb       $72
+                    fcb       $72
+                    clr       -$0e,s
+                    bra       L1EA6
+                    bra       L1E9D
+                    bcs       L1EF0
+                    bhi       L1EAD
+                    bra       L1EA1
+                    neg       L0063
+                    clr       $0d,s
+                    tst       $01,s
+                    jmp       $04,s
+                    abx
+                    bra       L1EB1
+                    com       L0D00
+L1E8F               fcb       $6e,$6f,$20,$65,$78,$70,$6C,$69
+                    fcb       $63,$69,$74,$20,$63,$6f
+L1E9D               fcb       $6d,$6d,$61,$6e
+L1EA1               fcb       $64,$0d,$00
+L1EA4               fcb       $22,$25
+L1EA6               fcb       $73,$22,$20,$2d,$20,$75,$6e
+L1EAD               fcb       $6b,$6e,$6f,$77
+L1EB1               fcb       $6e,$20,$6d,$61,$63,$72,$6f,$20
+                    fcb       $6f,$6e,$20,$63,$6f,$6d,$6d,$61
+                    fcb       $6e,$64,$20,$6C,$69,$6e,$65
+                    fcb       $0d,$00
+L1ECA               com       $6865
+                    inc       $0C,s
+                    neg       L0061
+                    fcb       $62,$6f,$72,$74,$65,$64,$20,$64
+                    fcb       $75,$65,$20,$74,$6f,$20,$65,$72
+                    fcb       $72,$6f,$72,$73,$0d,$00
+L1EE7               fcb       $61,$62,$6f,$72,$74,$65,$64,$20
+                    fcb       $64
+L1EF0               fcb       $75,$65,$20,$74,$6f,$20,$65,$72
+                    fcb       $72,$6f,$72,$73,$0d,$00
+L1EFE               fcb       $64,$6f,$6e,$27,$74,$20,$6b,$6e
+                    fcb       $6f,$77,$20,$61,$62,$6f,$75,$74
+                    fcb       $20,$27,$66,$27,$20,$6f,$72,$20
+                    fcb       $27,$70,$27,$20,$63,$6f,$6d,$70
+                    fcb       $69,$6C,$65,$72,$73,$2e,$0d
+                    neg       L0020
+                    blt       $1F9B
+                    mul
+                    neg       L0020
+                    blt       $1FA0
+                    bra       L1F30
+L1F30               fcb       $72
+                    pshu      y,x,dp
+                    neg       L002E
+                    neg       $002F
+                    neg       L0020
+                    blt       L1FAA
+                    mul
+                    neg       $002F
+                    neg       L0020
+                    blt       $1FA8
+                    mul
+                    neg       $002F
+                    neg       $000D
+                    neg       $0025
+                    com       $2F25
+                    com       >$0025
+                    com       $2F25
+                    com       >$0025
+                    com       $2F25
+                    com       >$0075
+                    neg       $6461
+                    lsr       $6564
+                    abx
+                    bra       L1F86
+                    bcs       $1FD9
+                    bhi       L1F75
+                    neg       $0025
+                    fcb       $73,$25,$2d,$33,$32,$73,$20,$64
+                    fcb       $61,$74,$65
+L1F75               fcb       $3a,$20,$25,$30,$32,$64,$2f,$25
+                    fcb       $30,$32,$64,$2f,$25,$30,$32,$64
+                    fcb       $20
+L1F86               fcb       $25,$30,$32,$64,$3a,$25,$30,$32
+                    fcb       $64,$0d,$00
+L1F91               ble       L1F93
+L1F93               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    lbsr      $33CF
+                    addd      #$000E
+                    lbsr      L21FB
+L1FAA               std       ,s
+                    pshs      u
+                    ldd       $02,s
+                    lbsr      L2015
+                    leas      $02,s
+                    ldd       ,s
+                    std       [$0005,y]
+                    addd      #$000B
+                    std       $0005
+L1FC0               bra       L1FF4
+
+L1FC2               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldd       $0025
+                    std       ,s
+                    beq       L1FE9
+L1FD4               pshs      u
+                    ldx       $02,s
+                    ldd       $02,x
+                    lbsr      L3427
+                    std       ,s++
+                    beq       L1FE9
+                    ldx       ,s
+                    ldd       $0b,x
+                    std       ,s
+                    bne       L1FD4
+L1FE9               ldd       ,s
+                    bne       L1FF4
+                    tfr       u,d
+                    lbsr      L1F93
+                    std       ,s
+L1FF4               ldd       ,s
+                    bra       L2034
+
+L1FF8               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    bsr       L1FC2
+                    std       ,s
+                    ldd       [,s]
+                    bne       L2034
+                    ldd       ,s
+                    lbsr      L0DA6
+                    bra       L2034
+
+L2015               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    clra
+                    clrb
+                    std       $04,u
+                    std       $0b,u
+                    std       ,u
+                    leax      $0d,u
+                    stx       $02,u
+                    ldd       $04,s
+                    pshs      d
+                    ldd       $02,u
+                    lbsr      L33E2
+L2034               leas      $02,s
+                    puls      pc,u
+L2038               pshs      u,d
+                    ldd       #$FFB4
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldd       $0025
+                    std       ,s
+                    ldd       $02,s
+                    beq       L2065
+L204A               ldd       $02,s
+                    pshs      d
+                    ldx       $02,s
+                    ldd       $02,x
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L205D
+                    ldd       [,s]
+                    bra       L207A
+
+L205D               ldx       ,s
+                    ldd       $0b,x
+                    std       ,s
+                    bne       L204A
+L2065               ldd       $02,s
+                    pshs      d
+                    leax      >L207E,pcr
+                    pshs      x
+L206F               ldd       #$0001
+L2072               lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L207A               leas      $04,s
+                    puls      pc,u
+L207E               fcb       $63,$61,$6e,$27,$74,$20,$66,$69
+                    fcb       $6e,$64,$20,$74,$61,$72,$67,$65
+                    fcb       $74,$20,$66,$69,$6C,$65,$3a,$20
+                    fcb       $25,$73,$2e,$0d,$00
+L209B               pshs      u,d
+                    ldd       #$FFB4
+                    lbsr      L00FB
+                    ldd       $0213,y
+                    lbeq      L225E
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $0a,s
+                    pshs      d
+                    ldd       $06,s
+                    lbsr      L28EF
+                    leas      $06,s
+                    lbra      L225E
+
+L20C1               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    lbsr      $33CF
+                    std       ,s
+                    leax      d,u
+                    ldb       -$02,x
+                    cmpb      #$2e
+                    bne       L2128
+                    ldb       -$01,x
+                    sex
+                    tfr       d,x
+                    cmpx      #$0063
+                    beq       L2122
+                    cmpx      #$0061
+                    beq       L2122
+                    cmpx      #$0066
+                    beq       L2122
+                    cmpx      #$0070
+                    beq       L2122
+                    bra       L2128
+
+L20F7               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBA
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    lbsr      $33CF
+                    std       ,s
+                    addd      #$FFFE
+                    leax      d,u
+                    ldb       ,x
+                    cmpb      #$2e
+                    bne       L2128
+                    ldd       ,s
+                    addd      #$FFFF
+                    leax      d,u
+                    ldb       ,x
+                    cmpb      #$72
+                    bne       L2128
+L2122               ldd       #$0001
+                    lbra      L225E
+
+L2128               clra
+                    clrb
+                    lbra      L225E
+
+L212D               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBE
+                    lbsr      L00FB
+                    leas      -$02,s
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L2149
+
+L213F               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    stb       ,u+
+L2149               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0005
+                    blt       L213F
+                    lbra      L225E
+                    pshs      u
+                    tfr       d,u
+                    ldd       #$FFBE
+                    lbsr      L00FB
+                    bra       L217F
+
+L2168               ldb       ,u
+                    sex
+                    pshs      d
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    sex
+                    cmpd      ,s++
+                    bne       L2183
+                    leau      $01,u
+                    bra       L217F
+
+L217F               ldb       ,u
+                    bne       L2168
+L2183               ldb       ,u
+                    lbne      L21F7
+                    ldb       [$04,s]
+                    cmpb      #$2e
+                    lbne      L21F7
+                    ldx       $04,s
+                    ldb       $01,x
+                    cmpb      #$72
+                    lbne      L21F7
+                    ldb       $02,x
+                    beq       L21C3
+                    lbra      L21F7
+
+L21A3               pshs      u
+                    tfr       d,u
+                    ldd       #$FFBE
+                    lbsr      L00FB
+                    bra       L21E4
+
+L21AF               ldb       ,u+
+                    cmpb      #$2e
+                    bne       L21E4
+                    ldb       [$04,s]
+                    sex
+                    tfr       d,x
+                    bra       L21C8
+
+L21BD               ldx       $04,s
+                    ldb       $01,x
+                    bne       L21F7
+L21C3               ldd       #$0001
+                    puls      pc,u
+L21C8               cmpx      #$0063
+                    beq       L21BD
+                    cmpx      #$0061
+                    lbeq      L21BD
+                    cmpx      #$0070
+                    lbeq      L21BD
+                    cmpx      #$0066
+                    lbeq      L21BD
+                    bra       L21F7
+
+L21E4               ldb       ,u
+                    sex
+                    pshs      d
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    sex
+                    cmpd      ,s++
+                    beq       L21AF
+L21F7               clra
+                    clrb
+                    puls      pc,u
+L21FB               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leas      -$02,s
+                    tfr       u,d
+                    lbsr      $380B
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L225C
+                    leax      >L2262,pcr
+                    pshs      x
+                    ldd       $01FD,y
+                    bsr       L2227
+                    leas      $02,s
+                    lbsr      L3949
+                    bra       L225C
+
+L2227               pshs      u,d
+                    ldd       #$FFB8
+                    lbsr      L00FB
+                    leax      $00A7,y
+                    pshs      x
+                    leax      >$2285,pcr
+                    tfr       x,d
+                    lbsr      L280A
+                    leas      $02,s
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $08,s
+                    lbsr      L28EF
+                    leas      $02,s
+                    leax      $00A7,y
+                    pshs      x
+                    leax      >L228C,pcr
+                    tfr       x,d
+                    lbsr      L280A
+                    leas      $02,s
+L225C               ldd       ,s
+L225E               leas      $02,s
+                    puls      pc,u
+L2262               bra       $2291
+                    bra       $22D9
+                    rol       $7374
+                    fcb       $65
+                    tst       0,y
+                    tst       $05,s
+                    tst       $0f,s
+                    fcb       $72
+                    rol       L2072
+                    fcb       $65
+                    fcb       $71
+                    fcb       $75
+                    fcb       $65
+                    com       $7420
+                    lsr       $05,s
+                    jmp       $09,s
+                    fcb       $65
+                    lsr       $0e,y
+                    bra       L22A4
+                    neg       $006D
+                    fcb       $61
+                    fcb       $6b
+                    fcb       $65
+                    abx
+                    bra       L228C
+
+L228C               tst       $0000
+L228E               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB2
+                    lbsr      L00FB
+                    leas      -$08,s
+                    stu       $04,s
+                    ldd       $0213,y
+                    beq       L22D3
+                    tfr       u,d
+L22A4               lbsr      L27EA
+                    bra       L22D3
+
+L22A9               ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       -$01,x
+                    sex
+                    tfr       d,x
+                    bra       L22BE
+
+L22B6               clra
+                    clrb
+                    ldx       $04,s
+                    stb       -$01,x
+                    bra       L22E1
+
+L22BE               cmpx      #$0020
+                    beq       L22B6
+                    cmpx      #$0009
+                    lbeq      L22B6
+                    cmpx      #$003D
+                    lbeq      L22B6
+                    bra       L22D3
+
+L22D3               ldb       [$04,s]
+                    bne       L22A9
+                    bra       L22E1
+
+L22DA               ldd       $0C,s
+                    addd      #$0001
+                    std       $0C,s
+L22E1               ldb       [$0C,s]
+                    cmpb      #$20
+                    beq       L22DA
+                    cmpb      #$09
+                    lbeq      L22DA
+                    ldd       $0C,s
+                    lbsr      $33CF
+                    std       $02,s
+                    ldx       $0C,s
+                    ldd       $02,s
+                    leax      d,x
+                    ldb       -$01,x
+                    cmpb      #$0d
+                    bne       L2310
+                    ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    addd      $0C,s
+                    tfr       d,x
+                    clra
+                    clrb
+                    stb       ,x
+L2310               tfr       u,d
+                    lbsr      $33CF
+                    std       ,s
+                    addd      #$0004
+                    addd      $02,s
+                    addd      #$0002
+                    lbsr      L21FB
+                    std       $06,s
+                    pshs      u
+                    ldd       $08,s
+                    addd      #$0004
+                    lbsr      L33E2
+                    leas      $02,s
+                    ldd       $0C,s
+                    pshs      d
+                    ldd       $08,s
+                    addd      #$0004
+                    addd      $02,s
+                    addd      #$0001
+                    std       [$08,s]
+                    lbsr      L33E2
+                    leas      $02,s
+                    leax      L260C,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L2372
+                    ldd       $01FF,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $01FF,y
+                    ldd       $0223,y
+                    addd      #$0001
+                    std       $0223,y
+                    lbra      L24A8
+
+L2372               leax      $2611,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L239E
+                    ldd       $0201,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $0201,y
+                    ldd       $0227,y
+                    addd      #$0001
+                    std       $0227,y
+                    lbra      L24A8
+
+L239E               leax      $2616,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L23CA
+                    ldd       $0203,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $0203,y
+                    ldd       $0225,y
+                    addd      #$0001
+                    std       $0225,y
+                    lbra      L24A8
+
+L23CA               leax      $261B,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L23EB
+                    ldd       $0207,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $0207,y
+                    lbra      L24A8
+
+L23EB               leax      $2622,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L240C
+                    ldd       $0209,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $0209,y
+                    lbra      L24A8
+
+L240C               leax      $2629,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L242D
+                    ldd       $0205,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $0205,y
+                    lbra      L24A8
+
+L242D               leax      $2630,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L2458
+                    ldd       $0229,y
+                    lbne      L24B3
+                    ldd       [$06,s]
+                    std       $020b,y
+                    ldd       $0229,y
+                    addd      #$0001
+                    std       $0229,y
+                    bra       L24A8
+
+L2458               leax      $2633,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L2481
+                    ldd       $022b,y
+                    bne       L24B3
+                    ldd       [$06,s]
+                    std       $020d,y
+                    ldd       $022b,y
+                    addd      #$0001
+                    std       $022b,y
+                    bra       L24A8
+
+L2481               leax      $2636,pcr
+                    pshs      x
+                    tfr       u,d
+                    lbsr      L3427
+                    std       ,s++
+                    bne       L24A8
+                    ldd       $022d,y
+                    bne       L24B3
+                    ldd       [$06,s]
+                    std       $020f,y
+                    ldd       $022d,y
+                    addd      #$0001
+                    std       $022d,y
+L24A8               ldd       $06,s
+                    std       [$0007,y]
+                    addd      #$0002
+                    std       $0007
+L24B3               leas      $08,s
+L24B5               puls      pc,u
+L24B7               pshs      u,d
+                    ldd       #$FFA6
+                    lbsr      L00FB
+                    leas      -$10,s
+                    ldu       #$0000
+                    ldd       $10,s
+                    addd      #$0001
+                    std       $10,s
+                    subd      #$0001
+                    std       $06,s
+                    std       $02,s
+                    ldd       #$0001
+                    std       $0a,s
+                    ldx       $10,s
+                    leax      $01,x
+                    stx       $10,s
+                    ldb       -$01,x
+                    cmpb      #$28
+                    bne       L2502
+                    ldd       $0a,s
+                    addd      #$0001
+                    std       $0a,s
+                    bra       L24F2
+
+L24F0               leau      $01,u
+L24F2               ldx       $10,s
+                    leax      $01,x
+                    stx       $10,s
+                    ldb       -$01,x
+                    cmpb      #$29
+                    bne       L24F0
+                    bra       L2504
+
+L2502               leau      $01,u
+L2504               pshs      u
+                    ldd       $08,s
+                    addd      $0C,s
+                    lbsr      L25C3
+                    leas      $02,s
+                    std       ,s
+                    lbeq      L25A7
+                    pshs      u
+                    ldd       $0C,s
+                    addd      ,s++
+                    addd      #$0001
+                    pshs      d
+                    ldd       [$02,s]
+                    lbsr      $33CF
+                    std       $0e,s
+                    cmpd      ,s++
+                    bge       L254B
+                    ldd       $06,s
+                    addd      $0C,s
+                    std       $08,s
+                    std       $04,s
+L2535               ldx       $10,s
+                    leax      $01,x
+                    stx       $10,s
+                    ldb       -$01,x
+                    ldx       $08,s
+                    leax      $01,x
+                    stx       $08,s
+                    stb       -$01,x
+                    bne       L2535
+                    bra       L258A
+
+L254B               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    beq       L2559
+                    ldd       #$0003
+                    bra       L255C
+
+L2559               ldd       #$0001
+L255C               pshs      d
+                    pshs      u
+                    ldd       $0a,s
+                    addd      $1a,s
+                    std       $0C,s
+                    addd      $10,s
+                    subd      ,s++
+                    subd      ,s++
+                    std       $04,s
+                    bra       L2582
+
+L2572               ldx       $08,s
+                    leax      -$01,x
+                    stx       $08,s
+                    ldb       $01,x
+                    ldx       $04,s
+                    leax      -$01,x
+                    stx       $04,s
+                    stb       $01,x
+L2582               ldd       $08,s
+                    cmpd      $10,s
+                    bcc       L2572
+L258A               ldd       [,s]
+                    std       $08,s
+                    bra       L25A0
+
+L2590               ldx       $08,s
+                    leax      $01,x
+                    stx       $08,s
+                    ldb       -$01,x
+                    ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    stb       -$01,x
+L25A0               ldb       [$08,s]
+                    bne       L2590
+                    bra       L25BC
+
+L25A7               ldd       $06,s
+                    pshs      d
+                    leax      $2639,pcr
+                    pshs      x
+                    ldd       #$0001
+                    lbsr      L2227
+                    leas      $04,s
+                    lbsr      L3949
+L25BC               ldd       $02,s
+                    leas      $12,s
+                    puls      pc,u
+L25C3               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB6
+                    lbsr      L00FB
+                    leas      -$02,s
+                    ldd       $0027
+                    std       ,s
+                    beq       L2606
+                    bra       L2602
+
+L25D7               ldd       $06,s
+                    pshs      d
+                    pshs      u
+                    ldd       $04,s
+                    addd      #$0004
+                    lbsr      L3492
+                    leas      $04,s
+                    std       -$02,s
+                    bne       L25FC
+                    ldd       ,s
+                    addd      #$0004
+                    lbsr      $33CF
+                    cmpd      $06,s
+                    bne       L25FC
+                    ldd       ,s
+                    bra       L2608
+
+L25FC               ldx       ,s
+                    ldd       $02,x
+                    std       ,s
+L2602               ldd       ,s
+                    bne       L25D7
+L2606               clra
+                    clrb
+L2608               leas      $02,s
+                    puls      pc,u
+L260C               comb
+                    lsra
+                    rola
+                    fcb       $52
+                    neg       L0052
+                    lsra
+                    rola
+                    fcb       $52
+                    neg       $004F
+                    lsra
+                    rola
+                    fcb       $52
+                    neg       $0043
+                    rora
+                    inca
+                    fcb       $41
+                    asra
+                    comb
+                    neg       L0052
+                    rora
+                    inca
+                    fcb       $41
+                    asra
+                    comb
+                    neg       L004C
+                    rora
+                    inca
+                    fcb       $41
+                    asra
+                    comb
+                    neg       $0043
+                    coma
+                    neg       L0052
+                    coma
+                    neg       L004C
+                    coma
+                    neg       $0022
+                    bcs       L26AF
+                    bhi       $265E
+                    blt       $2660
+                    fcb       $75
+                    jmp       $0b,s
+                    jmp       $0f,s
+                    asr       $6E20
+                    tst       $01,s
+                    com       -$0e,s
+                    clr       0,x
+L264E               pshs      u
+                    leau      $009a,y
+L2654               ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L265F
+                    tfr       u,d
+                    puls      pc,u
+L265F               leau      $0d,u
+                    pshs      u
+                    leax      $016a,y
+                    cmpx      ,s++
+                    bhi       L2654
+                    ldd       #$00C8
+                    std       $01FD,y
+                    clra
+                    clrb
+                    puls      pc,u
+                    puls      pc,u
+L2678               pshs      u,d
+                    ldu       $08,s
+                    bne       L2682
+                    bsr       L264E
+                    tfr       d,u
+L2682               stu       -$02,s
+                    beq       L26C7
+                    ldd       ,s
+                    std       $08,u
+                    ldx       $06,s
+                    ldb       $01,x
+                    cmpb      #$2b
+                    beq       L2698
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L269E
+L2698               ldd       $06,u
+                    orb       #$03
+                    bra       L26B8
+
+L269E               ldd       $06,u
+                    pshs      d
+                    ldb       ,x
+                    cmpb      #$72
+                    beq       L26AC
+                    cmpb      #$64
+                    bne       L26B1
+L26AC               ldd       #$0001
+L26AF               bra       L26B4
+
+L26B1               ldd       #$0002
+L26B4               ora       ,s+
+                    orb       ,s+
+L26B8               std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    tfr       u,d
+                    lbra      L27E6
+
+L26C7               clra
+                    clrb
+                    lbra      L27E6
+
+L26CC               pshs      u
+                    tfr       d,u
+                    leas      -$04,s
+                    clra
+                    clrb
+                    std       ,s
+                    ldx       $08,s
+                    ldb       $01,x
+                    sex
+                    tfr       d,x
+                    bra       L26FD
+
+L26DF               ldx       $08,s
+                    ldb       $02,x
+                    cmpb      #$2b
+                    bne       L26EC
+                    ldd       #$0007
+                    bra       L26F4
+
+L26EC               ldd       #$0004
+                    bra       L26F4
+
+L26F1               ldd       #$0003
+L26F4               std       ,s
+                    bra       L270D
+
+L26F8               leax      $04,s
+                    lbra      L2763
+
+L26FD               stx       -$02,s
+                    beq       L270D
+                    cmpx      #$0078
+                    beq       L26DF
+                    cmpx      #$002B
+                    beq       L26F1
+                    bra       L26F8
+
+L270D               ldb       [$08,s]
+                    sex
+                    tfr       d,x
+                    lbra      L2770
+
+L2716               ldd       ,s
+                    orb       #$01
+                    bra       L2756
+
+L271C               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    tfr       u,d
+                    lbsr      $36CC
+                    leas      $02,s
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L2745
+                    ldd       #$0002
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,s
+                    lbsr      $37A0
+                    leas      $06,s
+                    bra       L278A
+
+L2745               ldd       ,s
+                    orb       #$02
+                    pshs      d
+                    tfr       u,d
+                    lbsr      $36EA
+                    bra       L275D
+
+L2752               ldd       ,s
+                    orb       #$81
+L2756               pshs      d
+                    tfr       u,d
+                    lbsr      $36CC
+L275D               leas      $02,s
+                    std       $02,s
+                    bra       L278A
+
+L2763               leas      -$04,x
+L2765               ldd       #$00CB
+                    std       $01FD,y
+                    clra
+                    clrb
+                    bra       L278C
+
+L2770               cmpx      #$0072
+                    lbeq      L2716
+                    cmpx      #$0061
+                    lbeq      L271C
+                    cmpx      #$0077
+                    beq       L2745
+                    cmpx      #$0064
+                    beq       L2752
+                    bra       L2765
+
+L278A               ldd       $02,s
+L278C               leas      $04,s
+                    puls      pc,u
+                    pshs      u,d
+                    clra
+                    clrb
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $04,s
+                    bra       L27E1
+
+L279E               pshs      u,d
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    lbsr      L26CC
+                    leas      $02,s
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L27B7
+                    clra
+                    clrb
+                    bra       L27E6
+
+L27B7               clra
+                    clrb
+                    bra       L27D9
+                    pshs      u,d
+                    ldd       $08,s
+                    lbsr      L305B
+                    ldd       $06,s
+                    pshs      d
+                    ldd       $02,s
+                    lbsr      L26CC
+                    leas      $02,s
+                    tfr       d,u
+                    stu       -$02,s
+                    bge       L27D7
+                    clra
+                    clrb
+                    bra       L27E6
+
+L27D7               ldd       $08,s
+L27D9               pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    tfr       u,d
+L27E1               lbsr      L2678
+                    leas      $04,s
+L27E6               leas      $02,s
+                    puls      pc,u
+L27EA               pshs      u,d
+                    leax      $00A7,y
+                    pshs      x
+                    ldd       $02,s
+                    bsr       L280A
+                    leas      $02,s
+                    leax      $00A7,y
+                    pshs      x
+                    ldd       #$000D
+                    lbsr      L2F72
+                    leas      $02,s
+                    leas      $02,s
+                    puls      pc,u
+L280A               pshs      u
+                    tfr       d,u
+                    leas      -$01,s
+                    bra       L281E
+
+L2812               ldd       $05,s
+                    pshs      d
+                    ldb       $02,s
+                    sex
+                    lbsr      L2F72
+                    leas      $02,s
+L281E               ldb       ,u+
+                    stb       ,s
+                    bne       L2812
+                    leas      $01,s
+                    puls      pc,u
+                    pshs      u,d
+                    leas      -$02,s
+                    ldu       $02,s
+                    bra       L2834
+
+L2830               ldd       ,s
+                    stb       ,u+
+L2834               leax      $009a,y
+                    tfr       x,d
+                    lbsr      L31A9
+                    std       ,s
+                    cmpd      #$000D
+                    beq       L284D
+                    ldd       ,s
+                    cmpd      #$FFFF
+                    bne       L2830
+L284D               ldd       ,s
+                    cmpd      #$FFFF
+                    bne       L2859
+                    clra
+                    clrb
+                    bra       L285F
+
+L2859               clra
+                    clrb
+                    stb       ,u
+                    ldd       $02,s
+L285F               leas      $04,s
+                    puls      pc,u
+L2863               pshs      u,d
+                    ldu       $06,s
+                    leas      -$04,s
+                    ldd       $04,s
+                    std       ,s
+                    bra       L287D
+
+L286F               ldd       $02,s
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    cmpb      #$0d
+                    beq       L2892
+L287D               tfr       u,d
+                    leau      -$01,u
+                    std       -$02,s
+                    ble       L2892
+                    ldd       $0C,s
+                    lbsr      L31A9
+                    std       $02,s
+                    cmpd      #$FFFF
+                    bne       L286F
+L2892               clra
+                    clrb
+                    stb       [,s]
+                    ldd       $02,s
+                    cmpd      #$FFFF
+                    bne       L28A2
+                    clra
+                    clrb
+                    bra       L28A4
+
+L28A2               ldd       $04,s
+L28A4               leas      $06,s
+                    puls      pc,u
+L28A8               pshs      u
+                    tfr       d,u
+                    ldd       #$FFB6
+                    lbsr      L00FB
+                    leas      -$06,s
+                    ldd       $0C,s
+                    bra       L28E1
+
+L28B8               ldd       $0a,s
+                    bra       L28D2
+
+L28BC               ldd       $0e,s
+                    lbsr      L31A9
+                    std       ,s
+                    cmpd      #$FFFF
+                    beq       L28D8
+                    ldd       ,s
+                    stb       ,u+
+                    ldd       $04,s
+                    addd      #$FFFF
+L28D2               std       $04,s
+                    ldd       $04,s
+                    bne       L28BC
+L28D8               ldd       $04,s
+                    bne       L28E7
+                    ldd       $02,s
+                    addd      #$FFFF
+L28E1               std       $02,s
+                    ldd       $02,s
+                    bne       L28B8
+L28E7               ldd       $0C,s
+                    subd      $02,s
+                    leas      $06,s
+                    puls      pc,u
+L28EF               pshs      u,d
+                    leax      $00A7,y
+                    stx       $16D5,y
+                    leax      $06,s
+                    pshs      x
+                    ldd       $02,s
+                    bra       L290F
+
+L2901               pshs      u,d
+                    ldd       ,s
+                    std       $16D5,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+L290F               pshs      d
+                    leax      L2D95,pcr
+                    tfr       x,d
+                    bsr       L2943
+                    leas      $04,s
+                    bra       L293F
+
+L291D               pshs      u,d
+                    ldd       ,s
+                    std       $16D5,y
+                    leax      $08,s
+                    pshs      x
+                    ldd       $08,s
+                    pshs      d
+                    leax      L2DA6,pcr
+                    tfr       x,d
+                    bsr       L2943
+                    leas      $04,s
+                    clra
+                    clrb
+                    stb       [$16D5,y]
+                    ldd       ,s
+L293F               leas      $02,s
+                    puls      pc,u
+L2943               pshs      u,d
+                    ldu       $06,s
+                    leas      -$0b,s
+                    bra       L2955
+
+L294B               ldb       $08,s
+                    lbeq      L2B72
+                    sex
+                    jsr       [$0b,s]
+L2955               ldb       ,u+
+                    stb       $08,s
+                    cmpb      #$25
+                    bne       L294B
+                    ldb       ,u+
+                    stb       $08,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       $06,s
+                    ldb       $08,s
+                    cmpb      #$2d
+                    bne       L297A
+                    ldd       #$0001
+                    std       $16EB,y
+                    ldb       ,u+
+                    stb       $08,s
+                    bra       L2980
+
+L297A               clra
+                    clrb
+                    std       $16EB,y
+L2980               ldb       $08,s
+                    cmpb      #$30
+                    bne       L298B
+                    ldd       #$0030
+                    bra       L298E
+
+L298B               ldd       #$0020
+L298E               std       $16ED,y
+                    bra       L29AE
+
+L2994               ldd       $06,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L3A19
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $06,s
+                    ldb       ,u+
+                    stb       $08,s
+L29AE               ldb       $08,s
+                    sex
+                    leax      $016b,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L2994
+                    ldb       $08,s
+                    cmpb      #$2e
+                    bne       L29F7
+                    ldd       #$0001
+                    std       $04,s
+                    bra       L29E1
+
+L29CB               ldd       $02,s
+                    pshs      d
+                    ldd       #$000A
+                    lbsr      L3A19
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    addd      #$FFD0
+                    addd      ,s++
+                    std       $02,s
+L29E1               ldb       ,u+
+                    stb       $08,s
+                    ldb       $08,s
+                    sex
+                    leax      $016b,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$08
+                    bne       L29CB
+                    bra       L29FB
+
+L29F7               clra
+                    clrb
+                    std       $04,s
+L29FB               ldb       $08,s
+                    sex
+                    tfr       d,x
+                    lbra      L2B15
+
+L2A03               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    lbsr      L2B76
+                    lbra      L2AE5
+
+L2A17               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    lbsr      L2C31
+                    lbra      L2AE5
+
+L2A2B               ldd       $06,s
+                    pshs      d
+                    ldb       $0a,s
+                    sex
+                    leax      $016b,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$02
+                    pshs      d
+                    ldx       $17,s
+                    leax      $02,x
+                    stx       $17,s
+                    ldd       -$02,x
+                    lbsr      L2C7B
+                    lbra      L2B00
+
+L2A4F               ldd       $06,s
+                    pshs      d
+                    ldx       $15,s
+                    leax      $02,x
+                    stx       $15,s
+                    ldd       -$02,x
+                    pshs      d
+                    leax      $16D7,y
+                    tfr       x,d
+                    lbsr      L2BBA
+                    lbra      L2B00
+
+L2A6B               ldd       $04,s
+                    bne       L2A74
+                    ldd       #$0006
+                    std       $02,s
+L2A74               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldd       $06,s
+                    pshs      d
+                    ldb       $0e,s
+                    sex
+                    lbsr      $33C4
+                    leas      $04,s
+                    lbra      L2AE5
+
+L2A8C               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    lbra      L2B0F
+
+L2A99               ldx       $13,s
+                    leax      $02,x
+                    stx       $13,s
+                    ldd       -$02,x
+                    std       $09,s
+                    ldd       $04,s
+                    beq       L2ADF
+                    ldd       $09,s
+                    std       $04,s
+                    bra       L2ABB
+
+L2AAF               ldb       [$09,s]
+                    beq       L2AC7
+                    ldd       $09,s
+                    addd      #$0001
+                    std       $09,s
+L2ABB               ldd       $02,s
+                    addd      #$FFFF
+                    std       $02,s
+                    subd      #$FFFF
+                    bne       L2AAF
+L2AC7               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+                    subd      $06,s
+                    pshs      d
+                    ldd       $08,s
+                    pshs      d
+                    ldd       $11,s
+                    lbsr      L2CE9
+                    leas      $06,s
+                    bra       L2B09
+
+L2ADF               ldd       $06,s
+                    pshs      d
+                    ldd       $0b,s
+L2AE5               pshs      d
+                    bra       L2B02
+
+L2AE9               ldb       ,u+
+                    stb       $08,s
+                    bra       L2AF1
+                    leas      -$0d,x
+L2AF1               ldd       $06,s
+                    pshs      d
+                    leax      $15,s
+                    pshs      x
+                    ldb       $0C,s
+                    sex
+                    lbsr      L3384
+L2B00               std       ,s
+L2B02               ldd       $0f,s
+                    lbsr      L2D3F
+                    leas      $04,s
+L2B09               lbra      L2955
+
+L2B0C               ldb       $08,s
+                    sex
+L2B0F               jsr       [$0b,s]
+                    lbra      L2955
+
+L2B15               cmpx      #$0064
+                    lbeq      L2A03
+                    cmpx      #$006F
+                    lbeq      L2A17
+                    cmpx      #$0078
+                    lbeq      L2A2B
+                    cmpx      #$0058
+                    lbeq      L2A2B
+                    cmpx      #$0075
+                    lbeq      L2A4F
+                    cmpx      #$0066
+                    lbeq      L2A6B
+                    cmpx      #$0065
+                    lbeq      L2A6B
+                    cmpx      #$0067
+                    lbeq      L2A6B
+                    cmpx      #$0045
+                    lbeq      L2A6B
+                    cmpx      #$0047
+                    lbeq      L2A6B
+                    cmpx      #$0063
+                    lbeq      L2A8C
+                    cmpx      #$0073
+                    lbeq      L2A99
+                    cmpx      #$006C
+                    lbeq      L2AE9
+                    bra       L2B0C
+
+L2B72               leas      $0d,s
+                    puls      pc,u
+L2B76               pshs      u,d
+                    leas      -$02,s
+                    leax      $16D7,y
+                    stx       ,s
+                    ldd       $02,s
+                    bge       L2BAD
+                    nega
+                    negb
+                    sbca      #$00
+                    std       $02,s
+                    std       -$02,s
+                    bge       L2BA2
+                    leax      L2DBA,pcr
+                    pshs      x
+                    leax      $16D7,y
+                    tfr       x,d
+                    lbsr      L33E2
+                    leas      $02,s
+                    lbra      L2C77
+
+L2BA2               ldd       #$002D
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L2BAD               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    bsr       L2BBA
+                    leas      $02,s
+                    lbra      L2C71
+
+L2BBA               pshs      u,d
+                    leas      -$06,s
+                    ldu       $06,s
+                    clra
+                    clrb
+                    std       $02,s
+                    std       ,s
+                    bra       L2BD7
+
+L2BC8               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    ldd       $0C,s
+                    subd      $008d,y
+                    std       $0C,s
+L2BD7               ldd       $0C,s
+                    blt       L2BC8
+                    leax      $008d,y
+                    stx       $04,s
+                    bra       L2C17
+
+L2BE3               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+L2BEA               ldd       $0C,s
+                    subd      [$04,s]
+                    std       $0C,s
+                    bge       L2BE3
+                    addd      [$04,s]
+                    std       $0C,s
+                    ldd       ,s
+                    beq       L2C01
+                    ldd       #$0001
+                    std       $02,s
+L2C01               ldd       $02,s
+                    beq       L2C0C
+                    ldd       ,s
+                    addd      #$0030
+                    stb       ,u+
+L2C0C               clra
+                    clrb
+                    std       ,s
+                    ldd       $04,s
+                    addd      #$0002
+                    std       $04,s
+L2C17               ldd       $04,s
+                    cmpd      $0095,y
+                    bne       L2BEA
+                    ldd       $0C,s
+                    addd      #$0030
+                    stb       ,u+
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       $06,s
+                    leas      $08,s
+                    puls      pc,u
+L2C31               pshs      u,d
+                    leas      -$02,s
+                    leax      $16D7,y
+                    stx       ,s
+                    leau      $16E1,y
+L2C3F               ldd       $02,s
+                    clra
+                    andb      #$07
+                    addd      #$0030
+                    stb       ,u+
+                    ldd       $02,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    std       $02,s
+                    bne       L2C3F
+                    bra       L2C61
+
+L2C57               ldb       ,u
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L2C61               leau      -$01,u
+                    pshs      u
+                    leax      $16E1,y
+                    cmpx      ,s++
+                    bls       L2C57
+                    clra
+                    clrb
+                    stb       [,s]
+L2C71               leax      $16D7,y
+                    tfr       x,d
+L2C77               leas      $04,s
+                    puls      pc,u
+L2C7B               pshs      u,d
+                    leas      -$04,s
+                    leax      $16D7,y
+                    stx       $02,s
+                    leau      $16E1,y
+L2C89               ldd       $04,s
+                    clra
+                    andb      #$0f
+                    std       ,s
+                    pshs      d
+                    ldd       $02,s
+                    cmpd      #$0009
+                    ble       L2CAB
+                    ldd       $0C,s
+                    beq       L2CA3
+                    ldd       #$0041
+                    bra       L2CA6
+
+L2CA3               ldd       #$0061
+L2CA6               addd      #$FFF6
+                    bra       L2CAE
+
+L2CAB               ldd       #$0030
+L2CAE               addd      ,s++
+                    stb       ,u+
+                    ldd       $04,s
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    anda      #$0f
+                    std       $04,s
+                    bne       L2C89
+                    bra       L2CCE
+
+L2CC4               ldb       ,u
+                    ldx       $02,s
+                    leax      $01,x
+                    stx       $02,s
+                    stb       -$01,x
+L2CCE               leau      -$01,u
+                    pshs      u
+                    leax      $16E1,y
+                    cmpx      ,s++
+                    bls       L2CC4
+                    clra
+                    clrb
+                    stb       [$02,s]
+                    leax      $16D7,y
+                    tfr       x,d
+                    leas      $06,s
+                    puls      pc,u
+L2CE9               pshs      u,d
+                    ldu       $06,s
+                    ldd       $0a,s
+                    subd      $08,s
+                    std       $0a,s
+                    ldd       $16EB,y
+                    bne       L2D14
+                    bra       L2D01
+
+L2CFB               ldd       $16ED,y
+                    jsr       [,s]
+L2D01               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L2CFB
+                    bra       L2D14
+
+L2D0F               ldb       ,u+
+                    sex
+                    jsr       [,s]
+L2D14               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bne       L2D0F
+                    ldd       $16EB,y
+                    lbeq      L2DB6
+                    bra       L2D30
+
+L2D2A               ldd       $16ED,y
+                    jsr       [,s]
+L2D30               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L2D2A
+                    lbra      L2DB6
+
+L2D3F               pshs      u,d
+                    ldu       $06,s
+                    ldd       $08,s
+                    pshs      d
+                    tfr       u,d
+                    lbsr      $33CF
+                    nega
+                    negb
+                    sbca      #$00
+                    addd      ,s++
+                    std       $08,s
+                    ldd       $16EB,y
+                    bne       L2D75
+                    bra       L2D62
+
+L2D5C               ldd       $16ED,y
+                    jsr       [,s]
+L2D62               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L2D5C
+                    bra       L2D75
+
+L2D70               ldb       ,u+
+                    sex
+                    jsr       [,s]
+L2D75               ldb       ,u
+                    bne       L2D70
+                    ldd       $16EB,y
+                    beq       L2DB6
+                    bra       L2D87
+
+L2D81               ldd       $16ED,y
+                    jsr       [,s]
+L2D87               ldd       $08,s
+                    addd      #$FFFF
+                    std       $08,s
+                    subd      #$FFFF
+                    bgt       L2D81
+                    bra       L2DB6
+
+L2D95               pshs      u,d
+                    ldd       $16D5,y
+                    pshs      d
+                    ldd       $02,s
+                    lbsr      L2F72
+                    leas      $02,s
+                    bra       L2DB6
+
+L2DA6               pshs      u,d
+                    ldd       ,s
+                    ldx       $16D5,y
+                    leax      $01,x
+                    stx       $16D5,y
+                    stb       -$01,x
+L2DB6               leas      $02,s
+                    puls      pc,u
+L2DBA               blt       L2DEF
+                    leas      -$09,y
+                    pshu      y,x,dp
+                    neg       L0034
+                    nega
+                    tfr       d,u
+                    leas      -$06,s
+                    cmpu      #$0000
+                    beq       L2DD4
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L2DDA
+L2DD4               ldd       #$FFFF
+                    lbra      L2EEE
+
+L2DDA               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L2DEB
+                    tfr       u,d
+                    lbsr      L32F8
+                    lbra      L2EB7
+
+L2DEB               ldd       $06,u
+                    anda      #$01
+L2DEF               clrb
+                    std       -$02,s
+                    beq       L2E08
+                    tfr       u,d
+                    lbsr      L3090
+                    ldd       $06,u
+                    anda      #$FE
+                    std       $06,u
+                    ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    lbra      L2EB5
+
+L2E08               ldd       ,u
+                    cmpd      $04,u
+                    lbcc      L2EB7
+                    leax      $02,s
+                    pshs      x
+                    leax      $0C,s
+                    lbsr      L39E5
+                    ldx       $0e,s
+                    lbra      L2E85
+
+L2E1F               leax      $02,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L2F09
+                    lbsr      $396C
+                    lbsr      L39E5
+L2E36               ldd       $0b,u
+                    lbsr      L39CC
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    leax      $06,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       L2E53
+                    neg       $0000
+                    neg       $0000
+L2E53               puls      x
+                    lbsr      $3981
+                    bge       L2E61
+                    leax      $06,s
+                    lbsr      L39A5
+                    bra       L2E63
+
+L2E61               leax      $06,s
+L2E63               lbsr      $3981
+                    blt       L2E92
+                    ldd       $04,s
+                    addd      ,u
+                    std       ,s
+                    cmpd      $02,u
+                    bcs       L2E92
+                    cmpd      $04,u
+                    bcc       L2E92
+                    std       ,u
+                    ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    lbra      L2EEC
+                    bra       L2E92
+
+L2E85               stx       -$02,s
+                    lbeq      L2E1F
+                    cmpx      #$0001
+                    lbeq      L2E36
+L2E92               ldd       $0e,s
+                    cmpd      #$0001
+                    bne       L2EB3
+                    leax      $0a,s
+                    pshs      x
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $04,u
+                    subd      ,u
+                    lbsr      L39CC
+                    lbsr      $396C
+                    lbsr      L39E5
+L2EB3               ldd       $04,u
+L2EB5               std       ,u
+L2EB7               ldd       $06,u
+                    andb      #$EF
+                    std       $06,u
+                    ldd       $0e,s
+                    pshs      d
+                    leax      $0C,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    lbsr      $37A0
+                    leas      $06,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    bsr       $2EE0
+                    stu       $FFFF
+                    stu       L3510
+                    lbsr      $3981
+                    bne       L2EEC
+                    ldd       #$FFFF
+                    bra       L2EEE
+
+L2EEC               clra
+                    clrb
+L2EEE               leas      $06,s
+                    puls      pc,u
+                    pshs      u,d
+                    clra
+                    clrb
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $06,s
+                    lbsr      $2DC1
+                    leas      $06,s
+                    leas      $02,s
+                    puls      pc,u
+L2F09               pshs      u
+                    tfr       d,u
+                    cmpu      #$0000
+                    beq       L2F1A
+                    ldd       $06,u
+                    clra
+                    andb      #$03
+                    bne       L2F2D
+L2F1A               bsr       $2F20
+                    stu       $FFFF
+                    stu       L3510
+                    leau      $01F1,y
+                    pshs      u
+                    lbsr      L39E5
+                    puls      pc,u
+L2F2D               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L2F3B
+                    tfr       u,d
+                    lbsr      L32F8
+L2F3B               ldd       #$0001
+                    pshs      d
+                    clra
+                    clrb
+                    pshs      d
+                    pshs      d
+                    ldd       $08,u
+                    lbsr      $37A0
+                    leas      $06,s
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L2F62
+                    ldd       $02,u
+                    bra       L2F64
+
+L2F62               ldd       $04,u
+L2F64               pshs      d
+                    ldd       ,u
+                    subd      ,s++
+                    lbsr      L39CC
+                    lbsr      L3957
+                    puls      pc,u
+L2F72               pshs      u,d
+                    ldu       $06,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$22
+                    cmpd      #$8002
+                    beq       L2F94
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    lbne      L306B
+                    tfr       u,d
+                    lbsr      L32F8
+L2F94               ldd       $06,u
+                    clra
+                    andb      #$04
+                    beq       L2FD0
+                    ldd       #$0001
+                    pshs      d
+                    leax      $03,s
+                    pshs      x
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L2FB1
+                    leax      $3787,pcr
+                    bra       L2FB5
+
+L2FB1               leax      $3777,pcr
+L2FB5               tfr       x,d
+                    tfr       d,x
+                    ldd       $08,u
+                    jsr       ,x
+                    leas      $04,s
+                    cmpd      #$FFFF
+                    lbne      L308A
+                    ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    lbra      L306B
+
+L2FD0               ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L2FDE
+                    tfr       u,d
+                    lbsr      L30BE
+L2FDE               ldd       ,u
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldd       ,s
+                    stb       ,x
+                    ldd       ,u
+                    cmpd      $04,u
+                    bcc       L3008
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    lbeq      L308A
+                    ldd       ,s
+                    cmpd      #$000D
+                    lbne      L308A
+L3008               tfr       u,d
+                    lbsr      L30BE
+                    std       -$02,s
+                    lbne      L306B
+                    lbra      L308A
+                    pshs      u
+                    tfr       d,u
+                    ldd       $04,s
+                    pshs      d
+                    pshs      u
+                    ldd       #$0008
+                    lbsr      $3A78
+                    lbsr      L2F72
+                    leas      $02,s
+                    ldd       $04,s
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L2F72
+                    lbra      L308C
+                    pshs      u,d
+                    leau      $009a,y
+                    clra
+                    clrb
+                    std       ,s
+                    bra       L3049
+
+L3043               tfr       u,d
+                    leau      $0d,u
+                    bsr       L305B
+L3049               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    subd      #$0001
+                    cmpd      #$0010
+                    blt       L3043
+                    bra       L308C
+
+L305B               pshs      u
+                    tfr       d,u
+                    leas      -$02,s
+                    cmpu      #$0000
+                    beq       L306B
+                    ldd       $06,u
+                    bne       L3070
+L306B               ldd       #$FFFF
+                    bra       L308C
+
+L3070               ldd       $06,u
+                    clra
+                    andb      #$02
+                    beq       L307D
+                    tfr       u,d
+                    bsr       L3090
+                    bra       L307F
+
+L307D               clra
+                    clrb
+L307F               std       ,s
+                    ldd       $08,u
+                    lbsr      L36D9
+                    clra
+                    clrb
+                    std       $06,u
+L308A               ldd       ,s
+L308C               leas      $02,s
+                    puls      pc,u
+L3090               pshs      u
+                    tfr       d,u
+                    cmpu      #$0000
+                    beq       L30A5
+                    ldd       $06,u
+                    clra
+                    andb      #$22
+                    cmpd      #$0002
+                    beq       L30AA
+L30A5               ldd       #$FFFF
+                    puls      pc,u
+L30AA               ldd       $06,u
+                    anda      #$80
+                    clrb
+                    std       -$02,s
+                    bne       L30B8
+                    tfr       u,d
+                    lbsr      L32F8
+L30B8               tfr       u,d
+                    bsr       L30BE
+                    puls      pc,u
+L30BE               pshs      u
+                    tfr       d,u
+                    leas      -$04,s
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    bne       L30EC
+                    ldd       ,u
+                    cmpd      $04,u
+                    beq       L30EC
+                    clra
+                    clrb
+                    pshs      d
+                    tfr       u,d
+                    lbsr      L2F09
+                    ldd       $02,x
+                    pshs      d
+                    ldd       ,x
+                    pshs      d
+                    ldd       $08,u
+                    lbsr      $37A0
+                    leas      $06,s
+L30EC               ldd       ,u
+                    subd      $02,u
+                    std       $02,s
+                    lbeq      L3160
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    lbeq      L3160
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L3139
+                    ldd       $02,u
+                    bra       L3131
+
+L310C               ldd       $02,s
+                    pshs      d
+                    ldd       ,u
+                    pshs      d
+                    ldd       $08,u
+                    lbsr      $3787
+                    leas      $04,s
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L3127
+                    leax      $04,s
+                    bra       L314F
+
+L3127               ldd       $02,s
+                    subd      ,s
+                    std       $02,s
+                    ldd       ,u
+                    addd      ,s
+L3131               std       ,u
+                    ldd       $02,s
+                    bne       L310C
+                    bra       L3160
+
+L3139               ldd       $02,s
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $08,u
+                    lbsr      $3777
+                    leas      $04,s
+                    cmpd      $02,s
+                    beq       L3160
+                    bra       L3151
+
+L314F               leas      -$04,x
+L3151               ldd       $06,u
+                    orb       #$20
+                    std       $06,u
+                    ldd       $04,u
+                    std       ,u
+                    ldd       #$FFFF
+                    bra       L3170
+
+L3160               ldd       $06,u
+                    ora       #$01
+                    std       $06,u
+                    ldd       $02,u
+                    std       ,u
+                    addd      $0b,u
+                    std       $04,u
+                    clra
+                    clrb
+L3170               leas      $04,s
+                    puls      pc,u
+                    pshs      u,d
+                    ldd       ,s
+                    leax      $016b,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$04
+                    beq       L31A3
+                    ldd       ,s
+                    clra
+                    andb      #$DF
+                    bra       L31A5
+
+L318C               pshs      u,d
+                    ldd       ,s
+                    leax      $016b,y
+                    leax      d,x
+                    ldb       ,x
+                    clra
+                    andb      #$02
+                    beq       L31A3
+                    ldd       ,s
+                    orb       #$20
+                    bra       L31A5
+
+L31A3               ldd       ,s
+L31A5               leas      $02,s
+                    puls      pc,u
+L31A9               pshs      u
+                    tfr       d,u
+                    cmpu      #$0000
+                    beq       L31BC
+                    ldd       $06,u
+                    anda      #$01
+                    clrb
+                    std       -$02,s
+                    beq       L31C1
+L31BC               ldd       #$FFFF
+                    puls      pc,u
+L31C1               ldd       ,u
+                    cmpd      $04,u
+                    bcc       L31D7
+                    addd      #$0001
+                    std       ,u
+                    subd      #$0001
+                    tfr       d,x
+                    ldb       ,x
+                    clra
+                    bra       L31DC
+
+L31D7               tfr       u,d
+                    lbsr      L3247
+L31DC               puls      pc,u
+                    pshs      u,d
+                    ldu       $06,s
+                    lbeq      L32DE
+                    ldd       $06,u
+                    clra
+                    andb      #$01
+                    lbeq      L32DE
+                    ldd       ,s
+                    cmpd      #$FFFF
+                    lbeq      L32DE
+                    ldd       ,u
+                    cmpd      $02,u
+                    lbls      L32DE
+                    ldd       ,u
+                    addd      #$FFFF
+                    std       ,u
+                    tfr       d,x
+                    ldd       ,s
+                    stb       ,x
+                    lbra      L32F4
+                    pshs      u
+                    tfr       d,u
+                    leas      -$04,s
+                    tfr       u,d
+                    lbsr      L31A9
+                    std       $02,s
+                    cmpd      #$FFFF
+                    beq       L3232
+                    tfr       u,d
+                    lbsr      L31A9
+                    std       ,s
+                    cmpd      #$FFFF
+                    bne       L3237
+L3232               ldd       #$FFFF
+                    bra       L3243
+
+L3237               ldd       $02,s
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      L3A8F
+                    addd      ,s
+L3243               leas      $04,s
+                    puls      pc,u
+L3247               pshs      u
+                    tfr       d,u
+                    leas      -$02,s
+                    ldd       $06,u
+                    anda      #$80
+                    andb      #$31
+                    cmpd      #$8001
+                    beq       L326B
+                    ldd       $06,u
+                    clra
+                    andb      #$31
+                    cmpd      #$0001
+                    lbne      L32DE
+                    tfr       u,d
+                    lbsr      L32F8
+L326B               leax      $009a,y
+                    pshs      x
+                    cmpu      ,s++
+                    bne       L3286
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L3286
+                    leax      $00A7,y
+                    tfr       x,d
+                    lbsr      L3090
+L3286               ldd       $06,u
+                    clra
+                    andb      #$08
+                    beq       L32B0
+                    ldd       $0b,u
+                    pshs      d
+                    ldd       $02,u
+                    pshs      d
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L32A2
+                    leax      $3761,pcr
+                    bra       L32A6
+
+L32A2               leax      L3753,pcr
+L32A6               tfr       x,d
+                    tfr       d,x
+                    ldd       $08,u
+                    jsr       ,x
+                    bra       L32C0
+
+L32B0               ldd       #$0001
+                    pshs      d
+                    leax      $0a,u
+                    stx       $02,u
+                    pshs      x
+                    ldd       $08,u
+                    lbsr      L3753
+L32C0               leas      $04,s
+                    std       ,s
+                    ldd       ,s
+                    bgt       L32E3
+                    ldd       $06,u
+                    pshs      d
+                    ldd       $02,s
+                    beq       L32D5
+                    ldd       #$0020
+                    bra       L32D8
+
+L32D5               ldd       #$0010
+L32D8               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+L32DE               ldd       #$FFFF
+                    bra       L32F4
+
+L32E3               ldd       $02,u
+                    addd      #$0001
+                    std       ,u
+                    ldd       $02,u
+                    addd      ,s
+                    std       $04,u
+                    ldb       [$02,u]
+                    clra
+L32F4               leas      $02,s
+                    puls      pc,u
+L32F8               pshs      u
+                    tfr       d,u
+                    ldd       #$FF98
+                    lbsr      L00FB
+                    ldd       $06,u
+                    clra
+                    andb      #$C0
+                    bne       L3330
+                    leas      -$22,s
+                    leax      ,s
+                    pshs      x
+                    ldd       $08,u
+                    lbsr      L391C
+                    leas      $02,s
+                    ldd       $06,u
+                    pshs      d
+                    ldb       $02,s
+                    bne       L3324
+                    ldd       #$0040
+                    bra       L3327
+
+L3324               ldd       #$0080
+L3327               ora       ,s+
+                    orb       ,s+
+                    std       $06,u
+                    leas      $22,s
+L3330               ldd       $06,u
+                    ora       #$80
+                    std       $06,u
+                    clra
+                    andb      #$0C
+                    beq       L333D
+                    puls      pc,u
+L333D               ldd       $0b,u
+                    bne       L3352
+                    ldd       $06,u
+                    clra
+                    andb      #$40
+                    beq       L334D
+                    ldd       #$0080
+                    bra       L3350
+
+L334D               ldd       #$0100
+L3350               std       $0b,u
+L3352               ldd       $02,u
+                    bne       L3363
+                    ldd       $0b,u
+                    lbsr      $3871
+                    std       $02,u
+                    cmpd      #$FFFF
+                    beq       L336B
+L3363               ldd       $06,u
+                    orb       #$08
+                    std       $06,u
+                    bra       L337A
+
+L336B               ldd       $06,u
+                    orb       #$04
+                    std       $06,u
+                    leax      $0a,u
+                    stx       $02,u
+                    ldd       #$0001
+                    std       $0b,u
+L337A               ldd       $02,u
+                    addd      $0b,u
+                    std       $04,u
+                    std       ,u
+                    puls      pc,u
+L3384               pshs      u,d
+                    ldb       $01,s
+                    sex
+                    tfr       d,x
+                    bra       L33AA
+
+L338D               ldd       [$06,s]
+                    addd      #$0004
+                    std       [$06,s]
+                    leax      >L33C3,pcr
+                    bra       L33A6
+
+L339C               ldb       $01,s
+                    stb       $0098,y
+                    leax      $0097,y
+L33A6               tfr       x,d
+                    bra       L33BF
+
+L33AA               cmpx      #$0064
+                    beq       L338D
+                    cmpx      #$006F
+                    lbeq      L338D
+                    cmpx      #$0078
+                    lbeq      L338D
+                    bra       L339C
+
+L33BF               leas      $02,s
+                    puls      pc,u
+L33C3               neg       L0034
+                    nega
+                    leax      >L33CE,pcr
+                    tfr       x,d
+                    puls      pc,u
+L33CE               neg       L0034
+                    rora
+                    ldu       ,s
+L33D3               ldb       ,u+
+                    bne       L33D3
+                    tfr       u,d
+                    subd      ,s
+                    addd      #$FFFF
+                    leas      $02,s
+                    puls      pc,u
+L33E2               pshs      u,d
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $02,s
+                    std       ,s
+L33EC               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L33EC
+                    bra       L3421
+
+L33FA               pshs      u,d
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $02,s
+                    std       ,s
+L3404               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L3404
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L3415               ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L3415
+L3421               ldd       $02,s
+                    leas      $04,s
+                    puls      pc,u
+L3427               pshs      u
+                    tfr       d,u
+                    bra       L343D
+
+L342D               ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       -$01,x
+                    bne       L343B
+                    clra
+                    clrb
+                    puls      pc,u
+L343B               leau      $01,u
+L343D               ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$06,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L342D
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+                    puls      pc,u
+L3455               pshs      u,d
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $02,s
+                    std       ,s
+L345F               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L3483
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L345F
+                    bra       L3483
+
+L3479               clra
+                    clrb
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+L3483               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    bgt       L3479
+                    lbra      L3512
+
+L3492               pshs      u
+                    tfr       d,u
+                    bra       L34A8
+
+L3498               ldx       $04,s
+                    leax      $01,x
+                    stx       $04,s
+                    ldb       -$01,x
+                    bne       L34A6
+                    clra
+                    clrb
+                    puls      pc,u
+L34A6               leau      $01,u
+L34A8               ldd       $06,s
+                    addd      #$FFFF
+                    std       $06,s
+                    subd      #$FFFF
+                    ble       L34C2
+                    ldb       ,u
+                    sex
+                    pshs      d
+                    ldb       [$06,s]
+                    sex
+                    cmpd      ,s++
+                    beq       L3498
+L34C2               ldd       $06,s
+                    bge       L34CA
+                    clra
+                    clrb
+                    bra       L34D5
+
+L34CA               ldb       [$04,s]
+                    sex
+                    pshs      d
+                    ldb       ,u
+                    sex
+                    subd      ,s++
+L34D5               puls      pc,u
+                    pshs      u,d
+                    ldu       $06,s
+                    leas      -$02,s
+                    ldd       $02,s
+                    std       ,s
+L34E1               ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    ldb       -$01,x
+                    bne       L34E1
+                    ldd       ,s
+                    addd      #$FFFF
+                    std       ,s
+L34F2               ldd       $0a,s
+                    addd      #$FFFF
+                    std       $0a,s
+                    subd      #$FFFF
+                    ble       L350A
+                    ldb       ,u+
+                    ldx       ,s
+                    leax      $01,x
+                    stx       ,s
+                    stb       -$01,x
+                    bne       L34F2
+L350A               ldd       $0a,s
+                    bge       L3512
+                    clra
+                    clrb
+L3510               stb       [,s]
+L3512               ldd       $02,s
+                    leas      $04,s
+                    puls      pc,u
+L3518               pshs      u,d
+                    ldu       ,s
+L351C               ldx       $06,s
+                    leax      $01,x
+                    stx       $06,s
+                    ldb       -$01,x
+                    stb       ,u+
+                    bgt       L351C
+                    ldb       -$01,u
+                    clra
+                    andb      #$7f
+                    stb       -$01,u
+                    clra
+                    clrb
+                    stb       ,u
+                    ldd       ,s
+                    leas      $02,s
+                    puls      pc,u
+L3539               pshs      u,d
+                    leas      -$04,s
+                    ldd       $04,s
+                    addd      #$00FF
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      $3A78
+                    pshs      d
+                    ldd       #$0008
+                    lbsr      L3A8F
+                    std       ,s
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    lbsr      $380B
+                    tfr       d,u
+                    cmpu      #$FFFF
+                    bne       L3567
+                    clra
+                    clrb
+                    bra       L357B
+
+L3567               stu       $02,s
+                    ldd       ,s
+                    ldx       $02,s
+                    std       $02,x
+                    tfr       x,d
+                    addd      #$0004
+                    lbsr      L3602
+                    ldd       $01EB,y
+L357B               leas      $06,s
+                    puls      pc,u
+L357F               pshs      u,d
+                    leas      -$06,s
+                    ldd       $06,s
+                    addd      #$0003
+                    lsra
+                    rorb
+                    lsra
+                    rorb
+                    addd      #$0001
+                    std       ,s
+                    ldd       $01EB,y
+                    std       $04,s
+                    bne       L35AF
+                    leax      $16EF,y
+                    stx       $04,s
+                    tfr       x,d
+                    std       $01EB,y
+                    std       $16EF,y
+                    clra
+                    clrb
+                    std       $16F1,y
+L35AF               ldu       [$04,s]
+L35B2               ldd       $02,u
+                    cmpd      ,s
+                    bcs       L35E2
+                    cmpd      ,s
+                    bne       L35C5
+                    ldd       ,u
+                    std       [$04,s]
+                    bra       L35D3
+
+L35C5               subd      ,s
+                    std       $02,u
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    leau      d,u
+                    ldd       ,s
+                    std       $02,u
+L35D3               ldd       $04,s
+                    std       $01EB,y
+                    pshs      u
+                    ldd       #$0004
+                    addd      ,s++
+                    bra       L35FE
+
+L35E2               cmpu      $01EB,y
+                    bne       L35F8
+                    ldd       ,s
+                    lbsr      L3539
+                    tfr       d,u
+                    stu       -$02,s
+                    bne       L35F8
+                    clra
+                    clrb
+                    bra       L35FE
+
+L35F8               stu       $04,s
+                    ldu       ,u
+                    bra       L35B2
+
+L35FE               leas      $08,s
+                    puls      pc,u
+L3602               pshs      u,d
+                    leas      -$02,s
+                    ldd       $02,s
+                    addd      #$FFFC
+                    tfr       d,u
+                    ldd       $01EB,y
+                    bra       L3628
+
+L3613               ldd       ,s
+                    cmpd      [,s]
+                    bcs       L3626
+                    pshs      d
+                    cmpu      ,s++
+                    bhi       L3636
+                    cmpu      [,s]
+                    bcs       L3636
+L3626               ldd       [,s]
+L3628               std       ,s
+                    cmpu      ,s
+                    bls       L3613
+                    cmpu      [,s]
+                    lbcc      L3613
+L3636               pshs      u
+                    ldd       $02,u
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      ,s++
+                    cmpd      [,s]
+                    bne       L3656
+                    ldd       $02,u
+                    pshs      d
+                    ldx       [$02,s]
+                    ldd       $02,x
+                    addd      ,s++
+                    std       $02,u
+                    ldd       ,x
+                    bra       L3658
+
+L3656               ldd       [,s]
+L3658               std       ,u
+                    ldx       ,s
+                    ldd       $02,x
+                    aslb
+                    rola
+                    aslb
+                    rola
+                    addd      ,s
+                    pshs      d
+                    cmpu      ,s++
+                    bne       L3677
+                    ldd       $02,x
+                    addd      $02,u
+                    std       $02,x
+                    ldd       ,u
+                    std       ,x
+                    bra       L3679
+
+L3677               stu       ,x
+L3679               tfr       x,d
+                    std       $01EB,y
+                    bra       $36A5
+                    pshs      u,d
+                    leas      -$02,s
+                    ldd       $02,s
+                    pshs      u,dp,d,cc
+                    ror       $00EC
+                    dec       -$09,x
+                    com       $008B
+                    std       ,s
+                    lbsr      $3580
+                    tfr       d,u
+                    stu       -$02,s
+                    beq       L36A4
+                    ldd       ,s
+                    pshs      d
+                    tfr       u,d
+                    bsr       L36AA
+                    leas      $02,s
+L36A4               tfr       u,d
+                    leas      $04,s
+                    puls      pc,u
+L36AA               pshs      u
+                    tfr       d,u
+                    bra       L36B4
+
+L36B0               clra
+                    clrb
+                    stb       ,u+
+L36B4               ldd       $04,s
+                    addd      #$FFFF
+                    std       $04,s
+                    subd      #$FFFF
+                    bne       L36B0
+                    puls      pc,u
+                    tfr       d,x
+                    lda       $03,s
+                    os9       I$Open
+                    bcc       L36DC
+                    bra       L36DF
+                    tfr       d,x
+                    lda       $03,s
+                    os9       I$Open
+                    bcs       L372E
+                    tfr       a,b
+                    clra
+L36D9               rts
+                    tfr       b,a
+L36DC               os9       I$Close
+L36DF               lbra      L3945
+                    tfr       d,x
+                    ldb       $03,s
+                    os9       I$MakDir
+                    bra       L36DF
+                    pshs      d
+                    ldx       ,s
+                    lda       $05,s
+                    tfr       a,b
+                    andb      #$24
+                    orb       #$0b
+                    os9       I$Create
+                    bcs       L3702
+L36FC               leas      $02,s
+                    tfr       a,b
+                    clra
+                    rts
+
+L3702               cmpb      #$DA
+                    bne       L372C
+                    lda       $05,s
+                    bita      #$80
+                    bne       L372C
+                    anda      #$07
+                    ldx       ,s
+                    os9       I$Open
+                    bcs       L372C
+                    pshs      u,a
+                    ldx       #$0000
+                    leau      ,x
+                    ldb       #$02
+                    os9       I$SetStt
+                    puls      u,a
+                    bcc       L36FC
+                    pshs      b
+                    os9       I$Close
+                    puls      b
+L372C               leas      $02,s
+L372E               lbra      L393C
+                    tfr       d,x
+                    lda       $03,s
+                    ldb       $05,s
+                    os9       I$Create
+                    lbcs      L393C
+                    tfr       a,b
+                    clra
+                    rts
+                    tfr       d,x
+                    os9       I$Delete
+                    bra       L36DF
+                    tfr       b,a
+                    os9       I$Dup
+                    bcs       L372E
+                    tfr       a,b
+                    clra
+L3753               rts
+                    pshs      y
+                    tfr       b,a
+                    ldx       $04,s
+                    ldy       $06,s
+                    os9       I$Read
+                    bra       L376E
+                    pshs      y
+                    tfr       b,a
+                    ldx       $04,s
+                    ldy       $06,s
+                    os9       I$ReadLn
+L376E               bcc       L3798
+                    cmpb      #$D3
+                    bne       L379C
+                    clra
+                    clrb
+                    puls      pc,y
+                    pshs      y
+                    ldy       $06,s
+                    beq       L3798
+                    tfr       b,a
+                    ldx       $04,s
+                    os9       I$Write
+                    bra       L3796
+                    pshs      y
+                    ldy       $06,s
+                    beq       L3798
+                    tfr       b,a
+                    ldx       $04,s
+                    os9       I$WritLn
+L3796               bcs       L379C
+L3798               tfr       y,d
+                    puls      pc,y
+L379C               puls      y
+                    lbra      L393C
+                    pshs      u,d
+                    ldd       $0a,s
+                    bne       L37AF
+                    ldu       #$0000
+                    ldx       #$0000
+                    bra       L37E5
+
+L37AF               cmpd      #$0001
+                    beq       L37DC
+                    cmpd      #$0002
+                    beq       L37D1
+                    ldb       #$F7
+L37BD               clra
+                    std       $01FD,y
+                    ldd       #$FFFF
+                    leax      $01F1,y
+                    std       ,x
+                    std       $02,x
+                    leas      $02,s
+                    puls      pc,u
+L37D1               lda       $01,s
+                    ldb       #$02
+                    os9       I$GetStt
+                    bcs       L37BD
+                    bra       L37E5
+
+L37DC               lda       $01,s
+                    ldb       #$05
+                    os9       I$GetStt
+                    bcs       L37BD
+L37E5               tfr       u,d
+                    addd      $08,s
+                    tfr       d,u
+                    tfr       x,d
+                    adcb      $07,s
+                    adca      $06,s
+                    bmi       L37BD
+                    tfr       d,x
+                    stx       $01F1,y
+                    stu       $01F3,y
+                    lda       $01,s
+                    os9       I$Seek
+                    bcs       L37BD
+                    leax      $01F1,y
+                    leas      $02,s
+                    puls      pc,u
+                    pshs      y,d
+                    cmpd      $16F3,y
+                    bls       L3843
+                    subd      $16F3,y
+                    addd      $01EF,y
+                    subd      $02,s
+                    os9       F$Mem
+                    tfr       y,d
+                    ldy       $02,s
+                    bcc       L382F
+                    ldd       #$FFFF
+                    leas      $04,s
+                    rts
+
+L382F               ldx       $01EF,y
+                    std       $01EF,y
+                    pshs      x
+                    subd      ,s++
+                    addd      $16F3,y
+                    std       $16F3,y
+L3843               ldd       $01EF,y
+                    subd      $16F3,y
+                    tfr       d,x
+                    ldd       $16F3,y
+                    subd      ,s
+                    std       $16F3,y
+                    ldd       ,s
+                    stx       ,s
+                    bitb      #$01
+                    beq       L3862
+                    clr       ,x+
+                    decb
+L3862               tfr       d,y
+                    leay      ,y
+                    beq       L3870
+                    clra
+                    clrb
+L386A               std       ,x++
+                    leay      -$02,y
+                    bne       L386A
+L3870               puls      pc,y,d
+                    addd      $01F9,y
+                    bcs       L3899
+                    cmpd      $01FB,y
+                    bcc       L3899
+                    pshs      d
+                    ldx       $01F9,y
+                    clra
+                    bra       L388A
+
+L3888               sta       ,x+
+L388A               cmpx      ,s
+                    bcs       L3888
+                    ldd       $01F9,y
+                    puls      x
+                    stx       $01F9,y
+                    rts
+
+L3899               ldd       #$FFFF
+L389C               rts
+                    tfr       b,a
+                    ldb       $03,s
+                    os9       F$Send
+                    lbra      L3945
+                    tfr       d,x
+                    clra
+                    clrb
+                    os9       F$Wait
+                    lbcs      L393C
+                    stx       -$02,s
+                    beq       L38BA
+                    stb       $01,x
+                    clr       ,x
+L38BA               tfr       a,b
+                    clra
+                    rts
+                    tfr       b,a
+                    ldb       $03,s
+                    os9       F$SPrior
+                    lbra      L3945
+                    leau      $02,s
+                    leas      $00FF,y
+                    tfr       d,x
+                    ldy       ,u
+                    lda       $05,u
+                    asla
+                    asla
+                    asla
+                    asla
+                    ora       $07,u
+                    ldb       $09,u
+                    ldu       $02,u
+                    os9       F$Chain
+                    os9       F$Exit
+                    pshs      u,y
+                    tfr       d,x
+                    ldy       $06,s
+                    ldu       $08,s
+                    lda       $0b,s
+                    ora       $0d,s
+                    ldb       $0f,s
+                    os9       F$Fork
+                    puls      u,y
+                    lbcs      L393C
+                    tfr       a,b
+                    clra
+L3900               rts
+                    pshs      u
+                    tfr       y,u
+                    std       $16F5,y
+                    leax      >L3915,pcr
+                    os9       F$Icpt
+                    puls      u
+                    lbra      L3945
+
+L3915               tfr       u,y
+                    clra
+                    jsr       [$16F5,y]
+L391C               rti
+                    tfr       b,a
+                    ldb       #$00
+                    ldx       $02,s
+                    os9       I$GetStt
+                    lbra      L3945
+                    tfr       b,a
+                    ldb       #$0f
+                    ldx       $02,s
+                    pshs      y
+                    ldy       $06,s
+                    os9       I$GetStt
+                    puls      y
+                    lbra      L3945
+
+L393C               clra
+                    std       $01FD,y
+                    ldd       #$FFFF
+                    rts
+
+L3945               bcs       L393C
+                    clra
+                    clrb
+L3949               rts
+                    pshs      d
+                    lbsr      L3957
+                    lbsr      $3038
+                    puls      d
+                    os9       F$Exit
+L3957               rts
+                    ldd       $04,s
+                    addd      $02,x
+                    std       $01F3,y
+                    ldd       $02,s
+                    adcb      $01,x
+                    adca      ,x
+                    std       $01F1,y
+                    lbra      L39FC
+                    ldd       $04,s
+                    subd      $02,x
+                    std       $01F3,y
+                    ldd       $02,s
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       $01F1,y
+                    lbra      L39FC
+                    ldd       $02,s
+                    cmpd      ,x
+                    bne       L399B
+                    ldd       $04,s
+                    cmpd      $02,x
+                    beq       L399B
+                    bcs       L3998
+                    lda       #$01
+                    andcc     #$FE
+                    bra       L399B
+
+L3998               clra
+                    cmpa      #$01
+L399B               pshs      cc
+                    ldd       $01,s
+                    std       $05,s
+                    puls      cc
+                    leas      $04,s
+L39A5               rts
+                    lbsr      L3A0B
+                    ldd       #$0000
+                    subd      $02,x
+                    std       $02,x
+                    ldd       #$0000
+                    sbcb      $01,x
+                    sbca      ,x
+                    std       ,x
+                    rts
+                    ldd       ,x
+                    coma
+                    comb
+                    std       $01F1,y
+                    ldd       $02,x
+                    coma
+                    comb
+                    leax      $01F1,y
+                    std       $02,x
+L39CC               rts
+                    leax      $01F1,y
+                    std       $02,x
+                    tfr       a,b
+                    sex
+                    tfr       a,b
+                    std       ,x
+                    rts
+                    leax      $01F1,y
+                    std       $02,x
+                    clr       ,x
+                    clr       $01,x
+L39E5               rts
+                    pshs      y
+                    ldy       $04,s
+                    ldd       ,x
+                    std       ,y
+                    ldd       $02,x
+                    std       $02,y
+                    puls      x
+                    exg       y,x
+                    puls      d
+                    std       ,s
+                    rts
+
+L39FC               tfr       cc,a
+                    puls      x
+                    stx       $02,s
+                    leas      $02,s
+                    leax      $01F1,y
+                    tfr       a,cc
+                    rts
+
+L3A0B               ldd       ,x
+L3A0D               std       $01F1,y
+                    ldd       $02,x
+                    leax      $01F1,y
+                    std       $02,x
+L3A19               rts
+                    tsta
+                    bne       L3A2F
+                    tst       $02,s
+                    bne       L3A2F
+                    lda       $03,s
+                    mul
+                    ldx       ,s
+                    stx       $02,s
+                    ldx       #$0000
+                    std       ,s
+                    puls      pc,d
+L3A2F               pshs      d
+                    ldd       #$0000
+                    pshs      d
+                    pshs      d
+                    lda       $05,s
+                    ldb       $09,s
+                    mul
+                    std       $02,s
+                    lda       $05,s
+                    ldb       $08,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L3A4C
+                    inc       ,s
+L3A4C               lda       $04,s
+                    ldb       $09,s
+                    mul
+                    addd      $01,s
+                    std       $01,s
+                    bcc       L3A59
+                    inc       ,s
+L3A59               lda       $04,s
+                    ldb       $08,s
+                    mul
+                    addd      ,s
+                    std       ,s
+                    ldx       $06,s
+                    stx       $08,s
+                    ldx       ,s
+                    ldd       $02,s
+                    leas      $08,s
+                    rts
+                    tstb
+                    beq       L3A83
+L3A70               asr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L3A70
+                    bra       L3A83
+                    tstb
+                    beq       L3A83
+L3A7C               lsr       $02,s
+                    ror       $03,s
+                    decb
+                    bne       L3A7C
+L3A83               ldd       $02,s
+                    pshs      d
+                    ldd       $02,s
+                    std       $04,s
+                    ldd       ,s
+                    leas      $04,s
+L3A8F               rts
+                    tstb
+                    beq       L3A83
+L3A93               asl       $03,s
+                    rol       $02,s
+                    decb
+                    bne       L3A93
+                    bra       L3A83
+                    neg       $0009
+                    neg       $0000
+                    coma
+                    ror       $00D3
+                    neg       $0025
+                    neg       $0027
+                    fcb       $01
+                    andb      #$09
+                    andb      #$09
+                    addd      L0A2C
+                    dec       $0058
+                    dec       $0062
+                    dec       L008A
+                    dec       L00CA
+                    fcb       $0b
+                    asl       $000B
+                    nega
+                    fcb       $0b
+                    fcb       $7b
+                    fcb       $0b
+                    jsr       L0BFC
+                    inc       $0032
+                    bra       L3AE5
+                    bra       L3AE7
+                    bra       L3AE9
+                    bra       L3AEB
+                    bra       L3AED
+                    bra       L3AEF
+                    bra       L3AF1
+                    bra       L3AF3
+                    bra       L3AF5
+                    bra       L3AF7
+                    neg       L0020
+                    neg       $0064
+                    fcb       $6f,$6e,$27,$74,$20,$6b,$6e,$6f
+                    fcb       $77,$20
+L3AE5               fcb       $68,$6f
+L3AE7               fcb       $77,$20
+L3AE9               fcb       $74,$6f
+L3AEB               fcb       $20,$6d
+L3AED               fcb       $61,$6b
+L3AEF               fcb       $65,$20
+L3AF1               fcb       $22,$25
+L3AF3               fcb       $73,$22
+L3AF5               fcb       $2e,$0d
+L3AF7               neg       L0020
+                    bra       L3B1B
+                    bra       L3B1D
+                    bra       L3B1F
+                    bra       L3B21
+                    bra       $3B23
+                    bra       $3B25
+                    bra       $3B27
+                    bra       $3B29
+                    bra       $3B2B
+                    bra       L3B0D
+
+L3B0D               beq       L3B1F
+                    com       $00E8
+                    neg       $0064
+                    neg       $000A
+                    neg       $0095
+                    inc       -$08,s
+                    neg       $0000
+L3B1B               neg       $0000
+L3B1D               neg       $0000
+L3B1F               neg       $0000
+L3B21               fcb       $01
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $02
+                    neg       $0001
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    fcb       $42
+                    neg       $0002
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0000
+                    neg       $0001
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $11
+                    fcb       $11
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    fcb       $01
+                    leax      0,y
+                    bra       L3C2F
+                    bra       L3C31
+                    bra       L3C33
+                    bra       L3C35
+                    bra       L3C37
+                    bra       L3C39
+                    bra       L3C3B
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    asla
+                    bra       $3C47
+                    bra       $3C49
+                    bra       $3C4B
+                    bra       L3C6F
+                    fcb       $42
+                    fcb       $42
+L3C2F               fcb       $42
+                    fcb       $42
+L3C31               fcb       $42
+                    fcb       $02
+L3C33               fcb       $02
+                    fcb       $02
+L3C35               fcb       $02
+                    fcb       $02
+L3C37               fcb       $02
+                    fcb       $02
+L3C39               fcb       $02
+                    fcb       $02
+L3C3B               fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    fcb       $02
+                    bra       L3C68
+                    bra       L3C6A
+                    bra       $3C6C
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsra
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    lsr       $0004
+                    bra       $3C88
+
+L3C68               bra       $3C8A
+L3C6A               fcb       $01
+                    neg       $0000
+                    neg       $000D
+L3C6F               neg       $0033
+                    neg       $0031
+                    neg       $002F
+                    neg       $002D
+                    neg       $002B
+                    neg       $0029
+                    neg       $0041
+                    neg       $003F
+                    neg       $003D
+                    neg       $003B
+                    neg       $0039
+                    neg       $0037
+                    neg       $0035
+                    neg       $0005
+                    neg       $0001
+                    neg       $0003
+                    neg       $0005
+                    neg       $0007
+                    neg       $0095
+                    tst       $01,s
+                    fcb       $6b
+                    fcb       $65
+
+                    emod
+eom                 equ       *
+                    end

--- a/scripts/dis6809.py
+++ b/scripts/dis6809.py
@@ -1,0 +1,893 @@
+#!/usr/bin/env python3
+"""dis6809.py - 6809 disassembler for OS-9 module FCB-format files.
+
+Converts FCB hex-dump .asm files (as produced by older disassemblers or
+hand-dumped binaries) into proper lwasm-compatible 6809 assembly.
+
+Performs control-flow analysis from the module's execution entry point so
+that code bytes are disassembled as instructions and data bytes are emitted
+as fcb/fdb/fcc directives.
+
+Usage:
+    python3 scripts/dis6809.py input.asm > output.asm
+    python3 scripts/dis6809.py input.asm -o output.asm
+"""
+
+import sys
+import re
+import argparse
+from typing import Dict, List, Optional, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# OS-9 service call names
+# ---------------------------------------------------------------------------
+OS9_CALLS: Dict[int, str] = {
+    0x00: 'F$Link',   0x01: 'F$Load',   0x02: 'F$UnLink', 0x03: 'F$Fork',
+    0x04: 'F$Wait',   0x05: 'F$Chain',  0x06: 'F$Exit',   0x07: 'F$Mem',
+    0x08: 'F$Send',   0x09: 'F$Icpt',   0x0A: 'F$Sleep',  0x0B: 'F$SSpd',
+    0x0C: 'F$ID',     0x0D: 'F$SPrior', 0x0E: 'F$SSWI',   0x0F: 'F$PErr',
+    0x10: 'F$PrsNam', 0x11: 'F$CmpNam', 0x12: 'F$SchBit', 0x13: 'F$AllBit',
+    0x14: 'F$DelBit', 0x15: 'F$Time',   0x16: 'F$STime',  0x17: 'F$CRC',
+    0x18: 'F$GPrDsc', 0x19: 'F$GBlkMp', 0x1A: 'F$GModDr', 0x1B: 'F$CpyMem',
+    0x1C: 'F$SUser',  0x1D: 'F$UnLoad', 0x1E: 'F$Alarm',
+    0x21: 'F$NMLink', 0x22: 'F$NMLoad', 0x23: 'F$Debug',
+    0x24: 'F$TPS',    0x25: 'F$TimAlm',
+    0x80: 'I$Attach', 0x81: 'I$Detach', 0x82: 'I$Dup',    0x83: 'I$Delete',
+    0x84: 'I$Seek',   0x85: 'I$Read',   0x86: 'I$Write',  0x87: 'I$ReadLn',
+    0x88: 'I$WritLn', 0x89: 'I$GetStt', 0x8A: 'I$SetStt', 0x8B: 'I$Close',
+    0x8C: 'I$MakDir', 0x8D: 'I$ChgDir', 0x8E: 'I$Open',   0x8F: 'I$MakFil',
+    0x90: 'I$GStat',  0x91: 'I$SStat',  0x92: 'I$Creat',
+}
+
+# ---------------------------------------------------------------------------
+# Register tables
+# ---------------------------------------------------------------------------
+IDX_REGS = {0: 'x', 1: 'y', 2: 'u', 3: 's'}
+
+TFR_REGS = {
+    0x0: 'd', 0x1: 'x', 0x2: 'y', 0x3: 'u',
+    0x4: 's', 0x5: 'pc',
+    0x8: 'a', 0x9: 'b', 0xA: 'cc', 0xB: 'dp',
+    # 6309 extras
+    0x6: 'w', 0x7: 'v', 0xC: '0', 0xE: 'e', 0xF: 'f',
+}
+
+# Register bit positions in PSHS/PULS postbyte (bit -> name)
+RLIST_BITS_S = [(0, 'cc'), (1, 'a'), (2, 'b'), (3, 'dp'),
+                (4, 'x'),  (5, 'y'), (6, 'u'), (7, 'pc')]
+RLIST_BITS_U = [(0, 'cc'), (1, 'a'), (2, 'b'), (3, 'dp'),
+                (4, 'x'),  (5, 'y'), (6, 's'), (7, 'pc')]
+
+# ---------------------------------------------------------------------------
+# Instruction tables
+# Format: opcode -> (mnemonic, mode, terminates_flow)
+# mode values: INH, IMM1, IMM2, IMM4, DIR, EXT, IDX,
+#              REL1, REL2, REGS, RLIST_S, RLIST_U, OS9
+# ---------------------------------------------------------------------------
+
+# Page 0 (no prefix)
+P0: Dict[int, Tuple[str, str, bool]] = {
+    0x00: ('neg',   'DIR',    False), 0x03: ('com',   'DIR',    False),
+    0x04: ('lsr',   'DIR',    False), 0x06: ('ror',   'DIR',    False),
+    0x07: ('asr',   'DIR',    False), 0x08: ('asl',   'DIR',    False),
+    0x09: ('rol',   'DIR',    False), 0x0A: ('dec',   'DIR',    False),
+    0x0C: ('inc',   'DIR',    False), 0x0D: ('tst',   'DIR',    False),
+    0x0E: ('jmp',   'DIR',    True),  0x0F: ('clr',   'DIR',    False),
+    0x12: ('nop',   'INH',    False), 0x13: ('sync',  'INH',    True),
+    0x16: ('lbra',  'REL2',   True),  0x17: ('lbsr',  'REL2',   False),
+    0x19: ('daa',   'INH',    False), 0x1A: ('orcc',  'IMM1',   False),
+    0x1C: ('andcc', 'IMM1',   False), 0x1D: ('sex',   'INH',    False),
+    0x1E: ('exg',   'REGS',   False), 0x1F: ('tfr',   'REGS',   False),
+    0x20: ('bra',   'REL1',   True),  0x21: ('brn',   'REL1',   False),
+    0x22: ('bhi',   'REL1',   False), 0x23: ('bls',   'REL1',   False),
+    0x24: ('bcc',   'REL1',   False), 0x25: ('bcs',   'REL1',   False),
+    0x26: ('bne',   'REL1',   False), 0x27: ('beq',   'REL1',   False),
+    0x28: ('bvc',   'REL1',   False), 0x29: ('bvs',   'REL1',   False),
+    0x2A: ('bpl',   'REL1',   False), 0x2B: ('bmi',   'REL1',   False),
+    0x2C: ('bge',   'REL1',   False), 0x2D: ('blt',   'REL1',   False),
+    0x2E: ('bgt',   'REL1',   False), 0x2F: ('ble',   'REL1',   False),
+    0x30: ('leax',  'IDX',    False), 0x31: ('leay',  'IDX',    False),
+    0x32: ('leas',  'IDX',    False), 0x33: ('leau',  'IDX',    False),
+    0x34: ('pshs',  'RLIST_S',False), 0x35: ('puls',  'RLIST_S',False),
+    0x36: ('pshu',  'RLIST_U',False), 0x37: ('pulu',  'RLIST_U',False),
+    0x39: ('rts',   'INH',    True),  0x3A: ('abx',   'INH',    False),
+    0x3B: ('rti',   'INH',    True),  0x3C: ('cwai',  'IMM1',   True),
+    0x3D: ('mul',   'INH',    False), 0x3F: ('swi',   'OS9',    False),
+    0x40: ('nega',  'INH',    False), 0x43: ('coma',  'INH',    False),
+    0x44: ('lsra',  'INH',    False), 0x46: ('rora',  'INH',    False),
+    0x47: ('asra',  'INH',    False), 0x48: ('asla',  'INH',    False),
+    0x49: ('rola',  'INH',    False), 0x4A: ('deca',  'INH',    False),
+    0x4C: ('inca',  'INH',    False), 0x4D: ('tsta',  'INH',    False),
+    0x4F: ('clra',  'INH',    False), 0x50: ('negb',  'INH',    False),
+    0x53: ('comb',  'INH',    False), 0x54: ('lsrb',  'INH',    False),
+    0x56: ('rorb',  'INH',    False), 0x57: ('asrb',  'INH',    False),
+    0x58: ('aslb',  'INH',    False), 0x59: ('rolb',  'INH',    False),
+    0x5A: ('decb',  'INH',    False), 0x5C: ('incb',  'INH',    False),
+    0x5D: ('tstb',  'INH',    False), 0x5F: ('clrb',  'INH',    False),
+    0x60: ('neg',   'IDX',    False), 0x63: ('com',   'IDX',    False),
+    0x64: ('lsr',   'IDX',    False), 0x66: ('ror',   'IDX',    False),
+    0x67: ('asr',   'IDX',    False), 0x68: ('asl',   'IDX',    False),
+    0x69: ('rol',   'IDX',    False), 0x6A: ('dec',   'IDX',    False),
+    0x6C: ('inc',   'IDX',    False), 0x6D: ('tst',   'IDX',    False),
+    0x6E: ('jmp',   'IDX',    True),  0x6F: ('clr',   'IDX',    False),
+    0x70: ('neg',   'EXT',    False), 0x73: ('com',   'EXT',    False),
+    0x74: ('lsr',   'EXT',    False), 0x76: ('ror',   'EXT',    False),
+    0x77: ('asr',   'EXT',    False), 0x78: ('asl',   'EXT',    False),
+    0x79: ('rol',   'EXT',    False), 0x7A: ('dec',   'EXT',    False),
+    0x7C: ('inc',   'EXT',    False), 0x7D: ('tst',   'EXT',    False),
+    0x7E: ('jmp',   'EXT',    True),  0x7F: ('clr',   'EXT',    False),
+    0x80: ('suba',  'IMM1',   False), 0x81: ('cmpa',  'IMM1',   False),
+    0x82: ('sbca',  'IMM1',   False), 0x83: ('subd',  'IMM2',   False),
+    0x84: ('anda',  'IMM1',   False), 0x85: ('bita',  'IMM1',   False),
+    0x86: ('lda',   'IMM1',   False), 0x88: ('eora',  'IMM1',   False),
+    0x89: ('adca',  'IMM1',   False), 0x8A: ('ora',   'IMM1',   False),
+    0x8B: ('adda',  'IMM1',   False), 0x8C: ('cmpx',  'IMM2',   False),
+    0x8D: ('bsr',   'REL1',   False), 0x8E: ('ldx',   'IMM2',   False),
+    0x90: ('suba',  'DIR',    False), 0x91: ('cmpa',  'DIR',    False),
+    0x92: ('sbca',  'DIR',    False), 0x93: ('subd',  'DIR',    False),
+    0x94: ('anda',  'DIR',    False), 0x95: ('bita',  'DIR',    False),
+    0x96: ('lda',   'DIR',    False), 0x97: ('sta',   'DIR',    False),
+    0x98: ('eora',  'DIR',    False), 0x99: ('adca',  'DIR',    False),
+    0x9A: ('ora',   'DIR',    False), 0x9B: ('adda',  'DIR',    False),
+    0x9C: ('cmpx',  'DIR',    False), 0x9D: ('jsr',   'DIR',    False),
+    0x9E: ('ldx',   'DIR',    False), 0x9F: ('stx',   'DIR',    False),
+    0xA0: ('suba',  'IDX',    False), 0xA1: ('cmpa',  'IDX',    False),
+    0xA2: ('sbca',  'IDX',    False), 0xA3: ('subd',  'IDX',    False),
+    0xA4: ('anda',  'IDX',    False), 0xA5: ('bita',  'IDX',    False),
+    0xA6: ('lda',   'IDX',    False), 0xA7: ('sta',   'IDX',    False),
+    0xA8: ('eora',  'IDX',    False), 0xA9: ('adca',  'IDX',    False),
+    0xAA: ('ora',   'IDX',    False), 0xAB: ('adda',  'IDX',    False),
+    0xAC: ('cmpx',  'IDX',    False), 0xAD: ('jsr',   'IDX',    False),
+    0xAE: ('ldx',   'IDX',    False), 0xAF: ('stx',   'IDX',    False),
+    0xB0: ('suba',  'EXT',    False), 0xB1: ('cmpa',  'EXT',    False),
+    0xB2: ('sbca',  'EXT',    False), 0xB3: ('subd',  'EXT',    False),
+    0xB4: ('anda',  'EXT',    False), 0xB5: ('bita',  'EXT',    False),
+    0xB6: ('lda',   'EXT',    False), 0xB7: ('sta',   'EXT',    False),
+    0xB8: ('eora',  'EXT',    False), 0xB9: ('adca',  'EXT',    False),
+    0xBA: ('ora',   'EXT',    False), 0xBB: ('adda',  'EXT',    False),
+    0xBC: ('cmpx',  'EXT',    False), 0xBD: ('jsr',   'EXT',    False),
+    0xBE: ('ldx',   'EXT',    False), 0xBF: ('stx',   'EXT',    False),
+    0xC0: ('subb',  'IMM1',   False), 0xC1: ('cmpb',  'IMM1',   False),
+    0xC2: ('sbcb',  'IMM1',   False), 0xC3: ('addd',  'IMM2',   False),
+    0xC4: ('andb',  'IMM1',   False), 0xC5: ('bitb',  'IMM1',   False),
+    0xC6: ('ldb',   'IMM1',   False), 0xC8: ('eorb',  'IMM1',   False),
+    0xC9: ('adcb',  'IMM1',   False), 0xCA: ('orb',   'IMM1',   False),
+    0xCB: ('addb',  'IMM1',   False), 0xCC: ('ldd',   'IMM2',   False),
+    0xCE: ('ldu',   'IMM2',   False),
+    0xD0: ('subb',  'DIR',    False), 0xD1: ('cmpb',  'DIR',    False),
+    0xD2: ('sbcb',  'DIR',    False), 0xD3: ('addd',  'DIR',    False),
+    0xD4: ('andb',  'DIR',    False), 0xD5: ('bitb',  'DIR',    False),
+    0xD6: ('ldb',   'DIR',    False), 0xD7: ('stb',   'DIR',    False),
+    0xD8: ('eorb',  'DIR',    False), 0xD9: ('adcb',  'DIR',    False),
+    0xDA: ('orb',   'DIR',    False), 0xDB: ('addb',  'DIR',    False),
+    0xDC: ('ldd',   'DIR',    False), 0xDD: ('std',   'DIR',    False),
+    0xDE: ('ldu',   'DIR',    False), 0xDF: ('stu',   'DIR',    False),
+    0xE0: ('subb',  'IDX',    False), 0xE1: ('cmpb',  'IDX',    False),
+    0xE2: ('sbcb',  'IDX',    False), 0xE3: ('addd',  'IDX',    False),
+    0xE4: ('andb',  'IDX',    False), 0xE5: ('bitb',  'IDX',    False),
+    0xE6: ('ldb',   'IDX',    False), 0xE7: ('stb',   'IDX',    False),
+    0xE8: ('eorb',  'IDX',    False), 0xE9: ('adcb',  'IDX',    False),
+    0xEA: ('orb',   'IDX',    False), 0xEB: ('addb',  'IDX',    False),
+    0xEC: ('ldd',   'IDX',    False), 0xED: ('std',   'IDX',    False),
+    0xEE: ('ldu',   'IDX',    False), 0xEF: ('stu',   'IDX',    False),
+    0xF0: ('subb',  'EXT',    False), 0xF1: ('cmpb',  'EXT',    False),
+    0xF2: ('sbcb',  'EXT',    False), 0xF3: ('addd',  'EXT',    False),
+    0xF4: ('andb',  'EXT',    False), 0xF5: ('bitb',  'EXT',    False),
+    0xF6: ('ldb',   'EXT',    False), 0xF7: ('stb',   'EXT',    False),
+    0xF8: ('eorb',  'EXT',    False), 0xF9: ('adcb',  'EXT',    False),
+    0xFA: ('orb',   'EXT',    False), 0xFB: ('addb',  'EXT',    False),
+    0xFC: ('ldd',   'EXT',    False), 0xFD: ('std',   'EXT',    False),
+    0xFE: ('ldu',   'EXT',    False), 0xFF: ('stu',   'EXT',    False),
+}
+
+# Page 1 ($10 prefix) - standard 6809
+P1: Dict[int, Tuple[str, str, bool]] = {
+    0x21: ('lbrn',  'REL2',   False), 0x22: ('lbhi',  'REL2',   False),
+    0x23: ('lbls',  'REL2',   False), 0x24: ('lbcc',  'REL2',   False),
+    0x25: ('lbcs',  'REL2',   False), 0x26: ('lbne',  'REL2',   False),
+    0x27: ('lbeq',  'REL2',   False), 0x28: ('lbvc',  'REL2',   False),
+    0x29: ('lbvs',  'REL2',   False), 0x2A: ('lbpl',  'REL2',   False),
+    0x2B: ('lbmi',  'REL2',   False), 0x2C: ('lbge',  'REL2',   False),
+    0x2D: ('lblt',  'REL2',   False), 0x2E: ('lbgt',  'REL2',   False),
+    0x2F: ('lble',  'REL2',   False),
+    0x3F: ('swi2',  'INH',    True),
+    0x83: ('cmpd',  'IMM2',   False), 0x8C: ('cmpy',  'IMM2',   False),
+    0x8E: ('ldy',   'IMM2',   False),
+    0x93: ('cmpd',  'DIR',    False), 0x9C: ('cmpy',  'DIR',    False),
+    0x9E: ('ldy',   'DIR',    False), 0x9F: ('sty',   'DIR',    False),
+    0xA3: ('cmpd',  'IDX',    False), 0xAC: ('cmpy',  'IDX',    False),
+    0xAE: ('ldy',   'IDX',    False), 0xAF: ('sty',   'IDX',    False),
+    0xB3: ('cmpd',  'EXT',    False), 0xBC: ('cmpy',  'EXT',    False),
+    0xBE: ('ldy',   'EXT',    False), 0xBF: ('sty',   'EXT',    False),
+    0xCE: ('lds',   'IMM2',   False),
+    0xDE: ('lds',   'DIR',    False), 0xDF: ('sts',   'DIR',    False),
+    0xEE: ('lds',   'IDX',    False), 0xEF: ('sts',   'IDX',    False),
+    0xFE: ('lds',   'EXT',    False), 0xFF: ('sts',   'EXT',    False),
+}
+
+# Page 2 ($11 prefix) - standard 6809
+P2: Dict[int, Tuple[str, str, bool]] = {
+    0x3F: ('swi3',  'INH',    True),
+    0x83: ('cmpu',  'IMM2',   False), 0x8C: ('cmps',  'IMM2',   False),
+    0x93: ('cmpu',  'DIR',    False), 0x9C: ('cmps',  'DIR',    False),
+    0xA3: ('cmpu',  'IDX',    False), 0xAC: ('cmps',  'IDX',    False),
+    0xB3: ('cmpu',  'EXT',    False), 0xBC: ('cmps',  'EXT',    False),
+}
+
+# ---------------------------------------------------------------------------
+# Indexed addressing mode decoder
+# ---------------------------------------------------------------------------
+
+def decode_indexed(data: bytes, pos: int, instr_base: int) -> Tuple[str, int]:
+    """Decode indexed post-byte at data[pos].
+
+    instr_base: absolute byte offset of the instruction's opcode byte (used
+                for PC-relative offset calculations).
+
+    Returns (operand_text, bytes_consumed_including_postbyte).
+    """
+    if pos >= len(data):
+        return '?', 1
+    pb = data[pos]
+    r = IDX_REGS[(pb >> 5) & 3]
+
+    if not (pb & 0x80):
+        # 5-bit signed constant offset, no extra bytes
+        offset = pb & 0x1F
+        if offset & 0x10:
+            offset -= 0x20
+        if offset == 0:
+            return f',{r}', 1
+        elif offset > 0:
+            return f'<${offset:02X},{r}', 1
+        else:
+            return f'<-${(-offset):02X},{r}', 1
+
+    indirect = (pb & 0x10) != 0
+    mode = pb & 0x0F
+    inner: Optional[str] = None
+    extra = 1  # just the postbyte
+
+    if mode == 0x00:
+        inner = f',{r}+'
+    elif mode == 0x01:
+        inner = f',{r}++'
+    elif mode == 0x02:
+        inner = f',-{r}'
+    elif mode == 0x03:
+        inner = f',--{r}'
+    elif mode == 0x04:
+        inner = f',{r}'
+    elif mode == 0x05:
+        inner = f'b,{r}'
+    elif mode == 0x06:
+        inner = f'a,{r}'
+    elif mode == 0x07:
+        inner = f'e,{r}'     # 6309
+    elif mode == 0x08:
+        if pos + 1 >= len(data):
+            return '?', 1
+        off8 = data[pos + 1]
+        if off8 & 0x80:
+            off8 -= 0x100
+        inner = (f'<${off8:02X},{r}' if off8 >= 0 else f'<-${(-off8):02X},{r}')
+        extra = 2
+    elif mode == 0x09:
+        if pos + 2 >= len(data):
+            return '?', 1
+        off16 = (data[pos + 1] << 8) | data[pos + 2]
+        if off16 & 0x8000:
+            off16 -= 0x10000
+        inner = (f'>${off16:04X},{r}' if off16 >= 0 else f'>-${(-off16):04X},{r}')
+        extra = 3
+    elif mode == 0x0A:
+        inner = f'f,{r}'     # 6309
+    elif mode == 0x0B:
+        inner = f'd,{r}'
+    elif mode == 0x0C:
+        # 8-bit PC-relative offset.  Target = (address after postbyte+offset) + offset
+        if pos + 1 >= len(data):
+            return '?', 1
+        off8 = data[pos + 1]
+        if off8 & 0x80:
+            off8 -= 0x100
+        # The pc value at decode time is instr_base + (pos - instr_base) + 2
+        target = pos + 2 + off8   # pos is offset within data array = absolute addr
+        inner = f'>L{target:04X},pcr'
+        extra = 2
+    elif mode == 0x0D:
+        # 16-bit PC-relative offset
+        if pos + 2 >= len(data):
+            return '?', 1
+        off16 = (data[pos + 1] << 8) | data[pos + 2]
+        if off16 & 0x8000:
+            off16 -= 0x10000
+        target = pos + 3 + off16
+        inner = f'>L{target:04X},pcr'
+        extra = 3
+    elif mode == 0x0E:
+        inner = f'w,{r}'     # 6309
+    elif mode == 0x0F:
+        # Extended indirect
+        if pos + 2 >= len(data):
+            return '?', 1
+        addr = (data[pos + 1] << 8) | data[pos + 2]
+        return f'[>${addr:04X}]', 3
+    else:
+        return f'${pb:02X}', 1
+
+    if inner is None:
+        return f'${pb:02X}', 1
+
+    if indirect:
+        return f'[{inner}]', extra
+    return inner, extra
+
+
+def decode_rlist(pb: int, bits: list) -> str:
+    """Decode PSHS/PULS/PSHU/PULU register list postbyte."""
+    parts = [name for bit, name in bits if pb & (1 << bit)]
+    return ','.join(parts) if parts else '0'
+
+
+def decode_regs(pb: int) -> str:
+    """Decode TFR/EXG register pair postbyte."""
+    src = TFR_REGS.get(pb >> 4, f'${pb >> 4:X}')
+    dst = TFR_REGS.get(pb & 0xF, f'${pb & 0xF:X}')
+    return f'{src},{dst}'
+
+
+# ---------------------------------------------------------------------------
+# Single instruction decoder
+# ---------------------------------------------------------------------------
+
+def decode_instr(data: bytes, pos: int) -> Tuple[str, str, int, bool, List[int]]:
+    """Decode one instruction at data[pos].
+
+    Returns:
+        (mnemonic, operand_text, length_in_bytes, terminates_flow, branch_targets)
+        branch_targets: list of absolute byte offsets that this instruction
+                        may transfer control to (not counting fall-through).
+    """
+    if pos >= len(data):
+        return 'fcb', f'${data[pos]:02X}' if pos < len(data) else '?', 1, False, []
+
+    b0 = data[pos]
+    table = P0
+    pfx_len = 0
+
+    if b0 == 0x10:
+        if pos + 1 >= len(data):
+            return 'fcb', f'$10', 1, False, []
+        b1 = data[pos + 1]
+        entry = P1.get(b1)
+        if entry:
+            table = P1
+            b0 = b1
+            pfx_len = 1
+        else:
+            # Unknown $10 xx - emit as fcb pair
+            return 'fcb', f'$10,${b1:02X}', 2, False, []
+    elif b0 == 0x11:
+        if pos + 1 >= len(data):
+            return 'fcb', f'$11', 1, False, []
+        b1 = data[pos + 1]
+        entry = P2.get(b1)
+        if entry:
+            table = P2
+            b0 = b1
+            pfx_len = 1
+        else:
+            return 'fcb', f'$11,${b1:02X}', 2, False, []
+    else:
+        entry = P0.get(b0)
+
+    if entry is None:
+        return 'fcb', f'${data[pos]:02X}', 1, False, []
+
+    mnem, mode, terminates = entry
+    base = pos + pfx_len + 1   # offset of first operand byte in data
+    targets: List[int] = []
+    operand = ''
+    length = pfx_len + 1       # prefix + opcode byte
+
+    if mode == 'INH':
+        operand = ''
+    elif mode == 'OS9':
+        # $3F nn - OS9 trap
+        if base < len(data):
+            svc = data[base]
+            name = OS9_CALLS.get(svc, f'${svc:02X}')
+            operand = name
+            length += 1
+            terminates = False  # execution continues after os9 call
+        else:
+            operand = '?'
+            length += 1
+    elif mode == 'IMM1':
+        if base < len(data):
+            operand = f'#${data[base]:02X}'
+        length += 1
+    elif mode == 'IMM2':
+        if base + 1 < len(data):
+            val = (data[base] << 8) | data[base + 1]
+            operand = f'#${val:04X}'
+        length += 2
+    elif mode == 'IMM4':
+        if base + 3 < len(data):
+            val = ((data[base] << 24) | (data[base+1] << 16) |
+                   (data[base+2] << 8) | data[base+3])
+            operand = f'#${val:08X}'
+        length += 4
+    elif mode == 'DIR':
+        if base < len(data):
+            operand = f'<${data[base]:02X}'
+        length += 1
+    elif mode == 'EXT':
+        if base + 1 < len(data):
+            addr = (data[base] << 8) | data[base + 1]
+            operand = f'>L{addr:04X}'
+            targets.append(addr) if mnem == 'jmp' else None
+        length += 2
+    elif mode == 'IDX':
+        op_text, extra = decode_indexed(data, base, pos)
+        operand = op_text
+        length += extra
+        # If indexed JMP/JSR, target is unknown (indirect)
+    elif mode == 'REL1':
+        if base < len(data):
+            off = data[base]
+            if off & 0x80:
+                off -= 0x100
+            target = base + 1 + off   # base+1 = address after offset byte
+            operand = f'>L{target:04X}'
+            targets.append(target)
+        length += 1
+    elif mode == 'REL2':
+        if base + 1 < len(data):
+            off = (data[base] << 8) | data[base + 1]
+            if off & 0x8000:
+                off -= 0x10000
+            target = base + 2 + off
+            operand = f'>L{target:04X}'
+            targets.append(target)
+        length += 2
+    elif mode == 'REGS':
+        if base < len(data):
+            operand = decode_regs(data[base])
+        length += 1
+    elif mode == 'RLIST_S':
+        if base < len(data):
+            pb = data[base]
+            operand = decode_rlist(pb, RLIST_BITS_S)
+            # puls pc,... terminates sequential flow
+            if mnem == 'puls' and (pb & 0x80):
+                terminates = True
+            # pulu pc,... terminates
+            length += 1
+    elif mode == 'RLIST_U':
+        if base < len(data):
+            pb = data[base]
+            operand = decode_rlist(pb, RLIST_BITS_U)
+            if mnem == 'pulu' and (pb & 0x80):
+                terminates = True
+            length += 1
+
+    return mnem, operand, length, terminates, targets
+
+
+# ---------------------------------------------------------------------------
+# FCB file parser
+# ---------------------------------------------------------------------------
+
+def parse_fcb_file(path: str) -> Tuple[bytes, Dict[int, str]]:
+    """Parse an FCB-format .asm file.
+
+    Returns:
+        (data_bytes, label_map)
+        label_map: offset -> label_name for labels found in the file
+    """
+    data_list: List[int] = []
+    label_map: Dict[int, str] = {}
+
+    with open(path, 'r', errors='replace') as fh:
+        for line in fh:
+            line = line.rstrip('\r\n')
+
+            # Skip pure comment lines or blank lines
+            stripped = line.strip()
+            if not stripped or stripped.startswith('*'):
+                continue
+
+            # Look for lines that begin with a label (Lxxxx or similar) followed by fcb
+            m = re.match(
+                r'^([A-Za-z_][A-Za-z0-9_]*)\s+fcb\s+((?:\$[0-9A-Fa-f]{1,2},?)+)',
+                stripped, re.IGNORECASE)
+            if m:
+                label = m.group(1)
+                bytes_str = m.group(2)
+                # Derive the offset from the label if it's Lhhhh / Uhhhh etc.
+                lm = re.match(r'^[A-Za-z]([0-9A-Fa-f]{4})$', label)
+                if lm:
+                    off = int(lm.group(1), 16)
+                    label_map[off] = label
+                for bstr in bytes_str.split(','):
+                    bstr = bstr.strip()
+                    if bstr.startswith('$') or bstr.startswith('0x'):
+                        data_list.append(int(bstr.replace('$', ''), 16))
+                continue
+
+            # Lines without a leading label: just fcb data
+            m2 = re.match(r'^\s+fcb\s+((?:\$[0-9A-Fa-f]{1,2},?)+)', line, re.IGNORECASE)
+            if m2:
+                for bstr in m2.group(1).split(','):
+                    bstr = bstr.strip()
+                    if bstr.startswith('$') or bstr.startswith('0x'):
+                        data_list.append(int(bstr.replace('$', ''), 16))
+                continue
+
+    return bytes(data_list), label_map
+
+
+# ---------------------------------------------------------------------------
+# OS-9 module header parser
+# ---------------------------------------------------------------------------
+
+def parse_os9_header(data: bytes) -> dict:
+    """Parse OS-9 module header. Returns dict with header fields or raises."""
+    if len(data) < 13:
+        raise ValueError('Module too small for OS-9 header')
+    if data[0] != 0x87 or data[1] != 0xCD:
+        raise ValueError(f'Bad sync bytes: ${data[0]:02X},${data[1]:02X}')
+
+    mod_size   = (data[2] << 8) | data[3]
+    name_off   = (data[4] << 8) | data[5]
+    type_lang  = data[6]
+    attr_rev   = data[7]
+    # parity    = data[8]  (not used for disassembly)
+    exec_off   = (data[9] << 8) | data[10]
+    data_size  = (data[11] << 8) | data[12]
+
+    mod_type = (type_lang >> 4) & 0xF
+    language = type_lang & 0xF
+
+    # Decode module name (FCS - last byte has high bit set)
+    name_bytes = []
+    i = name_off
+    while i < len(data):
+        b = data[i]
+        name_bytes.append(chr(b & 0x7F))
+        i += 1
+        if b & 0x80:
+            break
+    mod_name = ''.join(name_bytes)
+
+    # Edition byte follows name
+    edition = data[i] if i < len(data) else 0
+
+    # Determine type/attr strings for assembly header
+    type_str = {
+        0x1: 'Prgrm', 0x2: 'Systm', 0xB: 'FlMgr',
+        0xC: 'Drivr', 0xD: 'Devic',
+    }.get(mod_type, f'${type_lang:02X}')
+
+    lang_str = {
+        0x1: 'Objct', 0x2: 'ICode', 0x3: 'PCode',
+        0x4: 'CCode', 0x5: 'CblCode', 0x6: 'FCode',
+    }.get(language, f'')
+
+    tylg_val = f'{type_str}+{lang_str}' if lang_str else type_str
+
+    # Attr: upper nibble, Rev: lower nibble
+    attr = (attr_rev >> 4) & 0xF
+    rev  = attr_rev & 0xF
+    attr_str = 'ReEnt' if attr & 0x8 else 'Objct'
+    atrv_val = f'{attr_str}+rev' if rev else attr_str
+
+    return {
+        'mod_size':   mod_size,
+        'name_off':   name_off,
+        'exec_off':   exec_off,
+        'data_size':  data_size,
+        'mod_name':   mod_name,
+        'edition':    edition,
+        'name_end':   i,          # offset of edition byte
+        'code_start': i + 1,      # first byte after edition
+        'tylg_val':   tylg_val,
+        'atrv_val':   atrv_val,
+        'rev':        rev,
+        'attr_rev':   attr_rev,
+        'type_lang':  type_lang,
+        'mod_type':   mod_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Control-flow analysis
+# ---------------------------------------------------------------------------
+
+def collect_code_addrs(data: bytes, entry: int, code_end: int) -> Set[int]:
+    """BFS/DFS from entry point, marking all reachable instruction addresses."""
+    visited: Set[int] = set()
+    worklist = [entry]
+
+    while worklist:
+        pos = worklist.pop()
+        if pos in visited or pos < 0 or pos >= code_end:
+            continue
+        visited.add(pos)
+
+        mnem, operand, length, terminates, targets = decode_instr(data, pos)
+
+        # Queue branch/call targets
+        for t in targets:
+            if 0 <= t < code_end and t not in visited:
+                worklist.append(t)
+
+        # Follow fall-through unless flow terminates
+        if not terminates:
+            nxt = pos + length
+            if nxt < code_end and nxt not in visited:
+                worklist.append(nxt)
+
+    return visited
+
+
+# ---------------------------------------------------------------------------
+# String detector
+# ---------------------------------------------------------------------------
+
+def _is_printable(b: int) -> bool:
+    return 0x20 <= b <= 0x7E or b == 0x0D or b == 0x0A or b == 0x09
+
+
+def find_string_at(data: bytes, pos: int, min_len: int = 3) -> int:
+    """Return length of printable string starting at pos (including terminator $0D or FCS high bit).
+    Returns 0 if no string found."""
+    i = pos
+    while i < len(data):
+        b = data[i]
+        if b & 0x80:
+            # FCS-terminated
+            if _is_printable(b & 0x7F) and i - pos >= min_len - 1:
+                return i - pos + 1
+            return 0
+        if b == 0x0D:
+            # CR-terminated
+            if i - pos >= min_len:
+                return i - pos + 1
+            return 0
+        if not _is_printable(b):
+            return 0
+        i += 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Output formatter
+# ---------------------------------------------------------------------------
+
+COL_LABEL  = 20
+COL_MNEM   = 30
+COL_OPERAND = 50
+
+def fmt_line(label: str, mnem: str, operand: str, comment: str = '') -> str:
+    line = label.ljust(COL_LABEL) + mnem.ljust(COL_MNEM - COL_LABEL)
+    if operand:
+        line += operand.ljust(COL_OPERAND - COL_MNEM)
+    if comment:
+        line += f'; {comment}'
+    return line.rstrip()
+
+
+def label_for(addr: int, known: Dict[int, str]) -> str:
+    if addr in known:
+        return known[addr]
+    return f'L{addr:04X}'
+
+
+# ---------------------------------------------------------------------------
+# Main disassembler
+# ---------------------------------------------------------------------------
+
+def disassemble(data: bytes, hdr: dict) -> List[str]:
+    """Disassemble the code section of an OS-9 module binary.
+
+    Returns lines of assembly text (without trailing newlines).
+    """
+    lines: List[str] = []
+    exec_off   = hdr['exec_off']
+    data_size  = hdr['data_size']
+    code_start = hdr['code_start']
+    mod_size   = hdr['mod_size']
+    name_off   = hdr['name_off']
+
+    # The code lives from code_start to mod_size - 3 (last 3 bytes = CRC)
+    code_end = mod_size - 3
+
+    # Collect all reachable code addresses
+    code_addrs = collect_code_addrs(data, exec_off, code_end)
+
+    # Build label map: address -> label string
+    # Pre-populate with code branch targets
+    labels: Dict[int, str] = {}
+    for addr in sorted(code_addrs):
+        # Will add labels lazily during second pass
+        pass
+
+    # Determine which addresses need labels (branch/call targets)
+    target_addrs: Set[int] = set()
+    for pos in sorted(code_addrs):
+        _, _, length, _, targets = decode_instr(data, pos)
+        for t in targets:
+            target_addrs.add(t)
+        if pos == exec_off:
+            target_addrs.add(pos)
+
+    # The entry point always gets a label
+    target_addrs.add(exec_off)
+
+    # Also label the start of any run of code that is preceded by data
+    prev_was_data = True
+    for pos in range(code_start, code_end):
+        if pos in code_addrs:
+            if prev_was_data:
+                target_addrs.add(pos)
+            prev_was_data = False
+        else:
+            prev_was_data = True
+
+    def lbl(addr: int) -> str:
+        return f'L{addr:04X}'
+
+    # ── Emit module header ──────────────────────────────────────────────────
+    mod_name = hdr['mod_name']
+    lines.append(fmt_line('', 'nam', mod_name))
+    lines.append(fmt_line('', 'ttl', f'program module'))
+    lines.append('')
+    lines.append(fmt_line('', 'use', 'defsfile'))
+    lines.append('')
+    lines.append(fmt_line('tylg', 'set', hdr['tylg_val']))
+    lines.append(fmt_line('atrv', 'set', hdr['atrv_val']))
+    lines.append(fmt_line('rev', 'set', f'${hdr["rev"]:02X}'))
+    lines.append(fmt_line('edition', 'set', f'${hdr["edition"]:02X}'))
+    lines.append('')
+
+    # ── Emit data segment (rmb block) ───────────────────────────────────────
+    # The data segment size is in the header.  We emit a single block for now;
+    # a more detailed analysis would break it into named fields.
+    if data_size > 0:
+        lines.append(fmt_line('', 'mod', f'eom,name,tylg,atrv,start,size'))
+        lines.append('')
+        lines.append(fmt_line('u0000', 'rmb', str(data_size),
+                               f'data segment ({data_size} bytes)'))
+        lines.append(fmt_line('size', 'equ', '.'))
+    else:
+        lines.append(fmt_line('', 'mod', f'eom,name,tylg,atrv,start,size'))
+        lines.append(fmt_line('size', 'equ', '0'))
+
+    lines.append('')
+
+    # ── Emit module name and edition ────────────────────────────────────────
+    lines.append(fmt_line('name', 'equ', '*'))
+    lines.append(fmt_line('', 'fcs', f'/{mod_name}/'))
+    lines.append(fmt_line('', 'fcb', f'edition'))
+    lines.append('')
+
+    # ── Emit code/data body ─────────────────────────────────────────────────
+    # Bytes between code_start and exec_off may be small data tables or
+    # helper subroutines placed before the main entry.
+    pos = code_start
+
+    def emit_fcb_run(start_pos: int, end_pos: int, lbl_name: str = '') -> None:
+        """Emit bytes from start_pos to end_pos-1 as fcb/fcc."""
+        i = start_pos
+        while i < end_pos:
+            label_here = lbl_name if i == start_pos else (lbl(i) if i in target_addrs else '')
+            # Try to detect a printable string
+            slen = find_string_at(data, i)
+            if slen >= 4 and i + slen <= end_pos:
+                raw = data[i:i+slen]
+                # Check if it's FCS or CR-terminated
+                last = raw[-1]
+                if last & 0x80:
+                    text = ''.join(chr(b & 0x7F) for b in raw)
+                    directive = 'fcs'
+                else:
+                    text = ''.join(chr(b) for b in raw[:-1])
+                    directive = 'fcc'
+                    lines.append(fmt_line(label_here, directive, f'/{text}/'))
+                    if last == 0x0D:
+                        lines.append(fmt_line('', 'fcb', '$0D'))
+                    i += slen
+                    continue
+                lines.append(fmt_line(label_here, directive, f'/{text}/'))
+                i += slen
+                continue
+
+            # Emit up to 8 bytes as fcb
+            chunk = min(8, end_pos - i)
+            hex_vals = ','.join(f'${b:02X}' for b in data[i:i+chunk])
+            lines.append(fmt_line(label_here, 'fcb', hex_vals))
+            i += chunk
+
+    while pos < code_end:
+        if pos in code_addrs:
+            # Emit label if needed
+            label_here = ''
+            if pos in target_addrs:
+                label_here = ('start' if pos == exec_off else lbl(pos))
+
+            mnem, operand, length, terminates, targets = decode_instr(data, pos)
+
+            # Special case: 'os9' instruction
+            if mnem == 'swi' and operand:
+                # operand already contains the OS9 call name
+                lines.append(fmt_line(label_here, 'os9', operand))
+            elif operand:
+                lines.append(fmt_line(label_here, mnem, operand))
+            else:
+                lines.append(fmt_line(label_here, mnem, ''))
+
+            pos += length
+        else:
+            # Data byte(s) - collect a run
+            run_start = pos
+            while pos < code_end and pos not in code_addrs:
+                pos += 1
+            label_here = lbl(run_start) if run_start in target_addrs else ''
+            emit_fcb_run(run_start, pos, label_here)
+
+    # ── eom ────────────────────────────────────────────────────────────────
+    lines.append('')
+    lines.append(fmt_line('eom', 'equ', '*'))
+    lines.append(fmt_line('', 'end'))
+    lines.append('')
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Disassemble OS-9 FCB-format .asm files to 6809 assembly')
+    parser.add_argument('input', help='Input FCB-format .asm file')
+    parser.add_argument('-o', '--output', help='Output file (default: stdout)')
+    args = parser.parse_args()
+
+    try:
+        data, orig_labels = parse_fcb_file(args.input)
+    except Exception as e:
+        print(f'Error reading {args.input}: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    if not data:
+        print(f'No FCB data found in {args.input}', file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        hdr = parse_os9_header(data)
+    except ValueError as e:
+        print(f'OS-9 header error: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    print(f'Module: {hdr["mod_name"]}  size=${hdr["mod_size"]:04X}  '
+          f'exec=${hdr["exec_off"]:04X}  data=${hdr["data_size"]:04X}',
+          file=sys.stderr)
+
+    result = disassemble(data, hdr)
+
+    out_lines = '\n'.join(result) + '\n'
+
+    if args.output:
+        with open(args.output, 'w') as fh:
+            fh.write(out_lines)
+    else:
+        sys.stdout.write(out_lines)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/fcb2bin.py
+++ b/scripts/fcb2bin.py
@@ -18,7 +18,7 @@ def parse_fcb_file(path: str) -> bytes:
             # Only care about lines that contain 'fcb' with hex byte values.
             # Handles both "Lhhhh    fcb  $xx,$xx..." and "         fcb  $xx,..."
             m = re.search(
-                r'\bfcb\s+((?:\$[0-9A-Fa-f]{1,2},?\s*)+)',
+                r'\bfcb\s+(\$[0-9A-Fa-f]{1,2}(?:,\$[0-9A-Fa-f]{1,2})*)',
                 line, re.IGNORECASE)
             if not m:
                 continue

--- a/scripts/fcb2bin.py
+++ b/scripts/fcb2bin.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""fcb2bin.py - extract raw binary from OS-9 FCB-format .asm file.
+
+Usage:
+    python3 scripts/fcb2bin.py input.asm output.bin
+    python3 scripts/fcb2bin.py input.asm   # writes to stdout
+"""
+
+import sys
+import re
+
+
+def parse_fcb_file(path: str) -> bytes:
+    data: list[int] = []
+    with open(path, 'r', errors='replace') as fh:
+        for raw in fh:
+            line = raw.rstrip('\r\n')
+            # Only care about lines that contain 'fcb' with hex byte values.
+            # Handles both "Lhhhh    fcb  $xx,$xx..." and "         fcb  $xx,..."
+            m = re.search(
+                r'\bfcb\s+((?:\$[0-9A-Fa-f]{1,2},?\s*)+)',
+                line, re.IGNORECASE)
+            if not m:
+                continue
+            for tok in re.findall(r'\$([0-9A-Fa-f]{1,2})', m.group(1)):
+                data.append(int(tok, 16))
+    return bytes(data)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} input.asm [output.bin]', file=sys.stderr)
+        sys.exit(1)
+
+    data = parse_fcb_file(sys.argv[1])
+    if not data:
+        print('No FCB data found', file=sys.stderr)
+        sys.exit(1)
+
+    print(f'Extracted {len(data)} bytes', file=sys.stderr)
+
+    if len(sys.argv) >= 3:
+        with open(sys.argv[2], 'wb') as fh:
+            fh.write(data)
+    else:
+        sys.stdout.buffer.write(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -120,31 +120,39 @@ def parse_os9_header(data: bytes) -> dict:
 def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, int]]:
     """Return list of (start, end) byte ranges for high-confidence string data.
 
-    To minimise false-positives we require strings to be:
-      - CR-terminated ($0D), at least 16 bytes of printable ASCII before the $0D
-      - Starting with a letter, '*', '/', '(', '"', '#', or '%'
-        (never starting with a digit or control character)
-      - Containing at least two different letter characters
+    Two terminator styles are recognised, both requiring a run of printable
+    ASCII that starts with a letter, '*', '/', '(', '"', '#', or '%' (never a
+    digit or control character) and contains at least two different letters:
 
-    FCS-terminated strings are deliberately excluded here because they are
-    much harder to distinguish from code bytes that happen to have bit 7 set.
+      - CR-terminated ($0D): at least 16 bytes total (long banner/message text).
+      - NUL-terminated ($00): at least 4 printable characters before the $00.
+        These are the short C string constants ("Init", "C.PREP ", paths, ...)
+        that would otherwise be decoded as code; because they are often odd in
+        length they push the decoder out of phase into the routine that follows
+        them, so catching them also rescues that routine's real entry point.
+
+    The terminator is included in the returned region so the decoder resumes
+    cleanly on the byte after it.  FCS-terminated strings are deliberately
+    excluded: they are much harder to tell from code bytes with bit 7 set.
     """
-    MIN_LEN = 16
+    CR_MIN_LEN      = 16    # CR-terminated: total bytes incl. the $0D
+    NUL_MIN_CONTENT = 4     # NUL-terminated: printable chars before the $00
     regions: list[tuple[int, int]] = []
     i = start
-    while i < end - MIN_LEN:
+    while i < end:
         first = data[i]
         # String must start with a letter or specific printable symbol
         if not (chr(first).isalpha() or first in b'*/(\"#%'):
             i += 1
             continue
-        # Scan forward for CR terminator
+        # Scan forward for a CR or NUL terminator over printable ASCII
         j = i
         letters: set[int] = set()
-        ok = True
+        term: int | None = None
         while j < end:
             b = data[j]
-            if b == 0x0D:               # CR terminator found
+            if b == 0x0D or b == 0x00:  # terminator found
+                term = b
                 j += 1
                 break
             if 0x20 <= b <= 0x7E:       # printable ASCII (no high bit)
@@ -152,14 +160,17 @@ def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, in
                     letters.add(b)
                 j += 1
             else:
-                ok = False
-                break
-        else:
-            ok = False                  # hit end without terminator
+                break                   # non-text byte: not a clean string
+        if term is None:                # hit a non-text byte or ran off the end
+            i += 1
+            continue
 
-        length = j - i
-        if ok and length >= MIN_LEN and len(letters) >= 2:
-            regions.append((i, j - 1))
+        total = j - i                   # printable run plus the terminator
+        accept = len(letters) >= 2 and (
+            (term == 0x0D and total >= CR_MIN_LEN) or
+            (term == 0x00 and total - 1 >= NUL_MIN_CONTENT))
+        if accept:
+            regions.append((i, j - 1))  # include the terminator byte
             i = j
         else:
             i += 1

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -167,10 +167,23 @@ def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, in
         # member is a 'real' (qualifying) string.  The run ends at the first
         # content stretch NOT terminated by NUL (e.g. code that merely looks
         # printable, like a 'pshs u' = $34,$40 = "4@").
-        run: list[tuple[int, int]] = []     # (start, terminator_pos)
+        run: list[tuple[int, int]] = []     # (start, end) regions
         anchored = False
         k = i
-        while k < end and is_content(data[k]):
+        while k < end:
+            if data[k] == 0x00:
+                # Extra NUL padding between table entries (e.g. "nop\0\0 endsect").
+                # Absorb only if another string follows; trailing NULs before
+                # code are left alone (could be a real 'neg' = $00,$xx).
+                p0 = k
+                while k < end and data[k] == 0x00:
+                    k += 1
+                if k < end and is_content(data[k]):
+                    run += [(p, p) for p in range(p0, k)]
+                    continue
+                break
+            if not is_content(data[k]):
+                break                       # code byte -> end of run
             s = k
             while k < end and is_content(data[k]):
                 k += 1

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -276,6 +276,59 @@ def coalesce_fcc(rows: list[str], fmt) -> list[str]:
     return out
 
 
+def find_inline_data_regions(data: bytes, start: int, end: int) -> list[tuple[int, int]]:
+    """Detect the inline-data-after-call idiom.
+
+    Microware C emits parameter blocks inline after a call:
+
+                        bsr   helper          ; push return address, call helper
+                        fcb   ...             ; inline data (the parameter block)
+        helper          puls  x               ; pull return address -> pointer in X
+                        ...                   ; consume inline data via X
+
+    The helper grabs the pushed return address with a ``puls`` into a pointer
+    register, so the bytes between the call and its target are data reached only
+    through that pointer, never executed as instructions.  A naive linear sweep
+    decodes them as garbage (typically ``neg $00xx`` runs from NUL padding).
+
+    Returns a list of (start, end) inclusive byte ranges to mark as data.  The
+    match is deliberately tight - a forward ``bsr``/``lbsr`` with a small gap
+    whose target is a ``puls`` of a pointer register (x, y or u) - so it cannot
+    misfire on ordinary control flow.
+    """
+    regions: list[tuple[int, int]] = []
+    PTR_REGS = 0x70  # x ($10) | y ($20) | u ($40) in a puls/pshs postbyte
+    p = start
+    while p < end:
+        b = data[p]
+        if b == 0x8D and p + 1 < end:               # bsr (8-bit relative)
+            disp = data[p + 1]
+            if disp & 0x80:
+                disp -= 0x100
+            ret = p + 2                             # address after the call
+            target = ret + disp
+        elif b == 0x17 and p + 2 < end:             # lbsr (16-bit relative)
+            disp = (data[p + 1] << 8) | data[p + 2]
+            if disp & 0x8000:
+                disp -= 0x10000
+            ret = p + 3
+            target = ret + disp
+        else:
+            p += 1
+            continue
+        gap = target - ret
+        # forward call, short inline block, target is a puls of a pointer reg
+        if (1 <= gap <= 16 and target + 1 < end
+                and data[target] == 0x35
+                and (data[target + 1] & PTR_REGS)
+                and not (data[target + 1] & 0x80)):
+            regions.append((ret, target - 1))
+            p = target
+        else:
+            p += 1
+    return regions
+
+
 def make_info(hdr: dict, data: bytes = b'') -> str:
     n0  = hdr['name_off']
     ne  = hdr['name_end']
@@ -313,6 +366,15 @@ def make_info(hdr: dict, data: bytes = b'') -> str:
             rows.append('* detected string/data regions')
             for s, e in string_regions:
                 rows.append(f'CHAR {s:04X}-{e:04X}')
+
+        # Mark inline parameter blocks (data reached only via a pulled return
+        # address) so f9dasm emits them as data instead of garbage instructions.
+        inline_regions = find_inline_data_regions(data, code_start, code_end)
+        if inline_regions:
+            rows.append('')
+            rows.append('* inline data after call (bsr/lbsr -> puls)')
+            for s, e in inline_regions:
+                rows.append(f'DATA {s:04X}-{e:04X}')
 
     return '\n'.join(rows) + '\n'
 

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -177,6 +177,71 @@ def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, in
     return regions
 
 
+_FCB_HEX = re.compile(r'^(\S*)\s+fcb\s+((?:\s*\$[0-9A-Fa-f]{2},?)+)\s*$')
+
+
+def coalesce_fcc(rows: list[str], fmt) -> list[str]:
+    """Re-render runs of consecutive `fcb $xx,...` rows as readable `fcc`.
+
+    Operates purely on already-emitted hex byte rows, so it is byte-exact: a
+    printable run of >= 4 bytes becomes `fcc /text/`, everything else stays
+    `fcb`.  Any label is kept at its exact byte offset within the run, so a
+    referenced address in the middle of a string still gets its own directive
+    (and NUL/CR bytes naturally split adjacent strings apart).
+    """
+    def pick(s: str) -> str:
+        for d in '/|!^"':
+            if d not in s:
+                return d
+        return '/'
+
+    def render(b: list[int], labels: dict) -> list[str]:
+        res: list[str] = []
+        o, n = 0, len(b)
+        while o < n:
+            lbl = labels.get(o, '')
+            if 0x20 <= b[o] <= 0x7E:
+                st = o; o += 1
+                while o < n and 0x20 <= b[o] <= 0x7E and o not in labels:
+                    o += 1
+                seg = b[st:o]
+                if len(seg) >= 4:
+                    t = bytes(seg).decode('latin1'); d = pick(t)
+                    res.append(fmt(lbl, 'fcc', f'{d}{t}{d}'))
+                else:
+                    res.append(fmt(lbl, 'fcb', ','.join(f'${x:02X}' for x in seg)))
+            else:
+                st = o; o += 1
+                while o < n and not (0x20 <= b[o] <= 0x7E) and o not in labels:
+                    o += 1
+                res.append(fmt(lbl, 'fcb', ','.join(f'${x:02X}' for x in b[st:o])))
+        return res
+
+    out: list[str] = []
+    i = 0
+    while i < len(rows):
+        m = _FCB_HEX.match(rows[i])
+        if not m:
+            out.append(rows[i]); i += 1
+            continue
+        b: list[int] = []
+        labels: dict = {}
+        if m.group(1):
+            labels[0] = m.group(1)
+        b += [int(h, 16) for h in re.findall(r'\$([0-9A-Fa-f]{2})', m.group(2))]
+        i += 1
+        while i < len(rows):
+            m2 = _FCB_HEX.match(rows[i])
+            if not m2:
+                break
+            if m2.group(1):
+                labels[len(b)] = m2.group(1)
+            b += [int(h, 16) for h in re.findall(r'\$([0-9A-Fa-f]{2})', m2.group(2))]
+            i += 1
+        out += render(b, labels)
+    return out
+
+
 def make_info(hdr: dict, data: bytes = b'') -> str:
     n0  = hdr['name_off']
     ne  = hdr['name_end']
@@ -602,6 +667,9 @@ def postprocess(raw: str, hdr: dict, data: bytes = b'') -> str:
 
         out.append(fmt(label_out, mnem, operand))
         prev_mnem = mnem
+
+    # Re-render runs of fcb hex bytes as readable fcc strings (byte-exact).
+    out = coalesce_fcc(out, fmt)
 
     # End of module — emod emits the 3-byte CRC; eom is defined AFTER emod so
     # it captures the address past the CRC, giving the total module size as

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -46,7 +46,7 @@ def parse_fcb_file(path: str) -> bytes:
     with open(path, 'r', errors='replace') as fh:
         for line in fh:
             m = re.search(
-                r'\bfcb\s+((?:\$[0-9A-Fa-f]{1,2},?\s*)+)',
+                r'\bfcb\s+(\$[0-9A-Fa-f]{1,2}(?:,\$[0-9A-Fa-f]{1,2})*)',
                 line, re.IGNORECASE)
             if m:
                 for tok in re.findall(r'\$([0-9A-Fa-f]{1,2})', m.group(1)):

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -135,45 +135,66 @@ def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, in
     cleanly on the byte after it.  FCS-terminated strings are deliberately
     excluded: they are much harder to tell from code bytes with bit 7 set.
     """
-    CR_MIN_LEN      = 16    # CR-terminated: total bytes incl. the $0D
-    NUL_MIN_CONTENT = 4     # NUL-terminated: printable chars before the $00
+    MIN_CONTENT = 4         # content bytes before the $00 to anchor a run
+
+    def is_print(b: int) -> bool:
+        return 0x20 <= b <= 0x7E
+
+    def is_content(b: int) -> bool:
+        # CR is part of message-string content (e.g. "%s\r"); NUL terminates.
+        return 0x20 <= b <= 0x7E or b == 0x0D
+
+    def qualifies(s: int, tpos: int) -> bool:
+        """A 'real' NUL-terminated string, strong enough to anchor a run
+        (anti false-positive): starts with a letter/symbol, has >= 2 distinct
+        letters, and >= MIN_CONTENT content bytes."""
+        if not (chr(data[s]).isalpha() or data[s] in b'*/(\"#%'):
+            return False
+        if len({b for b in data[s:tpos] if 0x41 <= (b & 0xDF) <= 0x5A}) < 2:
+            return False
+        return (tpos - s) >= MIN_CONTENT
+
     regions: list[tuple[int, int]] = []
     i = start
     while i < end:
-        first = data[i]
-        # String must start with a letter or specific printable symbol
-        if not (chr(first).isalpha() or first in b'*/(\"#%'):
+        if not is_print(data[i]):
             i += 1
             continue
-        # Scan forward for a CR or NUL terminator over printable ASCII
-        j = i
-        letters: set[int] = set()
-        term: int | None = None
-        while j < end:
-            b = data[j]
-            if b == 0x0D or b == 0x00:  # terminator found
-                term = b
-                j += 1
-                break
-            if 0x20 <= b <= 0x7E:       # printable ASCII (no high bit)
-                if chr(b).isalpha():
-                    letters.add(b)
-                j += 1
+        # Collect a maximal RUN of consecutive NUL-terminated strings (CR is
+        # content, not a terminator).  A string table interleaves short entries
+        # ("if", "do", " psect %s", "%s\r") that wouldn't pass the anchor test
+        # alone, so we accept the whole run as data as long as at least one
+        # member is a 'real' (qualifying) string.  The run ends at the first
+        # content stretch NOT terminated by NUL (e.g. code that merely looks
+        # printable, like a 'pshs u' = $34,$40 = "4@").
+        run: list[tuple[int, int]] = []     # (start, terminator_pos)
+        anchored = False
+        k = i
+        while k < end and is_content(data[k]):
+            s = k
+            while k < end and is_content(data[k]):
+                k += 1
+            if k < end and data[k] == 0x00:
+                run.append((s, k))          # string s..k-1 plus NUL at k
+                if qualifies(s, k):
+                    anchored = True
+                k += 1
             else:
-                break                   # non-text byte: not a clean string
-        if term is None:                # hit a non-text byte or ran off the end
-            i += 1
-            continue
-
-        total = j - i                   # printable run plus the terminator
-        accept = len(letters) >= 2 and (
-            (term == 0x0D and total >= CR_MIN_LEN) or
-            (term == 0x00 and total - 1 >= NUL_MIN_CONTENT))
-        if accept:
-            regions.append((i, j - 1))  # include the terminator byte
-            i = j
+                break                       # unterminated -> not part of the run
+        if run and anchored:
+            # Absorb leading NUL padding before the run: an isolated $00 just
+            # before a string table is otherwise decoded as 'neg' and eats the
+            # first character of the first string.
+            rs = run[0][0]
+            while rs > start and data[rs - 1] == 0x00:
+                rs -= 1
+            if rs < run[0][0]:
+                regions.append((rs, run[0][0] - 1))
+            regions.extend(run)             # (start, terminator) inclusive
+            i = run[-1][1] + 1
         else:
             i += 1
+    regions.sort()
     return regions
 
 

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -214,6 +214,14 @@ def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, in
 _FCB_HEX = re.compile(r'^(\S*)\s+fcb\s+((?:\s*\$[0-9A-Fa-f]{2},?)+)\s*$')
 
 
+def _pick_delim(s: str) -> str:
+    """Choose an fcc delimiter that does not occur in the string content."""
+    for d in '/|!^"':
+        if d not in s:
+            return d
+    return '/'
+
+
 def coalesce_fcc(rows: list[str], fmt) -> list[str]:
     """Re-render runs of consecutive `fcb $xx,...` rows as readable `fcc`.
 
@@ -223,11 +231,7 @@ def coalesce_fcc(rows: list[str], fmt) -> list[str]:
     referenced address in the middle of a string still gets its own directive
     (and NUL/CR bytes naturally split adjacent strings apart).
     """
-    def pick(s: str) -> str:
-        for d in '/|!^"':
-            if d not in s:
-                return d
-        return '/'
+    pick = _pick_delim
 
     def render(b: list[int], labels: dict) -> list[str]:
         res: list[str] = []
@@ -329,7 +333,7 @@ def find_inline_data_regions(data: bytes, start: int, end: int) -> list[tuple[in
     return regions
 
 
-def make_info(hdr: dict, data: bytes = b'') -> str:
+def make_info(hdr: dict, data: bytes = b'', forced_data=None) -> str:
     n0  = hdr['name_off']
     ne  = hdr['name_end']
     ed  = hdr['edition_off']
@@ -361,6 +365,14 @@ def make_info(hdr: dict, data: bytes = b'') -> str:
     if data:
         code_end = mod_size - 3  # last 3 bytes are the CRC
         string_regions = find_string_regions(data, code_start, code_end)
+        # A caller-forced data range wins: drop any auto-detected string region
+        # that overlaps it (e.g. a single-char token table inside a work-block
+        # image), so the whole range renders uniformly as data.
+        if forced_data:
+            string_regions = [
+                (s, e) for (s, e) in string_regions
+                if not any(s <= fe and fs <= e for fs, fe in forced_data)
+            ]
         if string_regions:
             rows.append('')
             rows.append('* detected string/data regions')
@@ -375,6 +387,14 @@ def make_info(hdr: dict, data: bytes = b'') -> str:
             rows.append('* inline data after call (bsr/lbsr -> puls)')
             for s, e in inline_regions:
                 rows.append(f'DATA {s:04X}-{e:04X}')
+
+    # Caller-forced data ranges (e.g. crt0 work-block images that no detector
+    # recognises).  Emitted last so they win over any heuristic above.
+    if forced_data:
+        rows.append('')
+        rows.append('* caller-forced data ranges (--data)')
+        for s, e in forced_data:
+            rows.append(f'DATA {s:04X}-{e:04X}')
 
     return '\n'.join(rows) + '\n'
 
@@ -469,9 +489,21 @@ def postprocess(raw: str, hdr: dict, data: bytes = b'') -> str:
         # ── FCC: "text" → /text/ — do this BEFORE any identifier processing
         # so that the string content is never treated as identifiers/registers.
         if mnem == 'fcc':
-            op = _NOISE_COMMENT.sub('', op).strip()
-            op = re.sub(r'^"(.*)"$', r'/\1/', op)
-            return op
+            # f9dasm wraps the text in a delimiter (the first character, usually
+            # " or /).  Extract the content between that delimiter and its next
+            # occurrence FIRST - before any comment handling - because the
+            # content itself may contain ';' (which the noise-comment stripper
+            # would otherwise treat as the start of a comment) or the '/' we
+            # would otherwise pick as our own delimiter.
+            op = op.lstrip()
+            if op and op[0] in '/"|!^':
+                d0 = op[0]
+                end = op.find(d0, 1)
+                if end != -1:
+                    content = op[1:end]
+                    nd = _pick_delim(content)
+                    return f'{nd}{content}{nd}'
+            return _NOISE_COMMENT.sub('', op).strip()
 
         # ── FCB quoted chars: 'c → $xx ─────────────────────────────────────
         # Apply BEFORE stripping the comment so that f9dasm's "' " encoding
@@ -764,6 +796,19 @@ def postprocess(raw: str, hdr: dict, data: bytes = b'') -> str:
         out.append(fmt(label_out, mnem, operand))
         prev_mnem = mnem
 
+    # A lone printable byte that f9dasm rendered as a single-character fcc
+    # (e.g. an isolated $43 inside a binary pointer table) is data, not text.
+    # Demote it to fcb so coalesce_fcc can merge it into the surrounding run.
+    _fcc1 = re.compile(r'^(\S*)\s+fcc\s+(.)(.)\2\s*$')
+    demoted: list[str] = []
+    for r in out:
+        m = _fcc1.match(r)
+        if m:
+            demoted.append(fmt(m.group(1), 'fcb', f'${ord(m.group(3)):02X}'))
+        else:
+            demoted.append(r)
+    out = demoted
+
     # Re-render runs of fcb hex bytes as readable fcc strings (byte-exact).
     out = coalesce_fcc(out, fmt)
 
@@ -794,7 +839,18 @@ def main() -> None:
                     help='Input is a raw OS-9 binary, not an FCB-format .asm')
     ap.add_argument('-f', '--f9dasm', default='f9dasm',
                     help='Path to f9dasm binary (default: f9dasm in PATH)')
+    ap.add_argument('--data', action='append', default=[], metavar='START-END',
+                    help='Force a hex byte range to be treated as data (e.g. '
+                         '3A9B-3C98 for a crt0 work-block image).  Repeatable.')
     args = ap.parse_args()
+
+    forced_data: list[tuple[int, int]] = []
+    for spec in args.data:
+        try:
+            lo, hi = spec.split('-')
+            forced_data.append((int(lo, 16), int(hi, 16)))
+        except ValueError:
+            sys.exit(f'bad --data range (expected START-END hex): {spec!r}')
 
     # 1. extract binary
     if args.binary:
@@ -830,7 +886,7 @@ def main() -> None:
         with open(bin_path,  'wb') as fh:
             fh.write(data)
         with open(info_path, 'w') as fh:
-            fh.write(make_info(hdr, data))
+            fh.write(make_info(hdr, data, forced_data))
 
         # 4. run f9dasm
         try:

--- a/scripts/os9dis.py
+++ b/scripts/os9dis.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""os9dis.py - Disassemble OS-9 FCB-format .asm files to lwasm-compatible assembly.
+
+Pipeline:
+  1. Parse FCB-format .asm file to extract the raw binary.
+  2. Parse the OS-9 module header (entry point, data size, module name).
+  3. Generate an f9dasm info file that marks the fixed header region as data.
+  4. Run f9dasm -noconv -os9 on the binary.
+  5. Post-process the f9dasm output to lwasm-compatible format, including:
+     - Lowercase mnemonics and register names
+     - Proper OS-9 module header directives (mod, rmb, fcs, etc.)
+     - Unified label naming (Lxxxx for all in-module addresses)
+     - Numeric literals for immediate constants that aren't code addresses
+     - Stripped hex-dump noise comments
+
+Requires: f9dasm in PATH (http://www.magicdomain.com/f9dasm/).
+
+Usage:
+    python3 scripts/os9dis.py input.asm > output.asm
+    python3 scripts/os9dis.py input.asm -o output.asm
+"""
+
+import sys
+import re
+import os
+import subprocess
+import tempfile
+import argparse
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Register names for lowercasing
+# ---------------------------------------------------------------------------
+REGS = frozenset(['a', 'b', 'd', 'e', 'f', 'w', 'q',
+                  'x', 'y', 'u', 's', 'pc', 'dp', 'cc', 'v',
+                  'pcr'])
+
+
+# ---------------------------------------------------------------------------
+# Step 1: extract raw binary from FCB-format .asm file
+# ---------------------------------------------------------------------------
+
+def parse_fcb_file(path: str) -> bytes:
+    data: list[int] = []
+    with open(path, 'r', errors='replace') as fh:
+        for line in fh:
+            m = re.search(
+                r'\bfcb\s+((?:\$[0-9A-Fa-f]{1,2},?\s*)+)',
+                line, re.IGNORECASE)
+            if m:
+                for tok in re.findall(r'\$([0-9A-Fa-f]{1,2})', m.group(1)):
+                    data.append(int(tok, 16))
+    return bytes(data)
+
+
+# ---------------------------------------------------------------------------
+# Step 2: parse OS-9 module header
+# ---------------------------------------------------------------------------
+
+def parse_os9_header(data: bytes) -> dict:
+    if len(data) < 13:
+        raise ValueError('binary too short for OS-9 header')
+    if data[0] != 0x87 or data[1] != 0xCD:
+        raise ValueError(f'bad sync bytes ${data[0]:02X},${data[1]:02X}')
+
+    mod_size  = (data[2] << 8) | data[3]
+    name_off  = (data[4] << 8) | data[5]
+    type_lang = data[6]
+    attr_rev  = data[7]
+    exec_off  = (data[9] << 8) | data[10]
+    data_size = (data[11] << 8) | data[12]
+
+    # Decode FCS module name (last byte has high bit set)
+    name_chars: list[str] = []
+    i = name_off
+    while i < len(data):
+        b = data[i]
+        name_chars.append(chr(b & 0x7F))
+        i += 1
+        if b & 0x80:
+            break
+    mod_name = ''.join(name_chars)
+    edition = data[i] if i < len(data) else 0
+
+    mod_type = (type_lang >> 4) & 0xF
+    language = type_lang & 0xF
+    attr     = (attr_rev >> 4) & 0xF
+    rev      = attr_rev & 0xF
+
+    type_str = {0x1: 'Prgrm', 0x2: 'Systm', 0xB: 'FlMgr',
+                0xC: 'Drivr', 0xD: 'Devic'}.get(mod_type, f'${type_lang:02X}')
+    lang_str = {0x1: 'Objct', 0x2: 'ICode', 0x3: 'PCode',
+                0x4: 'CCode'}.get(language, '')
+    tylg_val = f'{type_str}+{lang_str}' if lang_str else type_str
+
+    attr_str = 'ReEnt' if attr & 0x8 else 'Objct'
+    atrv_val = f'{attr_str}+rev' if rev else attr_str
+
+    return {
+        'mod_size':    mod_size,
+        'name_off':    name_off,
+        'name_end':    i - 1,       # last byte of FCS name
+        'edition_off': i,           # byte position of edition
+        'code_start':  i + 1,       # first byte after edition
+        'exec_off':    exec_off,
+        'data_size':   data_size,
+        'mod_name':    mod_name,
+        'edition':     edition,
+        'tylg_val':    tylg_val,
+        'atrv_val':    atrv_val,
+        'rev':         rev,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 3: build f9dasm info file
+# ---------------------------------------------------------------------------
+
+def find_string_regions(data: bytes, start: int, end: int) -> list[tuple[int, int]]:
+    """Return list of (start, end) byte ranges for high-confidence string data.
+
+    To minimise false-positives we require strings to be:
+      - CR-terminated ($0D), at least 16 bytes of printable ASCII before the $0D
+      - Starting with a letter, '*', '/', '(', '"', '#', or '%'
+        (never starting with a digit or control character)
+      - Containing at least two different letter characters
+
+    FCS-terminated strings are deliberately excluded here because they are
+    much harder to distinguish from code bytes that happen to have bit 7 set.
+    """
+    MIN_LEN = 16
+    regions: list[tuple[int, int]] = []
+    i = start
+    while i < end - MIN_LEN:
+        first = data[i]
+        # String must start with a letter or specific printable symbol
+        if not (chr(first).isalpha() or first in b'*/(\"#%'):
+            i += 1
+            continue
+        # Scan forward for CR terminator
+        j = i
+        letters: set[int] = set()
+        ok = True
+        while j < end:
+            b = data[j]
+            if b == 0x0D:               # CR terminator found
+                j += 1
+                break
+            if 0x20 <= b <= 0x7E:       # printable ASCII (no high bit)
+                if chr(b).isalpha():
+                    letters.add(b)
+                j += 1
+            else:
+                ok = False
+                break
+        else:
+            ok = False                  # hit end without terminator
+
+        length = j - i
+        if ok and length >= MIN_LEN and len(letters) >= 2:
+            regions.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+    return regions
+
+
+def make_info(hdr: dict, data: bytes = b'') -> str:
+    n0  = hdr['name_off']
+    ne  = hdr['name_end']
+    ed  = hdr['edition_off']
+    ex  = hdr['exec_off']
+    mod_size = hdr['mod_size']
+    code_start = hdr['code_start']
+    header_end = n0 - 1
+
+    rows = [
+        'OPTION nohex',
+        'OPTION noconv',
+        'OPTION os9',
+        '',
+        '* OS-9 module fixed header (sync bytes through data-size field)',
+        f'DATA 00-{header_end:02X}',
+        '',
+        '* module name FCS string',
+        f'CHAR {n0:02X}-{ne:02X}',
+        '',
+        '* edition byte',
+        f'DATA {ed:02X}',
+        '',
+        '* execution entry point',
+        f'LABEL {ex:04X} start',
+    ]
+
+    # Mark known data string regions so f9dasm doesn't decode them as code.
+    # Scan for printable strings in the code body (excluding the CRC at end).
+    if data:
+        code_end = mod_size - 3  # last 3 bytes are the CRC
+        string_regions = find_string_regions(data, code_start, code_end)
+        if string_regions:
+            rows.append('')
+            rows.append('* detected string/data regions')
+            for s, e in string_regions:
+                rows.append(f'CHAR {s:04X}-{e:04X}')
+
+    return '\n'.join(rows) + '\n'
+
+
+# ---------------------------------------------------------------------------
+# Step 5: post-process f9dasm output -> lwasm format
+# ---------------------------------------------------------------------------
+
+# Mnemonics that terminate sequential execution flow.
+TERMINATORS = frozenset(['rts', 'rti', 'bra', 'lbra', 'jmp', 'swi',
+                         'swi2', 'swi3', 'sync', 'cwai'])
+
+# All f9dasm inline comments are hex-dump noise (";'x'" style) — strip them all.
+_NOISE_COMMENT = re.compile(r"\s*;.*$")
+
+
+def postprocess(raw: str, hdr: dict, data: bytes = b'') -> str:
+    """Convert f9dasm output to lwasm-compatible assembly."""
+
+    mod_size    = hdr['mod_size']
+    mod_name    = hdr['mod_name']
+    exec_off    = hdr['exec_off']
+    data_size   = hdr['data_size']
+    edition     = hdr['edition']
+    tylg_val    = hdr['tylg_val']
+    atrv_val    = hdr['atrv_val']
+    rev         = hdr['rev']
+    edition_off = hdr['edition_off']
+    crc_start   = mod_size - 3
+
+    lines_raw = raw.splitlines()
+
+    # ── collect EQU definitions and defined instruction labels ───────────────
+    # f9dasm emits EQUs for every address referenced in operands.
+    # Those outside module bounds are numeric constants, not code addresses.
+    ext_equ: dict[str, int] = {}   # f9dasm label → value (external only)
+    all_equ: dict[str, int] = {}   # f9dasm label → value (all)
+    # defined_labels: f9dasm labels that appear as actual instruction/data labels
+    # (not just EQU entries).  Only labels above edition_off are relevant —
+    # header-region labels are suppressed in the output and must not become Lxxxx.
+    defined_labels: set[str] = set()
+
+    for line in lines_raw:
+        m = re.match(r'^([A-Za-z][0-9A-Fa-f]{4})\s+EQU\s+\$([0-9A-Fa-f]+)', line)
+        if m:
+            val = int(m.group(2), 16)
+            all_equ[m.group(1)] = val
+            if val >= mod_size:
+                ext_equ[m.group(1)] = val
+        else:
+            # Instruction / data label (non-EQU line with a leading M/Z label)
+            m2 = re.match(r'^([MZ][0-9A-Fa-f]{4})\s+', line)
+            if m2:
+                lbl = m2.group(1)
+                val = int(lbl[1:], 16)
+                if val > edition_off:   # exclude header-region labels
+                    defined_labels.add(lbl)
+
+    # ── label normaliser ────────────────────────────────────────────────────
+    def norm_lbl(tok: str, in_immediate: bool = False) -> str:
+        """Convert f9dasm M/Z label to L label or literal.
+
+        Only labels that actually appear as instruction/data labels in f9dasm
+        output (i.e. are in defined_labels) become Lxxxx references.  Labels
+        that exist only in the EQU section — mid-instruction bytes, header
+        addresses used as numeric constants, etc. — are emitted as $xxxx
+        literals so the assembler never sees an undefined reference.
+        """
+        m = re.match(r'^([MZ])([0-9A-Fa-f]{4})$', tok)
+        if not m:
+            return tok
+        val = int(m.group(2), 16)
+        # External (out of module) → always literal
+        if tok in ext_equ:
+            return f'${val:04X}'
+        # Immediate context → always literal (numeric constant, not code addr)
+        if in_immediate:
+            return f'${val:04X}'
+        # Label only in EQU section (not at an instruction boundary) → literal
+        if tok not in defined_labels:
+            return f'${val:04X}'
+        return f'L{val:04X}'
+
+    # ── operand rewriter ────────────────────────────────────────────────────
+    def rewrite_op(raw_op: str, mnem: str) -> str:
+        """Normalise addressing, label names and register case."""
+        if not raw_op:
+            return ''
+
+        op = raw_op
+
+        # ── FCC: "text" → /text/ — do this BEFORE any identifier processing
+        # so that the string content is never treated as identifiers/registers.
+        if mnem == 'fcc':
+            op = _NOISE_COMMENT.sub('', op).strip()
+            op = re.sub(r'^"(.*)"$', r'/\1/', op)
+            return op
+
+        # ── FCB quoted chars: 'c → $xx ─────────────────────────────────────
+        # Apply BEFORE stripping the comment so that f9dasm's "' " encoding
+        # (single-quote then space) for 0x20 is converted before the leading
+        # spaces of "  ;..." are consumed by the comment stripper.
+        op = re.sub(r"'(.)", lambda m: f'${ord(m.group(1)):02X}', op)
+        # A trailing lone "'" remains when the space in "' " was at the very
+        # end of the field abutting the comment separator; treat it as $27.
+        op = re.sub(r"'$", '$27', op)
+
+        # Strip f9dasm noise comment inside the operand field
+        op = _NOISE_COMMENT.sub('', op).strip()
+
+        # Is this an immediate operand?
+        is_imm = op.startswith('#')
+
+        # ── replace all identifier tokens ──────────────────────────────────
+        def _repl(m: re.Match) -> str:
+            tok = m.group(0)
+            tl  = tok.lower()
+            # Register names → force lowercase
+            if tl in REGS:
+                return tl
+            # Keep known assembler keywords
+            if tl in {'start', 'size', 'name', 'eom', 'edition'}:
+                return tl
+            # OS-9 service call names (F$SUser, I$Write, etc.) contain '$' and
+            # must keep their exact case to match definitions in os9.d.
+            if '$' in tok:
+                return tok
+            return norm_lbl(tok, in_immediate=is_imm)
+
+        # Include '$' in the identifier pattern so OS-9 call names like
+        # F$SUser are matched as a single token (not split at the '$').
+        op = re.sub(r'[A-Za-z][A-Za-z0-9_$]*', _repl, op)
+
+        # lwasm treats '$00,R' (hex zero) differently from '0,R' (decimal zero)
+        # for indexed addressing: '$00,R' → canonical zero-offset post-byte
+        # ($84/$A4/etc.) while '0,R' → 5-bit form ($00/$20/etc.).  The
+        # original Microware binaries use the 5-bit form, so convert all
+        # '$00,R' to '0,R' here.
+        op = re.sub(r'\$00,([XYUSxyus]\b)', lambda m: f'0,{m.group(1).lower()}', op)
+
+        return op
+
+        # ── force 16-bit indirect indexed addressing ─────────────────────────
+        # f9dasm uses M-labels (which become $XXXX 4-digit hex) for 16-bit
+        # indirect indexed post-bytes ($B9/$D9/$F9/$99 etc.) and uses raw
+        # hex literals ($XX 1-2 digits) for 8-bit forms ($B8/$D8/$F8/$98).
+        # Likewise, L-labels inside brackets were 16-bit in the original.
+        # Without '>', lwasm auto-selects 8-bit when the value fits, producing
+        # shorter (wrong) code.  Add '>' inside the brackets to force 16-bit.
+        op = re.sub(
+            r'\[([>]?)(\$[0-9A-Fa-f]{4}|L[0-9A-Fa-f]{4}),([XYUSxyus])\]',
+            lambda m: f'[>{m.group(2)},{m.group(3)}]',
+            op)
+
+        return op
+
+    # ── column formatter ────────────────────────────────────────────────────
+    C_LABEL = 20
+    C_MNEM  = 10
+
+    def fmt(label: str, mnem: str, operand: str, comment: str = '') -> str:
+        s = label.ljust(C_LABEL) + mnem.ljust(C_MNEM)
+        if operand:
+            s += operand
+        if comment:
+            s = s.ljust(C_LABEL + C_MNEM + 20) + comment
+        return s.rstrip()
+
+    # ── skip-line predicates ────────────────────────────────────────────────
+    SKIP = [
+        re.compile(r'^\s*$'),
+        re.compile(r'^f9dasm:'),
+        re.compile(r'^Loaded'),
+        re.compile(r'^\*[\s*]'),
+        re.compile(r'^\s*ORG\s'),
+        re.compile(r'^\s*END\s*$'),
+    ]
+
+    def skip(line: str) -> bool:
+        return any(p.match(line) for p in SKIP)
+
+    # ── pre-pass: detect instructions that straddle the CRC boundary ─────────
+    # An instruction that starts before crc_start but whose next instruction
+    # starts PAST crc_start extends into the CRC area.  We cannot simply emit
+    # it; instead we replace it with raw fcb bytes for the pre-CRC portion and
+    # let emod regenerate the CRC.
+    _idx_addr: list[tuple[int, int]] = []   # (line_index, module_address)
+    for _i, _line in enumerate(lines_raw):
+        if skip(_line):
+            continue
+        if re.match(r'^[A-Za-z][0-9A-Fa-f]{4}\s+EQU\s', _line):
+            continue
+        _am = re.search(r';\s*([0-9A-Fa-f]{4})\b', _line)
+        if _am:
+            _idx_addr.append((_i, int(_am.group(1), 16)))
+        else:
+            _lm = re.match(r'^([MZ])([0-9A-Fa-f]{4})\s', _line)
+            if _lm:
+                _idx_addr.append((_i, int(_lm.group(2), 16)))
+
+    _crc_overlap: set[int] = set()
+    for _k, (_li, _addr) in enumerate(_idx_addr):
+        if _addr >= crc_start:
+            continue
+        if _k + 1 < len(_idx_addr) and _idx_addr[_k + 1][1] > crc_start:
+            _crc_overlap.add(_li)
+
+    # ── build output ─────────────────────────────────────────────────────────
+    out: list[str] = []
+
+    # Module header
+    out += [
+        fmt('', 'nam', mod_name),
+        fmt('', 'ttl', 'program module'),
+        '',
+        fmt('', 'use', 'defsfile'),
+        '',
+        fmt('tylg', 'set', tylg_val),
+        fmt('atrv', 'set', atrv_val),
+        fmt('rev', 'set', f'${rev:02X}'),
+        fmt('edition', 'set', f'${edition:02X}'),
+        '',
+        fmt('', 'mod', 'eom,name,tylg,atrv,start,size'),
+        '',
+    ]
+    if data_size > 0:
+        out.append(fmt('u0000', 'rmb', str(data_size)))
+    out += [
+        fmt('size', 'equ', '.'),
+        '',
+        fmt('name', 'equ', '*'),
+        fmt('', 'fcs', f'/{mod_name}/'),
+        fmt('', 'fcb', 'edition'),
+        '',
+    ]
+
+    current_addr: Optional[int] = None
+    prev_mnem = ''   # for deciding when to emit a blank separator line
+
+    for _line_idx, line in enumerate(lines_raw):
+        if skip(line):
+            continue
+
+        # Skip EQU lines entirely
+        if re.match(r'^[A-Za-z][0-9A-Fa-f]{4}\s+EQU\s', line):
+            continue
+
+        # Parse: [label]  mnemonic  [rest]
+        pm = re.match(
+            r'^([A-Za-z_][A-Za-z0-9_.]*)?'
+            r'\s+'
+            r'([A-Za-z][A-Za-z0-9]*)'
+            r'(?:\s+(.*?))?'
+            r'\s*$',
+            line)
+        if not pm:
+            continue
+
+        raw_label = (pm.group(1) or '').strip()
+        raw_mnem  = pm.group(2).strip()
+        raw_rest  = (pm.group(3) or '').strip()
+
+        # Extract the module address from the f9dasm trailing comment (format
+        # "; ADDR  'ASCII'" — emitted when OPTION noaddr is NOT set in the
+        # info file).  This gives us an accurate address for every instruction,
+        # including unlabelled ones that follow a labelled instruction.
+        addr_m = re.search(r';\s*([0-9A-Fa-f]{4})\b', raw_rest)
+        if addr_m:
+            current_addr = int(addr_m.group(1), 16)
+
+        mnem = raw_mnem.lower()
+
+        # Track current module offset from the label (fallback when no comment)
+        lm = re.match(r'^[MZ]([0-9A-Fa-f]{4})$', raw_label)
+        if lm:
+            current_addr = int(lm.group(1), 16)
+        elif raw_label.lower() == 'start':
+            current_addr = exec_off
+
+        # Suppress header FCB/FCC/FDB rows (replaced by mod/fcs/fcb edition)
+        if current_addr is not None and current_addr <= edition_off:
+            if mnem in ('fcb', 'fcc', 'fdb', 'rmb'):
+                continue
+
+        # Suppress the 3 CRC bytes at the end of the module.
+        # emod recalculates and emits the CRC; we must not include these bytes.
+        # Also handle instructions that START before crc_start but EXTEND into
+        # the CRC area: replace them with raw fcb bytes for the content portion.
+        if current_addr is not None:
+            if current_addr >= crc_start:
+                continue
+            if _line_idx in _crc_overlap:
+                # Determine the label for this line
+                if raw_label:
+                    if raw_label.lower() == 'start':
+                        _fcb_label = 'start'
+                    else:
+                        _fcb_label = norm_lbl(raw_label)
+                else:
+                    _fcb_label = ''
+                # Emit only the bytes before the CRC boundary
+                pre_crc = data[current_addr:crc_start] if data else b''
+                if pre_crc:
+                    byte_str = ','.join(f'${b:02X}' for b in pre_crc)
+                    out.append(fmt(_fcb_label, 'fcb', byte_str))
+                continue
+
+        # Normalise label
+        if raw_label:
+            if raw_label.lower() == 'start':
+                label_out = 'start'
+            else:
+                label_out = norm_lbl(raw_label)
+        else:
+            label_out = ''
+
+        # Normalise operand
+        operand = rewrite_op(raw_rest, mnem)
+
+        # ── blank line logic ────────────────────────────────────────────────
+        # Emit a blank line before a labelled instruction when the previous
+        # instruction was a flow terminator (rts, bra, etc.) to create natural
+        # function boundaries.  Don't spam blank lines everywhere.
+        if label_out and mnem not in ('fcb', 'fcc', 'fdb', 'rmb', 'equ'):
+            if prev_mnem in TERMINATORS:
+                out.append('')
+
+        # ── OS-9 trap ────────────────────────────────────────────────────────
+        if mnem == 'os9':
+            out.append(fmt(label_out, 'os9', operand))
+            prev_mnem = 'os9'
+            continue
+
+        # ── pshu with no registers ($36,$00) ─────────────────────────────────
+        # f9dasm emits "PSHU" with an empty operand for byte $36 $00.
+        # lwasm requires at least one register name, so use fcb instead.
+        if mnem == 'pshu' and not operand:
+            out.append(fmt(label_out, 'fcb', '$36,$00'))
+            prev_mnem = 'fcb'
+            continue
+
+        # ── tfr/exg with unknown register ("??") ──────────────────────────────
+        # f9dasm emits "??" when the inter-register operand byte contains an
+        # undefined register code (e.g. code 7 = W in 6309, but undefined in
+        # 6809 mode).  lwasm rejects "??"; emit the raw bytes instead.
+        if mnem in ('tfr', 'exg') and '??' in operand:
+            _REG_NIBBLE = {
+                'd': 0, 'x': 1, 'y': 2, 'u': 3, 's': 4, 'pc': 5,
+                'a': 8, 'b': 9, 'cc': 0xA, 'dp': 0xB,
+            }
+            _opbyte = 0x1F if mnem == 'tfr' else 0x1E
+            import re as _re
+            _m = _re.match(r'^([^,]+),\?{2}$', operand.strip())
+            if _m:
+                _rn = _m.group(1).strip().lower()
+                _hi = _REG_NIBBLE.get(_rn, 0xF)
+                _lo = 7   # unknown register code 7
+                out.append(fmt(label_out, 'fcb', f'${_opbyte:02X},${(_hi<<4)|_lo:02X}'))
+            else:
+                _m2 = _re.match(r'^\?{2},([^,]+)$', operand.strip())
+                if _m2:
+                    _rn = _m2.group(1).strip().lower()
+                    _lo = _REG_NIBBLE.get(_rn, 0xF)
+                    out.append(fmt(label_out, 'fcb', f'${_opbyte:02X},${0x70|_lo:02X}'))
+                else:
+                    # Fallback: just emit as comment + fcb
+                    out.append(fmt(label_out, 'fcb', f'${_opbyte:02X},$07'))
+            prev_mnem = 'fcb'
+            continue
+
+        # ── reset ($3E) — undocumented 6809 opcode ────────────────────────────
+        # f9dasm emits "RESET" for byte $3E; lwasm does not support this
+        # mnemonic (it is only accepted in 6309 mode but means something
+        # different there).  Emit as a raw fcb byte.
+        if mnem == 'reset':
+            out.append(fmt(label_out, 'fcb', '$3E'))
+            prev_mnem = 'fcb'
+            continue
+
+        # PULS/PULU pc terminates flow
+        if mnem in ('puls', 'pulu'):
+            if operand and 'pc' in operand.lower():
+                prev_mnem = 'rts'  # treated as terminator
+            else:
+                prev_mnem = mnem
+
+        out.append(fmt(label_out, mnem, operand))
+        prev_mnem = mnem
+
+    # End of module — emod emits the 3-byte CRC; eom is defined AFTER emod so
+    # it captures the address past the CRC, giving the total module size as
+    # the size field (matching the NitrOS-9/Microware convention).
+    out += [
+        '',
+        fmt('', 'emod', ''),
+        fmt('eom', 'equ', '*'),
+        fmt('', 'end', ''),
+        '',
+    ]
+
+    return '\n'.join(out)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description='Disassemble OS-9 FCB-format .asm → lwasm-compatible .asm')
+    ap.add_argument('input',   help='Input file (.asm FCB-format or .bin with --binary)')
+    ap.add_argument('-o', '--output', help='Output file (default: stdout)')
+    ap.add_argument('-b', '--binary', action='store_true',
+                    help='Input is a raw OS-9 binary, not an FCB-format .asm')
+    ap.add_argument('-f', '--f9dasm', default='f9dasm',
+                    help='Path to f9dasm binary (default: f9dasm in PATH)')
+    args = ap.parse_args()
+
+    # 1. extract binary
+    if args.binary:
+        try:
+            with open(args.input, 'rb') as fh:
+                data = fh.read()
+        except OSError as e:
+            sys.exit(f'error reading {args.input}: {e}')
+    else:
+        try:
+            data = parse_fcb_file(args.input)
+        except Exception as e:
+            sys.exit(f'error reading {args.input}: {e}')
+        if not data:
+            sys.exit(f'no FCB data found in {args.input}')
+
+    # 2. parse header
+    try:
+        hdr = parse_os9_header(data)
+    except ValueError as e:
+        sys.exit(f'OS-9 header error: {e}')
+
+    print(f'Module: {hdr["mod_name"]}  '
+          f'size=${hdr["mod_size"]:04X}  '
+          f'exec=${hdr["exec_off"]:04X}  '
+          f'data=${hdr["data_size"]:04X}',
+          file=sys.stderr)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bin_path  = os.path.join(tmpdir, 'module.bin')
+        info_path = os.path.join(tmpdir, 'module.info')
+
+        with open(bin_path,  'wb') as fh:
+            fh.write(data)
+        with open(info_path, 'w') as fh:
+            fh.write(make_info(hdr, data))
+
+        # 4. run f9dasm
+        try:
+            result = subprocess.run(
+                [args.f9dasm, '-info', info_path, bin_path],
+                capture_output=True, text=True, check=False)
+        except FileNotFoundError:
+            sys.exit(f'f9dasm not found: {args.f9dasm}')
+
+        raw_dis = result.stdout
+
+    # 5. post-process
+    lwasm_src = postprocess(raw_dis, hdr, data)
+
+    if args.output:
+        with open(args.output, 'w') as fh:
+            fh.write(lwasm_src)
+    else:
+        sys.stdout.write(lwasm_src)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Summary
-------
This PR adds human-readable, byte-exact lwasm disassemblies of the OS-9/6809
Microware C compiler binaries, together with the Python tooling used to
produce them. Everything is additive — no existing modules or build output
change.

The compiler ships in 3rdparty/packages/ccompiler as opaque FCB byte-dumps
(c.comp.asm, c.pass1.asm, ...). Those are faithful but unreadable: they tell
you nothing about how the compiler works. This PR turns each binary into
proper, annotated lwasm source that assembles back to a byte-identical module,
so the compiler can finally be read, studied, diffed, and — longer term —
decompiled toward a self-hosting C source.

What's included
---------------
Disassemblies (3rdparty/packages/ccompiler/):
  cc1_dis.asm       - compiler driver
  c.comp_dis.asm    - main compiler pass
  c.pass1_dis.asm   - pass 1
  c.pass2_dis.asm   - pass 2
  c.opt_dis.asm     - peephole optimiser
  c.link_dis.asm    - linker
  make_dis.asm      - make
  defsfile          - shared equates (Level 2; os9.d, scf.d) for assembling the above

Tooling (scripts/):
  os9dis.py   - disassemble OS-9 FCB-format .asm into lwasm-compatible source
  fcb2bin.py  - extract the raw binary image from an FCB-format .asm
  dis6809.py  - standalone 6809 disassembler for OS-9 module files

State of the disassemblies
--------------------------
Each *_dis.asm is a complete, byte-exact reconstruction of its module: the code
is decoded as a clean 6809 instruction stream, and the embedded data is
correctly identified and rendered rather than mis-decoded as bogus
instructions. That includes fcs/fcc strings and string tables (with their
inter-entry NUL padding), work-block and buffer images, and the inline data
that follows bsr/lbsr calls. The result reads as ordinary lwasm source and
round-trips: assembling it reproduces the original binary exactly.

Build status — EARLY ACCESS
---------------------------
The disassemblies are NOT currently built. They are deliberately not yet wired
into the package makefile, so a normal NitrOS-9 build does not assemble them
and nothing in the existing build changes.

Build integration is coming soon. In the meantime these files are being
supplied as early access, for folks who want to read, assemble, and play with
the compiler internals right now rather than wait. Expect a follow-up that adds
the make targets to assemble each *_dis.asm and verify it against the original.

Verifying / using them now
--------------------------
Each disassembly is byte-exact: assembling a *_dis.asm with lwasm (via the
included defsfile) yields a module identical to the corresponding original
compiler binary. For example:

  lwasm --format=os9 --pragma=... -I. c.comp_dis.asm -o c.comp.test
  # c.comp.test is byte-for-byte identical to the original c.comp module

The os9dis.py / fcb2bin.py / dis6809.py scripts can regenerate the
disassemblies from the FCB sources and were used to produce everything here.

Scope / risk
------------
Purely additive: 7 disassembly files + a defsfile + 3 standalone scripts. No
existing source, descriptor, makefile, or disk image is modified, and no
shipped build artifact changes. Safe to merge independently of the rest of the
tree.
