### PR TITLE
Check bootfile size limit

### DIFF
--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -160,12 +160,26 @@ $(FEU_STARTUP): FORCE
 
 FORCE: ;
 
+# Level 2 bootfile must not exceed 32,256 bytes ($7E00), which is the
+# available window from $8000 to $FDFF (below $FE00 hardware I/O). Exceeding
+# 32,256 bytes causes the bootfile to spill into physical Block 3, corrupting
+# DAT slot mappings during early kernel initialization.
+MAX_BOOTFILE_SIZE = 32256
+
 ifeq ($(LEVEL),2)
   PADUP ?= ./padup256 bootfile
 endif
 bootfile: $(addprefix $(MODDIR)/,$(BOOTMODS))
 	$(MERGE) $(addprefix $(MODDIR)/,$(BOOTMODS))>$@
 	$(PADUP)
+ifeq ($(LEVEL),2)
+	@size=$$(wc -c < $@ | tr -d ' '); \
+	if [ "$$size" -gt $(MAX_BOOTFILE_SIZE) ]; then \
+		echo "Error: $@ size ($$size bytes) exceeds the 32,256 byte threshold by $$((size - $(MAX_BOOTFILE_SIZE))) bytes!" >&2; \
+		echo "Level 2 bootfile must be <= 32,256 bytes (\$$7E00) to avoid DAT slot mapping corruption during early kernel initialization." >&2; \
+		exit 1; \
+	fi
+endif
 
 ifeq ($(LEVEL),2)
 $(DSKIMAGE): bootfile $(MODDIR)/sysgo $(addprefix $(MODDIR)/,$(CMDS)) $(STARTUP) $(FEU_STARTUP) wildbits-sys-assets $(RECIPE_DEPS)


### PR DESCRIPTION
Make sure that the generated image will actually boot successfully. If the Level 2 bootfile exceeds 32,256 bytes ($7E00), which is the available window from $8000 to $FDFF (below $FE00 hardware I/O), the system will either crash or fail to boot and fall back to the prompt. A larger bootfile spills into physical Block 3, corrupting DAT slot mappings during early kernel initialization.