### PR TITLE
Interrupt controller hygiene …

### DIFF
--- a/level2/modules/clock.asm
+++ b/level2/modules/clock.asm
@@ -813,13 +813,24 @@ InitCont
                ifne      wildbits
 * Use the SOF to get a 1/60th or 1/70th interrupt
                orcc      #IntMasks
-               lda       #$FF
-               sta       INT_PENDING_0
-               sta       INT_PENDING_1
-               sta       INT_MASK_1
+* Interrupt-controller ownership model (2026-09-01):
+*   - krn cold start scrubs ALL four groups (masks to $FF, pendings
+*     cleared) on every boot, software reboots included, so no session
+*     inherits another session's controller state.
+*   - every driver clears and unmasks ONLY its own bits at its own Init
+*     (wizfi, SOLdrv, mousedrv_ps2, keydrv_ps2, sc16550 all do).
+*   - clock owns exactly one source: SOF.  So this Init touches exactly
+*     one bit - clear any stale SOF latch (pending is write-1-to-clear,
+*     per-bit), then unmask SOF with a read-modify-write.
+* This Init runs at the FIRST F$STime, which is AFTER vtio/mousedrv have
+* already installed and unmasked their bits.  Absolute mask stores or
+* blanket $FF pending clears here would wipe another driver's arming or
+* eat its latched-but-unserviced event.  Per-bit and RMW only, always.
+               lda       #INT_VKY_SOF
+               sta       INT_PENDING_0       clear only a stale SOF latch: fresh edge for the first tick
                lda       INT_MASK_0
                anda      #^INT_VKY_SOF
-               sta       INT_MASK_0
+               sta       INT_MASK_0          unmask SOF, preserving every other driver's bits
                else
                
 * Note: this code can go away once we have a rel_50hz

--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -235,10 +235,27 @@ entry               equ       *         ; define assembler symbol entry
                     sty       $2002     ; stash size of bootfile
                     ldd       #$FF00    ; A = $FF, B = $00
                     tfr       b,dp      ; transfer 0 to direct page
+* Scrub the FPGA interrupt controller - ALL four groups.  The controller
+* registers survive everything short of a hardware reset (wbreset, the
+* reset button, a power cycle), so a software reboot (bootos9, feu
+* re-entry, crash restart) arrives here with the previous session's
+* unmasked bits and stale pending latches intact - and an inherited
+* unmasked source with no handler installed re-fires forever (the
+* wizi-then-reboot interrupt storm).  Kernel cold start is the ONLY
+* safe place for absolute stores: it runs before any driver installs.
+* Anything later (clock Init runs at the first F$STime, after vtio and
+* mousedrv are live) must touch only its own bits, per-bit RMW.
+* Masks first, then pendings: an edge landing mid-sequence latches
+* harmlessly behind the mask.  Drivers clear + unmask their own bits
+* at their own Init.
                     sta       INT_MASK_0 ; A = $FF; mask all set 0 interrupts
                     sta       INT_MASK_1 ; A = $FF; mask all set 1 interrupts
+                    sta       INT_MASK_2 ; A = $FF; mask all set 2 interrupts
+                    sta       INT_MASK_3 ; A = $FF; mask all set 3 interrupts
                     sta       INT_PENDING_0 ; A = $FF; clear any pending set 0 interrupts
                     sta       INT_PENDING_1 ; A = $FF; clear any pending set 1 interrupts
+                    sta       INT_PENDING_2 ; A = $FF; clear any pending set 2 interrupts
+                    sta       INT_PENDING_3 ; A = $FF; clear any pending set 3 interrupts
 * Set up DAT registers. Here, B = 0
                     ldx       #DAT.Regs ; point X to the DAT registers
 loop@               stb       ,x+       ; write 8K bank to DAT to bank register
@@ -1369,7 +1386,7 @@ KrnReturn2          rts                 ; return
 
 *[[[ Wildbits PORT
                   IFNE    wildbits ; begin conditional assembly for wildbits
-CrashDump           fill      255,32
+CrashDump           fill      255,20    ; count shrunk 32->20: pays for the group 2/3 scrub above (krn must stay exactly 4096)
                   ENDC
 *]]] Wildbits PORT
 


### PR DESCRIPTION
krn scrubs all four groups; clock Init touches only SOF

The FPGA interrupt controller survives software reboots (bootos9, feu re-entry, crash restarts), so a new session inherited the previous session's mask/pending state - and an inherited unmasked source with no handler installed re-fires forever (the wizi-then-soft-reboot storm).

krn cold start now masks all four groups and clears all four pending registers with absolute stores - the only point in boot that runs before any driver installs. Paid for by shrinking the unused CrashDump filler (count 32->20); krn stays exactly 4,096 bytes.

Clock Init runs at the first F$STime, after vtio/mousedrv are already armed, so it is reduced to the one bit it owns: clear a stale SOF latch (per-bit write-1-to-clear) and RMW-unmask SOF. The old blanket $FF pending clears and INT_MASK_1 write are removed so it can never wipe another driver's arming or eat a latched event.