### PR TITLE
Fix CODEOWNERS typo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @tlindner @strickyak @DrPitre @rlucente-retro @n6il @nitrorobotics @jfed6000 @MatthewMassie
+* @tlindner @strickyak @DrPitre @rlucente-retro @n6il @nitrobotics @jfed6000 @MatthewMassie


### PR DESCRIPTION
@nitrobotics  is the correct spelling


