### PR TITLE
wildbits/feu: Mask interrupts before jumping to kernel in trampoline

### DIFF
--- a/level1/wildbits/feu/trampoline.asm
+++ b/level1/wildbits/feu/trampoline.asm
@@ -55,7 +55,10 @@ l2@                 leax      -1,x
                     bne       l2@
                     deca
                     bne       l1@
-                    
+
+* Mask interrupts before jumping to the kernel.
+                    orcc      #IntMasks
+
 * Jump to the kernel.
                     ldx       #$A000
                     ldy       #$5D00


### PR DESCRIPTION
### Summary
Ensures that 6809 hardware interrupts are masked (`orcc #IntMasks`) before jumping from the Flash FEU bootloader trampoline to the NitrOS-9 kernel entry point (`$A011`). This eliminates, an albeit very unlikely, non-deterministic timing race. More importantly, pressing reset on the physical device consistently reboots NitrOS-9 with no hangs. The reset button now works consistently!

### Rationale
In `level1/wildbits/feu/trampoline.asm`, interrupts are unmasked (`andcc #^IntMasks`) during reset to execute a delay loop and allow temporary `RTI` stubs to absorb any residual power-on keyboard interrupt from the PS/2 controller. However, interrupts were previously left unmasked when jumping into the kernel.

Entering the kernel with interrupts enabled introduces a race condition:
  - On **Wildbits Jr2**: TinyVicky 60 Hz SOF/VBLANK (`INT_VKY_SOF`) or PS/2 keyboard interrupts can trap through half-configured vector tables while MMU slots and low memory are being re-mapped.
  - On **Wildbits K2**: The hardware `INT_WIZFI` line asserts if the WizFi module outputs reset/banner data on boot, causing an immediate crash before the OS driver is loaded.

Adding `orcc #IntMasks` right after the delay loop guarantees a clean, atomic transition into the kernel on both K2 and Jr2.

### Testing
  - Built `recipes/wildbits/feu PLATFORM=jr2 libs booter` cleanly.
  - Verified boot sequence in MAME.