### PR TITLE
Fix Level 1 del command failure in IOMan

### DIFF
--- a/level1/modules/ioman.asm
+++ b/level1/modules/ioman.asm
@@ -1062,7 +1062,12 @@ IDelete             pshs      b         ; save delete call selector
                     ldb       #WRITE.   ; delete requires write access
                     bra       AllocCallFMgr ; allocate descriptor and call file manager
 
-IDeletX             ldb       #7        ; delete offset in file manager
+IDeletX
+                  IFEQ    Level-1
+                    ldb       #I$Delete ; raw I/O call code $87 for Level 1
+                  ELSE
+                    ldb       #7        ; delete offset in file manager for Level 2
+                  ENDC
                     pshs      b         ; save file manager delete-entry selector
                     ldb       R$A,u     ; get caller's access mode/path context
                     bra       AllocCallFMgr ; allocate descriptor and dispatch delete


### PR DESCRIPTION
In commit f23daf45, IOMan was merged for Level 1 and Level 2, replacing Level 1's IDeletX routine (which loaded #I$Delete, or #$87) with Level 2's pre-normalized routine (loading #7).

Level 1's CallFMgr expects the un-normalized I/O code (#$87) and subtracts #$83 to reach index 4 (Delete) in RBF's branch table. Loading #7 caused CallFMgr to calculate 7 - $83 = -124 ($84), jumping 396 bytes into RBF and corrupting memory.

Conditionalizing IDeletX restores #I$Delete for Level 1 while preserving #7 for Level 2.

## Problem
Executing `del` on NitrOS-9 Level 1 consistently fails with **ERROR #094** (memory corruption).

## Root Cause
In commit `f23daf45` (*Merge Level 1 and Level 2 IOMan source into single shared file*), Level 1's `IDeletX` routine was replaced with Level 2's implementation which loads `#7` into register `B`.

On Level 1, `CallFMgr` expects the un-normalized system call code (`I$Delete` = `$87`) and subtracts `$83` to calculate the branch table index (`$87 - $83 = 4`, pointing to `lbra Delete` in RBF). Passing `#7` causes `CallFMgr` to compute `7 - $83 = $84` (-124). Multiplied by 3 bytes per entry, it branches to offset `$018C` (396 bytes) into RBF—far beyond its 39-byte branch table—executing arbitrary memory and corrupting system state.

## Fix
Conditionalize `IDeletX` in `level1/modules/ioman.asm` to load `#I$Delete` on Level 1 while keeping `#7` for Level 2.