### PR TITLE
Fix CoCo 3 recipe builds in clean checkouts

### DIFF
--- a/recipes/coco3/coco3.mak
+++ b/recipes/coco3/coco3.mak
@@ -76,13 +76,19 @@ KERNEL_TRACK ?= $(REL) boot_1773_6ms krn
 KERNELFILE = kerneltrack
 STARTUP ?= $(NITROS9DIR)/level2/$(PORT)/startup
 
-SYSDIR      ?= $(L2PD)/sys
+SYSDIR      ?= .sys
 SYS_RECIPE  ?= $(NITROS9DIR)/recipes/support/coco3-system.mak
-SYSBIN      ?= $(shell make -C $(SYSDIR) -f $(SYS_RECIPE) --no-print-directory showbinobjs)
-SYSTEXT     ?= $(shell make -C $(SYSDIR) -f $(SYS_RECIPE) --no-print-directory showtextobjs)
+SYSBIN      ?= stdfonts stdpats_2 stdpats_4 stdpats_16 stdptrs ibmedcfont isolatin1font
+SYSTEXT     ?= helpmsg errmsg password motd inetd.conf
 PORTDEFSDIR ?= $(L2PD)/defs
 PORTDEFS_RECIPE ?= $(NITROS9DIR)/recipes/support/coco3-defs.mak
-PORTDEFS    ?= $(shell make -C $(PORTDEFSDIR) -f $(PORTDEFS_RECIPE) --no-print-directory showobjs)
+PORTDEFS    ?= os9.d rbf.d scf.d coco.d coco3vtio.d Defsfile
+
+ifneq ($(SYSDIR),)
+CLEAN_DIRS += $(SYSDIR)
+$(SYSDIR):
+	mkdir -p $@
+endif
 
 BOOTMODS ?= krnp2 ioman init \
 	$(RBF) \
@@ -113,7 +119,7 @@ kernelfile: $(addprefix $(MODDIR)/,$(KERNEL_TRACK))
 bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(MERGE) $(addprefix $(MODDIR)/,$(BOOTMODS))>$@
 
-$(DSKIMAGE): libs kernelfile bootfile $(MODDIR)/sysgo_dd $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(BASIC09_SAMPLES) $(RECIPE_DEPS)
+$(DSKIMAGE): libs kernelfile bootfile $(MODDIR)/sysgo_dd $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(BASIC09_SAMPLES) $(RECIPE_DEPS) | $(SYSDIR)
 	$(RM) $@
 	$(OS9FORMAT_CMD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
 	$(OS9GEN) $@ -b=bootfile -t=$(KERNELFILE)

--- a/recipes/support/coco3-system.mak
+++ b/recipes/support/coco3-system.mak
@@ -1,4 +1,4 @@
-include ../port.mak
+include $(NITROS9DIR)/level2/coco3/port.mak
 
 vpath %.hp $(LEVEL2)/sys:$(LEVEL1)/sys
 vpath %.asm $(LEVEL2)/sys


### PR DESCRIPTION
## Overview

Fix the clean-checkout failure introduced when the legacy `level2/coco3/sys/makefile` was removed. The CoCo 3 recipes now build generated system assets in a recipe-local `.sys` directory instead of assuming the old source-tree directory exists.

This addresses the failure in [Actions run 29653602277](https://github.com/nitros9project/nitros9/actions/runs/29653602277).

## Changes

- Build CoCo 3 system assets under each recipe directory in `.sys`.
- Replace parse-time recursive make queries with explicit system and definition asset lists.
- Load the CoCo 3 port rules from a stable repository path.
- Remove the generated `.sys` directory during `make clean`.

## Verification

Ran the exact `.github/workflows/nitros9.sh` build script from a fresh temporary clone with a fresh `nitros9-languages` checkout.

Verified artifacts:

```text
recipes/coco/floppy/l1_coco.dsk
recipes/coco/dw/l1_coco_dw.dsk
recipes/coco3/floppy/l2_coco3.dsk
recipes/coco3/dw/l2_coco3_dw.dsk
```

Also verified `git diff --check origin/main...HEAD`.