### PR TITLE
Add Sierra games to the DriveWire mega image

### DIFF
--- a/recipes/coco3/dw_mega/defsfile
+++ b/recipes/coco3/dw_mega/defsfile
@@ -3,3 +3,5 @@ Level equ 2
  use scf.d
  use rbf.d
  use coco.d
+ use cocovtio.d
+ use vdgdefs

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -1,12 +1,13 @@
 # CoCo 3 DriveWire "mega" recipe.
 #
-# Start with the standard CoCo 3 DriveWire configuration, then fetch and
-# build maintained external OS-9 software at pinned revisions.
+# Start with the standard CoCo 3 DriveWire configuration, add the Sierra AGI
+# collection, then fetch and build maintained external OS-9 software at pinned
+# revisions.
 
 include ../dw/recipe.mak
 
 RECIPE = coco3_dw_mega
-CLEAN_DIRS += .external
+CLEAN_DIRS += .external .sierra
 
 EXTERNAL_DIR ?= .external
 COCO_SHELF ?= $(abspath $(NITROS9DIR)/..)
@@ -31,14 +32,67 @@ FORTH09_COCO_DIR = $(FORTH09_SRC)/coco
 FORTH09_CMD = $(FORTH09_COCO_DIR)/forth09
 FORTH09_TEST = $(FORTH09_COCO_DIR)/forthtest.4th
 
+SIERRA_ROOT = $(3RDPARTY)/packages/sierra
+SIERRA_OBJDIR = $(SIERRA_ROOT)/objs
+SIERRA_BUILD_DIR = .sierra
+SIERRA_MAKE_TOC = ../sierra/make_toc.py
+SIERRA_GAMES = blackcauldron christmas86 goldrush kingsquest1 kingsquest2 \
+	kingsquest3 kingsquest4 leisuresuitlarry manhunter1 manhunter2 \
+	policequest1 spacequest0 spacequest1 spacequest2
+SIERRA_DATA_NAMES = logDir object picDir sndDir viewDir words.tok
+SIERRA_DATA_FILES = $(foreach game,$(SIERRA_GAMES), \
+	$(addprefix $(SIERRA_ROOT)/$(game)/,$(SIERRA_DATA_NAMES)) \
+	$(wildcard $(SIERRA_ROOT)/$(game)/vol.*))
+
+SIERRA_TOC_TXT_blackcauldron = $(SIERRA_ROOT)/blackcauldron/tOC_80d.txt
+SIERRA_TOC_TXT_christmas86 = $(SIERRA_ROOT)/christmas86/tOC.txt
+SIERRA_TOC_TXT_goldrush = $(SIERRA_ROOT)/goldrush/tOC_dw.txt
+SIERRA_TOC_TXT_kingsquest1 = $(SIERRA_ROOT)/kingsquest1/tOC_80d.txt
+SIERRA_TOC_TXT_kingsquest2 = $(SIERRA_ROOT)/kingsquest2/tOC_80d.txt
+SIERRA_TOC_TXT_kingsquest3 = $(SIERRA_ROOT)/kingsquest3/tOC_80d.txt
+SIERRA_TOC_TXT_kingsquest4 = $(SIERRA_ROOT)/kingsquest4/tOC_dw.txt
+SIERRA_TOC_TXT_leisuresuitlarry = $(SIERRA_ROOT)/leisuresuitlarry/tOC.txt
+SIERRA_TOC_TXT_manhunter1 = $(SIERRA_ROOT)/manhunter1/tOC_dw.txt
+SIERRA_TOC_TXT_manhunter2 = $(SIERRA_ROOT)/manhunter2/tOC_dw.txt
+SIERRA_TOC_TXT_policequest1 = $(SIERRA_ROOT)/policequest1/tOC_dw.txt
+SIERRA_TOC_TXT_spacequest0 = $(SIERRA_ROOT)/spacequest0/tOC_dw.txt
+SIERRA_TOC_TXT_spacequest1 = $(SIERRA_ROOT)/spacequest1/tOC_80d.txt
+SIERRA_TOC_TXT_spacequest2 = $(SIERRA_ROOT)/spacequest2/tOC_80d.txt
+SIERRA_TOCS = $(addsuffix /tOC,$(addprefix $(SIERRA_BUILD_DIR)/,$(SIERRA_GAMES)))
+
 # The interpreter supports Version 3 story files. Override INFOCOM_STORY_DIR
 # and INFOCOM_STORIES to package another legally obtained collection.
 INFOCOM_STORY_DIR ?= $(3RDPARTY)/packages/cpm/software/zork
 INFOCOM_STORIES ?= ZORK1.DAT ZORK2.DAT ZORK3.DAT
 INFOCOM_STORY_FILES = $(addprefix $(INFOCOM_STORY_DIR)/,$(INFOCOM_STORIES))
 
-CMDS_EXTRA += forth09 infocom raakatu
-RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) $(INFOCOM_STORY_FILES)
+CMDS_EXTRA += forth09 infocom raakatu sierra mnln scrn shdw
+RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) \
+	$(INFOCOM_STORY_FILES) $(SIERRA_DATA_FILES) $(SIERRA_TOCS)
+
+# Sierra's original sources select their own CPU paths and must not inherit the
+# recipe's H6309 define. These commands are shared by every packaged game.
+SIERRA_AFLAGS = $(filter-out -DH6309=0 -DH6309=1,$(AFLAGS))
+
+$(MODDIR)/sierra: $(SIERRA_OBJDIR)/sierra.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/mnln: $(SIERRA_OBJDIR)/mnln.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/scrn: $(SIERRA_OBJDIR)/scrn.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+$(MODDIR)/shdw: $(SIERRA_OBJDIR)/shdw.asm | $(MODDIR)
+	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
+
+define SIERRA_TOC_RULE
+$(SIERRA_BUILD_DIR)/$(1)/tOC: $$(SIERRA_TOC_TXT_$(1)) $$(SIERRA_MAKE_TOC)
+	@mkdir -p $$(@D)
+	python3 $$(SIERRA_MAKE_TOC) $$< $$@
+endef
+
+$(foreach game,$(SIERRA_GAMES),$(eval $(call SIERRA_TOC_RULE,$(game))))
 
 # The shared image builder copies commands from $(MODDIR). Link the external
 # build products there so they go through the normal copy and attribute path.
@@ -103,6 +157,17 @@ define RECIPE_INSTALL
 	$(MAKDIR) $(1),GAMES
 	$(MAKDIR) $(1),GAMES/INFOCOM
 	$(OS9COPY) $(INFOCOM_STORY_FILES) $(1),GAMES/INFOCOM
+	$(MAKDIR) $(1),GAMES/SIERRA
+	@for game in $(SIERRA_GAMES); do \
+		$(MAKDIR) $(1),GAMES/SIERRA/$$game; \
+		$(OS9COPY) $(SIERRA_ROOT)/$$game/logDir \
+			$(SIERRA_ROOT)/$$game/object $(SIERRA_ROOT)/$$game/picDir \
+			$(SIERRA_ROOT)/$$game/sndDir $(SIERRA_ROOT)/$$game/viewDir \
+			$(SIERRA_ROOT)/$$game/words.tok $(SIERRA_ROOT)/$$game/vol.* \
+			$(1),GAMES/SIERRA/$$game; \
+		$(CPL) $(SIERRA_BUILD_DIR)/$$game/tOC \
+			$(1),GAMES/SIERRA/$$game/tOC; \
+	done
 	$(MAKDIR) $(1),FORTH09
 	$(CPL) $(FORTH09_TEST) $(1),FORTH09/forthtest.4th
 	$(OS9ATTR_TEXT) $(1),FORTH09/forthtest.4th

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -7,6 +7,7 @@
 include ../dw/recipe.mak
 
 RECIPE = coco3_dw_mega
+SCF += vrn.dr vi.dd
 CLEAN_DIRS += .external .sierra
 
 EXTERNAL_DIR ?= .external


### PR DESCRIPTION
## Overview

Expand the CoCo 3 DriveWire mega image with all 14 supported Sierra AGI games. The image carries one shared Sierra interpreter command set while keeping each title's data and generated table of contents in its own directory.

This is stacked on #367 because the Sierra games use the shared `co3hires` services with CoWin.

## Notable Changes

- Add `sierra`, `mnln`, `scrn`, and `shdw` to `/CMDS` once for the full collection.
- Install every supported title under `/GAMES/SIERRA/<game>` with its resource files and a generated single-drive `tOC`.
- Select DriveWire TOCs where available and single-drive TOCs for the remaining titles.
- Add `vrn.dr` and `vi.dd` to the `dw_mega` bootfile for Sierra virtual-screen access.
- Keep the changes confined to `recipes/coco3/dw_mega`.

## Verification

```sh
make -C recipes/coco3/dw_mega -j4
make -C recipes/coco3/dw_mega -j4 CPU=6309 MODDIR=.mods6309 DSKIMAGE=l2_coco3_dw_mega_6309.dsk
make -C recipes/coco3/dw_mega -j4 bootfile
make -C recipes/coco3/dw_mega -j4 CPU=6309 MODDIR=.mods6309 bootfile
```

Verified results:

- Both 6809 and 6309 mega images contain all 14 game directories with `logDir`, `object`, `picDir`, `sndDir`, `viewDir`, `words.tok`, volume files, and generated `tOC` files.
- Both images contain executable `sierra`, `mnln`, `scrn`, and `shdw` modules in `/CMDS`.
- The merged 6809 and 6309 bootfiles identify `VRN` and `VI` with valid CRCs.
- The populated 6809 image retains about 117 MB free.
