### PR TITLE
Wb/v8 core, 2nd PR attempt

### DIFF
--- a/defs/wildbits.d
+++ b/defs/wildbits.d
@@ -834,5 +834,15 @@ WizFi_RxD_WR_Cnt    rmb       2
 WizFi_TxD_RD_Cnt    rmb       2
 WizFi_TxD_WR_Cnt    rmb       2
 
+* DIP Switches for Jr/Jr2/K2.. 
+K2_DIP_SW.Base      equ       $FF90
+SW_GAMMA_ON         equ       %10000000
+SW_USER2            equ       %01000000
+SW_USER1            equ       %00100000
+SW_USER0            equ       %00010000
+SW_BOOT_MODE3       equ       %00001000
+SW_BOOT_MODE2       equ       %00000100
+SW_BOOT_MODE1       equ       %00000010
+SW_BOOT_MODE0       equ       %00000001
 
                     ENDC

--- a/level1/wildbits/cmds/wbinfo.as
+++ b/level1/wildbits/cmds/wbinfo.as
@@ -122,8 +122,8 @@ ram@                lbsr      PRINTS
                     fcc       / - RAM/
                     fcb       $0
 turbo@              lda       >K2_DIP_SW.Base
-                    bita      #SW_BOOT_MODE0
-                    beq       exit@               if z=0, the Turbo mode DIP switch is not set
+                    bita      #SW_BOOT_MODE0      0=on, 1=off
+                    bne       exit@               if z=1, the Turbo mode DIP switch is OFF
                     lbsr      PRINTS
                     fcc       " - Turbo"
                     fcb       $0

--- a/level1/wildbits/cmds/wbinfo.as
+++ b/level1/wildbits/cmds/wbinfo.as
@@ -115,20 +115,23 @@ cont@               lbsr      PRINTS
                     cmpa      #$07                is it 7? (meaning this is loaded from RAM)
                     beq       ram@                branch if so
                     lbsr      PRINTS
-                    fcc       / (Flash Mode)/
-                    fcb       C$CR
-                    fcb       C$CR
+                    fcc       / - Flash/
                     fcb       $0
-                    rts
+                    bra       turbo@
 ram@                lbsr      PRINTS
-                    fcc       / (RAM Mode)/
-                    fcb       C$CR
+                    fcc       / - RAM/
+                    fcb       $0
+turbo@              lda       >K2_DIP_SW.Base
+                    bita      #SW_BOOT_MODE0
+                    beq       exit@               if z=0, the Turbo mode DIP switch is not set
+                    lbsr      PRINTS
+                    fcc       " - Turbo"
+                    fcb       $0
+exit@               lbsr      PRINTS
                     fcb       C$CR
                     fcb       $0
+
                     rts
-                    
-
-
 
 next@               lbsr      PUTS                print it
 

--- a/level1/wildbits/cmds/wildspeed.asm
+++ b/level1/wildbits/cmds/wildspeed.asm
@@ -1,0 +1,324 @@
+********************************************************************
+* wildspeed - CPU speed meter for the Wildbits machines
+*
+* Method (edition 2): fixed-time, counted-work. Align on an RTC second
+* edge, then run calibrated 4096-iteration chunks of a 12-cycle inner
+* loop, counting chunks until the RTC reaches the edge exactly 5
+* seconds later. MHz follows from chunks completed:
+*
+*   cycles/chunk = 4096*12 + 56 (exact, cycle-counted epilogue) = 49208
+*   MHz*100      = hi16( chunks * 64498 + $8000 )   (rounded)
+*                  (64498 = round(65536*49208/50000))
+*
+* Timing edges: RTC seconds register, raw BCD compares (fixed-cost
+* hardware poll, no syscalls, no data-dependent conversion in the
+* loop). IRQs are MASKED for the whole 5s window, so no tick/driver
+* ISR time pollutes the count - the OS software clock ends ~5s slow
+* (setime/ntptime to resync). Remaining error: one-chunk edge
+* quantization (~0.16%) plus the RTC crystal itself.
+*
+* Edt/Rev  YYYY/MM/DD  Modified by
+* Comment
+* ------------------------------------------------------------------
+*   2      2026/08/21  fixed-time counted-work rewrite; r2: exact
+*                      epilogue accounting + IRQ-masked window
+                nam       wildspeed
+                ttl       wildspeed
+
+                ifp1
+                use       defsfile
+                endc
+
+tylg            set       Prgrm+Objct
+atrv            set       ReEnt+rev
+rev             set       $00
+edition         set       2
+
+CHUNKITER       equ       4096                inner iterations per chunk
+* cycles/chunk = 4096*12 inner + 56 exact overhead (counted below) = 49208
+* MHZFACTOR    = round(65536*49208/50000) = 64498
+MHZFACTOR       equ       64498
+TESTSECS        equ       5
+
+                mod     eom,name,tylg,atrv,start,size
+
+StartSec        rmb     1                   RTC second at aligned start (BCD)
+TargetSec       rmb     1                   BCD second that ends the run
+Chunks          rmb     2                   completed chunk count
+MulA            rmb     2                   multiplicand scratch
+MulB            rmb     2                   multiplier scratch
+Prod            rmb     4                   32-bit product
+Rem             rmb     1                   Div16x8 remainder scratch
+DecBuf          rmb     2                   two ASCII digits (Byte2Dig out)
+IntBuf          rmb     2                   integer-part ASCII digits
+bufstrt         rmb     2
+bufcur          rmb     2
+linebuf         rmb     80
+                rmb     250                 stack
+size            equ     .
+
+name            fcs     /wildspeed/
+                fcb     edition
+
+start           leax    linebuf,u           output buffer address
+                stx     <bufstrt
+                stx     <bufcur
+
+                leax    Banner,pcr
+                lda     #1
+                ldy     #BannerLen
+                os9     I$WritLn
+
+                leax    MsgRunning,pcr
+                lda     #1
+                ldy     #MsgRunningLen
+                os9     I$WritLn
+
+* --- measure with IRQs masked: no tick/driver ISR time in the count.
+* The RTC runs in hardware regardless. The OS misses ~TESTSECS*60 ticks,
+* so its software clock ends ~5s slow (setime/ntptime to resync).
+                orcc    #IntMasks
+
+* --- align on an RTC second edge (raw BCD compares) ---
+                lbsr    GetRTCraw           A = current RTC second, BCD
+                sta     <StartSec
+align@          lbsr    GetRTCraw
+                cmpa    <StartSec
+                beq     align@              spin until the second rolls
+                sta     <StartSec           this instant is t=0
+* target = (start + TESTSECS) mod 60, in binary, then back to BCD
+                lbsr    bcd2binA            B = binary seconds
+                addb    #TESTSECS
+                cmpb    #60
+                blo     tgt@
+                subb    #60
+tgt@            tfr     b,a
+                lbsr    bin2bcd             A = target as BCD
+                sta     <TargetSec
+
+                clra
+                clrb
+                std     <Chunks
+
+* --- counted work: 12-cycle inner loop, CHUNKITER iterations/chunk ---
+* Chunk overhead is EXACT and folded into MHZFACTOR - keep in sync:
+*   ldx 3 + 4096*12 + ldd 5 + addd 4 + std 5 + ldx 3 + lda 5 + ora 2
+*   + sta 5 + lda 5 + ldb 5 + andb 2 + stb 5 + cmpa 4 + bne 3 = 49208
+chunk@          ldx     #CHUNKITER          3
+inner@          nop                         2 cycles
+                nop                         2
+                leax    -1,x                5
+                bne     inner@              3  => 12 cycles/iteration
+                ldd     <Chunks             5
+                addd    #1                  4
+                std     <Chunks             5
+                ldx     #$FE40              3
+                lda     RTC_CTRL,x          5
+                ora     #(RTC_UTI|RTC_24HR) 2  latch registers
+                sta     RTC_CTRL,x          5
+                lda     RTC_SEC,x           5  BCD seconds
+                ldb     RTC_CTRL,x          5
+                andb    #^(RTC_UTI)         2  unlatch
+                stb     RTC_CTRL,x          5
+                cmpa    <TargetSec          4  raw BCD compare
+                bne     chunk@              3  not 5 seconds yet
+                andcc   #^IntMasks          measurement done: IRQs back on
+
+* --- MHz*100 = hi16( Chunks * MHZFACTOR ), rounded ---
+                ldd     <Chunks
+                ldx     #MHZFACTOR
+                lbsr    Mul16               D = hi16 of the product
+                pshs    d
+                ldd     <Prod+2             low word decides rounding
+                cmpd    #$8000
+                puls    d
+                blo     nornd@
+                addd    #1                  round the hi word up
+nornd@          equ     *
+
+* split into integer and fraction
+                tfr     d,x
+                lda     #100
+                lbsr    Div16x8             X = integer MHz, B = fraction
+                pshs    b                   save fraction (0-99)
+                tfr     x,d
+                tfr     b,a                 integer MHz (shown as 2 digits)
+                lbsr    Byte2Dig
+                ldd     <DecBuf
+                std     <IntBuf
+                puls    a
+                lbsr    Byte2Dig            DecBuf = fraction digits
+
+                lda     <IntBuf
+                cmpa    #'0'                suppress a leading zero
+                beq     ones@
+                lbsr    bufchr
+ones@           lda     <IntBuf+1
+                lbsr    bufchr
+                lda     #'.'
+                lbsr    bufchr
+                lda     <DecBuf
+                lbsr    bufchr
+                lda     <DecBuf+1
+                lbsr    bufchr
+                leay    mhztxt,pcr
+                lbsr    tobuf
+                lbsr    wrbuf
+
+                clrb
+                os9     F$Exit
+
+* =============================================
+* Read raw BCD RTC seconds into A; preserves X.
+* Toggle UTI to latch the external registers, read, untoggle.
+GetRTCraw           pshs      x,b
+                    ldx       #$FE40              RTC base address
+                    lda       RTC_CTRL,x
+                    ora       #(RTC_UTI|RTC_24HR) UTI on: latch registers
+                    sta       RTC_CTRL,x
+                    ldb       RTC_SEC,x           BCD seconds
+                    lda       RTC_CTRL,x
+                    anda      #^(RTC_UTI)         UTI off again
+                    sta       RTC_CTRL,x
+                    tfr       b,a
+                    puls      x,b,pc
+
+* Convert BCD in A to binary in B.
+bcd2binA            clrb
+loop@               cmpa      #$10
+                    bcs       out@
+                    addd      #$F00A              A -= $10, B += 10
+                    bra       loop@
+out@                pshs      a
+                    addb      ,s+
+                    rts
+
+* Convert binary A (0-59) to BCD in A.
+bin2bcd             pshs      b
+                    clrb
+b2loop@             cmpa      #10
+                    bcs       b2out@
+                    suba      #10
+                    addb      #$10                bump tens nibble
+                    bra       b2loop@
+b2out@              pshs      b
+                    adda      ,s+
+                    puls      b,pc
+
+* =============================================
+* Mul16: D * X -> 32-bit product in Prod; returns hi 16 bits in D.
+Mul16
+        std     <MulA
+        stx     <MulB
+        clr     <Prod
+        clr     <Prod+1
+        lda     <MulA+1
+        ldb     <MulB+1
+        mul                             lo*lo
+        std     <Prod+2
+        lda     <MulA
+        ldb     <MulB+1
+        mul                             hi*lo -> middle
+        addd    <Prod+1
+        std     <Prod+1
+        bcc     m1@
+        inc     <Prod
+m1@     lda     <MulA+1
+        ldb     <MulB
+        mul                             lo*hi -> middle
+        addd    <Prod+1
+        std     <Prod+1
+        bcc     m2@
+        inc     <Prod
+m2@     lda     <MulA
+        ldb     <MulB
+        mul                             hi*hi -> top
+        addd    <Prod
+        std     <Prod
+        ldd     <Prod                   D = hi16
+        rts
+
+* =============================================
+* Div16x8: divide 16-bit X by 8-bit A.
+* Returns: X = quotient, B = remainder.
+Div16x8
+        pshs    a                       save divisor
+        clr     <Rem
+        ldb     #16
+DivLoop
+        pshs    x
+        lsl     1,s                     shift low byte left
+        rol     0,s                     rotate high byte left
+        puls    x
+        rol     <Rem                    old MSB of X into remainder
+        lda     <Rem
+        cmpa    ,s
+        blo     DivSkip
+        suba    ,s
+        sta     <Rem
+        leax    1,x                     set quotient bit
+DivSkip
+        decb
+        bne     DivLoop
+        ldb     <Rem
+        puls    a,pc
+
+* =============================================
+* Byte2Dig: A (0-99) -> two ASCII digits in DecBuf (tens, ones).
+Byte2Dig
+        clrb
+BD10    cmpa    #10
+        blo     BDDone
+        suba    #10
+        incb
+        bra     BD10
+BDDone  adda    #'0'
+        sta     <DecBuf+1               ones
+        tfr     b,a
+        adda    #'0'
+        sta     <DecBuf                 tens
+        rts
+
+* =============================================
+* Data
+Banner  fcc     "=== Foenix F256 FNX6809 MHz Meter (5s counted-work) ==="
+        fcb     $0D
+BannerLen equ   *-Banner
+
+MsgRunning fcc  "Counting for 5 RTC seconds (tick ISR time included)..."
+        fcb     $0D
+MsgRunningLen equ *-MsgRunning
+
+mhztxt  fcs     / MHz/
+
+* Store A at next position in output buffer.
+bufchr              pshs      x
+                    ldx       <bufcur
+                    sta       ,x+
+                    stx       <bufcur
+                    puls      pc,x
+
+* Append CR to the output buffer then print the output buffer.
+wrbuf               pshs      y,x,a
+                    lda       #C$CR
+                    bsr       bufchr
+                    ldx       <bufstrt
+                    stx       <bufcur
+                    ldy       #80
+                    lda       #$01
+                    os9       I$WritLn
+                    puls      pc,y,x,a
+
+* Append string at Y to output buffer.  Terminated by MSB=1.
+tobuf               pshs      a
+bufloop             lda       ,y
+                    anda      #$7F
+                    bsr       bufchr
+                    tst       ,y+
+                    bpl       bufloop
+                    puls      a
+                    rts
+
+                emod
+eom             equ *
+                end

--- a/level1/wildbits/modules/wizfi.asm
+++ b/level1/wildbits/modules/wizfi.asm
@@ -42,17 +42,24 @@
 *   "> " prompt wait and the reply purge (pop lines until "SEND OK" or
 *   "ERROR") can no longer wedge the writer - the old fixed 4-LF purge
 *   hung forever under ATE0 with IRQs masked.
+*
+*          2026/08/26  Roger Taylor
+* Timer0 machinery removed: the K2 architecture is now the ONLY code
+* path (Jr2 included). Init installs the WizFi F$IRQ packet on all
+* machines; the ISR just clears the edges and drains the output ring;
+* Read direct-pops the FIFO with tick-sleep blocking; WritSlp drains
+* the ring itself and tick-polls instead of suspending on a wake that
+* needed the Tx edge. No interrupt is load-bearing: the driver runs
+* unchanged on bitstreams without the WizFi edges. Interrupt equates
+* moved to wildbits.d (INT_WIZFI = Rx+Tx bits). Known gap: a byte
+* ParkOther hands to another socket's slot is not yet picked up by
+* that socket's direct-pop reader (concurrent multi-socket only).
 
                     ifp1
                     use       defsfile
                     endc
 
 
-* INT_TIMER_0 (25.175Mhz-based timer)
-* 25,175,000 / 11520 Bytes Per Second  = 2185 ticks @ 25.175Mhz (8, 137)
-* 25,175,000 / 92160 Bytes Per Second  =  273 ticks @ 25.175Mhz (1,  17)
-
-TRATE               equ       350                 Tweak for goldilox (300 = quick response) (800 = choppy response)
 D.WZStatTbl         equ       D.SWPage            Borrowed from incompatible SmartWatch variable
 WORK_SLOT	    equ       MMU_SLOT_2
 MMU_WINDOW          equ       $4000
@@ -169,19 +176,11 @@ strConnect          fcc       "0,CONNECT"
 strCipSend          fcc       "AT+CIPSEND="
                     fcb       0
 
-* WizFi requires a high-speed hardware IRQ service.
-* Clock-based VIRQ has never worked out.
 ***********************************************************************************
 * F$IRQ packet.
-*
-T0IRQ_Pckt          equ       *
-T0IRQ_Pckt.Flip     fcb       %00000000           the flip byte
-T0IRQ_Pckt.Mask     fcb       INT_TIMER_0         the mask byte for machines without actual WizFi Interrupt
-                    fcb       $F1                 the priority byte
-
-* One F$IRQ entry serves BOTH WizFi sources: the mask byte carries the Rx
-* data edge and the Tx drain-complete edge; iService clears and services
-* whichever fired (the send path runs first either way).
+* One F$IRQ entry serves BOTH WizFi sources: INT_WIZFI (defs) carries
+* the Rx data edge and the Tx drain-complete edge; iService clears and
+* services whichever fired.
 WIIRQ_Pckt          equ       *
 WIIRQ_Pckt.Flip     fcb       %00000000           the flip byte
 WIIRQ_Pckt.Mask     fcb       INT_WIZFI           the mask byte for the WizFi interrupts
@@ -230,35 +229,22 @@ c@                  clr       ,x+
                     decb
                     bne       c@
 
-* K2 (machine ID $16) has the WizFi hardware interrupt wired; other
-* machines (Jr2 = $1A) poll via Timer0. NOTE: the interrupt is NOT
-* unmasked here on either path - unmasking before F$IRQ install (or
-* before the ind_* pointers exist) let the first interrupt run iService
-* through null pointers / with no handler: storm, dead before shell
-* (proven by LED probe 2026-08-20). Pending cleared, handler installed,
-* everything initialized, THEN unmask at the end of Init.
-Init2               lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupt?
-                    bne       InstallTimer0       no: poll via Timer0
-InstallWizIRQ       lda       #INT_WIZFI
+* Both machines (K2 $16, Jr2 $1A) use the WizFi hardware edges (defs:
+* INT_WIZFI = Rx-data + Tx-drain bits); the Timer0 polling machinery is
+* gone (2026-08-26 reduction). The ISR is only a latency optimizer -
+* receive is reader-polled and Write drains synchronously - so the
+* driver stays fully functional on bitstreams where the edges never
+* fire. NOTE: the interrupt is NOT unmasked here -
+* unmasking before F$IRQ install (or before the ind_* pointers exist)
+* let the first interrupt run iService through null pointers / with no
+* handler: storm, dead before shell (proven by LED probe 2026-08-20).
+* Pending cleared, handler installed, everything initialized, THEN
+* unmask at the end of Init.
+Init2               lda       #INT_WIZFI
                     sta       >INT_PENDING_3       clear any stale latched pendings
                     ldd       #INT_PENDING_3       polling address for the packet
                     leax      WIIRQ_Pckt,pcr       point to the IRQ packet
-                    bra       Install
-InstallTimer0       ldd       #TRATE
-                    sta       T0_VAL+0            registers are still Little Endian?
-                    stb       T0_VAL+1
-                    clr       T0_VAL+2
-                    lda       #%00000001
-                    sta       >T0_CTR
-                    lda       #%00000010          Timer reloads Value, for continuous run
-                    sta       >T0_CMP_CTR
-                    lda       #INT_TIMER_0
-                    sta       >INT_PENDING_0      clear any pending from the just-started timer
-                    ldd       #INT_PENDING_0      get the pending interrupt pending address
-                    leax      T0IRQ_Pckt,pcr      point to the IRQ packet
-
-Install             leay      iService,pcr        and the service routine
+                    leay      iService,pcr        and the service routine
                     os9       F$IRQ               install the interrupt handler
 * NOTE: interrupt is NOT unmasked here. The ind_* hardware pointers are
 * initialized further down; unmasking before they exist let the first
@@ -303,17 +289,9 @@ Install             leay      iService,pcr        and the service routine
 *                    stb       MasterRxDBlock,u
 
 * Everything initialized (incl. ind_* pointers): NOW enable the source.
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupt?
-                    bne       unmt0@
                     lda       >INT_MASK_3
-                    anda      #^(INT_WIZFI)       enable Rx data + Tx drain edges
+                    anda      #^(INT_WIZFI)       enable both WizFi edges
                     sta       >INT_MASK_3
-                    bra       unmx@
-unmt0@              lda       >INT_MASK_0
-                    anda      #^INT_TIMER_0       enable the TIMER_0 interrupt
-                    sta       >INT_MASK_0
-unmx@               equ       *
 InitExit            puls      y
                     puls      cc,dp,pc            recover IRQ/Carry status, system DP, return
 
@@ -327,20 +305,13 @@ Term                clrb                          default to no error...
                 *     ora       ,s+
                 *     sta       >INT_MASK_0          and save it back
 
-* Silence our interrupt sources BEFORE removing the handler: a Tx
-* drain-complete (or Rx) edge landing after removal has no handler.
+* Silence our interrupt sources BEFORE removing the handler: an edge
+* landing after removal has no handler.
                      orcc      #IntMasks
-                     lda       SYS0_MACHINE_ID
-                     cmpa      #$16                K2 with hardware WizFi interrupts?
-                     bne       tmt0@
                      lda       >INT_MASK_3
                      ora       #INT_WIZFI          mask both WizFi edges
                      sta       >INT_MASK_3
-                     bra       tmx@
-tmt0@                lda       >INT_MASK_0
-                     ora       #INT_TIMER_0        mask the poll timer
-                     sta       >INT_MASK_0
-tmx@                 ldx       #$0000              remove IRQ table entry
+                     ldx       #$0000              remove IRQ table entry
                      os9       F$IRQ
 
                 *     pshs      u                   save data pointer
@@ -475,76 +446,16 @@ srpe@               cmpb      #'S                 "SEND OK" line?
 xx@                 andcc     #^Zero              sent a burst: return Z clear
 sr9@                puls      y,pc
 
+* ISR: clear the edge and opportunistically drain the output ring.
+* Receive is entirely reader-driven (Read polls and pops the hardware
+* FIFO); writers never suspend (Write drains synchronously, WritSlp
+* drains and tick-polls) - so the ISR wakes nobody and touches no RAM
+* state. It is a latency optimization, not a dependency: the driver is
+* fully functional even if this never runs.
 iService            pshs      cc,dp,x
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupts?
-                    bne       ClearTimer0
-                    lda       #INT_WIZFI          clear whichever fired: Rx data
-                    sta       >INT_PENDING_3      edge and/or Tx drain-complete edge
-                    bra       iSendPkt
-ClearTimer0         lda       #INT_TIMER_0
-                    sta       >INT_PENDING_0
-iSendPkt            lbsr      SendRing            drain any queued output first
-                    lbeq      iRead               nothing was queued: service receive
-                    lbra      iWake               sent a burst: wake any sleeper
-*                    lbra      iExit               Return from ISR, no payload update
-
-iRead
-* K2: the ISR does NOTHING for receive - not even a status read. Every
-* RX defense that consulted the vpr page was poisoned by it (measured:
-* the no-sleeper gate read spurious vpr_wake and popped 5 bytes with no
-* reader). Read polls and pops the hardware FIFO directly; blocked
-* readers tick-sleep on the FIFO count. The marginal-SRAM page is fully
-* out of the K2 receive path. Timer machines keep the parked path.
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupts?
-                    lbeq      iExit               yes: RX is reader-driven only
-                    ldb       DevChan,u           Get the connection/channel # for the current device
-                    lbsr      GetVpPtr            Point to associated payload
-                    lda       vpr_stat,x          Has the mainline code signaled that it has consumed the last data byte?
-                    lbmi      iThrottle           No: just exit - the Timer0 poll retries next tick
-                    lbsr      RxFCheck            Are there any pending RxD FIFO bytes?
-                    lbeq      iExit               Return from ISR, no payload update
-
-                    lda       [ind_DataReg,u]     Pop next FIFO byte
-                    ldb       DeviceMode,u        Device descriptor has the Packets bit set
-                    lbeq      iBroadcast          Device is using the WizFi360 passthrough/raw mode
-                    lbsr      PktByte             run byte through the +IPD machine
-                    lbeq      iExit               header/bookkeeping byte: consumed
-iBroadcast          ldb       PacketChannel,u
-                    lbsr      GetVpPtr
-                    ldb       PacketChannel,u
-                    orb       #$80
-                    stb       vpr_stat,x
-                    sta       vpr_data,x
-
-iWake               ldb       PacketChannel,u
-                    lbsr      GetVpPtr
-                    clrb                          clear Carry (for exit) and LSB of process descriptor address
-                    lda       vpr_wake,x          anybody waiting? ([D]=process descriptor address)
-                    beq       iExit               no, go return...
-                    stb       vpr_wake,x          mark I/O done
-                    tfr       d,x                 copy process descriptor pointer
-                    lda       P$State,x           get state flags
-                    anda      #^Suspend           clear suspend state
-                    sta       P$State,x           save state flags
-
-* Driver-side flow control, so the driver survives WITHOUT the kernel's
-* DoneIRQ mask-on-carry pacing (i.e. with the mainline clrb DoToggle):
-* the payload buffer holds ONE byte; returning with it full and our
-* interrupt enabled lets the module re-interrupt before the reader can
-* ever consume (boot chatter at 'iniz wz' kills the machine before
-* shell). Mask our source here; Read unmasks after consuming.
-* Timer0 machines are paced by the timer and are left alone.
-* Buffer full: on the hardware-IRQ K2, mask our interrupt until the
-* reader consumes (Read unmasks); Timer0 machines just wait for the
-* next tick - the timer paces the polling.
-iThrottle           lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupt?
-                    bne       iExit               no: timer paces the polling
-                    lda       >INT_MASK_3
-                    ora       #INT_WIZFI          mask the WizFi interrupt
-                    sta       >INT_MASK_3
+                    lda       #INT_WIZFI          clear whichever edge fired
+                    sta       >INT_PENDING_3
+                    lbsr      SendRing            drain any queued output
 * Return with carry explicitly CLEAR ('interrupt serviced'): the entry
 * CC pushed at iService would otherwise be returned as-is - a random
 * carry handed to the kernel's IRQ tail, which masks IRQs on carry set.
@@ -629,40 +540,14 @@ ParkOther           pshs      a
                     sta       P$State,x
 po9@                rts
 
-ReadSlp             ldb       DevChan,u
-                    lbsr      GetVpPtr
-                    ldd       >D.Proc             Level II process descriptor address
-                    sta       vpr_wake,x           V.WAKE,u             save MSB for IRQ service routine
-                    tfr       d,x                 copy process descriptor address
-                    ldb       P$State,x
-                    orb       #Suspend
-                    stb       P$State,x
-                    lbsr      Sleep1              go suspend process...
-                    ldx       >D.Proc             process descriptor address
-                    ldb       P$Signal,x          pending signal for this process?
-                    beq       c@                  no, go check process state...
-                    cmpb      #S$Intrpt           do we honor signal?
-                    lbls      ErrExit             yes, go do it...
-c@                  ldb       P$State,x
-                    bitb      #Condem
-                    lbne      PrAbtErr            yes, go do it...
-                    ldb       DevChan,u
-                    lbsr      GetVpPtr
-                    ldb       vpr_wake,x           V.WAKE,u            true interrupt?
-                    beq       ReadD               yes, go read the char.
-                    bra       ReadSlp             no, go suspend the process
-
 * x bits 1..0 is socket #, bit 4 = isPacketChannel	ldd <V.PORT
 Read                clrb                          default to no errors...
                     pshs      cc,dp               save IRQ/Carry status, system DP
 
 ReadD               orcc      #IntMasks
-* K2: fully vpr-free receive - poll and pop the hardware FIFO directly;
-* when empty, tick-sleep and re-poll (signals honored). No parking, no
-* wake handshake, no marginal-SRAM round-trips anywhere in the path.
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupts?
-                    bne       rdtmr@              timer machines: parked path as always
+* Both machines: fully vpr-free receive - poll and pop the hardware FIFO
+* directly; when empty, tick-sleep and re-poll (signals honored). No
+* parking, no wake handshake, no marginal-SRAM round-trips in the path.
 rdk2@               lbsr      RxFCheck            bytes waiting in the hardware FIFO?
                     beq       rdk2w@              no: tick-sleep and re-poll
                     lda       [ind_DataReg,u]     pop directly
@@ -687,27 +572,6 @@ rdk2c@              ldb       P$State,x
                     bitb      #Condem
                     lbne      PrAbtErr
                     bra       rdk2@
-rdtmr@              ldb       DevChan,u
-                    lbsr      GetVpPtr
-                    ldb       vpr_stat,x
-                    lbpl      ReadSlp             nothing parked: sleep for the tick
-rdgo@               andb      #3
-                    stb       vpr_stat,x           Notify the hub that we've taken our data
-                    cmpb      DevChan,u
-                    lbne      ReadSlp
-                    lda       vpr_data,x           Get our data
-* Byte consumed: on the hardware-IRQ K2, re-enable the interrupt that
-* iThrottle masked. IRQs are masked here (orcc at ReadD): race-free RMW.
-rdunm@              pshs      a
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupts?
-                    bne       u@
-                    lda       >INT_MASK_3
-                    anda      #^INT_WIZFI          unmask the WizFi interrupt
-                    sta       >INT_MASK_3
-u@                  puls      a
-                    puls      cc,dp,pc            recover IRQ/Carry status, dummy B, system DP, return
-
 
 PrAbtErr            ldb       #E$PrcAbt
                     bra       ErrExit
@@ -733,16 +597,14 @@ NRdyErr             ldb       #E$NotRdy
 UnSvcErr            ldb       #E$UnkSvc
                     bra       ErrExit
 
-WritSlp             ldb       DevChan,u
-                    lbsr      GetVpPtr
-                    ldd       >D.Proc             Level II process descriptor address
-                    sta       vpr_wake,x             save MSB for IRQ service routine
-                    tfr       d,x                 copy process descriptor address
-                    ldb       P$State,x
-                    orb       #Suspend
-                    stb       P$State,x
-                    lbsr      Sleep1              go suspend process...
-                    ldx       >D.Proc             process descriptor address
+* Ring full: drain it ourselves (IRQs are masked - no ISR race), give
+* up a tick honoring signals, and retry. No suspend, no wake handshake:
+* the writer never depends on an interrupt to make progress. In packet
+* mode a full ring flushes as one CIPSEND mid-line - acceptable, and
+* only reachable when a single line exceeds the 256-byte ring.
+WritSlp             lbsr      SendRing            push the ring into the TX FIFO
+                    lbsr      Sleep1              breathe, honor signals
+                    ldx       >D.Proc
                     ldb       P$Signal,x          pending signal for this process?
                     beq       c@                  no, go check process state...
                     cmpb      #S$Intrpt           do we honor signal?
@@ -750,11 +612,7 @@ WritSlp             ldb       DevChan,u
 c@                  ldb       P$State,x
                     bitb      #Condem
                     lbne      PrAbtErr            yes, go do it...
-                    ldb       DevChan,u
-                    lbsr      GetVpPtr
-                    ldb       vpr_wake,x            true interrupt?
-                    beq       WriteD               yes, go read the char.
-                    bra       WritSlp             no, go suspend the process
+                    bra       WriteD              ring drained: lay the byte down
 
 Write               clrb                          default to no error...
                     pshs      cc,a                save IRQ/Carry status, Tx character, system DP
@@ -769,20 +627,15 @@ WriteD              orcc      #IntMasks
                     abx
                     lda       1,s
                     sta       ,x
-* Background-send kick (hardware-IRQ machines only). Raw mode drains the
-* ring on EVERY byte; packet mode only on CR/LF so an AT line becomes ONE
+* Synchronous send kick (both machines). Raw mode drains the ring on
+* EVERY byte; packet mode only on CR/LF so an AT line becomes ONE
 * CIPSEND instead of one per character. The drain is UNCONDITIONAL - the
 * 2048-byte hardware TX FIFO does the pacing. Gating this on "TX FIFO
 * empty" (the old prime) stranded bytes in the ring whenever the FIFO
-* was momentarily busy: with no autonomous TX drain (old bitstreams have
-* no Tx edge) the tail of a command sat in the ring until the NEXT
-* session's first Write pushed it, mangling command boundaries (proven:
-* AT+SLEEP=0 arrived as "AT+SLEEP=" + next-session prefix "0"). On new
-* bitstreams the Tx drain-complete edge is now just a safety net.
+* was momentarily busy: the tail of a command sat in the ring until the
+* NEXT session's first Write pushed it, mangling command boundaries
+* (proven: AT+SLEEP=0 arrived as "AT+SLEEP=" + next-session prefix "0").
 * IRQs are masked above, so there is no race with the ISR.
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupts?
-                    bne       WrExit              no: the poll timer paces sending
                     ldb       DeviceMode,u
                     beq       WrKick              raw mode: drain on every byte
                     lda       1,s                 packet mode: flush on end of line
@@ -806,16 +659,11 @@ GStt                clrb                          default to no error...
                     lda       vpr_stat,x
                     puls      x
                     bmi       Rdy1                payload byte already delivered
-* Payload empty. On the hardware-IRQ K2 the Rx FIFO can hold bytes with
-* NO edge pending (boot chatter predates Init; bursts behind a consumed
-* edge). Count those as ready so the reader calls Read, whose pump
-* actually delivers them - otherwise SS.Ready pollers (modem's listen
-* loop) spin forever on data that is sitting in the FIFO.
-* (Packet mode: FIFO content may be just header chars, so a Read after
-* this can still block briefly until real payload arrives.)
-                    lda       SYS0_MACHINE_ID
-                    cmpa      #$16                K2 with hardware WizFi interrupts?
-                    lbne      NRdyErr             timer machines: next tick delivers
+* Payload empty: report ready when the hardware FIFO holds bytes so the
+* poller calls Read, whose pump actually delivers them - otherwise
+* SS.Ready pollers (modem's listen loop) spin forever on data that is
+* sitting in the FIFO. (Packet mode: FIFO content may be just header
+* chars, so a Read after this can still block until real payload.)
                     lbsr      RxFCheck            anything in the hardware FIFO?
                     lbeq      NRdyErr             no: genuinely not ready
 Rdy1                ldb       #1                  at least one byte is available

--- a/level2/wildbits/startup
+++ b/level2/wildbits/startup
@@ -1,3 +1,3 @@
 load utilpak1
 link shell
-iniz wz
+wbinfo

--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -36,7 +36,7 @@ FUJINET ?= 0
 FM ?= 0
 
 BOOT_RBF ?= dds0
-RBF = rbf rbsuper llwbsd rbmem $(BOOT_RBF) s1 f0 f1 $(RBF_EXTRA)
+RBF = rbf rbsuper llwbsd rbmem $(BOOT_RBF) s0 s1 f0 f1 c0 c1 $(RBF_EXTRA)
 SCF = scf vtio $(KEYSUB) term bannerfont palette $(SCF_EXTRA)
 ifeq ($(LEVEL),2)
 SCF += mousedrv_ps2
@@ -82,8 +82,8 @@ CMDS_EXTRA += $(FM_CMDS)
 endif
 CMDS += $(STDCMDS) shell \
 	bootos9 scfg wbinfo wbreset modem \
-	inetd telnet dw httpd $(BASIC09) $(BF) \
-	$(CMDS_EXTRA)
+inetd telnet dw httpd $(BASIC09) $(BF) \
+	$(CMDS_EXTRA) wildspeed
 
 ifeq ($(LEVEL),2)
 UTILPAK1_MODS = attr copy date del deiniz dir display list makdir mdir \
@@ -173,7 +173,7 @@ else
 $(DSKIMAGE): bootfile $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(FEU_STARTUP) wildbits-sys-assets $(RECIPE_DEPS)
 endif
 	$(RM) $@
-	$(OS9FORMAT_CMD) -q $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
+	$(OS9FORMAT_CMD) -q -e $@ -n"NitrOS-9/$(CPU) Level $(LEVEL)"
 	$(OS9COPY) bootfile $@,OS9Boot
 ifeq ($(LEVEL),2)
 	$(OS9COPY) $(MODDIR)/sysgo $@,sysgo


### PR DESCRIPTION
Overhaul WizFi to use INT_WIZFI interrupts.
Update wbinfo to show - Turbo status (DIP switch https://github.com/nitros9project/nitros9/pull/1)
Remove iniz wz from startup AGAIN. Only the end user needs to put that there.
Update Modem command, fix bugs.
