### PR TITLE
makefile: Reproducible builds

### DIFF
--- a/level1/wildbits/feu/makefile
+++ b/level1/wildbits/feu/makefile
@@ -275,7 +275,7 @@ f0.dsk: feu/startup
 feu/startup: FORCE
 	echo "display 1b 61 1 ff 0 0 ff 5 22 f0 1b 20 2 0 0 50 18 0 1 0 1b 32 7" > $@
 	echo "echo FEU - First Execution Unit" >> $@
-	echo "echo Build date:" `date` >> $@
+	echo "echo Build date: $(BUILD_DATE)" >> $@
 	echo "wbinfo" >> $@
 	echo "chd .../feu" >> $@
 	echo "pick -pFEU: main.pick</1" >> $@

--- a/recipes/rules.mak
+++ b/recipes/rules.mak
@@ -235,3 +235,12 @@ STDCMDS = asm attr backup bawk binex build cmp copy date dcheck debug \
 	padrom park pick printerr procs prompt pwd pxd rename save \
 	setime shellplus shell_21 sleep tee tmode touch tsmon unlink verify \
 	xmode
+
+# Date/time
+# Use SOURCE_DATE_EPOCH when provided for reproducible builds.
+# Otherwise preserve the normal system date behavior.
+ifdef SOURCE_DATE_EPOCH
+  BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)")
+else
+  BUILD_DATE = $(shell date)
+endif

--- a/recipes/wildbits/feu/makefile
+++ b/recipes/wildbits/feu/makefile
@@ -127,7 +127,7 @@ f0.dsk: startup $(addprefix $(MODDIR)/,$(F0_CMDS))
 startup:
 	echo "display 1b 61 1 ff 0 0 ff 5 22 f0 1b 20 2 0 0 50 18 0 1 0 1b 32 7" > $@
 	echo "echo FEU - First Execution Unit" >> $@
-	echo "echo Build date:" `date` >> $@
+	echo "echo Build date: $(BUILD_DATE)" >> $@
 	echo "wbinfo" >> $@
 	echo "chd .../feu" >> $@
 	echo "pick -pFEU: main.pick</1" >> $@

--- a/rules.mak
+++ b/rules.mak
@@ -186,3 +186,12 @@ buildinfo:
 	COMMITHASH="$$(git rev-parse --short HEAD)"; \
 	BRANCHNAME="$$(git branch --show-current)"; \
 	echo " fcc !$${BUILDDATE} ($${COMMITHASH} - $${BRANCHNAME})!" > "$(NITROS9DIR)/defs/buildinfo";
+
+# Date/time
+# Use SOURCE_DATE_EPOCH when provided for reproducible builds.
+# Otherwise preserve the normal system date behavior.
+ifdef SOURCE_DATE_EPOCH
+  BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)")
+else
+  BUILD_DATE = $(shell date)
+endif


### PR DESCRIPTION
In my work on ToolShed, I often use NitrOS-9's many disk images to verify that my changes have not affected the project.

This change to the makefiles will make it easier for me to compare the output of different tools without affecting your normal builds.
