### PR TITLE
docs, ci: list and build the Pico-Thing port

### DIFF
--- a/.github/workflows/nitros9.sh
+++ b/.github/workflows/nitros9.sh
@@ -21,3 +21,7 @@ make -C recipes/coco/floppy
 make -C recipes/coco/dw
 make -C recipes/coco3/floppy
 make -C recipes/coco3/dw
+make -C recipes/picothing/l1
+make -C recipes/picothing/l1dw
+make -C recipes/picothing/l2
+make -C recipes/picothing/l2dw

--- a/docs/supported-ports.md
+++ b/docs/supported-ports.md
@@ -13,6 +13,7 @@ The maintained source tree currently includes these ports:
 | Atari with Liber809 | Level 1 | 6809 |
 | Corsham 6809 SS-50 | Level 1 | 6809 |
 | Wildbits 6809 | Levels 1 and 2 | 6809 |
+| Pico-Thing | Levels 1 and 2 | 6809 and 6309 |
 
 The recipe directories are the authoritative list of routinely buildable
 products and currently cover a subset of these ports. Some platform source


### PR DESCRIPTION
Adds the Pico-Thing to the supported-ports matrix and builds its four primary recipes (l1, l1dw, l2, l2dw) in CI, alongside the existing
  coco and coco3 products. The port itself is already upstream; this fills in the docs/CI entries that the merge left out.