### PR TITLE
Add a CoCo 3 Rogue recipe

### DIFF
--- a/recipes/coco3/README.md
+++ b/recipes/coco3/README.md
@@ -32,12 +32,15 @@ From the repository root, ensure:
 - `nitros9-languages` is checked out beside NitrOS-9, or `LANGUAGES` points to it
 - for `dw_mega`, `nitros9-apps` is checked out beside NitrOS-9, or
   `NITROS9_APPS_DIR` points to it
+- for `rogue`, `nitros9-games` is checked out beside NitrOS-9, or
+  `NITROS9_GAMES_DIR` points to it
 
 ## Build Directories
 
 - [`floppy/`](floppy/) builds CoCo 3 Level 2 double-sided floppy disk images
 - [`dw/`](dw/) builds a CoCo 3 DriveWire-oriented disk image
 - [`dw_mega/`](dw_mega/) builds an expanded CoCo 3 DriveWire image with third-party software
+- [`rogue/`](rogue/) builds a CoCo 3 disk image with Rogue and its support files
 
 Each build directory keeps intermediate artifacts local:
 
@@ -101,6 +104,20 @@ This recipe defaults to:
 Optional features:
 
 - add `FUJINET=1` in `recipe.mak` to include the FujiNet utility commands listed above
+
+## Rogue Build ([`coco3/rogue`](rogue/))
+
+```sh
+cd rogue
+make
+```
+
+Primary output:
+
+- `l2_coco3_rogue.dsk`
+
+The recipe builds Rogue from the sibling `nitros9-games/rogue` source directory
+and installs its data, help, screen, and character files under `/ROGUE`.
 
 ## Mega DriveWire Build ([`coco3/dw_mega`](dw_mega/))
 

--- a/recipes/coco3/rogue/makefile
+++ b/recipes/coco3/rogue/makefile
@@ -1,0 +1,2 @@
+LEVEL = 2
+include ../coco3.mak

--- a/recipes/coco3/rogue/recipe.mak
+++ b/recipes/coco3/rogue/recipe.mak
@@ -1,0 +1,32 @@
+# CoCo 3 Rogue recipe defaults.
+
+RECIPE = coco3_rogue
+TERM_COLS = 80
+STARTUP = ./startup
+
+NITROS9_GAMES_DIR ?= $(abspath $(NITROS9DIR)/../nitros9-games)
+ROGUE_DIR ?= $(NITROS9_GAMES_DIR)/rogue
+ROGUE_SUPPORT_FILES = rogue.dat rogue.hlp rogue.scr rogue.chr
+ROGUE_SUPPORT_PATHS = $(addprefix $(ROGUE_DIR)/,$(ROGUE_SUPPORT_FILES))
+
+override SHELLMODS = shell_21 date deiniz display echo iniz link load save unlink
+
+BOOTMODS = krnp2 ioman init \
+	$(RBF) \
+	$(SCF) \
+	$(PIPE) \
+	$(CLOCK) \
+	$(BOOTMODS_EXTRA)
+
+CMDS_BASE = grfdrv shell utilpak1
+CMDS_EXTRA += rogue
+RECIPE_DEPS += $(ROGUE_SUPPORT_PATHS)
+
+$(MODDIR)/rogue: $(ROGUE_DIR)/rogue.asm | $(MODDIR)
+	$(AS) $(AFLAGS) $< $(ASOUT)$@
+
+define RECIPE_INSTALL
+	$(MAKDIR) $(1),ROGUE
+	$(OS9COPY) $(ROGUE_SUPPORT_PATHS) $(1),ROGUE
+	$(OS9ATTR_TEXT) $(foreach file,$(ROGUE_SUPPORT_FILES),$(1),ROGUE/$(file))
+endef

--- a/recipes/coco3/rogue/startup
+++ b/recipes/coco3/rogue/startup
@@ -1,0 +1,10 @@
+* Echo welcome message
+echo * Welcome to NitrOS-9 Level 2 *
+echo *   on the Color Computer 3   *
+* Lock shell and std utils into memory
+link shell
+load utilpak1
+* Start system time from keyboard
+setime </1
+date -t
+rogue </1


### PR DESCRIPTION
## Overview

Add a focused CoCo 3 recipe for building and packaging Rogue from a sibling `nitros9-games` checkout. The recipe follows the current centralized recipe infrastructure and leaves the older mixed Makefile changes behind.

## Notable Changes

- Add a `recipes/coco3/rogue` entry point and recipe definition.
- Assemble Rogue directly from `$(NITROS9_GAMES_DIR)/rogue/rogue.asm`.
- Install the Rogue data and support files under `/ROGUE` on the generated disk.
- Document the sibling repository requirement and the `NITROS9_GAMES_DIR` override.

## Verification

```sh
make -C recipes/coco3/rogue NITROS9_GAMES_DIR=/private/tmp/nitros9-games -B .mods/rogue
git diff --check origin/main...HEAD
```

The Rogue module assembled successfully from `nitros9-games` at commit `f157bca`, and the diff passed whitespace validation.

## Environment Note

A full `clean all` disk build progressed through Rogue assembly but could not complete in this local environment because the existing kernel-track build requires `/dd/defs/os9.d`, which is unavailable here.