### PR TITLE
Fix wildbits recipe: build basic09/runb if missing

### DIFF
--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -228,9 +228,15 @@ $(MODDIR)/tmode: xmode.asm | $(MODDIR)
 $(MODDIR)/basic09: $(BASIC09_BIN) | $(MODDIR)
 	$(CP) $< $@
 
+$(BASIC09_BIN):
+	$(MAKE) -C $(LANGUAGES)/basic09 basic09_6809
+
 $(MODDIR)/runb: $(RUNB_BIN) | $(MODDIR)
 	$(CP) $< $@
 	@printf '%s  %s\n' "$(RUNB_SHA256)" $@ | shasum -a 256 -c -
+
+$(RUNB_BIN):
+	$(MAKE) -C $(LANGUAGES)/basic09 runb_6809
 
 ifeq ($(LEVEL),2)
 $(MODDIR)/utilpak1: $(addprefix $(MODDIR)/,$(UTILPAK1_MODS)) | $(MODDIR)


### PR DESCRIPTION
## Summary
- Roger reported the wildbits K2 port doesn't build due to basic09 references.
- Root cause: `recipes/wildbits/wildbits.mak` depends on `$(LANGUAGES)/basic09/basic09_6809` and `runb_6809`, but has no rule to build them if they don't already exist in a `nitros9-languages` checkout (these binaries are gitignored/generated, not committed). On a fresh checkout, `make` fails with `No rule to make target '.../basic09_6809'`.
- Added fallback rules mirroring the existing pattern in `recipes/coco3/floppy/makefile`, so `make -C $(LANGUAGES)/basic09 basic09_6809`/`runb_6809` runs automatically when the binaries are missing.

## Test plan
- Verified in a simulated fresh checkout (no pre-built `basic09_6809`/`runb_6809`) that `make PLATFORM=k2` in `recipes/wildbits/l2` now succeeds end-to-end and produces `l2_wildbitsk2.dsk`, whereas it previously failed with the missing-target error.