### PR TITLE
wildbits/sysgo: Set default interactive shell parameter to i=/term

### DIFF
--- a/level1/wildbits/modules/sysgo.as
+++ b/level1/wildbits/modules/sysgo.as
@@ -48,7 +48,7 @@ InitScrnL2          equ       *-InitScrn2
 
 ShellPrm            equ       *
                     ifgt      Level-1
-                    fcc       "i=/1"
+                    fcc       "i=/term"
                     endc
 CRtn                fcb       C$CR
 ShellPL             equ       *-ShellPrm


### PR DESCRIPTION
### Summary
Sets the default interactive shell parameter (`ShellPrm`) to `i=/term` for the Wildbits platform in `level1/wildbits/modules/sysgo.as`.

### Problem & Background
On CoCo 3, `SysGo` launches the shell with `i=/1` to bind to the 80-column window descriptor. On Wildbits, the primary console device is `/term`, and no `/1` descriptor exists.

Passing `i=/1` caused `Shell`'s `I$Open("/1")` to fail with `E$PNNF` (Path Name Not Found). The shell handled the error by aborting redirection and falling back to its inherited parent I/O (`/term`). While the system reached a prompt, it relied on a failed open call on every boot and risked hijacking if a `/1` device was ever created.

### Solution
Explicitly pass `i=/term` in `ShellPrm` on Wildbits so `I$Open` succeeds directly without error recovery.

### Verification
* Built Level 2 images for both `PLATFORM=jr2` and `PLATFORM=k2`.
* Verified clean boot to the `{TERM|02}/dd:` prompt using the MAME `wbjr2` emulator.