### PR TITLE
DriveWire hardening

### DIFF
--- a/docs/wildbits-drivewire-hardening.md
+++ b/docs/wildbits-drivewire-hardening.md
@@ -1,0 +1,173 @@
+# WildBits DriveWire Serial Driver Hardening
+
+**Dates:** 2026-08-28 / 2026-08-29
+**Files changed:**
+- `level1/wildbits/modules/dwinit_wildbits_serial.asm` (baud divisor)
+- `level1/wildbits/modules/dwread_wildbits_serial.asm` (timeout purge)
+- `level1/wildbits/modules/dwwrite_wildbits_serial.asm` (bounded TX wait)
+- `level1/modules/rbdw.asm` (protocol completion + error-path resync,
+  all additions `ifne wildbits` so other ports assemble byte-identical)
+
+## Background
+
+DriveWire on the K2 had a long-standing failure pattern under sustained
+`/x1` traffic: successful transfers, then an error #244 (`E$Read`),
+then cascades of strange errors (#214, #216, #254) ending in a machine
+frozen at the shell. The campaign found one root cause in the FPGA core
+and a chain of structural weaknesses in the driver stack. Each fix was
+validated against DriveWire 4 server logs captured in the field; each
+subsequent log exposed the next layer.
+
+## Root cause 1 (FPGA core, fixed in v8_rc3): UART baud error
+
+The UART's baud generator ran from the raw 25.175MHz clock, where no
+divisor lands on a standard rate: the closest speed to 230,400 was
+**224,777 baud (-2.4%)** — just inside 8N1 tolerance, so links worked
+until sustained traffic found the margin. The v8_rc3 cores add a
+fractional clock-enable running the baud generator at exactly
+22.1184MHz, making standard rates exact. The paired driver change is
+`dwinit` writing divisor **5** (= 230,400 exactly) instead of 6.
+Core and disk deploy as a pair; either half alone leaves the UART at a
+dead rate. Field result: frequent crash-under-load became a rare,
+occasional #244 — which exposed everything below.
+
+## Root cause 2 (driver): DWWrite could hang the machine forever
+
+`DWWrite` waited on the transmitter-empty flag with no timeout, inside
+an interrupt-masked section — the driver's only true infinite-spin
+path. **Fix:** the drain wait is bounded (~65k polls per byte); a
+wedged transmitter now abandons the packet and surfaces as an ordinary
+error with interrupts restored.
+
+## Root cause 3 (protocol): aborting a read desynced the SERVER
+
+On a failed sector read the stock driver jumps to its error exit
+without sending the 2-byte checksum the server is still blocked
+waiting for. The server then consumes the next command's first bytes
+as "the checksum" — server-side frame slip, visible in the DW4 log as
+`UNKNOWN OPCODE` warnings and requests for garbage LSNs.
+**Fix (`ReadAbort`):** on any failed read, send a deliberately-wrong
+checksum and collect the status byte before erroring out, so both
+parsers stay framed. Field-verified: `UNKNOWN OPCODE` disappeared from
+subsequent failure logs.
+
+## Root cause 4 (driver): an off-by-N stream never resyncs itself
+
+A byte lost mid-sector leaves every later transfer shifted: reads
+complete *promptly* with wrong data, so a timeout-based purge never
+fires, every checksum fails at the server, and the "status byte" the
+client reads is actually a shifted data byte — which the stock driver
+returned verbatim as the error code. That is where the mystery #214 /
+#216 / #254 reports came from.
+**Fixes:** a receive purge (`PurgeRX`) runs on **every** failed
+transaction, not only timeouts; and a status byte that is neither OK
+nor E$CRC is treated as proof of desync (purge + honest #244) instead
+of being passed through as an error number.
+
+## Root cause 5 (server-side stalls): the late sector remainder
+
+The remaining field failure had a distinct signature: the server log
+shows `OP_READEX took ~620ms` — a Java GC / scheduler stall in the DW4
+server mid-sector. The client times out, aborts cleanly, purges — and
+finds a silent line, *because the server is still stalled*. The server
+then wakes and transmits the rest of the sector into a client that has
+stopped listening: 16 bytes land in the RX FIFO, the rest overrun, and
+(in this 16750 core) the overrun can wedge FIFO pointer state in a way
+that byte-draining never clears. Every later transfer arrives corrupt;
+RBF's directory searches read garbage (#216 Path Not Found on
+subsequent files); the OS descends into an unbounded retry storm that
+presents as a freeze (interrupts are masked for nearly the whole duty
+cycle while the DW4 log keeps scrolling).
+**Fixes (2026-08-29, current build):**
+- `PurgeRX` now strobes the UART's **FCR RX-FIFO hardware reset** on
+  entry, clearing any overrun-wedged FIFO state.
+- The purge idle window was stretched from ~0.6ms to **~200-350ms**,
+  long enough to outlast a server stall and consume the late-arriving
+  sector remainder in real time before declaring the line clean.
+
+## Root cause 6 (driver): the retry loop SUSTAINED a lagged stream
+
+The decisive field log (2026-08-29 13:14, first error #216 then lockup)
+showed the post-stall end-state exactly: every read *completes* — the
+server always receives a full checksum and answers — yet every checksum
+fails, forever, with sane opcodes and no timeouts. That is a client
+running **one response behind**: a whole stale response (256 bytes +
+status) queued ahead in the stream. Each read consumes the *previous*
+transaction's data, fails the server CRC, gets E$CRC — and the E$CRC
+retry path went straight back to OP_REREADEX **without purging**, so
+the retry re-read the stale response and the desync sustained itself
+through all retries, then through RBF's retries: the freeze. Worse, a
+stale status of $00 was *accepted with wrong sector data* — the source
+of the #216 (directory search over garbage) and the LSN 0/65537
+retry-storm targets (corrupted drive table).
+**Fixes (2026-08-29, current build):**
+- **Purge before every retry**: the E$CRC/REREADEX path now runs
+  PurgeRX first, so a retry always reads fresh, aligned data — a
+  lagged stream self-heals in one retry instead of freezing.
+- **Trailing-byte check on status OK**: on a synced line the server
+  sends *nothing* after the status byte. If a byte trails it (watched
+  ~200µs; a lagged flowing stream delivers the next byte within ~43µs
+  at 230400), the "OK" belonged to the previous transaction — the read
+  is retried instead of silently accepting wrong data.
+- **Abort long-listen**: when an aborted read's status never arrives
+  (server deep in a stall), the driver now listens up to ~2s for the
+  late burst to start before declaring the line clean, so a stall
+  longer than the purge window can no longer establish the lag. A
+  status-read timeout after the checksum leg takes the same path.
+
+## What was audited and deliberately not changed
+
+- `rbdw` retries only server-reported CRC failures (8 `OP_REREADEX`
+  attempts); serial-level timeouts fail immediately — unchanged.
+- Every exit path in the driver stack restores the caller's interrupt
+  mask from the stack; no error exit leaves IRQs masked.
+- The SHELLMODS merge order and the DriveWire modules' presence in the
+  boot list are recipe-level changes documented separately.
+
+## Expected behavior after the current build
+
+- A server stall or line glitch costs **one** #244 (~1s of masked
+  time), after which the very next operation succeeds.
+- No error-code roulette (#214/#216/#254), no cascades, no freeze.
+- Optional future polish: 64-byte FIFO mode in DWInit (widens the
+  interrupt-window overrun margin from ~700µs to ~2.8ms); reducing DW4
+  JVM pauses server-side (more heap / low-pause GC) shrinks how often
+  the stall path is exercised at all.
+
+## Field validation (2026-08-29, rbdw $252)
+
+A 2-hour K2 dsave marathon over /x1 (14.7MB of DW4 server log): the
+server stalled 8 times (224-641ms, Java GC). Seven stalls were
+absorbed **invisibly** — the driver aborted cleanly, resynced, and
+RBF never saw an error. One surfaced as a single #244 on one file;
+the next command succeeded immediately, and the affected file was
+verified intact at the destination (`cmp` match). Zero UNKNOWN
+OPCODEs, zero error cascades, zero freezes. Each stall leaves exactly
+two WARN lines in the server log (the deliberate abort checksum's
+"CRC check failed" + the stall duration) — that is the expected,
+healthy signature.
+
+## Deployment pairing
+
+Disks built from this branch require the BAUDCE-fixed cores. Minimum:
+`wildbits_k2_6809_v8_rc3` / `wildbits_jr2_6809_v8_rc3` (2026-08-28, the
+fractional-BAUDCE fix in `SuperIO_JR.v`). Driver hardening itself has no
+core dependency beyond that baud pairing.
+
+**Current cores (2026-09-03): `wildbits_k2_6809_v8_rc10` and
+`wildbits_jr2_6809_v8_rc7`.** Both carry the sprite-engine fixes (rc7); the K2
+adds the hardware typematic engine (rc8), the shared flash/cartridge/RTC
+write-strobe policy (rc9) and 24-tick turbo fast RAM writes (rc10). The Jr2
+has had the write-strobe policy since rc6 and needs no rc8/rc9 counterpart.
+
+Core and disk ship together in the parity kits
+(`FoenixMgrWin/parity_wildbits_k2_v8_rc10`, `parity_wildbits_jr2_v8_rc7`):
+each kit holds that machine's core, the matching `l2_wildbits*.dsk`, the FEU
+booter/f0 blocks and the install script, so a kit is always a consistent
+pair. Mixing a kit disk with an older core, or an older disk with a newer
+core, reintroduces the 2.4% baud mismatch described above.
+
+Module fingerprints for `mdir -e` verification: `dwio_serial` = $37A,
+`rbdw` = $252 (current: retry purge + trailing-byte check + abort
+long-listen), $211 (FIFO reset + long purge), $20C (no FIFO reset),
+$1E6 (abort only), $1CF (stock).

--- a/level1/modules/rbdw.asm
+++ b/level1/modules/rbdw.asm
@@ -33,6 +33,15 @@
 
 NUMRETRIES          equ       8
 
+                    ifne      wildbits
+* COM1 16750 direct-access equates for the receive-purge path (the
+* 16550.d defs are not in this module's include chain).
+DWU.TRHB            equ       $FE60               RX holding register
+DWU.FCR             equ       $FE62               FIFO control register (write-only)
+DWU.LSR             equ       $FE65               line status register
+DWU.RXRDY           equ       $01                 LSR data-available bit
+                    endc
+
                     ifp1
                     use       defsfile
                     use       drivewire.d
@@ -208,7 +217,11 @@ ReadSect            pshs      cc
                     cmpa      #NumDrvs
                     blo       Read1
                     ldb       #E$Unit
+                    ifne      wildbits
+                    lbra      ReadEr2             long branch - the PurgeRX/ReadAbort block sits in between
+                    else
                     bra       ReadEr2
+                    endc
 Read1               sta       driveno,u
                     lda       #OP_READEX          load A with READ opcode
 
@@ -230,8 +243,20 @@ Read2
                     ldx       PD.BUF,x            get buffer pointer into X
                     ldy       #$0100
                     jsr       DW$Read,u
+                    ifne      wildbits
+* Protocol-completion error path (2026-08-29): on a failed sector read
+* the server has already sent the data and is BLOCKED waiting for our
+* 2-byte checksum. Aborting without it makes the server consume the
+* next command's first bytes as the checksum - server-side frame slip
+* (UNKNOWN OPCODE / garbage-LSN / CRC-fail storms in the DW4 log).
+* Send a deliberately-wrong checksum, collect and discard the status
+* byte, and only then return the error - both parsers stay framed.
+                    bcs       ReadAbort
+                    bne       ReadAbort
+                    else
                     bcs       ReadEr1
                     bne       ReadEr1
+                    endc
                     pshs      y
                     leax      ,s
                     ldy       #$0002
@@ -242,19 +267,135 @@ Read2
                     ldy       #$0001
                     jsr       DW$Read,u
                     puls      d
+                    ifne      wildbits
+* A failed status read here means the server stalled AFTER the data
+* leg (checksum already sent) - the status byte is still owed and
+* would land inside the next transaction. Wait for it, then purge.
+                    lbcs      AbWait
+                    lbne      AbWait
+                    else
                     bcs       ReadEr0             branch if we timed out
                     bne       ReadEr0
+                    endc
                     tfr       a,b                 transfer byte to B (in case of error)
                     tstb                          is it zero?
+                    ifne      wildbits
+                    lbeq      ReadOkChk           OK status - verify the line is actually silent
+                    else
                     beq       ReadEx              if not, exit with error
+                    endc
                     cmpb      #E$CRC
+                    ifne      wildbits
+                    lbne      ReadBadSt
+                    else
                     bne       ReadEr2
-                    ldu       7,s                 get U from stack
+                    endc
+ReadRetry           ldu       7,s                 get U from stack
                     dec       retries,u           decrement retries
+                    ifne      wildbits
+* Resync before EVERY retry (2026-08-29): when the reply stream is
+* lagged (a stale response queued ahead of us), each REREADEX otherwise
+* re-reads the PREVIOUS response, fails the server-side CRC again, and
+* the retry loop sustains the desync forever - the field signature of
+* endless completed-but-CRC-failed reads with no timeouts. Purging
+* here drains the backlog so the retry reads fresh, aligned data.
+                    lbeq      ReadBadSt           out of retries: purge, then honest E$Read
+                    bsr       PurgeRX
+                    lda       #OP_REREADEX        reread opcode
+                    lbra      Read2
+                    else
                     beq       ReadEr1
 
                     lda       #OP_REREADEX        reread opcode
-                    bra       Read2               and try getting sector again
+                    bra       Read2
+                    endc               and try getting sector again
+                    ifne      wildbits
+* Drain the receive path until the line has been idle 10+ character
+* times, so an off-by-N stream from a failed transaction cannot poison
+* the next one. A shifted-but-still-flowing stream never times out
+* inside DWRead (reads complete promptly with wrong bytes), so this
+* must run on EVERY failed transaction, not only on timeouts. Bounded:
+* max 1200 discards, ~0.6ms idle window. IRQs are masked here.
+PurgeRX             pshs      d,x,y
+* Hardware RX FIFO reset first: an overrun (server dumping a sector
+* remainder into a client that stopped listening) can wedge the FIFO
+* pointer state in ways byte-draining never clears.
+                    lda       #%11000010          FCR: RX FIFO reset strobe (self-clearing)
+                    sta       >DWU.FCR
+                    ldy       #1200               max stale bytes to discard
+* Idle window ~65536 polls (roughly 200-350ms): must outlast a
+* server-side stall (Java GC in DW4, measured ~620ms total) that
+* resumes sending a sector remainder long after our timeouts fired.
+* The window restarts on every discarded byte, so an in-progress
+* remainder is consumed in real time and the wait only runs in full
+* once, after the final straggler.
+pur0@               ldx       #0                  idle window (65536 polls)
+pur1@               lda       >DWU.LSR
+                    bita      #DWU.RXRDY
+                    bne       pur2@               byte present - discard, restart window
+                    leax      -1,x
+                    bne       pur1@
+                    puls      d,x,y,pc            line idle - resynced
+pur2@               lda       >DWU.TRHB           discard stale byte
+                    leay      -1,y
+                    bne       pur0@
+                    puls      d,x,y,pc            discard cap hit - stop
+
+ReadAbort           ldd       #$FFFF              deliberately-wrong checksum
+                    pshs      d
+                    leax      ,s
+                    ldy       #$0002
+                    jsr       DW$Write,u          complete the checksum leg for the server
+                    leax      ,s
+                    ldy       #$0001
+                    jsr       DW$Read,u           collect (and discard) its status byte
+                    puls      d
+                    bcs       AbWait              nothing came back - server still stalled
+                    bne       AbWait
+AbPurge             bsr       PurgeRX             drain any residue before erroring out
+                    bra       ReadEr1
+* The server never sent a byte: it is deep in a stall (DW4 Java GC,
+* measured 620ms+) and the WHOLE response is still owed. If we purge
+* now the line looks idle, we declare it clean, and the late burst
+* lands inside the NEXT transaction - establishing the one-response
+* lag. Listen up to ~2s for the burst to start; PurgeRX then consumes
+* it in real time. A truly dead server just costs one slow error.
+AbWait              ldb       #12                 12 x 65536 polls, roughly 2s
+abw0@               ldx       #0
+abw1@               lda       >DWU.LSR
+                    bita      #DWU.RXRDY
+                    bne       AbPurge             burst arriving - purge drains it live
+                    leax      -1,x
+                    bne       abw1@
+                    decb
+                    bne       abw0@
+                    bra       AbPurge             still silent - purge anyway, then error
+* Status byte was $00 (OK) - but on a synced line the server sends
+* NOTHING after the status byte, so the line must now be silent. A
+* byte trailing it means we just consumed a STALE response: the "OK"
+* belongs to the PREVIOUS transaction and the sector data is wrong
+* (accepting it is where the #216/garbage-LSN corruption came from).
+* In a lagged, flowing stream the next byte arrives within ~43us at
+* 230400; watch ~200us to be sure, then purge and retry the sector.
+ReadOkChk           pshs      x
+                    ldx       #360                ~600us of LSR polls (was 120; see dwread purge note -
+*                                                 these windows are cycle-counted and shrank when rc10's
+*                                                 fast writes sped the CPU up)
+okc0@               lda       >DWU.LSR
+                    bita      #DWU.RXRDY
+                    bne       okc1@               trailing byte - stale response consumed
+                    leax      -1,x
+                    bne       okc0@
+                    puls      x
+                    lbra      ReadEx              line silent - clean accept
+okc1@               puls      x
+                    lbra      ReadRetry           purge happens inside the retry path
+* A nonzero status byte that is not E$CRC means the reply stream is
+* shifted - we just read a data byte as "status". Purge to resync and
+* report a plain read error instead of passing the garbage byte through
+* as a random error code (the mystery #214/#216 reports).
+ReadBadSt           lbsr      PurgeRX
+                    endc
 ReadEr0
 ReadEr1             ldb       #E$Read             read error
 ReadEr2             lda       9,s

--- a/level1/modules/rbdw.asm
+++ b/level1/modules/rbdw.asm
@@ -36,8 +36,8 @@ NUMRETRIES          equ       8
 * rc11 cores and shrinks with every faster CPU; a DriveWire4 server stall (Java
 * GC) measures ~620ms. Multipliers keep the windows above that with margin at a
 * 2x faster CPU. Proper fix: TIMER0 ($FE30) counts the fixed 25.175MHz IO clock.
-DW_PURGE_MULT       equ       4                   PurgeRX idle window: ~0.9s turbo (~0.45s at 2x)
-DW_ABWAIT_MULT      equ       24                  AbWait listen for a stalled server: ~4s turbo (~2s at 2x)
+DW_PURGE_MULT       equ       6                   PurgeRX idle window: ~1.3s turbo (~0.7s at 2x)  [+50% 2026-09-05, was 4]
+DW_ABWAIT_MULT      equ       36                  AbWait listen for a stalled server: ~6s turbo (~3s at 2x)  [+50%, was 24]
 
                     ifne      wildbits
 * COM1 16750 direct-access equates for the receive-purge path (the
@@ -329,7 +329,7 @@ PurgeRX             pshs      d,x,y
                     lda       #%11000010          FCR: RX FIFO reset strobe (self-clearing)
                     sta       >DWU.FCR
                     ldy       #1200               max stale bytes to discard
-* Idle window DW_PURGE_MULT x 65536 polls (~0.9s turbo): must outlast a
+* Idle window DW_PURGE_MULT x 65536 polls (~1.3s turbo): must outlast a
 * server-side stall (Java GC in DW4, measured ~620ms total) that
 * resumes sending a sector remainder long after our timeouts fired.
 * The window restarts on every discarded byte, so an in-progress
@@ -369,7 +369,7 @@ AbPurge             bsr       PurgeRX             drain any residue before error
 * lands inside the NEXT transaction - establishing the one-response
 * lag. Listen up to ~2s for the burst to start; PurgeRX then consumes
 * it in real time. A truly dead server just costs one slow error.
-AbWait              ldb       #DW_ABWAIT_MULT                 DW_ABWAIT_MULT x 65536 polls: ~4s turbo, ~2s at a 2x faster CPU
+AbWait              ldb       #DW_ABWAIT_MULT                 DW_ABWAIT_MULT x 65536 polls: ~6s turbo, ~3s at a 2x faster CPU
 abw0@               ldx       #0
 abw1@               lda       >DWU.LSR
                     bita      #DWU.RXRDY

--- a/level1/modules/rbdw.asm
+++ b/level1/modules/rbdw.asm
@@ -32,6 +32,12 @@
                     ttl       DriveWire RBF driver
 
 NUMRETRIES          equ       8
+* Cycle-counted windows (2026-09-05): 65536 polls is ~220ms under turbo on the
+* rc11 cores and shrinks with every faster CPU; a DriveWire4 server stall (Java
+* GC) measures ~620ms. Multipliers keep the windows above that with margin at a
+* 2x faster CPU. Proper fix: TIMER0 ($FE30) counts the fixed 25.175MHz IO clock.
+DW_PURGE_MULT       equ       4                   PurgeRX idle window: ~0.9s turbo (~0.45s at 2x)
+DW_ABWAIT_MULT      equ       24                  AbWait listen for a stalled server: ~4s turbo (~2s at 2x)
 
                     ifne      wildbits
 * COM1 16750 direct-access equates for the receive-purge path (the
@@ -323,18 +329,21 @@ PurgeRX             pshs      d,x,y
                     lda       #%11000010          FCR: RX FIFO reset strobe (self-clearing)
                     sta       >DWU.FCR
                     ldy       #1200               max stale bytes to discard
-* Idle window ~65536 polls (roughly 200-350ms): must outlast a
+* Idle window DW_PURGE_MULT x 65536 polls (~0.9s turbo): must outlast a
 * server-side stall (Java GC in DW4, measured ~620ms total) that
 * resumes sending a sector remainder long after our timeouts fired.
 * The window restarts on every discarded byte, so an in-progress
 * remainder is consumed in real time and the wait only runs in full
 * once, after the final straggler.
-pur0@               ldx       #0                  idle window (65536 polls)
+pur0@               ldb       #DW_PURGE_MULT      idle window = DW_PURGE_MULT x 65536 polls
+pur0a@              ldx       #0
 pur1@               lda       >DWU.LSR
                     bita      #DWU.RXRDY
                     bne       pur2@               byte present - discard, restart window
                     leax      -1,x
                     bne       pur1@
+                    decb                          16-bit window wrapped: one outer count down
+                    bne       pur0a@
                     puls      d,x,y,pc            line idle - resynced
 pur2@               lda       >DWU.TRHB           discard stale byte
                     leay      -1,y
@@ -360,7 +369,7 @@ AbPurge             bsr       PurgeRX             drain any residue before error
 * lands inside the NEXT transaction - establishing the one-response
 * lag. Listen up to ~2s for the burst to start; PurgeRX then consumes
 * it in real time. A truly dead server just costs one slow error.
-AbWait              ldb       #12                 12 x 65536 polls, roughly 2s
+AbWait              ldb       #DW_ABWAIT_MULT                 DW_ABWAIT_MULT x 65536 polls: ~4s turbo, ~2s at a 2x faster CPU
 abw0@               ldx       #0
 abw1@               lda       >DWU.LSR
                     bita      #DWU.RXRDY

--- a/level1/wildbits/modules/dwinit_wildbits_serial.asm
+++ b/level1/wildbits/modules/dwinit_wildbits_serial.asm
@@ -8,8 +8,20 @@ DWInit
 
                     lda       #0
                     sta       UART_DLH,x
-*               lda       #13                 (25.125Mhz / (16 * 115200)) = 13.65 (internal speed of Devices inside FPGA is 25.175Mhz (not 6Mhz))
-                    lda       #6                  (25.125Mhz / (16 * 230400)) = 6.82 (internal speed of Devices inside FPGA is 25.175Mhz (not 6Mhz))
+* The UART core divides by 16*(divisor+1) - its baud counter is inclusive.
+* On the raw 25.175MHz UART clock no standard rate is reachable closer than
+* -2.4% (divisor 6 = 224,777 real at "230400"), the margin behind the
+* DriveWire E$Read #244 failures under sustained traffic.
+* Cores with the fractional-BAUDCE fix (SuperIO_JR.v, 2026-08-28) run the
+* baud generator at exactly 22.1184MHz, where standard rates are EXACT:
+* 230400 -> 5, 115200 -> 11, 57600 -> 23, 460800 -> 2.
+* PAIRING NOTE: divisor and core must match as a pair - a divisor-5 boot
+* on a pre-fix core yields 262,240 baud (DW dead); divisor 6 on a fixed
+* core yields 197,486 (DW dead). Disks built from this source require the
+* BAUDCE-fixed cores, v8_rc3 (2026-08-28) or later, on BOTH machines.
+* Current cores as of 2026-09-03: K2 v8_rc10, Jr2 v8_rc7; the parity kits
+* ship core and disk together so the pair stays consistent.
+                    lda       #5                  22.1184MHz / (16 * (5+1)) = 230400 exactly (BAUDCE-fixed cores)
                     sta       UART_DLL,x
 
                     lda       UART_LCR,x

--- a/level1/wildbits/modules/dwread_wildbits_serial.asm
+++ b/level1/wildbits/modules/dwread_wildbits_serial.asm
@@ -3,7 +3,7 @@
 * DWRead
 *    Receive a response from the DriveWire server.
 *    Times out if the serial port goes idle for DW_TIMEOUT_MULT x 65536 polls:
-*    ~1.8s under turbo on the rc11 cores, ~2.7s at stock speed (the CoCo
+*    ~2.7s under turbo on the rc11 cores, ~4s at stock speed (the CoCo
 *    original was 1.4/0.7s at 0.89/1.79MHz).
 *    Serial data format:  1-8-N-1
 *
@@ -21,13 +21,13 @@
 * Cycle-counted timeouts (2026-09-05): the 16-bit poll counter wraps after 65536
 * polls, ~335ms at stock speed and ~220ms under turbo - shorter than a DriveWire4
 * server stall (Java GC, measured ~620ms), and it shrinks again with every faster
-* CPU. DW_TIMEOUT_MULT multiplies the window (8 x 65536 polls = ~1.8s under
-* today's turbo, still ~0.9s at a 2x faster CPU). DW_PURGE_IDLE is the
-* post-timeout idle window in polls (2048 = ~3.7ms turbo, ~1.9ms at 2x; 10 char
+* CPU. DW_TIMEOUT_MULT multiplies the window (12 x 65536 polls = ~2.7s under
+* today's turbo, still ~1.4s at a 2x faster CPU). DW_PURGE_IDLE is the
+* post-timeout idle window in polls (3072 = ~5.5ms turbo, ~2.8ms at 2x; 10 char
 * times at 230400 is 434us). Proper fix: time both off TIMER0 ($FE30), which
 * counts the fixed 25.175MHz IO clock and is untouched by turbo.
-DW_TIMEOUT_MULT     equ       8
-DW_PURGE_IDLE       equ       2048
+DW_TIMEOUT_MULT     equ       12                  +50% 2026-09-05 (was 8)
+DW_PURGE_IDLE       equ       3072                +50% 2026-09-05 (was 2048)
 DWRead              clra                          clear carry (no framing error)
                     clrb
                     pshs      u,x,d,cc            preserve registers
@@ -69,7 +69,7 @@ loop2@              lda       UART.Base+UART_LSR  get the LSR register value
 * this purge exists to prevent.  768 restores ~3x margin at any plausible clock.
 * Proper fix is to time this off a hardware timer ($FE30) instead of counting
 * cycles - see the notes in the drivewire kit.
-prg0@               ldx       #DW_PURGE_IDLE      idle window (2048 polls: ~3.7ms turbo, >80 char times at 230400)
+prg0@               ldx       #DW_PURGE_IDLE      idle window (3072 polls: ~5.5ms turbo, >120 char times at 230400)
 prg1@               lda       UART.Base+UART_LSR
                     bita      #LSR_DATA_AVAIL
                     bne       prg2@               late byte - discard it, restart idle window

--- a/level1/wildbits/modules/dwread_wildbits_serial.asm
+++ b/level1/wildbits/modules/dwread_wildbits_serial.asm
@@ -36,7 +36,33 @@ loop2@              lda       UART.Base+UART_LSR  get the LSR register value
                     lda       ,s                  get CC off stack
                     anda      #^$04               clear the Z flag to indicate not all bytes received.
                     sta       ,s
-                    bra       bye@
+* RX resync purge (2026-08-28): after a timeout, the server's remaining
+* bytes may still arrive and sit in the 16-byte FIFO, poisoning the NEXT
+* transaction (the cascading-#244 pattern). Drain the FIFO and any late
+* stragglers until the line has been idle for 10+ character times.
+* Bounded (max ~1200 discards); IRQs are still masked here; X is
+* restored from the stack at exit so it is free to use.
+                    ldy       #1200               max stale bytes to discard
+* 2026-09-04: was 256, which measured ~0.5ms only at the ~9MHz the machine ran
+* at when this was tuned (2026-08-28, pre-fast-writes).  10 char times at 230400
+* is 434us, so 256 left barely 15% margin - and rc10's fast RAM writes shortened
+* write frames 32->24 ticks, speeding the CPU up and eating it.  The purge then
+* declared the line idle with bytes still in flight, left stragglers in the
+* 16-byte FIFO and poisoned the next transaction: the cascading-#244 pattern
+* this purge exists to prevent.  768 restores ~3x margin at any plausible clock.
+* Proper fix is to time this off a hardware timer ($FE30) instead of counting
+* cycles - see the notes in the drivewire kit.
+prg0@               ldx       #768                idle window, >=1.4ms (>30 char times at 230400)
+prg1@               lda       UART.Base+UART_LSR
+                    bita      #LSR_DATA_AVAIL
+                    bne       prg2@               late byte - discard it, restart idle window
+                    leax      -1,x
+                    bne       prg1@
+                    bra       bye@                line went idle - resync complete
+prg2@               lda       UART.Base+UART_TRHB discard stale byte
+                    leay      -1,y
+                    bne       prg0@
+                    bra       bye@                discard cap hit - stop draining
 getbyte@            ldb       UART.Base+UART_TRHB get the data byte
                     stb       ,u+                 save off acquired byte
                     abx                           update checksum

--- a/level1/wildbits/modules/dwread_wildbits_serial.asm
+++ b/level1/wildbits/modules/dwread_wildbits_serial.asm
@@ -2,7 +2,9 @@
 *
 * DWRead
 *    Receive a response from the DriveWire server.
-*    Times out if serial port goes idle for more than 1.4 (0.7) seconds.
+*    Times out if the serial port goes idle for DW_TIMEOUT_MULT x 65536 polls:
+*    ~1.8s under turbo on the rc11 cores, ~2.7s at stock speed (the CoCo
+*    original was 1.4/0.7s at 0.89/1.79MHz).
 *    Serial data format:  1-8-N-1
 *
 * Entry:
@@ -16,6 +18,16 @@
 *    U is preserved.  All accumulators are clobbered
 *
 
+* Cycle-counted timeouts (2026-09-05): the 16-bit poll counter wraps after 65536
+* polls, ~335ms at stock speed and ~220ms under turbo - shorter than a DriveWire4
+* server stall (Java GC, measured ~620ms), and it shrinks again with every faster
+* CPU. DW_TIMEOUT_MULT multiplies the window (8 x 65536 polls = ~1.8s under
+* today's turbo, still ~0.9s at a 2x faster CPU). DW_PURGE_IDLE is the
+* post-timeout idle window in polls (2048 = ~3.7ms turbo, ~1.9ms at 2x; 10 char
+* times at 230400 is 434us). Proper fix: time both off TIMER0 ($FE30), which
+* counts the fixed 25.175MHz IO clock and is untouched by turbo.
+DW_TIMEOUT_MULT     equ       8
+DW_PURGE_IDLE       equ       2048
 DWRead              clra                          clear carry (no framing error)
                     clrb
                     pshs      u,x,d,cc            preserve registers
@@ -24,15 +36,20 @@ DWRead              clra                          clear carry (no framing error)
                     ldx       #$0000
 loop@               ldd       #$0000              store counter
                     std       1,s
+                    lda       #DW_TIMEOUT_MULT    outer timeout count
+                    pshs      a                   ,s = outer count; saved CC now 1,s, counter 2,s
 loop2@              lda       UART.Base+UART_LSR  get the LSR register value
                     bita      #LSR_DATA_AVAIL     test for data available
                     bne       getbyte@            if available, get byte
-                    ldd       1,s
+                    ldd       2,s
                     addb      #$01
                     adca      #$00
-                    std       1,s
+                    std       2,s
                     cmpd      #$0000
                     bne       loop2@
+                    dec       ,s                  16-bit counter wrapped: one outer count down
+                    bne       loop2@
+                    leas      1,s                 drop the outer count
                     lda       ,s                  get CC off stack
                     anda      #^$04               clear the Z flag to indicate not all bytes received.
                     sta       ,s
@@ -52,7 +69,7 @@ loop2@              lda       UART.Base+UART_LSR  get the LSR register value
 * this purge exists to prevent.  768 restores ~3x margin at any plausible clock.
 * Proper fix is to time this off a hardware timer ($FE30) instead of counting
 * cycles - see the notes in the drivewire kit.
-prg0@               ldx       #768                idle window, >=1.4ms (>30 char times at 230400)
+prg0@               ldx       #DW_PURGE_IDLE      idle window (2048 polls: ~3.7ms turbo, >80 char times at 230400)
 prg1@               lda       UART.Base+UART_LSR
                     bita      #LSR_DATA_AVAIL
                     bne       prg2@               late byte - discard it, restart idle window
@@ -63,7 +80,8 @@ prg2@               lda       UART.Base+UART_TRHB discard stale byte
                     leay      -1,y
                     bne       prg0@
                     bra       bye@                discard cap hit - stop draining
-getbyte@            ldb       UART.Base+UART_TRHB get the data byte
+getbyte@            leas      1,s                 drop the outer count
+                    ldb       UART.Base+UART_TRHB get the data byte
                     stb       ,u+                 save off acquired byte
                     abx                           update checksum
                     leay      ,-y                 decrement Y

--- a/level1/wildbits/modules/dwwrite_wildbits_serial.asm
+++ b/level1/wildbits/modules/dwwrite_wildbits_serial.asm
@@ -10,17 +10,33 @@
 *
 * Exit:
 *    X  = address of last byte sent + 1
-*    Y  = 0
+*    Y  = 0 (bytes remaining if the transmitter wedged)
 *    All others preserved
 *
+* 2026-08-28: the wait for LSR_XMIT_DONE is now bounded (~0.3s per byte).
+* The old unbounded spin was the driver's only true hard-hang path: a
+* wedged transmitter froze the machine with IRQs masked forever.  On
+* timeout the remaining bytes are abandoned; the transaction then fails
+* at the next DWRead (which purges and resyncs) and surfaces as a clean
+* E$Read error with IRQs restored.
+*
 
-DWWrite             pshs      u,a,cc              preserve registers
+DWWrite             pshs      u,d,cc              preserve registers (B too - D is the timeout counter)
                     orcc      #IntMasks           mask interupts
-loop@               lda       UART.Base+UART_LSR  get status register
+                    leas      -2,s                local 16-bit drain-wait timeout counter
+loop@               ldd       #$0000              reset the timeout for each byte
+                    std       ,s
+wait@               lda       UART.Base+UART_LSR  get status register
                     anda      #LSR_XMIT_DONE      is transmit FIFO empty?
-                    beq       loop@               branch if not
+                    beq       tick@               not yet - count down the timeout
                     lda       ,x+                 get byte from buffer
                     sta       UART.Base+UART_TRHB put it to PIA
                     leay      -1,y                decrement byte counter
                     bne       loop@               loop if more to send
-                    puls      cc,a,u,pc           restore registers and return
+                    bra       bye@
+tick@               ldd       ,s
+                    addd      #$0001
+                    std       ,s
+                    bne       wait@               ~65536 polls before giving up
+bye@                leas      2,s                 drop timeout counter
+                    puls      cc,d,u,pc           restore registers and return


### PR DESCRIPTION
Update rbdw.asm
Update dwinit_wildbits_serial.asm
Update dwrite_wildbits_serial.asm
Update dwread_wildbits_serial.asm
Update wildbits-drivewire-hardening.md (the fix explained)

This is not a willy-nilly whack-a-mole patch.  It took several days for Claude and I to run tests until the long dsave /x1 /s1 sessions were totally error-free with no lockups or OS crashes.  Also works in turbo mode.  I don't think noise on the USB channels stands a chance.

Jr2/K2 "V8" core is recommended.
