### PR TITLE
wildbits: kernel/driver fixes bundle (slot-2 map-window safety + interrupt hygiene)

### DIFF
--- a/defs/wildbits_vtio.d
+++ b/defs/wildbits_vtio.d
@@ -179,6 +179,7 @@ V.FONTNAME          RMB      33
 *V.SOLTable         RMB      32
                     endc
 
+V.MapSav            RMB       1                   saved MMU map-window slot value (vtio: no stack use inside a mapped window)
 V.InBuf             RMB       KBufSz              the input buffer
 V.KSBuf             RMB       KBufSz
                     RMB       250-.

--- a/docs/wildbits-interrupt-hygiene.md
+++ b/docs/wildbits-interrupt-hygiene.md
@@ -1,0 +1,66 @@
+# WildBits Interrupt-Controller Hygiene (krn + clock)
+
+**Date:** 2026-09-01
+**Platforms:** F256 WildBits K2 and Jr2
+**Status:** field-verified on the K2 (rc8 typematic test matrix, 2026-09-01), shipped in `wb/fixes_bundle`
+
+---
+
+## The problem
+
+The FPGA interrupt controller (`IRQ_Controller_Jr.v`) has four groups,
+each with PENDING ($FE20+n), POLARITY, EDGE and MASK registers. Its reset
+input is wired to the board's **physical** reset only. A software restart
+(`bootos9`, a debugger restart, a crash path) therefore inherits whatever
+the previous session left behind: masks opened by drivers that never got
+to Term, and pending bits latched by hardware that kept running.
+
+In practice: after a session in which `wizi` had unmasked the WiFi bits in
+group 3, the next kernel came up with those bits already unmasked and
+pending before any driver had installed a handler for them — an
+interrupt with nobody to service it, i.e. a storm or a wander waiting for
+the first tick. Every driver assumed "reset means everything masked", and
+that assumption was false.
+
+## The fix
+
+**krn.asm (cold start, `IFNE wildbits`).** Before any driver installs,
+the kernel writes $FF to all four INT_MASK registers and then $FF to all
+four INT_PENDING registers (write-1-to-clear), with absolute stores. The
+controller is now in its power-on state regardless of how the kernel was
+entered. Drivers still unmask their own bits at Init as before.
+
+**clock.asm (Init).** Clock Init used to write whole INT_PENDING/INT_MASK
+registers. That was harmless when it ran first, but on wildbits clock Init
+runs at the first `F$STime`, *after* vtio and mousedrv have armed their
+interrupts, so the absolute writes silently wiped mousedrv's unmask. Init
+now clears only its own stale SOF pending bit and unmasks SOF with a
+read-modify-write; every other driver's bits are preserved. The comment
+block in the source explains the ordering constraint.
+
+## Why the scrub lives in krn and not in clock
+
+Clock Init is too late (see above) and drivers are too early to know
+about each other. The kernel's cold start is the one point that runs
+before everything and after nothing, and it is the only place where a
+blanket "mask and clear all four groups" cannot disturb a live driver.
+
+## Cost and verification
+
+- 24 bytes of krn, paid for out of the CrashDump padding (now computed at
+  assembly time, see `wildbits-mmu-slot-safety.md`); krn image still
+  exactly 4,096 bytes.
+- Verified alongside the rc8 typematic work: `wizi` then the remote shell,
+  mouse (the riskiest case: mousedrv arms before clock Init), `wbreset`
+  cycles, held-key + WiFi traffic soak — all clean. `bootos9` from a
+  running system refuses by design ("Can't boot in RAM mode"), so the
+  inherited-state scenario cannot normally occur on wildbits any more; the
+  scrub remains defence in depth for debug and crash restarts.
+
+## Related
+
+- `wildbits-mmu-slot-safety.md` — the other half of this bundle.
+- `defs/wildbits.d` group-3 bit names (INT_OPT_KBD, INT_WIZNET, …) were
+  added in the same campaign; note that `INT_SDC_INS` is still defined on
+  the wrong bit there (collides with INT_VIA1; hardware uses bit 7) — an
+  open defs fix.

--- a/docs/wildbits-mmu-slot-safety.md
+++ b/docs/wildbits-mmu-slot-safety.md
@@ -1,0 +1,181 @@
+# WildBits MMU Slot Safety — the "one character, then freeze" fork crash
+
+**Date:** 2026-09-02
+**Platforms:** F256 WildBits K2 and Jr2 (shared Level 2 sources)
+**Status:** root cause proven from RAM dumps, fix field-verified on the K2
+(`l2_wildbitsk2_wc4u`); the Jr2 carries the same sources and needs a rebuild
+**Branch:** `wb/fixes_bundle` (vtio.asm, defs/wildbits_vtio.d, krn.asm, clock.asm; see also `wildbits-interrupt-hygiene.md`)
+
+---
+
+## Symptom
+
+With four WizFi listeners running (`tsmon /wz0&` … `/wz3&`), the next fork
+from a script — the trailing `echo` in `wiz4up`, or `proc`/`wbinfo` typed
+on the console once remote shells were connected — printed exactly **one
+character** and the machine froze. Three listeners were always "rock
+solid". The same signature appeared on both machines, at stock speed and
+in turbo, on every driver and kernel variant tried over August. Earlier
+investigations chased the scheduler (a "cleared process descriptor on the
+active queue at $5F00"), fork linkage, the tick VIRQ, the DAT refresh path
+and a stale-PID reap; none of those was the cause.
+
+Separately, the K2 had twice "lost" its flash drives to error 241
+(E$Sect) under load. Same fault, different driver (see below).
+
+## How it was found
+
+The K2's FPGA debug port reads RAM independently of the halted CPU. A
+healthy snapshot (four tsmons up) and a frozen one were dumped and
+compared; the boot is deterministic, so the two 512K images differed in
+only 25 bytes. Those bytes told the story:
+
+- The process queues were intact and the kernel had **finished** the
+  script — no echo process, no sub-shell, the shell back asleep on its
+  keyboard read. The *console* had died, not the scheduler.
+- Kernel page 0 had 13 scattered single-byte writes (the wizfi stat-page
+  pointer, D.SysDAT's high byte, D.BlkMap's high byte among them) plus five
+  random 2-byte stores elsewhere: the signature of a CPU executing garbage.
+- The old "$5F00 corpse" was not a freed descriptor at all: it was a
+  different block showing through system slot 2 when the dispatcher looked.
+
+Tools: `Wildbits\FoenixMgrWin\k2dump.py` (whole-RAM dump; 64-byte
+transfers, resets the machine on exit) and `k2post.py` (queue walker).
+Two hard limits of the debug engine: never request more than $64 bytes
+per transfer, and never read above the 512K RAM — either one desyncs the
+engine until the board is **power-cycled** (resets do not clear it).
+
+## Root cause
+
+Every wildbits driver that needs to touch VKY, flash or RAM-disk memory
+uses **system slot 2 ($4000–$5FFF)** as a temporary map window:
+
+| driver | constant | what it maps |
+|---|---|---|
+| vtio | `MAPSLOT equ MMU_SLOT_2` (Level 2) | text $C2, attributes $C3, LUT $C0, font $C1, sound $C4 |
+| mousedrv | `MAPSLOT equ MMU_SLOT_2` | $C0 for the pointer sprite |
+| rbmem | `MMU_SLOT equ 2` | flash / RAM-disk sector blocks |
+| wizfi | `WORK_SLOT equ MMU_SLOT_2` | (debug only, commented out) |
+
+Each window masks IRQs, saves the slot's current block, maps its block,
+does its work and restores the saved value. That is safe only while
+nothing the kernel needs lives in slot 2.
+
+But the Level 2 kernel's `F$SRqMem` allocates system pages **from the top
+of the map downward**, and on wildbits the bootfile occupies $71–$FE, so
+the free system pool is $20–$70. After about 17 pages of use (four tsmons
+is enough) allocations cross into $40–$5F — slot 2 — and **process
+descriptors land there**. A descriptor's second page is that process's
+**system stack**.
+
+vtio's character-write path did this:
+
+```
+    ldb   MAPSLOT          save the slot
+    pshs  b                ... on the stack
+    ldb   #$C2 / stb MAPSLOT / sta ,x        text block mapped, char written
+    ldb   #$C3 / stb MAPSLOT / sta ,x        attribute block mapped
+    lda   ,s+              <-- stack is in slot 2: this reads the ATTRIBUTE BLOCK
+    sta   MAPSLOT          <-- restores junk into system slot 2
+    puls  cc / rts         <-- pops garbage from the wrong block: CPU wanders
+```
+
+The first character is already on screen when the restore goes wrong,
+hence exactly one character. The scroll, erase-line, palette, bitmap and
+bell windows had the same pattern. Why script speed mattered: while the
+sub-shell running `wiz4up` is alive it holds the $6F00 gap, so the echo
+child's descriptor is allocated at $5700 (slot 2); a human-paced fork
+after the script exits gets $6F00 (slot 3) and survives. Three listeners
+never pushed the map into slot 2 at all.
+
+rbmem's flash command path pushes return addresses **inside** a window
+with a flash block mapped; with a slot-2 stack those pushes vanish into
+the flash chip. That is the error-241 loss of /f0 and /f1.
+
+## The fix (two layers)
+
+1. **vtio.asm** — no window uses the stack for the saved slot any more.
+   The value is parked in a new statics byte, `V.MapSav`
+   (`defs/wildbits_vtio.d`), and no stack traffic crosses a block change
+   inside a window (BellTone's and SetBitmap's temporaries moved to the
+   IRQ-masked DP scratch `D.IRQTmp`). This works at Level 1 (the FEU build,
+   window in slot 7) and Level 2 alike.
+2. **krn.asm** (`IFNE wildbits`, 12 bytes paid from the CrashDump fill,
+   module size unchanged) — after the kernel marks its global memory used,
+   it also marks pages $40–$5F used, so the kernel **never allocates in
+   slot 2 again**. Cost: 8K of system RAM. Benefit: every driver's window,
+   including rbmem's and mousedrv's untouched inside-window pushes, is
+   safe by construction.
+
+Verify in a bootfile: krn contains `9E 4E 30 88 40 C6 20 6C 80 5A 26 FB`;
+vtio no longer contains `35 04 F7 FF AA` (`puls b / stb MAPSLOT`) — the
+two occurrences left in a bootfile belong to mousedrv and vtio's boot-time
+InitDisplay, both harmless once slot 2 is reserved.
+
+## Field verification (K2, 2026-09-02, `l2_wildbitsk2_wc4u`)
+
+| test | result |
+|---|---|
+| `wizi` → `wiz4up` with its trailing `echo` (the deterministic repro) | completes, prompt returns |
+| four remote clients connected, four shells | all alive |
+| console `proc` and `wbinfo` with all shells up (the Jr2's classic crash) | clean |
+| `dir` in each remote shell | separate clean streams |
+| client disconnect → reconnect on the same channel | hangup emulation re-arms |
+| `dir /f0`, `dir /f1` with everything up (rbmem window) | clean |
+
+## Rules for driver authors (wildbits)
+
+- Slot 2 is the drivers' window and the kernel stays out of it. Do not
+  map anything into slots 0, 1 or 3–7 from a driver.
+- Never park the saved slot value on the stack; use statics (or the DP
+  scratch with IRQs masked). Assume the caller's stack can be anywhere.
+- Inside a window, avoid `pshs`/`puls`/`bsr` while the mapped block is
+  not plain RAM — flash swallows pushes, VKY blocks return them but from
+  the wrong place if the block changes between push and pull.
+- Windows stay IRQ-masked and short. The tick path (cursor, sound) opens
+  the same window from interrupt context.
+
+## How this relates to the WizCon4 work and the "keyboard freezes"
+
+Three different faults were tangled together during the August/September
+WizFi campaign, and they were routinely mistaken for one another. For the
+record:
+
+| what people saw | actual fault | where it is fixed |
+|---|---|---|
+| K2: first keystroke after starting a `tsmon` on a WizFi channel wedges the machine (cursor keeps blinking, keyboard dead) | The WizFi driver kept its shared stat-page pointer in `D.SWPage` (DP $03), which on the K2 sits inside the keyboard driver's row-state bytes ($00–$08); every keystroke zeroed the pointer and the driver then used the kernel's page 0 as its queue page | WizFi driver (`D.DbgMem`), on the WizCon4 branch — **not** part of this bundle |
+| Both machines: with four WizFi listeners up, the next fork that writes to the console prints one character and freezes | **This document**: vtio's map window in system slot 2 vs. the kernel growing the system map into slot 2 | vtio + krn, this bundle |
+| K2: /f0 and /f1 "lost" with error 241 under load | Same slot-2 fault through rbmem's flash window | krn reservation, this bundle |
+
+Two points worth stating plainly:
+
+- **tsmon plays no part in the mechanism.** A tsmon never writes to the
+  console, so it never enters a vtio window; the tsmons survived with their
+  own descriptors sitting inside slot 2. Four listeners simply cost enough
+  system memory (a two-page descriptor plus path descriptors each) to push
+  the kernel's page allocations down into slot 2 for the first time. Any
+  other load that consumes ~17 system pages would do the same, and the
+  victim is whichever process next writes to the screen from a slot-2
+  stack.
+- **Why script speed mattered.** While the `wiz4up` sub-shell is alive it
+  holds the free gap at $6F00 (slot 3), so a fork launched from the script
+  gets its descriptor at $5700 (slot 2) and dies; a fork typed by hand after
+  the script has exited gets $6F00 and survives. That is the whole
+  "human-paced works, script-speed dies" mystery.
+
+The WizCon4 driver itself (four packet-mode channels, link gating, hangup
+emulation, the first-connection fixes) is independent of this bundle and
+ships on its own branch; it was the *test load* that finally made the
+slot-2 fault reproducible on demand, which is how the root cause was found.
+
+## Still open
+
+- `dmem <block> …` on a non-zero block freezes the machine: F$CpyMem
+  builds a temporary DAT image and copies through slots 5–6 with F$Move;
+  same family as the known user-mode F$MapBlk problem. Not caused by the
+  reservation (no slot-2 use in that path); not yet investigated.
+- rbmem's `TfrSect`/`SendCmd` and mousedrv's `MakeMSPointer` still push
+  inside their windows. Harmless while slot 2 is reserved; worth cleaning
+  up for the same discipline as vtio.
+- The Jr2 needs its disk and FEU blocks rebuilt from these sources and the
+  same ladder run.

--- a/level1/wildbits/modules/vtio.asm
+++ b/level1/wildbits/modules/vtio.asm
@@ -36,6 +36,19 @@ D.KbdSta            equ       D.Boot
 MAPSLOT             equ       MMU_SLOT_7
                     else
 MAPSLOT             equ       MMU_SLOT_2
+* MAPSLOT FIX (2026-09-02): the Level 2 kernel allocates system pages from
+* the top of the map downward, so under enough load the system map grows
+* into slot 2 ($4000-$5FFF) - the very slot these routines borrow as their
+* temporary map window. A process descriptor's second page is that
+* process's SYSTEM STACK, so a caller's stack could then sit inside the
+* window. Parking the saved slot value on that stack and pulling it back
+* while a VKY block was mapped read VKY memory instead of the stack,
+* restored junk into system slot 2, hid live descriptors and sent the CPU
+* wandering ("one character on screen, then freeze"; both machines, any
+* speed). Every window now parks the saved slot value in the driver statics
+* (V.MapSav) instead of on the stack and keeps NO stack traffic that crosses
+* a block change inside the window. Works at Level 1 (slot 7) and Level 2
+* (slot 2) alike. The kernel additionally reserves slot 2 (see krn.asm).
                     endc
 MAPADDR             equ       (MAPSLOT-MMU_SLOT_0)*$2000
 G.ScrStart          equ       MAPADDR
@@ -146,9 +159,14 @@ BellTone            tst       D.SndPrcID
                     bne       exit
                     stb       D.TnCnt             store the duration counter in the global
                     pshs      cc,a
+                    coma                          complement since attenuation is inverted on the PSG
+                    anda      #%00001111          turn off all but attenuation bits for tone 1
+                    ora       #%10010000          set latch bit and attenuation control bit for tone 1
+                    tfr       a,b                 B = tone-1 volume byte, computed BEFORE the window (no stack reads inside it)
+                    lda       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    sta       V.MapSav,u
                     lda       #$C4                get the sound MMU block
                     orcc      #IntMasks           mask interrupts
-                    ldb       MAPSLOT             get the MMU slot we'll map to
                     sta       MAPSLOT             store it in the MMU slot to map it in
 * Turn off attenuation for tones 2, 3, and noise channel.
                     lda       #%10111111          set tone 2 attenuation to 0
@@ -159,22 +177,17 @@ BellTone            tst       D.SndPrcID
                     lda       #%11111111          set noise attenuation to 0
                     sta       ,x
 * Turn on PSG.
-                    lda       1,s                 get the volume byte from the stack
-                    coma                          complement since attenuation is inverted on the PSG
-                    anda      #%00001111          turn off all but attenuation bits for tone 1
-                    ora       #%10010000          set latch bit and attenuation control bit for tone 1
-                    sta       ,x                  store in PSG hardware
+                    stb       ,x                  store the tone-1 volume byte in PSG hardware
 
 * Set frequency of tone
-                    pshs      b                   save original MAP slot value                    
                     tfr       y,d                 transfer frequency over
                     coma
                     comb
-                    pshs      d                   only 10 bits are significant
+                    std       <D.IRQTmp           only 10 bits are significant (IRQs masked: DP scratch, not the stack)
                     andb      #%00001111          clear all but bits 0-3
-                    orb       #%10000000          set the latch to 1 for tone 1         
+                    orb       #%10000000          set the latch to 1 for tone 1
                     stb       ,x                  send it to the hardware
-                    puls      d                   obtain the value again
+                    ldd       <D.IRQTmp           obtain the value again
                     lsrb                          shift the...
                     lsrb                          first four...
                     lsrb                          bits out...
@@ -184,11 +197,11 @@ BellTone            tst       D.SndPrcID
                     lsla                          up to...
                     lsla                          the upper nibble
                     anda      #%00110000          clear all other bits
-                    pshs      a                   save on the stack
-                    orb       ,s+                 OR in with bits 7-4
+                    sta       <D.IRQTmp           park bits 7-4 (DP scratch)
+                    orb       <D.IRQTmp           OR in with bits 7-4
                     stb       ,x
-                    puls      b                   get the original MAP slot value
-                    stb       MAPSLOT             restore it to the hardware
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     lda       V.BUSY,u            get active process ID
                     sta       D.SndPrcID
                     ldx       #$0000
@@ -595,8 +608,8 @@ RawWrite            pshs      a                   else save the character to wri
                     puls      a                   get the character to write
                     pshs      cc                  save CC
                     orcc      #IntMasks           mask interrupts
-                    ldb       MAPSLOT             get the MMU block number for the slot
-                    pshs      b                   save it
+                    ldb       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    stb       V.MapSav,u
                     ldb       #$C2                get the text MMU block number
                     stb       MAPSLOT             set the block number to text
                     sta       ,x                  save the character there
@@ -607,8 +620,8 @@ RawWrite            pshs      a                   else save the character to wri
                     cmpx      #G.ScrStart+(80*60)-1 are we at the end of largest possible screen?
                     bcc       l@                  branch if so
                     sta       1,x                 and the next location (for the cursor)
-l@                  lda       ,s+                 recover the initial MMU slot value
-                    sta       MAPSLOT             and restore it
+l@                  ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     puls      cc                  recover CC (this may unmask interrupts)
                     ldd       V.CurRow,u          get the current row and column
                     incb                          increment the column
@@ -630,8 +643,8 @@ SCROLL              equ       1
                     puls      d                   restore D
                     pshs      cc,d                save off the row/column and CC
                     orcc      #IntMasks           mask interrupts
-                    lda       MAPSLOT             get the current MMU slot
-                    pshs      a                   save it on the stack
+                    ldb       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    stb       V.MapSav,u
 scroll_loop1@       lda       #$C2                get the text block #
                     sta       MAPSLOT             and map it in
                     ldb       V.WWidth,u
@@ -644,8 +657,8 @@ scroll_loop1@       lda       #$C2                get the text block #
                     std       ,x++                and store it
                     leay      -2,y                decrement Y
                     bne       scroll_loop1@       branch if not 0
-                    puls      a                   recover the original slot
-                    sta       MAPSLOT             and restore it
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     puls      cc,d                recover CC and the row/column
                     else
                     clra                          just clear the row (goes to top)
@@ -728,8 +741,8 @@ EraseLineCore       pshs      b                   save the number of columns
                     suba      ,s+                 subtract the column to start erasing from
                     pshs      cc                  save CC
                     orcc      #IntMasks           mask interrupts
-                    ldb       MAPSLOT             get the MMU slot value
-                    pshs      b                   save it
+                    ldb       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    stb       V.MapSav,u
 clrloop@            ldb       #$C2                get the text MMU block
                     stb       MAPSLOT             store it in the MMU slot
                     clr       ,x                  clear the value there
@@ -739,8 +752,8 @@ clrloop@            ldb       #$C2                get the text MMU block
                     stb       ,x+                 store it and increment the index register
                     deca                          decrement the loop value
                     bne       clrloop@            branch if not done
-                    puls      b                   restore the MMU slot value
-                    stb       MAPSLOT             into the hardware
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     puls      cc,pc               restore CC and return
 
 ;;; ClrScrn
@@ -1137,8 +1150,8 @@ Do1B60_Param3
 
 Do1B60_Param4       pshs      cc
                     orcc      #IntMasks
-                    ldb       MAPSLOT
-                    pshs      b
+                    ldb       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    stb       V.MapSav,u
                     ldb       #TEXT_LUT_BLK
                     stb       MAPSLOT
                     ldx       V.EscParms+4,u
@@ -1153,7 +1166,7 @@ Do1B60_Param4       pshs      cc
                     sta       1,x
                     lda       V.EscParms+1,u get red component
                     sta       2,x
-                    puls      b
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
                     stb       MAPSLOT
                     puls      cc
                     lbra      ResetHandler
@@ -1838,12 +1851,12 @@ map@                lda       R$Y+1,x             load bitmap@
 *                   **** Store physical address of bitmap in TinyVicky BM0, BM1 or BM2
                     pshs      cc
                     orcc      #IntMasks           mask interrupts
-                    lda       MAPSLOT
-                    pshs      a
+                    lda       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    sta       V.MapSav,u
                     lda       #BITMAP_BLK         get the MMU Block for bitmap addresses
                     sta       MAPSLOT             store it in the MMU slot to map it in
 *                   **** Calculate starting address at 1000,1008,1010
-                    pshs      b                   push block# to stack
+                    stb       <D.IRQTmp           park block# (IRQs masked: DP scratch, not the stack)
                     ldb       R$Y+1,x             ldb with bitmap#
                     lslb                          multiply by 8
                     lslb
@@ -1851,19 +1864,19 @@ map@                lda       R$Y+1,x             load bitmap@
                     lda       #(MAPADDR+$1000)/256
                     tfr       d,y                 y is address of BM(0-2) registers
 *                   **** Convert b from block number to physical address
-                    ldb       ,s                  load b with block# from stack
+                    ldb       <D.IRQTmp           load b with block#
                     lbsr      Blk2Addr            convert blk# to high 16 bits of address in d
 *                   **** Load Bitmap start block physical address into Vicky BM0, BM1 or BM2
-                    pshs      a                   push high byte of bitmap address
+                    sta       <D.IRQTmp+1         park high byte of bitmap address
                     lda       #%00000001          enable bitmapX with CLUT 0
                     sta       ,y+                 enable bitmap with CLUT 0
-                    puls      a                   
+                    lda       <D.IRQTmp+1
                     std       ,y++
                     lda       #$0
                     sta       ,y+                 clear AD7-AD0
-                    puls      b,a
-                    sta       MAPSLOT
-noerror@            puls      cc,pc     
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
+noerror@            puls      cc,pc
 error@              coma                          set carry bit on error
 end@                rts             
 
@@ -1987,8 +2000,8 @@ clr_bmvar@          leay      V.BM0Blk,u           clear the bitmap storage
                     sta       ,y
 clr_bmReg@          pshs      cc                   clear the bitmap registers,disable bitmap
                     orcc      #IntMasks            mask interrupts
-                    lda       MAPSLOT
-                    pshs      a                    preserve current mmu block
+                    lda       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    sta       V.MapSav,u
                     lda       #BITMAP_BLK          get the MMU Block for bitmap addresses
                     sta       MAPSLOT              store it in the MMU slot to map it in
 * Calculate starting address at 1000,1008,1010
@@ -2004,8 +2017,8 @@ clr_bmReg@          pshs      cc                   clear the bitmap registers,di
                     sta       ,y+                  clear AD7-AD0
                     sta       ,y+                  clear AD15-AD8
                     sta       ,y                   clear AD18-AD16
-                    puls      a
-                    sta       MAPSLOT
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     puls      cc
 end@                rts
 
@@ -2022,8 +2035,8 @@ end@                rts
 ;;;
 SSPalet             pshs      cc
                     orcc      #IntMasks           mask interrupts
-                    lda       MAPSLOT
-                    pshs      a
+                    lda       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    sta       V.MapSav,u
                     lda       #$C0                was TEXT_LUT_BLK - get the MMU Block
                     sta       MAPSLOT             store it in the MMU slot to map it in
 *                   **** Calculate starting address at 1000,1008,1010
@@ -2038,8 +2051,8 @@ SSPalet             pshs      cc
                     rolb                          shift B, and rotate in enable it
 *                   **** Load Bitmap start block physical address into Vicky BM0, BM1 or BM2
                     stb       ,y                  enable bitmap with CLUT R$X
-                    puls      a
-                    sta       MAPSLOT
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     puls      cc,pc
 
 
@@ -2192,9 +2205,9 @@ DeleteLine
 * Block scroll loop: copy characters and attributes 2 bytes at a time
                     pshs      cc                  * Save CC (interrupt state)
                     orcc      #IntMasks           * Disable interrupts during mapping
-                    lda       MAPSLOT             * Save original MMU mapping slot
-                    pshs      a
 
+                    lda       MAPSLOT             MAPSLOT fix: save the slot in statics (stack may live in the window)
+                    sta       V.MapSav,u
 dl_loop             lda       #$C2                * Map text block into MMU slot
                     sta       MAPSLOT
                     ldb       V.WWidth,u
@@ -2210,8 +2223,8 @@ dl_loop             lda       #$C2                * Map text block into MMU slot
                     leay      -2,y                * Decrement byte copy counter by 2
                     bne       dl_loop             * Loop until all bytes copied
 
-                    puls      a                   * Restore original MMU slot mapping
-                    sta       MAPSLOT
+                    ldb       V.MapSav,u          MAPSLOT fix: restore the slot from statics, never from a stacked copy
+                    stb       MAPSLOT
                     puls      cc                  * Restore interrupts state
                     puls      y                   * Restore path descriptor register Y
 

--- a/level2/modules/clock.asm
+++ b/level2/modules/clock.asm
@@ -813,13 +813,24 @@ InitCont
                ifne      wildbits
 * Use the SOF to get a 1/60th or 1/70th interrupt
                orcc      #IntMasks
-               lda       #$FF
-               sta       INT_PENDING_0
-               sta       INT_PENDING_1
-               sta       INT_MASK_1
+* Interrupt-controller ownership model (2026-09-01):
+*   - krn cold start scrubs ALL four groups (masks to $FF, pendings
+*     cleared) on every boot, software reboots included, so no session
+*     inherits another session's controller state.
+*   - every driver clears and unmasks ONLY its own bits at its own Init
+*     (wizfi, SOLdrv, mousedrv_ps2, keydrv_ps2, sc16550 all do).
+*   - clock owns exactly one source: SOF.  So this Init touches exactly
+*     one bit - clear any stale SOF latch (pending is write-1-to-clear,
+*     per-bit), then unmask SOF with a read-modify-write.
+* This Init runs at the FIRST F$STime, which is AFTER vtio/mousedrv have
+* already installed and unmasked their bits.  Absolute mask stores or
+* blanket $FF pending clears here would wipe another driver's arming or
+* eat its latched-but-unserviced event.  Per-bit and RMW only, always.
+               lda       #INT_VKY_SOF
+               sta       INT_PENDING_0       clear only a stale SOF latch: fresh edge for the first tick
                lda       INT_MASK_0
                anda      #^INT_VKY_SOF
-               sta       INT_MASK_0
+               sta       INT_MASK_0          unmask SOF, preserving every other driver's bits
                else
                
 * Note: this code can go away once we have a rel_50hz

--- a/level2/modules/kernel/krn.asm
+++ b/level2/modules/kernel/krn.asm
@@ -235,10 +235,27 @@ entry               equ       *         ; define assembler symbol entry
                     sty       $2002     ; stash size of bootfile
                     ldd       #$FF00    ; A = $FF, B = $00
                     tfr       b,dp      ; transfer 0 to direct page
+* Scrub the FPGA interrupt controller - ALL four groups.  The controller
+* registers survive everything short of a hardware reset (wbreset, the
+* reset button, a power cycle), so a software reboot (bootos9, feu
+* re-entry, crash restart) arrives here with the previous session's
+* unmasked bits and stale pending latches intact - and an inherited
+* unmasked source with no handler installed re-fires forever (the
+* wizi-then-reboot interrupt storm).  Kernel cold start is the ONLY
+* safe place for absolute stores: it runs before any driver installs.
+* Anything later (clock Init runs at the first F$STime, after vtio and
+* mousedrv are live) must touch only its own bits, per-bit RMW.
+* Masks first, then pendings: an edge landing mid-sequence latches
+* harmlessly behind the mask.  Drivers clear + unmask their own bits
+* at their own Init.
                     sta       INT_MASK_0 ; A = $FF; mask all set 0 interrupts
                     sta       INT_MASK_1 ; A = $FF; mask all set 1 interrupts
+                    sta       INT_MASK_2 ; A = $FF; mask all set 2 interrupts
+                    sta       INT_MASK_3 ; A = $FF; mask all set 3 interrupts
                     sta       INT_PENDING_0 ; A = $FF; clear any pending set 0 interrupts
                     sta       INT_PENDING_1 ; A = $FF; clear any pending set 1 interrupts
+                    sta       INT_PENDING_2 ; A = $FF; clear any pending set 2 interrupts
+                    sta       INT_PENDING_3 ; A = $FF; clear any pending set 3 interrupts
 * Set up DAT registers. Here, B = 0
                     ldx       #DAT.Regs ; point X to the DAT registers
 loop@               stb       ,x+       ; write 8K bank to DAT to bank register
@@ -566,6 +583,33 @@ pt_clr@             sta       ,x+       clear this slot
 KrnMarkUsed         inc       ,x+       ; mark it as used
                     decb                ; done?
                     bne       KrnMarkUsed ; no, go back till done
+
+*[[[ Wildbits PORT
+* Reserve MMU slot 2 ($4000-$5FFF, pages $40-$5F) in the system page map.
+* The wildbits device drivers use slot 2 as their temporary map window for
+* VKY, flash and RAM-disk blocks (IRQs masked, slot saved and restored
+* around each window). F$SRqMem allocates system pages from the top of the
+* map DOWNWARD, so under enough load (about 17 pages in use) it grew the
+* system map into this slot and process descriptors - whose second page is
+* the process's SYSTEM STACK - landed inside the window. A driver's pushes
+* and pulls while a VKY or flash block was mapped then hit that block instead
+* of the stack: the slot was restored with junk, live descriptors vanished
+* and the CPU wandered (the 2026-08/09 "one character on screen, then
+* freeze" crash under load and the lost /f0,/f1 (E$Sect 241) incidents, both
+* machines, any speed - proven by RAM dumps over the debug port on
+* 2026-09-02). Marking these 32 pages used keeps the kernel out of slot 2
+* for good, at the cost of 8K of system RAM; the system DAT image entry for
+* slot 2 stays free, so the drivers' window never aliases live kernel
+* memory. 12 bytes, paid from the CrashDump fill.
+                  IFNE    wildbits ; begin conditional assembly for wildbits
+                    ldx       <D.SysMem ; get the system memory map pointer
+                    leax      $40,x     ; page $40 = first page of slot 2
+                    ldb       #$20      ; 32 pages = the whole slot
+KrnRsvSlot2         inc       ,x+       ; mark it as used
+                    decb                ; done?
+                    bne       KrnRsvSlot2 ; no, keep going
+                  ENDC
+*]]] Wildbits PORT
 
                   IFNE    picothing ; begin conditional assembly for picothing
 * Mark kernel block pages ($E0-$FF) as in-use so FSRqMem doesn't allocate them.
@@ -1369,7 +1413,14 @@ KrnReturn2          rts                 ; return
 
 *[[[ Wildbits PORT
                   IFNE    wildbits ; begin conditional assembly for wildbits
-CrashDump           fill      255,32
+* KrnTail: the offset where the constant-page tail (FIRQVCT and everything
+* after it, which must live in the $FDxx page the hardware keeps mapped) has
+* to start. The padding below is computed by lwasm from it, so code added or
+* removed above needs no hand-maintained fill count any more; if the code
+* ever overruns the tail the count goes negative and the assembly FAILS
+* ("Invalid fill length") instead of silently moving the tail.
+KrnTail             equ       $0F7F
+CrashDump           fill      255,KrnTail-*  ; pad up to the tail (computed at assembly time)
                   ENDC
 *]]] Wildbits PORT
 


### PR DESCRIPTION

Squash of wb/proper_slot_preservation and wb/interrupts_hygiene onto main. Field-verified on the K2 (l2_wildbitsk2_wc4u): wiz4up completes, four remote shells, console proc/wbinfo with all shells up, /f0 and /f1 clean.

Files:

level1/wildbits/modules/vtio.asm
  All nine MMU map windows (character write, scroll, erase-line, delete-
  line, text LUT, palette, two bitmap register paths, bell) no longer park
  the saved slot value on the stack. It goes to the new statics byte
  V.MapSav before the block is mapped and is restored from there after;
  no stack traffic crosses a block change inside a window (BellTone's
  and SetBitmap's temporaries moved to the IRQ-masked DP scratch
  D.IRQTmp). Same code assembles for Level 1 (FEU, slot 7) and Level 2
  (slot 2). Header comment explains the fault. Module grows 3152 -> 3215.

defs/wildbits_vtio.d
  Add V.MapSav (one byte) ahead of V.Last for the saved map-window slot.

level2/modules/kernel/krn.asm (all IFNE wildbits)
  - Cold start masks all four interrupt groups then clears all four pending registers with absolute stores, before any driver installs: the FPGA controller's registers survive software resets.
  - After marking global memory used, also mark system pages $40-$5F used so F$SRqMem never grows the system map into slot 2, the drivers' map window (8K of system RAM; 12 bytes of code).
  - The CrashDump padding before the constant-page tail is now `fill 255,KrnTail-*` with KrnTail equ $0F7F: lwasm computes the count, and an overrun fails the assembly ("Invalid fill length") instead of silently moving the tail. Image stays exactly 4096 bytes.

level2/modules/clock.asm
  Init clears only its own stale SOF pending bit and unmasks SOF with a
  read-modify-write, instead of writing whole INT_PENDING/INT_MASK
  registers (which wiped mousedrv's arming, since clock Init runs at the
  first F$STime, after vtio/mousedrv). Comment block documents why.

docs/wildbits-mmu-slot-safety.md
  New: symptom, how the RAM dumps found it, root cause, the two-layer
  fix, field verification table, rules for driver authors, open items.