### PR TITLE
Repair recipe integration and CI coverage

### DIFF
--- a/.github/workflows/nitros9.sh
+++ b/.github/workflows/nitros9.sh
@@ -5,6 +5,18 @@
 ls -al
 export NITROS9DIR="$(pwd)"
 
+# Catch unresolved merges and makefile parse failures in every recipe, including
+# optional recipes that are too expensive or dependency-heavy for routine CI.
+if git grep -n -E '^(<<<<<<< |>>>>>>> |=======$)' -- ':!archive'; then
+    echo "Unresolved merge conflict markers found."
+    exit 1
+fi
+
+while IFS= read -r makefile; do
+    recipe_dir="$(dirname "$makefile")"
+    make -C "$recipe_dir" --no-print-directory -n clean >/dev/null
+done < <(find recipes -mindepth 2 -maxdepth 3 -name makefile -print | sort)
+
 make -C recipes/coco/floppy
 make -C recipes/coco/dw
 make -C recipes/coco3/floppy

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ default.proraw
 .mods/
 .obj/
 .lib/
+.sys/
+recipes/**/cfg/
+level2/coco3/defs/*.d
 
 # Assembler/linker listings and maps
 *.list

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ To build NitrOS-9, you need the following:
 
 - [lwtools](http://lwtools.projects.l-w.ca). This package contains the required 6809 assembler and linker.
 - [ToolShed](https://github.com/n6il/toolshed). ToolShed provides file system tools for creating disk images, copying files to and from those disk images, and more.
+- A sibling checkout of [nitros9-languages](https://github.com/nitros9project/nitros9-languages), used by recipes that package BASIC09 and its utilities.
+
+Some expanded recipes also use a sibling checkout of
+[nitros9-apps](https://github.com/nitros9project/nitros9-apps). The default
+layout is:
+
+```text
+parent/
+  nitros9/
+  nitros9-apps/
+  nitros9-languages/
+```
+
+Override `NITROS9_APPS_DIR` or `LANGUAGES` when using another layout.
 
 Once downloaded and installed, select a build recipe under `recipes`. For
 example, to build the CoCo 3 Level 2 floppy image:

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -23,6 +23,10 @@ You must set:
 
 - `NITROS9DIR` to the root of your NitrOS-9 source tree
 
+Recipes that package BASIC09 expect `nitros9-languages` beside the NitrOS-9
+checkout. Expanded application recipes may also expect `nitros9-apps` there.
+Override `LANGUAGES` or `NITROS9_APPS_DIR` for another checkout layout.
+
 Example:
 
 ```sh

--- a/recipes/coco3/README.md
+++ b/recipes/coco3/README.md
@@ -100,30 +100,30 @@ and the CMOC OS-9 runtime. By default it expects the usual coco-shelf layout:
 `bin/cmoc` and `cmoc_os9/` alongside the `nitros9/` checkout. Set
 `COCO_SHELF=/path/to/coco-shelf` if yours differs.
 
-The mega recipe extends the existing [`dw/`](dw/) recipe and adds native OS-9
-software fetched and built from pinned upstream revisions:
+The mega recipe extends the existing [`dw/`](dw/) recipe and adds OS-9
+software and story files fetched from pinned upstream revisions:
 
-- [`drpitre/raakatu`](https://github.com/drpitre/raakatu), installed as the
-  `raakatu` command
 - [`drpitre/forth09`](https://github.com/drpitre/forth09), installed as the
   `forth09` command, with its test program in `/FORTH09/forthtest.4th`
 - [`rlucente-retro/infocom-os9-port`](https://github.com/rlucente-retro/infocom-os9-port),
   installed as the `infocom` command
 - the Version 3 Zork I-III story files under `/GAMES/INFOCOM`
+- the Version 3 [`drpitre/raakatu`](https://github.com/drpitre/raakatu) story,
+  installed as `/GAMES/INFOCOM/raakatu.z3`
 
 The upstream checkouts are kept in `dw_mega/.external` and removed by `make
 clean`. The pinned `FORTH09_REF`, `INFOCOM_REF`, and `RAAKATU_REF` values make
 normal builds repeatable; all repository URLs and revisions can be overridden
 on the `make` command line.
 
-After booting, run Raaka-Tu directly. Start an Infocom title by passing its
-story file to the native interpreter:
+After booting, start an Infocom title by passing its story file to the native
+interpreter:
 
 ```text
-raakatu
 forth09
 forth09 </dd/FORTH09/forthtest.4th
 infocom /dd/GAMES/INFOCOM/ZORK1.DAT
+infocom /dd/GAMES/INFOCOM/raakatu.z3
 ```
 
 `INFOCOM_STORY_DIR` and `INFOCOM_STORIES` may be overridden to package another

--- a/recipes/coco3/README.md
+++ b/recipes/coco3/README.md
@@ -28,6 +28,9 @@ From the repository root, ensure:
 
 - `NITROS9DIR` is set to your NitrOS-9 source tree
 - toolchain is on `PATH`: `make`, `lwasm`, `lwlink`, `lwar`, `os9`
+- `nitros9-languages` is checked out beside NitrOS-9, or `LANGUAGES` points to it
+- for `dw_mega`, `nitros9-apps` is checked out beside NitrOS-9, or
+  `NITROS9_APPS_DIR` points to it
 
 ## Build Directories
 
@@ -90,7 +93,7 @@ make
 
 Primary output:
 
-- `l2_coco3_mega.dsk`
+- `l2_coco3_dw_mega.dsk`
 
 In addition to the normal recipe prerequisites, this build needs `git`, CMOC,
 and the CMOC OS-9 runtime. By default it expects the usual coco-shelf layout:

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -22,10 +22,10 @@ INFOCOM_CHECKOUT = $(INFOCOM_SRC)/.checkout-$(INFOCOM_REF)
 INFOCOM_CMD = $(INFOCOM_SRC)/infocom
 
 RAAKATU_REPO ?= https://github.com/drpitre/raakatu.git
-RAAKATU_REF ?= 9777b7f626ecece7992ac384d3c94ed306417365
+RAAKATU_REF ?= 14f175c3d20ffad71fb960d989a25c7904e3fd7d
 RAAKATU_SRC = $(EXTERNAL_DIR)/raakatu
 RAAKATU_CHECKOUT = $(RAAKATU_SRC)/.checkout-$(RAAKATU_REF)
-RAAKATU_CMD = $(RAAKATU_SRC)/raakatu
+RAAKATU_STORY = $(RAAKATU_SRC)/raakatu.z3
 
 FORTH09_REPO ?= https://github.com/drpitre/forth09.git
 FORTH09_REF ?= c96200c25ee1e9a1091f52d42d5a452d9802c9cb
@@ -65,15 +65,13 @@ $(MODDIR)/z6_scdwv.dd: scdwvdesc.asm | $(MODDIR)
 $(MODDIR)/z7_scdwv.dd: scdwvdesc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DAddr=23
 
-CMDS_EXTRA += forth09 infocom raakatu
-RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) $(INFOCOM_STORY_FILES)
+CMDS_EXTRA += forth09 infocom
+RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) \
+	$(INFOCOM_STORY_FILES) $(RAAKATU_STORY)
 
 # The shared image builder copies commands from $(MODDIR). Link the external
 # build products there so they go through the normal copy and attribute path.
 $(MODDIR)/infocom: $(INFOCOM_CMD) | $(MODDIR)
-	ln -sf $(abspath $<) $@
-
-$(MODDIR)/raakatu: $(RAAKATU_CMD) | $(MODDIR)
 	ln -sf $(abspath $<) $@
 
 $(MODDIR)/forth09: $(FORTH09_CMD) | $(MODDIR)
@@ -103,11 +101,8 @@ $(FORTH09_CHECKOUT):
 $(INFOCOM_CMD): $(INFOCOM_CHECKOUT)
 	$(MAKE) -C $(INFOCOM_SRC) --no-print-directory NITROS9DIR=$(NITROS9DIR) infocom
 
-$(RAAKATU_CMD): $(RAAKATU_CHECKOUT)
-	$(MAKE) -C $(RAAKATU_SRC) --no-print-directory os9 \
-		COCO_SHELF=$(COCO_SHELF) \
-		CMOC=$(COCO_SHELF)/bin/cmoc \
-		CMOC_OS9_DIR=$(COCO_SHELF)/cmoc_os9
+$(RAAKATU_STORY): $(RAAKATU_CHECKOUT)
+	@test -f $@
 
 $(FORTH09_CMD): $(FORTH09_CHECKOUT)
 	$(COCO_SHELF)/bin/cmoc --cpp="cpp -Wno-builtin-macro-redefined" \
@@ -130,7 +125,7 @@ $(FORTH09_CMD): $(FORTH09_CHECKOUT)
 define RECIPE_INSTALL
 	$(MAKDIR) $(1),GAMES
 	$(MAKDIR) $(1),GAMES/INFOCOM
-	$(OS9COPY) $(INFOCOM_STORY_FILES) $(1),GAMES/INFOCOM
+	$(OS9COPY) $(INFOCOM_STORY_FILES) $(RAAKATU_STORY) $(1),GAMES/INFOCOM
 	$(MAKDIR) $(1),FORTH09
 	$(CPL) $(FORTH09_TEST) $(1),FORTH09/forthtest.4th
 	$(OS9ATTR_TEXT) $(1),FORTH09/forthtest.4th

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -1,18 +1,16 @@
 # CoCo 3 DriveWire "mega" recipe.
 #
-# Start with the standard CoCo 3 DriveWire configuration, add the Sierra AGI
-# collection, then fetch and build maintained external OS-9 software at pinned
-# revisions.
+# Start with the standard CoCo 3 DriveWire configuration, then fetch and build
+# maintained external OS-9 software at pinned revisions.
 
 include ../dw/recipe.mak
 
 RECIPE = coco3_dw_mega
 SCF += scdwp.dr p_scdwp.dd \
-	vrn.dr vi.dd \
 	midi_scdwv.dd \
 	z1_scdwv.dd z2_scdwv.dd z3_scdwv.dd \
 	z4_scdwv.dd z5_scdwv.dd z6_scdwv.dd z7_scdwv.dd
-CLEAN_DIRS += .external .sierra
+CLEAN_DIRS += .external
 
 EXTERNAL_DIR ?= .external
 COCO_SHELF ?= $(abspath $(NITROS9DIR)/..)
@@ -37,41 +35,12 @@ FORTH09_COCO_DIR = $(FORTH09_SRC)/coco
 FORTH09_CMD = $(FORTH09_COCO_DIR)/forth09
 FORTH09_TEST = $(FORTH09_COCO_DIR)/forthtest.4th
 
-SIERRA_ROOT = $(3RDPARTY)/packages/sierra
-SIERRA_OBJDIR = $(SIERRA_ROOT)/objs
-SIERRA_BUILD_DIR = .sierra
-SIERRA_MAKE_TOC = ../sierra/make_toc.py
-SIERRA_GAMES = blackcauldron christmas86 goldrush kingsquest1 kingsquest2 \
-	kingsquest3 kingsquest4 leisuresuitlarry manhunter1 manhunter2 \
-	policequest1 spacequest0 spacequest1 spacequest2
-SIERRA_DATA_NAMES = logDir object picDir sndDir viewDir words.tok
-SIERRA_DATA_FILES = $(foreach game,$(SIERRA_GAMES), \
-	$(addprefix $(SIERRA_ROOT)/$(game)/,$(SIERRA_DATA_NAMES)) \
-	$(wildcard $(SIERRA_ROOT)/$(game)/vol.*))
-
-SIERRA_TOC_TXT_blackcauldron = $(SIERRA_ROOT)/blackcauldron/tOC_80d.txt
-SIERRA_TOC_TXT_christmas86 = $(SIERRA_ROOT)/christmas86/tOC.txt
-SIERRA_TOC_TXT_goldrush = $(SIERRA_ROOT)/goldrush/tOC_dw.txt
-SIERRA_TOC_TXT_kingsquest1 = $(SIERRA_ROOT)/kingsquest1/tOC_80d.txt
-SIERRA_TOC_TXT_kingsquest2 = $(SIERRA_ROOT)/kingsquest2/tOC_80d.txt
-SIERRA_TOC_TXT_kingsquest3 = $(SIERRA_ROOT)/kingsquest3/tOC_80d.txt
-SIERRA_TOC_TXT_kingsquest4 = $(SIERRA_ROOT)/kingsquest4/tOC_dw.txt
-SIERRA_TOC_TXT_leisuresuitlarry = $(SIERRA_ROOT)/leisuresuitlarry/tOC.txt
-SIERRA_TOC_TXT_manhunter1 = $(SIERRA_ROOT)/manhunter1/tOC_dw.txt
-SIERRA_TOC_TXT_manhunter2 = $(SIERRA_ROOT)/manhunter2/tOC_dw.txt
-SIERRA_TOC_TXT_policequest1 = $(SIERRA_ROOT)/policequest1/tOC_dw.txt
-SIERRA_TOC_TXT_spacequest0 = $(SIERRA_ROOT)/spacequest0/tOC_dw.txt
-SIERRA_TOC_TXT_spacequest1 = $(SIERRA_ROOT)/spacequest1/tOC_80d.txt
-SIERRA_TOC_TXT_spacequest2 = $(SIERRA_ROOT)/spacequest2/tOC_80d.txt
-SIERRA_TOCS = $(addsuffix /tOC,$(addprefix $(SIERRA_BUILD_DIR)/,$(SIERRA_GAMES)))
-
 # The interpreter supports Version 3 story files. Override INFOCOM_STORY_DIR
 # and INFOCOM_STORIES to package another legally obtained collection.
 INFOCOM_STORY_DIR ?= $(NITROS9_APPS_DIR)/cpm/software/zork
 INFOCOM_STORIES ?= ZORK1.DAT ZORK2.DAT ZORK3.DAT
 INFOCOM_STORY_FILES = $(addprefix $(INFOCOM_STORY_DIR)/,$(INFOCOM_STORIES))
 
-<<<<<<< HEAD
 $(MODDIR)/midi_scdwv.dd: scdwvdesc.asm | $(MODDIR)
 	$(AS) $(AFLAGS) $< $(ASOUT)$@ -DAddr=14
 
@@ -98,35 +67,6 @@ $(MODDIR)/z7_scdwv.dd: scdwvdesc.asm | $(MODDIR)
 
 CMDS_EXTRA += forth09 infocom raakatu
 RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) $(INFOCOM_STORY_FILES)
-=======
-CMDS_EXTRA += forth09 infocom raakatu sierra mnln scrn shdw
-RECIPE_DEPS += $(FORTH09_CMD) $(FORTH09_TEST) $(INFOCOM_CMD) $(RAAKATU_CMD) \
-	$(INFOCOM_STORY_FILES) $(SIERRA_DATA_FILES) $(SIERRA_TOCS)
-
-# Sierra's original sources select their own CPU paths and must not inherit the
-# recipe's H6309 define. These commands are shared by every packaged game.
-SIERRA_AFLAGS = $(filter-out -DH6309=0 -DH6309=1,$(AFLAGS))
-
-$(MODDIR)/sierra: $(SIERRA_OBJDIR)/sierra.asm | $(MODDIR)
-	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
-
-$(MODDIR)/mnln: $(SIERRA_OBJDIR)/mnln.asm | $(MODDIR)
-	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
-
-$(MODDIR)/scrn: $(SIERRA_OBJDIR)/scrn.asm | $(MODDIR)
-	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
-
-$(MODDIR)/shdw: $(SIERRA_OBJDIR)/shdw.asm | $(MODDIR)
-	$(AS) $(SIERRA_AFLAGS) $< $(ASOUT)$@
-
-define SIERRA_TOC_RULE
-$(SIERRA_BUILD_DIR)/$(1)/tOC: $$(SIERRA_TOC_TXT_$(1)) $$(SIERRA_MAKE_TOC)
-	@mkdir -p $$(@D)
-	python3 $$(SIERRA_MAKE_TOC) $$< $$@
-endef
-
-$(foreach game,$(SIERRA_GAMES),$(eval $(call SIERRA_TOC_RULE,$(game))))
->>>>>>> main
 
 # The shared image builder copies commands from $(MODDIR). Link the external
 # build products there so they go through the normal copy and attribute path.
@@ -191,17 +131,6 @@ define RECIPE_INSTALL
 	$(MAKDIR) $(1),GAMES
 	$(MAKDIR) $(1),GAMES/INFOCOM
 	$(OS9COPY) $(INFOCOM_STORY_FILES) $(1),GAMES/INFOCOM
-	$(MAKDIR) $(1),GAMES/SIERRA
-	@for game in $(SIERRA_GAMES); do \
-		$(MAKDIR) $(1),GAMES/SIERRA/$$game; \
-		$(OS9COPY) $(SIERRA_ROOT)/$$game/logDir \
-			$(SIERRA_ROOT)/$$game/object $(SIERRA_ROOT)/$$game/picDir \
-			$(SIERRA_ROOT)/$$game/sndDir $(SIERRA_ROOT)/$$game/viewDir \
-			$(SIERRA_ROOT)/$$game/words.tok $(SIERRA_ROOT)/$$game/vol.* \
-			$(1),GAMES/SIERRA/$$game; \
-		$(CPL) $(SIERRA_BUILD_DIR)/$$game/tOC \
-			$(1),GAMES/SIERRA/$$game/tOC; \
-	done
 	$(MAKDIR) $(1),FORTH09
 	$(CPL) $(FORTH09_TEST) $(1),FORTH09/forthtest.4th
 	$(OS9ATTR_TEXT) $(1),FORTH09/forthtest.4th

--- a/recipes/rules.mak
+++ b/recipes/rules.mak
@@ -116,7 +116,7 @@ MKDSKINDEX	= perl $(NITROS9DIR)/scripts/mkdskindex
 DROP_EXTRA_SPACES = fn() { mv "$$1" "$$1.tmp" && sed 's/  */ /g' "$$1.tmp" > "$$1" && rm "$$1.tmp"; }; fn
 
 # Directories
-3RDPARTY	= $(NITROS9DIR)/3rdparty
+NITROS9_APPS_DIR ?= $(abspath $(NITROS9DIR)/../nitros9-apps)
 LANGUAGES	?= $(abspath $(NITROS9DIR)/../nitros9-languages)
 LEVEL1		= $(NITROS9DIR)/level1
 LEVEL2		= $(NITROS9DIR)/level2

--- a/rules.mak
+++ b/rules.mak
@@ -93,7 +93,6 @@ MKDSKINDEX	= perl $(NITROS9DIR)/scripts/mkdskindex
 DROP_EXTRA_SPACES = fn() { mv "$$1" "$$1.tmp" && sed 's/  */ /g' "$$1.tmp" > "$$1" && rm "$$1.tmp"; }; fn
 
 # Directories
-3RDPARTY	= $(NITROS9DIR)/3rdparty
 NITROS9_APPS_DIR ?= $(abspath $(NITROS9DIR)/../nitros9-apps)
 LANGUAGES	?= $(abspath $(NITROS9DIR)/../nitros9-languages)
 LEVEL1		= $(NITROS9DIR)/level1


### PR DESCRIPTION
## Overview

Repair the recipe tree after the third-party repository migration. This removes stale Sierra integration from the CoCo 3 DriveWire mega recipe, restores valid Make syntax, and gives sibling application and language repositories explicit defaults and documentation.

The mega image now packages Raaka-Tu in its preferred Version 3 Z-machine form under `/GAMES/INFOCOM`; the obsolete standalone OS-9 command is no longer built or installed.

CI now catches unresolved merge markers and parses every recipe entry point, including optional recipes that are not fully built during routine CI.

## Notable Changes

- Remove committed conflict markers and obsolete `3rdparty`/Sierra dependencies from `dw_mega`.
- Replace the standalone Raaka-Tu command with the pinned `raakatu.z3` story used by the native Infocom interpreter.
- Retain and validate the DriveWire MIDI and `z1`–`z7` descriptor rules.
- Default `NITROS9_APPS_DIR` and `LANGUAGES` to sibling repositories.
- Document the external repository layout and correct the `dw_mega` image name.
- Ignore recipe-generated `.sys`, MAME configuration, and CoCo 3 definition files.
- Add CI guards for merge markers and Makefile parse failures across all recipes.

## Verification

```sh
bash .github/workflows/nitros9.sh
NITROS9DIR=$PWD make -C recipes/coco3/dw_mega
os9 dir -e recipes/coco3/dw_mega/l2_coco3_dw_mega.dsk,GAMES/INFOCOM
os9 dir -e recipes/coco3/dw_mega/l2_coco3_dw_mega.dsk,CMDS
git diff --check
```

Verified results:

- The complete primary CI recipe build passed.
- All 12 recipe entry points parsed successfully.
- The complete `dw_mega` image built successfully.
- `/GAMES/INFOCOM/raakatu.z3` is present at 22,528 bytes.
- No standalone `CMDS/raakatu` is present.
- Retained `dw_mega` descriptors assembled and passed `os9 ident`.
- No unresolved conflict markers or whitespace errors remain outside the archival tree.