### PR TITLE
Wb/recipes clut exec l2dw

### DIFF
--- a/recipes/wildbits/l2dw/padup256
+++ b/recipes/wildbits/l2dw/padup256
@@ -1,0 +1,9 @@
+#!/bin/sh
+if stat -f "%z" $1 > /dev/null 2>&1 ; then
+     export padding=`stat -f "(%z + 255) / 256 * 256" $1 | bc`
+else
+     export padding=`stat -c "(%s + 255) / 256 * 256" $1 | bc`
+fi
+ls -l $@
+os9 padrom -b $padding $1
+ls -l $@

--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -196,6 +196,7 @@ endif
 	$(OS9COPY) $(addprefix $(FONT_DIR)/,$(FONTS)) $@,SYS/fonts
 	$(MAKDIR) $@,SYS/backgrounds
 	$(OS9COPY) $(addprefix $(BACKGROUND_DIR)/,$(BACKGROUNDS)) $@,SYS/backgrounds
+	$(OS9ATTR_EXEC) $(foreach file,$(BACKGROUNDS),$@,SYS/backgrounds/$(file))
 	$(CPL) $(STARTUP) $@,startup
 	$(OS9ATTR_TEXT) $@,startup
 	$(MAKDIR) $@,BASIC09


### PR DESCRIPTION
- Update fixes CLUT executable attributes so sys/backgrounds images are visible when building from recipes.
- Fix Level2 Drivewire missing padup256 when building from recipes (recipes/wildbits/l2dw).