### PR TITLE
Share HiRes screen services across CoWin and CoVDG

### DIFF
--- a/defs/cocovtio.d
+++ b/defs/cocovtio.d
@@ -389,6 +389,20 @@ S$GetStt            RMB       3                   sound GetStats
 S$SetStt            RMB       3                   sound SetStats
 S$Term              RMB       3                   sound termination
 
+**********************
+* HiRes Entry Points
+                    ORG       0
+H$Init              RMB       3                   initialize per-device application screens
+H$Term              RMB       3                   free per-device application screens
+H$SetStt            RMB       3                   process application-screen SetStat calls
+H$Show              RMB       3                   display selected application screen
+
+HRS.Chg             EQU       $23                 nonzero requests a hardware screen update
+HRS.DGBuf           EQU       $100                selected application screen
+HRS.HiRes           EQU       $101                first screen descriptor
+HRS.NBlk            EQU       1                   block-count offset within a descriptor
+HRS.SType           EQU       2                   screen-type offset within a descriptor
+
 ********************************
 * Window/Menu Bar Data Structure
 *
@@ -585,6 +599,12 @@ V.DWNum             RMB       1                   dwnum from descriptor         
 V.CallCde           RMB       1                   internal comod call code #                   $37
 CC3Parm             RMB       128-.               global parameter area
 ReadBuf             RMB       256-.               read input buffer (keyboard)
+V.HRBuf             RMB       1                   displayed application screen (0=normal)     $100
+V.HiRes             RMB       1                   application screen 1 starting block         $101
+V.HRNBlk            RMB       1                   application screen 1 block count
+V.HRType            RMB       1                   application screen 1 type
+V.HR2               RMB       3                   application screen 2 descriptor
+V.HR3               RMB       3                   application screen 3 descriptor
 CC3DSiz             EQU       .
 
 *****************************************************************************
@@ -618,7 +638,8 @@ G.BelVec            RMB       2                   BELL routine vector
 G.DefPal            RMB       2                   pointer to default palette data in global mem
 G.TnCnt             RMB       1                   SS.Tone duration counter
 G.BelTnF            RMB       1                   BELL tone flag
-g001D               RMB       3
+G.HRSEnt            RMB       2                   HiRes subroutine module entry point ($1D)
+g001F               RMB       1
 G.CurDev            RMB       2                   current device's static memory pointer ($20)
 G.PrWMPt            RMB       2                   previous window static mem pointer $(22)
 G.BCFFlg            RMB       1                   bit coded co-module found flags ($24)

--- a/level2/cmds/hirestest.asm
+++ b/level2/cmds/hirestest.asm
@@ -1,0 +1,124 @@
+********************************************************************
+* HiresTest - Exercise the application screen services
+*
+* Allocate a 320x192 four-color screen, draw four color bands in its
+* mapped memory, display it until a key is read, then restore and free it.
+*
+* Edt/Rev  YYYY/MM/DD  Modified by
+* Comment
+* ------------------------------------------------------------------
+*   1      2026/07/15  Initial version.
+
+                    nam       HiresTest
+                    ttl       Test the application screen services
+
+                    ifp1
+                    use       defsfile
+                    endc
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $00
+edition             set       1
+
+                    mod       eom,name,tylg,atrv,start,size
+
+ScreenNum           rmb       1                   allocated application screen number
+ScreenAddr          rmb       2                   mapped address of screen memory
+ErrorCode           rmb       1                   first error encountered during the test
+Key                 rmb       1                   byte read while the screen is displayed
+                    rmb       128                 local stack
+size                equ       .
+
+name                fcs       /HiresTest/
+                    fcb       edition
+
+start               clr       <ErrorCode          assume success until an OS-9 call fails
+                    lda       #$01                use standard output's VTIO path
+                    ldx       #$0001              request type 1: 320x192, four colors
+                    ldy       #$0000              SS.AScrn does not use an input Y value
+                    ldb       #SS.AScrn           select the allocate-screen service
+                    pshs      u                   preserve the program data pointer across F$MapBlk
+                    os9       I$SetStt            allocate and map the application screen
+                    puls      u                   restore access to the program's data area
+                    lbcs      ExitError           missing co3hires or allocation failure
+                    stx       <ScreenAddr         remember the mapped screen address
+                    tfr       y,d                 move the returned screen number into B
+                    stb       <ScreenNum          remember the screen for display and free
+                    bsr       DrawBands           paint the bitmap before changing display hardware
+                    clra                          form the returned screen number in D/Y
+                    ldb       <ScreenNum          get the allocated application screen
+                    tfr       d,y                 pass its screen number in Y
+                    lda       #$01                issue the service on standard output
+                    ldb       #SS.DScrn           select the display-screen service
+                    os9       I$SetStt            make the application screen visible
+                    bcs       SaveAndCleanup      restore and free if display failed
+                    ldx       #$0002              allow VTIO two ticks to switch hardware
+                    os9       F$Sleep             wait until the application screen is active
+                    bcs       SaveAndCleanup      clean up if the wait was interrupted
+                    ldd       #$0009              black and blue for pixel values zero and one
+                    std       >$FFB0              program GIME palette registers zero and one
+                    ldd       #$243F              red and white for pixel values two and three
+                    std       >$FFB2              program GIME palette registers two and three
+                    clra                          read from standard input
+                    leax      Key,u               point at the one-byte input buffer
+                    ldy       #$0001              wait for exactly one input byte
+                    os9       I$Read              leave the test image up until a key arrives
+                    bcc       Cleanup             a key was read; tear down normally
+
+SaveAndCleanup      stb       <ErrorCode          retain the failure across cleanup calls
+Cleanup             ldy       #$0000              screen zero restores VTIO's normal display
+                    lda       #$01                issue display service on standard output
+                    ldb       #SS.DScrn           select the display-screen service
+                    os9       I$SetStt            switch away from application screen memory
+                    bcc       ResetPalette        restore colors after switching displays
+                    bsr       RecordError         retain this error only if none came first
+ResetPalette        lda       #$01                send reset command on standard output
+                    leax      DefaultPalette,pcr  point to the default-palette command
+                    ldy       #$0002              command contains escape and reset bytes
+                    os9       I$Write             restore the terminal's default palette
+                    bcc       FreeScreen          continue when palette restoration succeeds
+                    bsr       RecordError         retain this error only if none came first
+FreeScreen          clra                          form the saved screen number in D/Y
+                    ldb       <ScreenNum          get the application screen to release
+                    tfr       d,y                 pass its screen number in Y
+                    lda       #$01                issue free service on standard output
+                    ldb       #SS.FScrn           select the free-screen service
+                    os9       I$SetStt            unmap and release application screen memory
+                    bcc       Exit                cleanup completed successfully
+                    bsr       RecordError         retain this error only if none came first
+Exit                ldb       <ErrorCode          return the first error, or zero on success
+                    beq       ExitProcess         no error needs to be reported
+                    pshs      b                   preserve the error while printing its message
+                    os9       F$PErr              identify the failed screen operation for the user
+                    puls      b                   return the original error status to the shell
+ExitProcess         os9       F$Exit              return control to the shell
+
+ExitError           stb       <ErrorCode          report an allocation or missing-module error
+                    bra       Exit                nothing was allocated, so no cleanup is needed
+
+* Record B as the result only when an earlier operation has not already failed.
+RecordError         tst       <ErrorCode          has an earlier failure already been saved?
+                    bne       RecordDone          yes, preserve the original error code
+                    stb       <ErrorCode          no, make this cleanup error the result
+RecordDone          rts                           return to cleanup
+
+DefaultPalette      fcb       $1B,$30              restore the driver's default palette
+
+* A type-1 screen has 80 bytes per row and 192 rows. Each byte holds four
+* two-bit pixels, so $00, $55, $AA, and $FF produce solid color bands.
+DrawBands           ldx       <ScreenAddr         point X at mapped application screen memory
+                    clra                          begin with four pixels of color zero
+                    ldb       #$04                draw one band in each of the four colors
+NextBand            ldy       #3840               48 rows times 80 bytes per row
+FillBand            sta       ,x+                 write four same-color pixels and advance
+                    leay      -1,y                count down bytes remaining in this band
+                    bne       FillBand            fill all 48 rows with the current color
+                    adda      #$55                advance to the next repeated two-bit color
+                    decb                          count this completed color band
+                    bne       NextBand            draw all four bands
+                    rts                           return with the visible bitmap complete
+
+                    emod
+eom                 equ       *
+                    end

--- a/level2/coco3/bootlists/dw.bl
+++ b/level2/coco3/bootlists/dw.bl
@@ -119,6 +119,8 @@
 *
 * CoCo 3 I/O sub-drivers
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb
 * Joystick modules: choose joy for hi-res joystick adapter or

--- a/level2/coco3/bootlists/standard.bl
+++ b/level2/coco3/bootlists/standard.bl
@@ -119,6 +119,8 @@
 *
 * CoCo 3 I/O sub-drivers
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb
 * Joystick modules: choose joy for hi-res joystick adapter or

--- a/level2/coco3/modules/co3hires.asm
+++ b/level2/coco3/modules/co3hires.asm
@@ -1,0 +1,400 @@
+********************************************************************
+* co3hires - shared CoCo 3 application screen services
+*
+* Edt/Rev  YYYY/MM/DD  Modified by
+* Comment
+* ------------------------------------------------------------------
+*   1      2026/07/15  Codex
+* Moved SS.AScrn, SS.DScrn, SS.PScrn, SS.FScrn, and the CoVDG form
+* of SS.ScInf into a subroutine module shared by CoWin and CoVDG.
+
+                    nam       co3hires
+                    ttl       CoCo 3 application screen services
+
+                  IFP1
+                    use       defsfile
+                    use       cocovtio.d
+                  ENDC
+
+tylg                set       Sbrtn+Objct
+atrv                set       ReEnt+rev
+rev                 set       $00
+edition             set       1
+
+                    mod       eom,name,tylg,atrv,entry,0
+
+name                fcs       /co3hires/
+                    fcb       edition
+
+* Entry table. U is always the VTIO device static-memory pointer.
+entry               lbra      Init                            initialize application-screen state
+                    lbra      Term                            release all application screens
+                    lbra      SetStat                         process an application-screen SetStat
+                    lbra      Show                            display the selected application screen
+
+Init                clr       >HRS.DGBuf,u                    select the driver's normal screen
+                    leax      >HRS.HiRes,u                    point to the three screen descriptors
+                    ldb       #9                              clear all three three-byte descriptors
+InitLoop            clr       ,x+
+                    decb
+                    bne       InitLoop
+                    rts
+
+Term                pshs      y,x,d                           preserve the caller's working registers
+                    clr       >HRS.DGBuf,u                    no application screen remains selected
+                    leay      >HRS.HiRes,u                    point to the first screen descriptor
+                    ldb       #3                              visit all three descriptors
+                    pshs      b                               keep the descriptor count on the stack
+TermLoop            tfr       y,x                             pass the current descriptor to FreeBlks
+                    lbsr      FreeBlks                        release its high-RAM allocation, if any
+                    leay      3,y                             advance to the next descriptor
+                    dec       ,s                              count this descriptor
+                    bne       TermLoop
+                    leas      1,s                             discard the descriptor count
+                    puls      pc,y,x,d                        restore registers and return
+
+* Entry: A=SetStat code, Y=path descriptor, U=device static memory.
+SetStat             ldx       PD.RGS,y                        get the caller's register stack
+                    cmpa      #SS.ScInf                       CoVDG-compatible application-screen info
+                    lbeq      Rt.ScInf
+                    cmpa      #SS.DScrn                       display an allocated application screen
+                    lbeq      Rt.DScrn
+                    cmpa      #SS.PScrn                       change an allocated screen's type
+                    lbeq      Rt.PScrn
+                    cmpa      #SS.AScrn                       allocate and map an application screen
+                    lbeq      Rt.AScrn
+                    cmpa      #SS.FScrn                       free an allocated application screen
+                    lbeq      Rt.FScrn
+                    comb                                      reject unrelated SetStat calls
+                    ldb       #E$UnkSvc
+                    rts
+
+* Display code and 8K-block count for application screen types 0-4.
+DTabl               fcb       $14,$02                         640x192, 2 colors, 16K
+                    fcb       $15,$02                         320x192, 4 colors, 16K
+                    fcb       $16,$02                         160x192, 16 colors, 16K
+                    fcb       $1D,$04                         640x192, 4 colors, 32K
+                    fcb       $1E,$04                         320x192, 16 colors, 32K
+
+* Allocate and map a high-resolution application screen.
+Rt.AScrn            ldd       R$X,x                           get the requested screen type
+                    cmpd      #$0004                          screen types 0-4 are supported
+                    bhi       IllArg
+                    pshs      y,x,d                           preserve path, register stack, and type
+                    ldd       #$0303                          three descriptors, three bytes each
+                    leay      >HRS.HiRes,u                    point to the descriptor table
+                    lbsr      FindFree                        find an unused descriptor
+                    bcs       AllocExit
+                    sta       ,s                              save the one-based descriptor number
+                    ldb       1,s                             recover the requested screen type
+                    stb       HRS.SType,y                     save it in the descriptor
+                    leax      >DTabl,pcr                      point to the screen type table
+                    lslb                                      convert the type to a two-byte index
+                    abx
+                    ldb       1,x                             get the required block count
+                    stb       HRS.NBlk,y                      save it in the descriptor
+                    lda       #$FF                            begin with no rejected allocations
+AllocRetry          inca                                      count the next allocation attempt
+                    ldb       HRS.NBlk,y                      get the required block count
+                    pshs      a                               preserve the rejected-allocation count
+                    os9       F$AlHRAM                        allocate contiguous high RAM
+                    puls      a
+                    bcs       DeAll                           release rejected allocations on failure
+                    pshs      b                               save the candidate starting block
+                    andb      #$3F                            reduce it to its 512K-bank position
+                    pshs      b
+                    addb      HRS.NBlk,y                      include the last block in the range
+                    decb
+                    andb      #$3F                            detect a crossing of a 512K boundary
+                    cmpb      ,s+
+                    blo       AllocRetry                      reject candidates that cross the boundary
+                    puls      b                               recover the accepted starting block
+                    stb       ,y                              record it in the descriptor
+                    bsr       DeMost                          release all rejected candidates
+                    leas      a,s                             discard their saved block numbers
+                    ldb       ,y                              recover the accepted starting block
+                    lda       1,x                             recover its block count
+                    lbsr      MapBlocks                       find or map the screen in the caller's address space
+                    bcs       AllocExit
+                    ldx       2,s                             recover the caller's register stack
+                    std       R$X,x                           return the mapped address
+                    ldb       ,s                              get the one-based descriptor number
+                    clra
+                    std       R$Y,x                           return the screen number
+AllocExit           leas      2,s                             discard the saved screen type
+                    puls      pc,y,x
+
+IllArg              comb                                      report an invalid screen number or type
+                    ldb       #E$IllArg
+                    rts
+
+DeAll               bsr       DeMost                          release every rejected allocation
+                    bra       AllocExit
+
+* Entry: A=count of rejected allocations, Y=accepted screen descriptor.
+DeMost              tsta
+                    beq       DeMostExit
+                    ldb       HRS.NBlk,y                      get blocks per allocation
+                    pshs      a                               save the rejected-allocation count
+                    pshs      d,y,x                           preserve working registers
+                    leay      9,s                             point to saved rejected block numbers
+                    clra
+DeMostLoop          ldb       ,y+                             get a rejected allocation's first block
+                    tfr       d,x
+                    ldb       1,s                             get its block count
+                    pshs      a                               preserve the loop register
+                    os9       F$DelRAM                        release the rejected allocation
+                    puls      a
+                    dec       ,s                              count it
+                    bne       DeMostLoop
+                    puls      d,y,x                           restore working registers
+                    puls      a                               return the saved-byte count in A
+DeMostExit          rts
+
+* Return information about and optionally map an application screen.
+Rt.ScInf            pshs      x                               preserve the caller's register stack
+                    ldd       R$Y,x                           get unmap/map screen numbers
+                    bmi       ScInfMap                        skip unmapping when the high byte is negative
+                    bsr       GetInfo
+                    bcs       ScInfExit
+                    lbsr      UnmapBlocks                     unmap the requested screen
+                    bcs       ScInfExit
+ScInfMap            ldx       ,s                              recover the caller's register stack
+                    ldb       R$Y+1,x                         get the screen number to map
+                    bmi       ScInfDone                       negative means no mapping request
+                    bsr       GetInfo
+                    bcs       ScInfExit
+                    lbsr      MapBlocks                       map the requested screen
+                    bcs       ScInfExit
+                    ldx       ,s
+                    std       R$X,x                           return its mapped address
+ScInfDone           clrb
+ScInfExit           puls      pc,x
+
+* Entry: B=screen number 1-3. Exit: A=block count, B=starting block.
+GetInfo             beq       IllArg
+                    cmpb      #3
+                    bhi       IllArg
+                    bsr       GetScrn
+                    beq       IllArg
+                    ldb       ,x
+                    beq       IllArg
+                    lda       1,x
+                    andcc     #^Carry
+                    rts
+
+* Change an allocated application screen to a type requiring no more RAM.
+Rt.PScrn            ldd       R$X,x                           get the requested screen type
+                    cmpd      #$0004
+                    bhi       IllArg
+                    pshs      b,a                             save the type and a zero byte
+                    leax      >DTabl,pcr
+                    lslb
+                    incb
+                    lda       b,x                             get the new type's block count
+                    sta       ,s
+                    ldx       PD.RGS,y
+                    ldd       R$Y,x                           screen zero has no application-screen type
+                    lbeq      PScrnError
+                    bsr       ValidateScreen                  find the requested screen descriptor
+                    bcs       PScrnError
+                    lda       ,s
+                    cmpa      1,x                             ensure the allocated screen is large enough
+                    bhi       PScrnError
+                    lda       1,s
+                    sta       2,x                             save the new screen type
+                    leas      2,s
+                    bra       SelectScreen                    redisplay it with the new type
+PScrnError          leas      2,s
+                    lbra      IllArg
+
+ValidateScreen      ldd       R$Y,x                           get the requested screen number
+                    beq       SelectScreen                    zero selects the driver's normal screen
+                    cmpd      #$0003
+                    lbgt      IllArg
+                    bsr       GetScrn
+                    lbeq      IllArg
+                    clra
+                    rts
+
+Rt.DScrn            bsr       ValidateScreen                  validate the requested screen number
+                    bcs       DisplayExit
+SelectScreen        stb       >HRS.DGBuf,u                    select normal screen 0 or application screen 1-3
+                    inc       <HRS.Chg,u                      ask VTIO to update the display hardware
+                    clrb
+DisplayExit         rts
+
+* Point X at a one-based screen descriptor and set Z if it is unused.
+GetScrn             leax      >HRS.HiRes,u                   point to the first screen descriptor
+                    leax      -3,x                            make screen number 1 select the first descriptor
+                    abx
+                    abx
+                    abx
+                    tst       ,x
+                    rts
+
+Rt.FScrn            ldd       R$Y,x                           get the requested screen number
+                    lbeq      IllArg
+                    cmpd      #$0003
+                    lbhi      IllArg
+                    cmpb      >HRS.DGBuf,u                    refuse to free the displayed screen
+                    lbeq      IllArg
+                    bsr       GetScrn
+                    lbeq      IllArg
+
+* Entry: X=three-byte screen descriptor.
+FreeBlks            lda       1,x                             get the screen's block count
+                    ldb       ,x                              get its starting block
+                    beq       FreeExit
+                    pshs      a
+                    clra
+                    sta       ,x                              mark the descriptor unused
+                    tfr       d,x
+                    puls      b                               pass the block count in B
+                    os9       F$DelRAM                        release the high-RAM allocation
+FreeExit            rts
+
+* Display the application screen selected in device static memory.
+Show                ldb       >HRS.DGBuf,u                    get the selected screen number
+                    cmpb      #3
+                    bhi       ShowExit
+                    bsr       GetScrn
+                    beq       ShowExit
+                    ldb       2,x                             get its screen type
+                    cmpb      #4
+                    bhi       ShowExit
+                    lslb
+                    pshs      x
+                    leax      >DTabl,pcr
+                    lda       b,x                             get the GIME display code
+                    puls      x
+                    clrb
+                    std       >$FF99                          set resolution and border color
+                    std       >D.VIDRS
+                    lda       >D.HINIT
+                    anda      #$7F                            select native CoCo 3 video mode
+                    sta       >D.HINIT
+                    sta       >$FF90
+                    lda       >D.VIDMD
+                    ora       #$80                            select graphics mode
+                    anda      #$F8                            select one scanline per character row
+                    sta       >D.VIDMD
+                    sta       >$FF98
+                    ldb       ,x                              get the first physical block
+                    clra
+                    lslb                                      convert the block to the GIME video offset
+                    rola
+                    lslb
+                    rola
+                    sta       >$FF9B
+                    tfr       b,a
+                    clrb
+                    std       <D.VOFF1
+                    std       >$FF9D
+                    clr       >D.VOFF2
+                    clr       >$FF9C
+ShowExit            clrb
+                    rts
+
+* Find an unused descriptor. Entry: A=count, B=record size, Y=table.
+FindFree            clr       ,-s                             initialize one-based descriptor number
+                    inc       ,s
+FindFreeLoop        tst       ,y
+                    beq       FindFreeExit
+                    leay      b,y
+                    inc       ,s
+                    deca
+                    bne       FindFreeLoop
+                    comb
+                    ldb       #E$BMode
+FindFreeExit        puls      pc,a
+
+* Map A blocks beginning with physical block B into the current process.
+MapBlocks           pshs      u,x,d
+                    bsr       ScanBlocks                      are the blocks already mapped contiguously?
+                    bcc       MapKnown
+                    clra
+                    ldb       1,s                             recover the starting physical block
+                    tfr       d,x
+                    ldb       ,s                              recover the block count
+                    os9       F$MapBlk
+                    stb       1,s                             preserve an error code
+                    tfr       u,d                             return the logical address
+                    bcs       MapError
+MapKnown            leas      2,s                             discard saved D on success
+                    puls      pc,u,x
+MapError            puls      pc,u,x,d
+
+* Remove A blocks beginning with physical block B from the process DAT image.
+UnmapBlocks         pshs      y,x,a
+                    bsr       ScanBlocks
+                    bcs       UnmapExit
+                    ldd       #DAT.Free
+UnmapLoop           std       ,x++
+                    dec       ,s
+                    bne       UnmapLoop
+UnmapExit           puls      pc,y,x,a
+
+* Locate A contiguous physical blocks ending at B in the current DAT image.
+ScanBlocks          equ       *
+                  IFNE    H6309
+                    pshs      a
+                    lde       #8
+                  ELSE
+                    pshs      d
+                    lda       #8
+                    sta       1,s
+                  ENDC
+                    ldx       <D.Proc
+                    leax      <P$DATImg+$10,x                 start at the end of the DAT image
+                    clra
+                    addb      ,s                              calculate the last physical block
+                    decb
+ScanFind            cmpd      ,--x
+                    beq       ScanMatch
+                  IFNE    H6309
+                    dece
+                  ELSE
+                    dec       1,s
+                  ENDC
+                    bne       ScanFind
+                    bra       ScanBad
+ScanMatch           equ       *
+                  IFNE    H6309
+                    dece
+                  ELSE
+                    dec       1,s
+                  ENDC
+                    dec       ,s
+                    beq       ScanFound
+                    decb
+                    cmpd      ,--x
+                    beq       ScanMatch
+                    bra       ScanBad
+ScanFound           equ       *
+                  IFNE    H6309
+                    tfr       e,a
+                  ELSE
+                    lda       1,s
+                  ENDC
+                    lsla
+                    lsla
+                    lsla
+                    lsla
+                    lsla                                      convert the DAT slot to a logical address
+                    clrb
+                  IFNE    H6309
+                    puls      b,pc
+ScanBad             puls      a
+                  ELSE
+                    leas      2,s
+                    rts
+ScanBad             puls      d
+                  ENDC
+                    comb
+                    ldb       #E$BPAddr
+                    rts
+
+                    emod
+eom                 equ       *
+                    end

--- a/level2/coco3/modules/covdg.asm
+++ b/level2/coco3/modules/covdg.asm
@@ -96,6 +96,10 @@ name                fcs       /CoVDG/
 
 * Init VDG screen (allocate memory, etc)
 Init                pshs      u,y,x               save regs
+                    ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       InitNoHiRes         continue when the optional module is absent
+                    jsr       H$Init,x            initialize this device's screen descriptors
+InitNoHiRes         equ       *
                     bsr       SetupPal            set up palettes
                     lda       #$AF                Blue VDG char
                     sta       <VD.CColr,u         save as default color cursor
@@ -223,13 +227,10 @@ L012A               fcb       $00,$0A,$03,$0E,$06,$09,$04,$10 0-7
 
 * Terminate device
 Term                pshs      u,y,x
-                    ldb       #$03
-L004E               pshs      b
-                    lbsr      GetScrn             get screen table entry into X
-                    lbsr      FreeBlks            free blocks used by screen
-                    puls      b                   get count
-                    decb                          decrement
-                    bne       L004E               branch until zero
+                    ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       TermNoHiRes         skip application-screen cleanup when absent
+                    jsr       H$Term,x            release this device's application screens
+TermNoHiRes         equ       *
                     clr       <VD.Start,u         no screens in use
                     ldd       #512                size of alpha screen
                     ldu       <VD.ScrnA,u         get pointer to alpha screen
@@ -266,8 +267,14 @@ start               lbra      Init                Initialize VDG window
                     tsta                          Select new window to be active?
                     bne       L0035               No, try next function code
 * Select new window to be active
-                    ldb       <VD.DGBuf,u         Yes, get number of currently displayed buffer
-                    lbne      ShowS               Not primary buffer, go handle
+                    ldb       >V.HRBuf,u          yes, get the selected application screen
+                    beq       ShowAlpha           Primary buffer, use the VDG display path
+                    ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    lbeq      MissingHiRes        report that the optional module is unavailable
+                    jsr       H$Show,x            display the selected application screen
+                    lbcs      L0440               return any display error
+                    lbra      SetPals             apply this VDG device's palette
+ShowAlpha           equ       *
                     ldd       <VD.TFlg1,u         Primary, get bits to set in $FF22 and VD.Alpha (0=alpha mode)
                     lbra      DispAlfa            Update the hardware
 
@@ -679,7 +686,7 @@ DispAlfa            pshs      x,y,a               Preserve regs (A=video bits to
                     IFNE      COCO2
                     stb       <VD.Alpha,u         0=Alpha mode, else graphics mode
                     ENDC
-                    clr       <VD.DGBuf,u         Clear currently displayed medium res buffer # (inactive)
+                    clr       >V.HRBuf,u          clear the selected application screen
                     lda       >PIA1Base+2         Get current screen mode settings byte from PIA
                     anda      #%00000111          Only keep non-video bits
                     ora       ,s+                 Merge in video bits we saved on stack
@@ -1782,18 +1789,17 @@ SetStat             ldx       PD.RGS,y            Get caller's register stack pt
                     cmpa      #SS.SLGBf
                     beq       Rt.SLGBf
                     ENDC
-                    cmpa      #SS.ScInf           new NitrOS-9 call
-                    lbeq      Rt.ScInf
-                    cmpa      #SS.DScrn
-                    lbeq      Rt.DScrn
-                    cmpa      #SS.PScrn
-                    lbeq      Rt.PScrn
-                    cmpa      #SS.AScrn
-                    lbeq      Rt.AScrn
-                    cmpa      #SS.FScrn
-                    lbeq      Rt.FScrn
-                    comb
+
+SharedScreen        ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       MissingHiRes        report that the optional module is unavailable
+                    jmp       H$SetStt,x          process the request in HiRes
+
+MissingHiRes        comb                          return Unknown Service without disturbing VTIO
                     ldb       #E$UnkSvc
+                    rts
+
+IllArg              comb                          return an illegal-argument error
+                    ldb       #E$IllArg
                     rts
 
 * Allow switch between true/inverse lowercase
@@ -1866,259 +1872,14 @@ L0B2B               stb       <VD.DFlag,u
                     rts
                     ENDC
 
-* Display Table
-* 1st entry = display code
-* 2nd entry = # of 8K blocks
-DTabl               fcb       $14,$02             0: 640x192, 2 color, 16K
-                    fcb       $15,$02             1: 320x192, 4 color, 16K
-                    fcb       $16,$02             2: 160x192, 16 color, 16K
-                    fcb       $1D,$04             3: 640x192, 4 color, 32K
-                    fcb       $1E,$04             4: 320x192, 16 color, 32K
-
-* Allocates and maps a hires screen into process address
-* LCB proposals:
-*   1) type 5 to be 160x192x256 color for GIME-X
-*   2) Allow high byte of X to have a bit (default 0), if set, to mean
-*      x200 screen. Maybe even 2 bits and support x225 as well, although
-*      that means adding 1 block to each of the above tables, and will require
-*      more checks for how many screens we can fit in our address space.
-Rt.AScrn            ldd       R$X,x               get screen type from caller's X
-* LCB - add support for 160x192x256 here as type 5 for GIME-X
-                    cmpd      #$0004              screen type 0-4
-                    bhi       IllArg              if higher than legal limit, return error
-                    pshs      y,x,d               else save off regs
-                    ldd       #$0303
-                    leay      <VD.HiRes,u         pointer to screen descriptor
-                    lbsr      L06C7               gets next free screen descriptor
-                    bcs       L05AF               branch if none found
-                    sta       ,s                  save screen descriptor on stack
-                    ldb       $01,s               get screen type
-                    stb       (VD.SType-VD.HiRes),y and store in VD.SType
-                    leax      >DTabl,pcr          point to display table
-                    lslb                          multiply index by 2 (word entries)
-                    abx                           point to display code, #blocks
-                    ldb       $01,x               get number of blocks
-                    stb       (VD.NBlk-VD.HiRes),y VD.NBlk
-                    lda       #$FF                start off with zero screens allocated
-BA010               inca                          count up by one
-                    ldb       (VD.NBlk-VD.HiRes),y get number of blocks
-                    pshs      a                   needed to protect regA; RG.
-                    os9       F$AlHRAM            allocate a screen
-                    puls      a
-                    bcs       DeAll               de-allocate ALL allocated blocks on error
-                    pshs      b                   save starting block number of the screen
-                    andb      #$3F                keep block BL= block MOD 63
-                    pshs      b
-                    addb      (VD.NBlk-VD.HiRes),y add in the block size of the screen
-                    decb                          in case last block is $3F,$7F,$BF,$FF; RG.
-                    andb      #$3F                (BL+S) mod 63 < BL? (overlap 512k bank)
-                    cmpb      ,s+                 is all of it in this bank?
-                    blo       BA010               if not, allocate another screen
-                    puls      b                   restore the block number for this screen
-                    stb       ,y                  VD.HiRes - save starting block number
-                    bsr       DeMost              deallocate all of the other screens
-                    leas      a,s                 move from within DeMost; RG.
-                    ldb       ,y                  Restore the starting block number again
-                    lda       1,x                 number of blocks
-                    lbsr      L06E3
-                    bcs       L05AF
-                    ldx       $02,s
-                    std       R$X,x
-                    ldb       ,s
-                    clra
-                    std       R$Y,x
-L05AF               leas      2,s
-                    puls      pc,y,x
-
-L05B3X              leas      2,s
-IllArg              comb
-                    ldb       #E$IllArg
-                    rts
-
-* De-allocate the screens
-DeAll               bsr       DeMost              de-allocate all of the screens
-                    bra       L05AF               restore stack and exit
-
-DeMost              tsta
-                    beq       DA020               quick exit if zero additional screens
-                    ldb       (VD.NBlk-VD.HiRes),y get # blocks of screen to de-allocate
-                    pshs      a                   save count of blocks for later
-                    pshs      d,y,x               save rest of regs
-                    leay      9,s                 account for d,y,x,a,calling PC
-                    clra
-DA010               ldb       ,y+                 get starting block number
-                    tfr       d,x                 in X
-                    ldb       1,s                 get size of the screen to de-allocate
-                    pshs      a                   needed to protect regA; RG.
-                    os9       F$DelRAM            de-allocate the blocks *** IGNORING ERRORS ***
-                    puls      a
-                    dec       ,s                  count down
-                    bne       DA010
-                    puls      d,y,x               restore registers
-                    puls      a                   and count of extra bytes on the stack
-DA020               rts                           and exit
-
-* Get current screen info for direct writes - added in NitrOS-9
-Rt.ScInf            pshs      x                   save caller's regs ptr
-                    ldd       R$Y,x               get ??? (Y from caller)
-* 6809/6309: This can actually skip one instruction to the ldb R$Y+1,x since X hasn't changed
-                    bmi       L05C8               If high bit set, skip ahead
-                    bsr       L05DE
-                    bcs       L05DC
-                    lbsr      L06FF
-                    bcs       L05DC
-L05C8               ldx       ,s                  get caller's regs ptr from stack
-                    ldb       R$Y+1,x
-                    bmi       L05DB
-                    bsr       L05DE
-                    bcs       L05DC
-                    lbsr      L06E3
-                    bcs       L05DC
-                    ldx       ,s
-                    std       R$X,x               Return in caller's X
-L05DB               clrb
-L05DC               puls      pc,x
-
-L05DE               beq       IllArg
-                    cmpb      #$03
-                    bhi       IllArg
-                    bsr       GetScrn
-                    beq       IllArg
-                    ldb       ,x
-                    beq       IllArg
-                    lda       $01,x
-                    andcc     #^Carry
-                    rts
-
-* Convert screen to a different type
-Rt.PScrn            ldd       R$X,x
-                    cmpd      #$0004
-                    bhi       IllArg
-                    pshs      b,a                 save screen type, and a zero
-                    leax      >DTabl,pcr
-                    lslb
-                    incb
-                    lda       b,x                 get number of blocks the screen requires
-                    sta       ,s                  kill 'A' on the stack
-                    ldx       PD.RGS,y
-                    bsr       L061B
-                    bcs       L05B3X
-                    lda       ,s
-                    cmpa      $01,x
-                    lbhi      L05B3X              if new one takes more blocks than old
-                    lda       $01,s
-                    sta       $02,x
-                    leas      $02,s
-                    bra       L0633
-
-L061B               ldd       R$Y,x
-                    beq       L0633
-                    cmpd      #$0003
-                    lbgt      IllArg
-                    bsr       GetScrn             point X to 3 byte screen descriptor
-                    lbeq      IllArg
-                    clra
-                    rts
-
-* Displays screen
-Rt.DScrn            bsr       L061B
-                    bcs       L063A
-L0633               stb       <VD.DGBuf,u
-                    inc       <VD.DFlag,u
-                    clrb
-L063A               rts
-
-* Entry: B = screen 1-3
-* Exit:  X = ptr to screen entry
-*GetScrn  pshs  b,a
-*         leax  <VD.GBuff,u
-*         lda   #$03
-*         mul
-*         leax  b,x
-*         puls  pc,b,a
-GetScrn             leax      <VD.GBuff,U         point X to screen descriptor table
-                    abx
-                    abx
-                    abx
-                    tst       ,x                  is this screen valid? (0 = not)
-                    rts
-
-* Frees memory of screen allocated by SS.AScrn
-Rt.FScrn            ldd       R$Y,x
-                    lbeq      IllArg
-                    cmpd      #$03
-                    lbhi      IllArg
-                    cmpb      <VD.DGBuf,u
-                    lbeq      IllArg              illegal arg if screen is being displayed
-                    bsr       GetScrn             point to buffer
-                    lbeq      IllArg              error if screen unallocated
-* Entry: X = pointer to screen table entry
-FreeBlks            lda       $01,x               get number of blocks
-                    ldb       ,x                  get starting block
-                    beq       L066D               branch if none
-                    pshs      a                   else save count
-                    clra                          clear A
-                    sta       ,x                  clear block # in entry
-                    tfr       d,x                 put starting block # in X
-                    puls      b                   get block numbers
-                    os9       F$DelRAM            delete
-L066D               rts                           and return
-
-* Entry: B=Which graphics buffer to make active display
-ShowS               cmpb      #$03                no more than 3 graphics buffers
-                    bhi       L066D               Exit if past maximum
-                    bsr       GetScrn             point X to appropriate screen descriptor
-                    beq       L066D               branch if not allocated
-                    ldb       $02,x               VD.SType - screen type 0-4
-* LCB Change to allow for 160x192x256 for GIME-X
-                    cmpb      #$04
-                    bhi       L066D               Not a valid screen type, return
-                    lslb
-                    pshs      x
-                    leax      >DTabl,pcr
-                    lda       b,x                 get proper display code
-                    puls      x
-* LCB - this should be timed HSYNC or VSYNC to cut sparklies (see VDGINT 1.16 source)
-                    clrb
-                    std       >$FF99              set border color, too
-                    std       >D.VIDRS
-                    lda       >D.HINIT
-                    anda      #$7F                make coco 3 only mode
-                    sta       >D.HINIT
-                    sta       >$FF90
-                    lda       >D.VIDMD
-                    ora       #$80                graphics mode
-                    anda      #$F8                1 line/character row
-                    sta       >D.VIDMD
-                    sta       >$FF98
-*         lda   ,x          get block #
-*         lsla
-*         lsla
-*** start of 2MB patch by RG
-                    ldb       ,x                  get block # (2Meg patch)
-                    clra
-                    lslb
-                    rola
-                    lslb
-                    rola
-                    sta       >$FF9B
-                    tfr       b,a
-*** end of 2MB patch by RG
-                    clrb
-                    std       <D.VOFF1            display it
-                    std       >$FF9D
-                    clr       >D.VOFF2
-                    clr       >$FF9C
-                    lbra      SetPals
-
-* Get next free screen descriptor
+* Get next free medium-resolution screen descriptor.
 L06C7               clr       ,-s                 clear an area on the stack
                     inc       ,s                  set to 1
-L06CB               tst       ,y                  check block #
-                    beq       L06D9               if not used yet
-                    leay      b,y                 go to next screen descriptor
-                    inc       ,s                  increment count on stack
-                    deca                          decrement A
+L06CB               tst       ,y                  check block number
+                    beq       L06D9               stop at an unused descriptor
+                    leay      b,y                 advance by the descriptor size
+                    inc       ,s                  increment the one-based result
+                    deca                          count this descriptor
                     bne       L06CB
                     comb
                     ldb       #E$BMode
@@ -2145,15 +1906,6 @@ L06F9               leas      $02,s               destroy D on no error
                     puls      pc,u,x
 
 L06FD               puls      pc,u,x,d            if error, then restore D
-
-L06FF               pshs      y,x,a               deallocate screen
-                    bsr       L0710
-                    bcs       L070E
-                    ldd       #DAT.Free           set memory to unused
-L0708               std       ,x++
-                    dec       ,s
-                    bne       L0708
-L070E               puls      pc,y,x,a
 
 L0710               equ       *
                     IFNE      H6309

--- a/level2/coco3/modules/cowin.asm
+++ b/level2/coco3/modules/cowin.asm
@@ -201,6 +201,10 @@ L0131               fcs       "grfdrv"
 *
 * Initialization routine
 Init                pshs      u,y                 Preserve regs
+                    ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       InitNoHiRes         continue when the optional module is absent
+                    jsr       H$Init,x            initialize this device's screen descriptors
+InitNoHiRes         equ       *
                     ldd       >WGlobal+G.GrfEnt   Grfdrv there?
                     lbne      L01DB               Yes, go on
 * Setup window allocation bit map table
@@ -494,6 +498,10 @@ L0282               rts                           Return
 * Entry: U=Static mem ptr
 *        Y=Path dsc. ptr
 Term
+                    ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       TermNoHiRes         skip application-screen cleanup when absent
+                    jsr       H$Term,x            release this device's application screens
+TermNoHiRes         equ       *
 * Next two lines added by Boisy on 08/22/2007
 * This test is necessary to prevent a crash in the case that grfdrv cannot be
 * loaded.  If grfdrv isn't properly initialized, then the high bit of BCFFlg will
@@ -2324,7 +2332,14 @@ SetStt              cmpa      #SS.Open            Open window call (for /W)
                     cmpa      #SS.UMBar           Update menu bar
                     lbeq      L13F5
                     ENDC
-                    lbra      L0A96               Unknown SetStat, return with error
+
+SharedScreen        ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       MissingHiRes        report that the optional module is unavailable
+                    jmp       H$SetStt,x          process the request in HiRes
+
+MissingHiRes        comb                          return Unknown Service without disturbing VTIO
+                    ldb       #E$UnkSvc
+                    rts
 
 * SS.DfPal entry point
 L0B38               ldx       PD.RGS,y            get register stack pointer
@@ -2601,13 +2616,23 @@ L0CCA               ldu       >WGlobal+G.CurDev   get current device mem pointer
                     bmi       L0CE1               Wasn't an overlay, skip ahead
                     sta       V.WinNum,u          save it as current
 L0CE1               leas      1,s                 purge stack
-                    jmp       [>WGlobal+G.MsInit] initialize mouse & return
+                    ldb       >V.HRBuf,u          application screen selected for this window?
+                    beq       InitMouse           no, keep the normal window screen selected
+                    ldx       >WGlobal+G.HRSEnt   get shared application-screen services
+                    beq       InitMouse           no module means there is no screen to restore
+                    jsr       H$Show,x            replace the normal screen after its palette is set
+                    bcs       L0CF1               return a display error
+InitMouse           jmp       [>WGlobal+G.MsInit] initialize mouse & return
 
 * Update text & mouse cursors
-L0CE7               lbsr      L06A0               verify window table
-                    bcs       L0CF1               not good, return error
+L0CE7               tst       >V.HRBuf,u          is an application screen currently displayed?
+                    bne       AppCursorDone       yes, leave its hardware setup untouched
+                    lbsr      L06A0               verify window table
+                    lbcs      L0CF1               not good, return error
 L0CEC               ldb       #$46                get set window code
                     lbra      L0101               send it to grfdrv
+AppCursorDone       clrb                           return without updating window cursors
+                    rts
 
 * Checks for any overlay windows & framed or scroll barred windows
 * Entry: U=Static mem pointer

--- a/level2/coco3/modules/vtio.asm
+++ b/level2/coco3/modules/vtio.asm
@@ -228,6 +228,15 @@ Init                ldx       <D.CCMem            get ptr to CC mem
 *         leau  >G.KeyMem,u  point U to keydrv statics
 *         jsr   ,y           call init routine of sub module (K$Init)
 
+                    leax      <HiRes,pcr        point to shared application-screen services
+                    bsr       LinkSub             link the subroutine module
+                    bcs       NoHiRes             continue when the optional module is absent
+                    sty       >G.HRSEnt,u         save its entry point for CoWin and CoVDG
+                    bra       LinkJoy
+NoHiRes             clra                          leave a null entry point when HiRes is unavailable
+                    clrb
+                    std       >G.HRSEnt,u
+LinkJoy             equ       *
                     leax      <JoyDrv,pcr         point to joystick driver sub module name
                     bsr       LinkSys             link to it (restores U to D.CCMem)
                     sty       >G.JoyEnt,u         and save the entry point
@@ -253,8 +262,15 @@ PerWinInit          ldd       #$0078              Default mouse sample rate (0) 
                     lbra      FindCoMod           go find and init co-module
 
 *KeyDrv   fcs   /KeyDrv/     Name of keyboard driver subroutine module
+HiRes             fcs       /co3hires/
 JoyDrv              fcs       /JoyDrv/     Name of joystick driver subroutine module
 SndDrv              fcs       /SndDrv/     Name of sound driver subroutine module
+
+* Link to the shared application-screen subroutine module.
+LinkSub             lda       #Sbrtn+Objct
+                    os9       F$Link
+                    ldu       <D.CCMem            restore the CC global-memory pointer
+                    rts
 
 * Link to subroutine module
 * Entry: X=ptr to module name

--- a/level2/coco3_6309/bootlists/dw.bl
+++ b/level2/coco3_6309/bootlists/dw.bl
@@ -119,6 +119,8 @@
 *
 * CoCo 3 I/O sub-drivers
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb
 * Joystick modules: choose joy for hi-res joystick adapter or

--- a/level2/coco3_6309/bootlists/standard.bl
+++ b/level2/coco3_6309/bootlists/standard.bl
@@ -119,6 +119,8 @@
 *
 * CoCo 3 I/O sub-drivers
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb
 * Joystick modules: choose joy for hi-res joystick adapter or

--- a/level2/coco3fpga/bootlists/standard.bl
+++ b/level2/coco3fpga/bootlists/standard.bl
@@ -143,6 +143,8 @@
 * CoCo 3 I/O sub-drivers
 * Keyboard modules: choose cc3 for CoCo 3 keyboard
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 ../MODULES/SCF/keydrv_cc3.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb

--- a/level2/mc09l2/bootlists/dw.bl
+++ b/level2/mc09l2/bootlists/dw.bl
@@ -119,6 +119,8 @@
 *
 * CoCo 3 I/O sub-drivers
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 ../MODULES/SCF/keydrv_cc3.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb

--- a/level2/mc09l2/bootlists/standard.bl
+++ b/level2/mc09l2/bootlists/standard.bl
@@ -120,6 +120,8 @@
 * CoCo 3 I/O sub-drivers
 * Keyboard modules: choose cc3 for CoCo 3 keyboard
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 ../MODULES/SCF/keydrv_cc3.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb

--- a/level2/realcocofpga/bootlists/standard.bl
+++ b/level2/realcocofpga/bootlists/standard.bl
@@ -147,6 +147,8 @@
 * CoCo 3 I/O sub-drivers
 * Keyboard modules: choose cc3 for CoCo 3 keyboard
 ../MODULES/SCF/vtio.dr
+* Shared high-resolution application screen services
+../MODULES/SCF/co3hires.sb
 ../MODULES/SCF/keydrv_cc3.sb
 * Sound module: CoCo 3 built-in sound generator
 ../MODULES/SCF/snddrv_cc3.sb

--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -67,7 +67,7 @@ DSDD40 = -DCyls=40 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDe
 DSDD80 = -DCyls=80 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDensity=1
 
 RBF ?= rbf.mn rb1773.dr ddd0_$(TRACKS)d.dd d0_$(TRACKS)d.dd d1_$(TRACKS)d.dd d2_$(TRACKS)d.dd
-SCF ?= scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb $(TERM_IO) \
+SCF ?= scf.mn vtio.dr co3hires.sb snddrv_cc3.sb joydrv_joy.sb $(TERM_IO) \
 	$(TERM_WIN_DT) w.dw w1.dw w2.dw w3.dw w4.dw w5.dw w6.dw w7.dw \
 	w8.dw w9.dw w10.dw w11.dw w12.dw w13.dw w14.dw w15.dw
 PIPE ?= pipeman.mn piper.dr pipe.dd
@@ -89,11 +89,13 @@ BOOTMODS ?= krnp2 ioman init \
 	$(CLOCK) \
 	$(BOOTMODS_EXTRA)
 
+$(addprefix $(MODDIR)/,vtio.dr co3hires.sb cowin.io covdg.io covdg_small.io): $(DEFSDIR)/cocovtio.d
+
 SHELLMODS = shellplus date deiniz echo iniz link load save unlink
 UTILPAK1 = attr build copy del deldir dir display list makdir mdir merge mfree procs rename tmode
 
 CMDS_BASE ?= $(STDCMDS) grfdrv shell utilpak1
-CMDS += $(CMDS_BASE) \
+CMDS += $(CMDS_BASE) hirestest \
 	$(CMDS_EXTRA)
 BASIC09_SAMPLES ?=
 RECIPE_DEPS ?=

--- a/recipes/coco3/dw/recipe.mak
+++ b/recipes/coco3/dw/recipe.mak
@@ -6,7 +6,7 @@ OS9FORMAT_CMD = $(OS9FORMAT_DW)
 KERNEL_TRACK = rel_80 boot_dw krn
 
 RBF = rbf.mn rbdw.dr dwio.sb ddx0.dd x1.dd x2.dd x3.dd
-SCF = scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb cowin.io \
+SCF = scf.mn vtio.dr co3hires.sb snddrv_cc3.sb joydrv_joy.sb cowin.io \
 	term_win80.dt w.dw w1.dw w2.dw w3.dw w4.dw w5.dw w6.dw w7.dw \
 	w8.dw w9.dw w10.dw w11.dw w12.dw w13.dw w14.dw w15.dw \
 	scdwv.dr n_scdwv.dd n1_scdwv.dd n2_scdwv.dd \

--- a/recipes/coco3/dw_mega/defsfile
+++ b/recipes/coco3/dw_mega/defsfile
@@ -3,3 +3,5 @@ Level equ 2
  use scf.d
  use rbf.d
  use coco.d
+ use cocovtio.d
+ use vdgdefs

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -1,12 +1,13 @@
 # CoCo 3 DriveWire "mega" recipe.
 #
-# Start with the standard CoCo 3 DriveWire configuration, then fetch and
-# build maintained external OS-9 software at pinned revisions.
+# Start with the standard CoCo 3 DriveWire configuration, add the Sierra AGI
+# collection, then fetch and build maintained external OS-9 software at pinned
+# revisions.
 
 include ../dw/recipe.mak
 
 RECIPE = coco3_dw_mega
-CLEAN_DIRS += .external
+CLEAN_DIRS += .external .sierra
 
 EXTERNAL_DIR ?= .external
 COCO_SHELF ?= $(abspath $(NITROS9DIR)/..)
@@ -31,14 +32,67 @@ FORTH09_COCO_DIR = $(FORTH09_SRC)/coco
 FORTH09_CMD = $(FORTH09_COCO_DIR)/forth09
 FORTH09_TEST = $(FORTH09_COCO_DIR)/forthtest.4th
 
+SIERRA_ROOT = $(3RDPARTY)/packages/sierra
+SIERRA_OBJDIR = $(SIERRA_ROOT)/objs
+SIERRA_BUILD_DIR = .sierra
+SIERRA_MAKE_TOC = ../sierra/make_toc.py
+SIERRA_GAMES = blackcauldron christmas86 goldrush kingsquest1 kingsquest2 \
+	kingsquest3 kingsquest4 leisuresuitlarry manhunter1 manhunter2 \
+	policequest1 spacequest0 spacequest1 spacequest2
+SIERRA_DATA_NAMES = logDir object picDir sndDir viewDir words.tok
+SIERRA_DATA_FILES = $(foreach game,$(SIERRA_GAMES), \
+	$(addprefix $(SIERRA_ROOT)/$(game)/,$(SIERRA_DATA_NAMES)) \
+	$(wildcard $(SIERRA_ROOT)/$(game)/vol.*))
+
+SIERRA_TOC_TXT_blackcauldron = $(SIERRA_ROOT)/blackcauldron/tOC_80d.txt
+SIERRA_TOC_TXT_christmas86 = $(SIERRA_ROOT)/christmas86/tOC.txt
+SIERRA_TOC_TXT_goldrush = $(SIERRA_ROOT)/goldrush/tOC_dw.txt
+SIERRA_TOC_TXT_kingsquest1 = $(SIERRA_ROOT)/kingsquest1/tOC_80d.txt
+SIERRA_TOC_TXT_kingsquest2 = $(SIERRA_ROOT)/kingsquest2/tOC_80d.txt
+SIERRA_TOC_TXT_kingsquest3 = $(SIERRA_ROOT)/kingsquest3/tOC_80d.txt
+SIERRA_TOC_TXT_kingsquest4 = $(SIERRA_ROOT)/kingsquest4/tOC_dw.txt
+SIERRA_TOC_TXT_leisuresuitlarry = $(SIERRA_ROOT)/leisuresuitlarry/tOC.txt
+SIERRA_TOC_TXT_manhunter1 = $(SIERRA_ROOT)/manhunter1/tOC_dw.txt
+SIERRA_TOC_TXT_manhunter2 = $(SIERRA_ROOT)/manhunter2/tOC_dw.txt
+SIERRA_TOC_TXT_policequest1 = $(SIERRA_ROOT)/policequest1/tOC_dw.txt
+SIERRA_TOC_TXT_spacequest0 = $(SIERRA_ROOT)/spacequest0/tOC_dw.txt
+SIERRA_TOC_TXT_spacequest1 = $(SIERRA_ROOT)/spacequest1/tOC_80d.txt
+SIERRA_TOC_TXT_spacequest2 = $(SIERRA_ROOT)/spacequest2/tOC_80d.txt
+SIERRA_TOCS = $(addsuffix /tOC,$(addprefix $(SIERRA_BUILD_DIR)/,$(SIERRA_GAMES)))
+
 # The interpreter supports Version 3 story files. Override INFOCOM_STORY_DIR
 # and INFOCOM_STORIES to package another legally obtained collection.
 INFOCOM_STORY_DIR ?= $(3RDPARTY)/packages/cpm/software/zork
 INFOCOM_STORIES ?= ZORK1.DAT ZORK2.DAT ZORK3.DAT
 INFOCOM_STORY_FILES = $(addprefix $(INFOCOM_STORY_DIR)/,$(INFOCOM_STORIES))
 
-CMDS_EXTRA += forth09 infocom raakatu
-RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) $(INFOCOM_STORY_FILES)
+CMDS_EXTRA += forth09 infocom raakatu sierra mnln scrn shdw
+RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) \
+	$(INFOCOM_STORY_FILES) $(SIERRA_DATA_FILES) $(SIERRA_TOCS)
+
+# Sierra's original sources select their own CPU paths and must not inherit the
+# recipe's H6309 define. These commands are shared by every packaged game.
+SIERRA_AFLAGS = $(filter-out -DH6309=0 -DH6309=1,$(AFLAGS))
+
+$(MODDIR)/sierra: $(SIERRA_OBJDIR)/sierra.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/mnln: $(SIERRA_OBJDIR)/mnln.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/scrn: $(SIERRA_OBJDIR)/scrn.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/shdw: $(SIERRA_OBJDIR)/shdw.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+define SIERRA_TOC_RULE
+$(SIERRA_BUILD_DIR)/$(1)/tOC: $$(SIERRA_TOC_TXT_$(1)) $$(SIERRA_MAKE_TOC)
+	@mkdir -p $$(@D)
+	python3 $$(SIERRA_MAKE_TOC) $$< $$@
+endef
+
+$(foreach game,$(SIERRA_GAMES),$(eval $(call SIERRA_TOC_RULE,$(game))))
 
 # The shared image builder copies commands from $(MODDIR). Link the external
 # build products there so they go through the normal copy and attribute path.
@@ -103,6 +157,17 @@ define RECIPE_INSTALL
 	$(MAKDIR) $(1),GAMES
 	$(MAKDIR) $(1),GAMES/INFOCOM
 	$(OS9COPY) $(INFOCOM_STORY_FILES) $(1),GAMES/INFOCOM
+	$(MAKDIR) $(1),GAMES/SIERRA
+	@for game in $(SIERRA_GAMES); do \
+		$(MAKDIR) $(1),GAMES/SIERRA/$$game; \
+		$(OS9COPY) $(SIERRA_ROOT)/$$game/logDir \
+			$(SIERRA_ROOT)/$$game/object $(SIERRA_ROOT)/$$game/picDir \
+			$(SIERRA_ROOT)/$$game/sndDir $(SIERRA_ROOT)/$$game/viewDir \
+			$(SIERRA_ROOT)/$$game/words.tok $(SIERRA_ROOT)/$$game/vol.* \
+			$(1),GAMES/SIERRA/$$game; \
+		$(CPL) $(SIERRA_BUILD_DIR)/$$game/tOC \
+			$(1),GAMES/SIERRA/$$game/tOC; \
+	done
 	$(MAKDIR) $(1),FORTH09
 	$(CPL) $(FORTH09_TEST) $(1),FORTH09/forthtest.4th
 	$(OS9ATTR_TEXT) $(1),FORTH09/forthtest.4th

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -7,6 +7,7 @@
 include ../dw/recipe.mak
 
 RECIPE = coco3_dw_mega
+SCF += vrn.dr vi.dd
 CLEAN_DIRS += .external .sierra
 
 EXTERNAL_DIR ?= .external

--- a/recipes/coco3/floppy/recipe.mak
+++ b/recipes/coco3/floppy/recipe.mak
@@ -11,7 +11,7 @@ CLEAN_EXTRA += startup.keyrpt startup.minimal
 ifeq ($(MINIMAL),1)
 RECIPE = coco3_minimal
 RBF = rbf.mn rb1773.dr ddd0_$(TRACKS)d.dd
-SCF ?= scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb $(TERM_IO) \
+SCF ?= scf.mn vtio.dr co3hires.sb snddrv_cc3.sb joydrv_joy.sb $(TERM_IO) \
 	$(TERM_WIN_DT)
 PIPE =
 CMDS_BASE = shell grfdrv

--- a/recipes/coco3/sierra/recipe.mak
+++ b/recipes/coco3/sierra/recipe.mak
@@ -2,9 +2,9 @@
 
 GAME ?= kingsquest3
 RECIPE = coco3_$(GAME)
-TERM_COLS = 32
+TERM_COLS = 40
 STARTUP = ./startup
-CMDS_BASE = shell utilpak1
+CMDS_BASE = shell utilpak1 grfdrv
 SIERRA_DIR = $(3RDPARTY)/packages/sierra/$(GAME)
 SIERRA_DATA_FILES = $(notdir $(wildcard $(SIERRA_DIR)/logDir $(SIERRA_DIR)/object \
 	$(SIERRA_DIR)/picDir $(SIERRA_DIR)/sndDir $(SIERRA_DIR)/viewDir \
@@ -59,19 +59,19 @@ endif
 ifeq ($(SIERRA_MEDIA),80d)
 OS9FORMAT_CMD = $(OS9FORMAT_DS80)
 RBF = rbf.mn rb1773.dr ddd0_80d.dd
-KERNEL_TRACK = rel_32 boot_1773_6ms krn
+KERNEL_TRACK = $(REL) boot_1773_6ms krn
 else ifeq ($(SIERRA_MEDIA),dw)
 OS9FORMAT_CMD = $(OS9FORMAT_DW)
 RBF = rbf.mn rbdw.dr dwio.sb ddx0.dd
-KERNEL_TRACK = rel_32 boot_dw krn
+KERNEL_TRACK = $(REL) boot_dw krn
 else
 $(error Unsupported SIERRA_MEDIA "$(SIERRA_MEDIA)")
 endif
 
-# Sierra's AGI games expect the CoCo 3 VDG-compatible terminal stack plus
-# the VRN and VI modules.
-SCF = scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb covdg_small.io \
-	term_vdg.dt vrn.dr vi.dd
+# Run Sierra's AGI games with a 40-column CoWin terminal. Co3HiRes supplies
+# the application-screen services formerly provided by CoVDG.
+SCF = scf.mn vtio.dr co3hires.sb snddrv_cc3.sb joydrv_joy.sb cowin.io \
+	term_win40.dt vrn.dr vi.dd
 PIPE =
 BOOTMODS = krnp2 ioman init \
 	$(RBF) \

--- a/recipes/coco3/sierra/sierra.mak
+++ b/recipes/coco3/sierra/sierra.mak
@@ -17,9 +17,6 @@ SIERRA_MAKE_TOC ?= ../sierra/make_toc.py
 DSDD80 = -DCyls=80 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDensity=1
 DSDD40 = -DCyls=40 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDensity=1
 
-$(MODDIR)/covdg_small.io: covdg.asm | $(MODDIR)
-	$(AS) $(AFLAGS) $< $(ASOUT)$@
-
 $(MODDIR)/shell_21: $(LEVEL1)/cmds/shell_21.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@
 

--- a/recipes/coco3_6309/coco3_6309.mak
+++ b/recipes/coco3_6309/coco3_6309.mak
@@ -42,7 +42,7 @@ LFLAGS += $(LFLAGS_EXTRA)
 DSDD40 = -DCyls=40 -DSides=2 -DSectTrk=18 -DSectTrk0=18 -DInterlv=3 -DSAS=8 -DDensity=1
 
 RBF ?= rbf.mn rb1773.dr ddd0_40d.dd d0_40d.dd d1_40d.dd d2_40d.dd
-SCF ?= scf.mn vtio.dr snddrv_cc3.sb joydrv_joy.sb $(TERM_IO) \
+SCF ?= scf.mn vtio.dr co3hires.sb snddrv_cc3.sb joydrv_joy.sb $(TERM_IO) \
 	$(TERM_WIN_DT) w.dw w1.dw w2.dw w3.dw w4.dw w5.dw w6.dw w7.dw \
 	w8.dw w9.dw w10.dw w11.dw w12.dw w13.dw w14.dw w15.dw
 PIPE ?= pipeman.mn piper.dr pipe.dd
@@ -59,11 +59,13 @@ BOOTMODS ?= krnp2 ioman init \
 	sysgo_dd shell_21 \
 	$(BOOTMODS_EXTRA)
 
+$(addprefix $(MODDIR)/,vtio.dr co3hires.sb cowin.io covdg.io covdg_small.io): $(DEFSDIR)/cocovtio.d
+
 SHELLMODS = shellplus date deiniz echo iniz link load save unlink
 UTILPAK1 = attr build copy del deldir dir display list makdir mdir merge mfree procs rename tmode
 
 CMDS_BASE ?= $(STDCMDS) grfdrv shell utilpak1
-CMDS += $(CMDS_BASE) \
+CMDS += $(CMDS_BASE) hirestest \
 	$(CMDS_EXTRA)
 
 all: libs $(DSKIMAGE)


### PR DESCRIPTION
## Overview

Extract the CoCo 3 application-screen services from CoVDG into an optional `co3hires` subroutine module. CoWin and CoVDG now share the same implementations of `SS.AScrn`, `SS.DScrn`, `SS.PScrn`, and `SS.FScrn`; CoVDG also delegates `SS.ScInf`.

This lets CoWin-based boots support application screens without loading all of CoVDG. Both drivers handle their local SetStat calls first and forward remaining calls to Co3HiRes. If `co3hires` is omitted, VTIO and the terminal driver continue normally and forwarded calls return `E$UnkSvc` (error 208).

## Size

| 6809 artifact/use case | Before | After | Difference |
| --- | ---: | ---: | ---: |
| CoVDG module | 3,499 bytes | 3,060 bytes | -439 bytes |
| CoWin application-screen dependency | 3,499-byte CoVDG | 674-byte `co3hires` | -2,825 bytes |
| CoVDG plus application-screen services | 3,499 bytes | 3,734 bytes | +235 bytes |

The combined CoVDG+Co3HiRes increase is the module-boundary cost. The primary saving is for CoWin boots that need application-screen services without the rest of CoVDG.

## Notable Changes

- Add the re-entrant `co3hires` subroutine module and shared per-device screen state.
- Delegate application-screen operations from both CoWin and CoVDG.
- Forward unmatched driver SetStat calls directly to Co3HiRes without duplicating application-screen service checks.
- Preserve a selected application screen across CoWin cursor/window refreshes.
- Treat `co3hires` as optional and return `E$UnkSvc` when forwarded services are requested while absent.
- Add `hirestest`, which draws four color bands, waits for a key, restores the terminal, and frees the screen.
- Update CoCo 3 recipes and bootlists to include `co3hires`; keep non-recipe makefiles unchanged.
- Convert the Sierra recipe to 40-column CoWin with `co3hires`, add `grfdrv` to `/CMDS`, and retain executable root `/sysgo`.

## Verification

Recipe and module builds:

```sh
make -C recipes/coco3/floppy clean
make -C recipes/coco3/floppy MINIMAL=1 TERM_COLS=32
make -C recipes/coco3/floppy MINIMAL=1 TERM_COLS=80
make -C recipes/coco3_6309/40d clean
make -C recipes/coco3_6309/40d TERM_COLS=80
make -C recipes/coco3/sierra clean
make -C recipes/coco3/sierra GAME=kingsquest3
make -C recipes/coco3/floppy TERM_COLS=80 .mods/cowin.io
make -C recipes/coco3/floppy TERM_COLS=32 .mods/covdg.io
make -C recipes/coco3_6309/40d TERM_COLS=80 .mods/cowin.io
make -C recipes/coco3_6309/40d TERM_COLS=32 .mods/covdg.io
```

Full visible MAME matrix:

| CPU | MAME machine | Driver | Result |
| --- | --- | --- | --- |
| 6809 | `coco3 -ramsize 2M` | CoVDG | Four bands displayed; terminal restored; shell usable |
| 6809 | `coco3 -ramsize 2M` | CoWin | Four bands displayed; terminal restored; shell usable |
| 6309 | `coco3h` | CoVDG | Four bands displayed; terminal restored; shell usable |
| 6309 | `coco3h` | CoWin | Four bands displayed; terminal restored; shell usable |

Additional checks:

- `hirestest` is executable in all four test images.
- Sierra contains executable `grfdrv`, `hirestest`, and `AutoEx`, with executable `sysgo` in the root.
- CoWin and CoVDG route unhandled SetStat calls through Co3HiRes and return `ERROR #208` when it is absent.
