### PR TITLE
Add initial l2win recipe files

### DIFF
--- a/recipes/wildbits/l2win/README.md
+++ b/recipes/wildbits/l2win/README.md
@@ -1,0 +1,90 @@
+# l2win — WildBits Level 2 disk recipe for Windows build hosts
+
+`l2win` builds the same Level 2 SD disk as `../l2`, but works out of
+the box on a Windows / cygwin64 / GnuWin32-make-3.81 / toolshed 2.6
+host. All differences live in `recipe.mak`, picked up through
+`wildbits.mak`'s existing `-include recipe.mak` hook (the same
+mechanism `l1dw` uses); `wildbits.mak` and `l2` are untouched.
+
+Usage, from this directory:
+
+    make clean PLATFORM=k2      (or jr2)
+    make PLATFORM=k2
+
+No environment setup is required — no NITROS9DIR/LANGUAGES arguments,
+no SHELLOPTS, no PATH preparation.
+
+## The SHELLMODS ordering bug (proven empirically)
+
+The stock `SHELLMODS` merge order is alphabetical:
+
+    shellplus date deiniz echo iniz link load save unlink
+
+A `shell` module merged in that order **on this host** produces a
+system that freezes before the shell prompt ever appears — proven
+repeatedly during the 2026-08 DriveWire campaign: the same source
+tree, same toolchain, same disk contents, differing only in merge
+order, reproducibly freezes with `date` directly after `shellplus`
+and reliably boots with:
+
+    shellplus echo iniz link load save unlink date deiniz
+
+(`date`/`deiniz` moved to the end). Multiple independent disks
+confirmed both directions across many reboots.
+
+The suspected root cause is shellplus reading past its own module end
+into whatever the merge places next (interacting with how this
+toolshed 2.6 build pads merged modules), but that has NOT been
+confirmed at the code level — only the ordering fix is proven. A
+related unexplained symptom, likely the same defect: a stray
+high-bit character occasionally appears at the shell prompt when a
+sub-shell exits (harmless, backspaces away). Once the real bug is
+found and fixed upstream, the `override SHELLMODS` in `recipe.mak`
+should be dropped.
+
+## Extra cleaning of level1/wildbits/sys outputs
+
+The `wildbits-sys-assets` target generates font and background
+binaries **into the source tree** (`level1/wildbits/sys/fonts/`,
+`level1/wildbits/sys/backgrounds/`). The stock recipes never clean
+those, so they accumulate as untracked files in git status. `l2win`
+adds a `clean-sys-assets` prerequisite to `clean` that runs those two
+support makefiles' own `clean` targets. `wildbits.mak`'s clean recipe
+itself is not modified.
+
+(`recipe.mak` also declares a bare `all:` first — it is included
+before `wildbits.mak` defines `all`, and make's default goal is the
+first target seen; without this, a plain `make` would clean instead
+of build.)
+
+## BASIC09 inclusion
+
+BASIC09 (`basic09 runb inkey syscall wild`) is on the disk. The
+binaries build from the sibling **nitros9-languages** repo (post-2026
+languages split), expected at `../nitros9-languages` next to this
+repo. Its build invokes `python3`; on Windows the bare name resolves
+to the Microsoft Store alias stub, so the build host carries a
+`python3` shim in cygwin's `/usr/local/bin` pointing at the real
+interpreter. `runb` is verified against the `RUNB_SHA256` pin in
+`wildbits.mak` during every disk build.
+
+## Everything else recipe.mak fixes (with the why)
+
+- **Drive-letter paths**: GnuWin32 make 3.81 has a broken `$(abspath)`
+  and reads the `:` of `e:/...` in a rule line as a second target
+  separator (`multiple target patterns` at the basic09 rule).
+  `NITROS9DIR`/`LANGUAGES` are forced to colon-free drive-relative
+  forms and exported so recursive sub-makes inherit them.
+- **Full-size images**: `OS9FORMAT_SD` is the one format variant in
+  `rules.mak` defined *without* `-e`; `recipe.mak` pins
+  `OS9FORMAT_CMD = $(OS9FORMAT_SD) -e` so images always come out
+  full-size regardless of the disk rule's own flags.
+- **padup256 CRLF**: the pad script has CRLF endings; it is run via
+  `bash -o igncr` so the shell doesn't require SHELLOPTS from the
+  environment.
+- **DriveWire in the boot list**: `dwio_serial`, the pipe modules,
+  and `rbdw`+`x0`-`x3` are merged into OS9Boot. `sc16550`/`t0` are
+  deliberately excluded: the booter loads OS9Boot at `$FE00` minus
+  its size, so past 32,256 bytes the load address drops below `$8000`
+  and boot wedges at "Loading sector." — and `/t0` points at the same
+  $FE60 UART DriveWire uses, so the two cannot run together anyway.

--- a/recipes/wildbits/l2win/defsfile
+++ b/recipes/wildbits/l2win/defsfile
@@ -1,0 +1,8 @@
+Level equ 2
+ use os9.d
+ use scf.d
+ use rbf.d
+ use wildbits.d
+
+MappedIOStart equ $FE00
+MappedIOEnd equ $FFFF

--- a/recipes/wildbits/l2win/makefile
+++ b/recipes/wildbits/l2win/makefile
@@ -1,0 +1,3 @@
+LEVEL = 2
+SCF_EXTRA = SOLdrv fSOL wizfi wz wz0 wz1 wz2 wz3
+include ../wildbits.mak

--- a/recipes/wildbits/l2win/padup256
+++ b/recipes/wildbits/l2win/padup256
@@ -1,0 +1,9 @@
+#!/bin/sh
+if stat -f "%z" $1 > /dev/null 2>&1 ; then
+     export padding=`stat -f "(%z + 255) / 256 * 256" $1 | bc`
+else
+     export padding=`stat -c "(%s + 255) / 256 * 256" $1 | bc`
+fi
+ls -l $@
+os9 padrom -b $padding $1
+ls -l $@

--- a/recipes/wildbits/l2win/recipe.mak
+++ b/recipes/wildbits/l2win/recipe.mak
@@ -1,0 +1,86 @@
+# ===================================================================
+# l2win - Level 2 disk recipe for Windows / cygwin64 / toolshed 2.6
+# build hosts. Identical to ../l2 except for the two overrides below,
+# which wildbits.mak picks up via its "-include recipe.mak" hook.
+# The `override` directives win over wildbits.mak's own definitions,
+# so wildbits.mak needs no changes and l2 stays stock.
+# ===================================================================
+
+# 0) GnuWin32 make 3.81 cannot parse drive-letter paths in rules
+#    (broken $(abspath) + the ":" read as a target separator ->
+#    "multiple target patterns" at the $(MODDIR)/basic09 rule when
+#    NITROS9DIR comes from the Windows env as e:/...). Force
+#    colon-free drive-relative paths; native tools resolve them
+#    against the current drive (E:) and the E:\cygwin64\cygwin64
+#    junction makes them work for cygwin coreutils too.
+override NITROS9DIR := /cygwin64/home/taylo/nitros9
+override LANGUAGES := /cygwin64/home/taylo/nitros9-languages
+# export so recursive sub-makes (sys-assets/fonts/backgrounds) see the
+# corrected paths instead of re-reading e:/... from the environment
+export NITROS9DIR LANGUAGES
+
+# 0a0) ALWAYS format with -e (extend to full image size): rules.mak's
+#      OS9FORMAT_SD is the one variant defined WITHOUT -e, and only
+#      the disk rule's own command line has been adding it. Pin it
+#      here so every branch's build gets a full-size image even if
+#      that rule changes. (A duplicated -e is harmless.)
+OS9FORMAT_CMD = $(OS9FORMAT_SD) -e
+
+# 0a) padup256 has CRLF line endings; cygwin sh chokes on it unless
+#     igncr is in effect. wildbits.mak's "PADUP ?=" honors this.
+PADUP = bash -o igncr ./padup256 bootfile
+
+# 0b) BASIC09 binaries build from the sibling nitros9-languages repo
+#     (LANGUAGES above). Its build invokes python3, which on this box
+#     needs the /usr/local/bin/python3 shim (else the bare name hits
+#     the Windows Store alias stub) - installed 2026-08-29, spare
+#     copy: wildbits-buildkit\pyshim-python3. runb is integrity-pinned
+#     by RUNB_SHA256 in wildbits.mak.
+
+# 1) DriveWire in the boot: dwio_serial + pipes + rbdw/x0-x3.
+#    sc16550/t0 deliberately NOT included: OS9Boot must stay under
+#    32,256 bytes (the booter loads it at $FE00-minus-size; below
+#    $8000 it wedges at "Loading sector.") and /t0 shares the DW
+#    UART at $FE60 anyway.
+ifeq ($(LEVEL),2)
+override BOOTMODS = krnp2 ioman init \
+	$(SCF) \
+	$(RBF) \
+	dwio_serial $(PIPE) $(DRIVEWIRE_RBF) \
+	$(CLOCK) \
+	$(BOOTMODS_EXTRA) \
+	krn
+else
+override BOOTMODS = krn krnp2 ioman init \
+	$(SCF) \
+	$(RBF) \
+	dwio_serial $(PIPE) $(DRIVEWIRE_RBF) \
+	$(CLOCK) \
+	sysgo shell_21 \
+	$(BOOTMODS_EXTRA)
+endif
+
+# 1b) "make clean" here also cleans the font/background outputs that
+#     wildbits-sys-assets generates INTO the source tree
+#     (level1/wildbits/sys/{fonts,backgrounds}) - the stock recipe
+#     never recurses there, leaving them behind as untracked files.
+#     Added as a prerequisite of clean, so wildbits.mak's own clean
+#     recipe is untouched. "-" keeps clean going if a sub-clean fails.
+#     NOTE: this file is included before wildbits.mak's "all" target,
+#     and make's default goal is the FIRST target seen - declare all
+#     first (bare; wildbits.mak adds its prerequisites later) so a
+#     plain "make" still builds instead of cleaning.
+all:
+clean: clean-sys-assets
+.PHONY: clean-sys-assets
+clean-sys-assets:
+	-$(MAKE) -C $(FONT_DIR) -f $(NITROS9DIR)/recipes/support/wildbits-fonts.mak clean
+	-$(MAKE) -C $(BACKGROUND_DIR) -f $(NITROS9DIR)/recipes/support/wildbits-backgrounds.mak clean
+
+# 2) SHELLMODS merge order: with the stock alphabetical order (date
+#    directly after shellplus) the toolshed-2.6-merged shell module
+#    freezes before the prompt on Windows/cygwin64 build hosts.
+#    Merging date/deiniz LAST is the proven clean ordering. Root
+#    cause (suspected read past module end in shellplus) still open;
+#    drop this override once fixed upstream.
+override SHELLMODS = shellplus echo iniz link load save unlink date deiniz


### PR DESCRIPTION
Special recipe for Windows + cygwin64 systems that resolves several painful issues that keep popping up in the other recipes and makefiles.