### PR TITLE
Play command improvements

### DIFF
--- a/level1/wildbits/cmds/play.as
+++ b/level1/wildbits/cmds/play.as
@@ -88,7 +88,7 @@ edition = 16
 
 * Here are some tweakable options
 DOHELP              set       1                   1 = include help info
-SID_MAX_VOL         equ       15                  (0 = silence, 15 = loud) for all SID Voices
+SID_MAX_VOL         equ       6                   (0 = silence, 15 = loud) for all SID Voices - halved 2026-08-28 to balance against the quieter SAM2695 (.lyr) analog path
 SID_V1_CR1          equ       %00010001           SID Voice 1 Gate
 SID_V2_CR1          equ       %00010001           SID Voice 2 Gate
 SID_V3_CR1          equ       %00010001           SID Voice 3 Gate
@@ -98,7 +98,13 @@ SID_V3_PULSE_DUTY   equ       $800
 SID_V1_ADSR         equ       $00F0
 SID_V2_ADSR         equ       $00F0
 SID_V3_ADSR         equ       $00F0
-MIDIVEL_DEFAULT     equ       80                  0..127 for MIDI velocity
+* MIDI loudness model (2026-09-05). A Lyra $E0 event is a TRACK VOLUME (0-7), not a
+* per-note articulation, so it drives CC11 (expression) on the track's channel via
+* LyraExprConv, and every note goes out at one natural velocity. CC7 stays at 127
+* (mixer at unity, MidiVolAll). Machine-independent: absolute loudness is the codec's job.
+NOTE_VELOCITY       equ       100                 constant note-on velocity (sequencer convention; keeps GM patches off their hard-hit layers)
+LYRA_DEFAULT_LEVEL  equ       6                   Lyra volume assumed for a track that never sets one (mf: -8dB, two 4dB steps below 7)
+LYRA_DEFAULT_EXPR   equ       118                 = LyraExprConv[LYRA_DEFAULT_LEVEL] - keep in step with the table
 PLAYLISTITEM_MAXSTR equ       255
 
 FILETYPE_MUSICA     equ       1
@@ -107,8 +113,8 @@ FILETYPE_COCOLYRA   equ       3
 FILETYPE_ULTIMUSE   equ       4
 FILETYPE_MIDIPATCH  equ       5
 
-MIDI_CtrlReg        equ       SAM2695.Base+MIDI_CTRL
-MIDI_DataReg        equ       SAM2695.Base+MIDI_DATA
+MIDI_CtrlReg        equ       MIDI.Base+MIDI_CTRL
+MIDI_DataReg        equ       MIDI.Base+MIDI_DATA
 MIDITABENTSIZ       equ       4                   MIDI Note Table entry size in bytes
 MIDITABOCTSIZ       equ       7*MIDITABENTSIZ     MIDI Note Table octave size in bytes
 
@@ -468,16 +474,28 @@ PlaySidR2           leax      SampleBuf,u
                     lda       14+4,x 
                     sta       14+4,y 
 
-                    lda       22,x 
+                    lda       22,x
                     sta       22,y
-                    lda       23,x 
-                    sta       23,y 
-                    lda       24,x 
-                    sta       24,y 
+                    lda       23,x
+                    sta       23,y
+* Register 24 ($18) = filter mode / master volume. Raw dumps usually
+* carry volume 15, which bypasses the SID_MAX_VOL calibration and
+* leaves .rsd ~8dB louder than .mus. Rescale the volume nibble
+* through RsdVolScale; the filter/mode bits pass through untouched.
+* (X is free to clobber here - it is reloaded just below.)
+                    lda       24,x
+                    tfr       a,b
+                    andb      #$F0                keep the dump's filter/mode bits
+                    anda      #$0F                the dump's volume nibble
+                    leax      RsdVolScale,pcr
+                    lda       a,x                 rescale 0-15 -> 0-SID_MAX_VOL
+                    pshs      b
+                    ora       ,s+                 merge the filter bits back in
+                    sta       24,y
 
                     ldx       #$0002
                     os9       F$Sleep
-                    bra       PlaySidR2
+                    lbra      PlaySidR2           long branch - the volume rescale above grew the loop
 
 Load2Local          ldb       #SS.Size
                     lda       <bFilePath
@@ -519,7 +537,7 @@ a@                  ldd       1,s                 Recall address of top of file
                     clra
                     clrb
                     std       TRACK_CYCLES,y
-                    lda       #MIDIVEL_DEFAULT    Reset velocity
+                    lda       #LYRA_DEFAULT_EXPR  Expression (CC11) value in force until a Lyra volume event arrives
                     sta       TRACK_VELOC,y
                     leay      TRACK_ENTRYSIZE,y
                     dec       ,s 
@@ -535,7 +553,9 @@ a@                  ldd       1,s                 Recall address of top of file
                     bne       gm@                 User has applied a patch file
                     lbsr      MidiMuteAll
                     lbsr      SetupInstruments    Auto-sensing instrument translation
-gm@                 ldb       #1                  Enable the sequencer
+gm@                 lbsr      MidiVolAll          CC7 max on all channels - AFTER MidiMuteAll (its GM-reset sysex restores the quiet power-on volume default)
+                    lbsr      MidiExprAll         CC11 = default expression on all channels (the GM reset put it at 127)
+                    ldb       #1                  Enable the sequencer
                     stb       <fDoSequencer
 
 ********************************************************************
@@ -601,13 +621,16 @@ r@                  ldd       ,x                  Get current note
                     beq       c@                  No, it must be a note or rest
 * Process Event Codes
                     anda      #$F0                Mask out non event bits
-                    cmpa      #$E0                Is this velocity control?
+                    cmpa      #$E0                Is this a track volume event?
                     bne       te@                 Assume this is a musical note/rest
-                    andb      #7                  Make safe velocity value
-                    leay      LyraVelocConv,pcr   Point to Lyra-to-MIDI velocity conversion table
-                    lda       b,y                 Convert 0..7 to 0..127
+                    andb      #7                  Lyra volume level 0..7
+                    leay      LyraExprConv,pcr    Point to Lyra-volume-to-CC11 table
+                    lda       b,y                 Convert 0..7 to expression 0..127
                     ldy       <pThisTrack         Restore track pointer
-                    sta       TRACK_VELOC,y       Set new velocity for this channel
+                    cmpa      TRACK_VELOC,y       Same level as before? then spend no MIDI bytes
+                    beq       se@
+                    sta       TRACK_VELOC,y       Remember this track's expression value
+                    lbsr      MidiExpression      CC11 on this track's channel = A
                     bra       se@
 te@                 cmpa      #$A0                Tempo event?
                     bne       se@
@@ -715,7 +738,7 @@ MidiNoteOn          ldb       #MIDICMD_NOTE_ON    Send MIDI Note On
                     stb       >MIDI_DataReg
                     lda       TRACK_MIDIPITCH,y
                     sta       >MIDI_DataReg       The note value to turn on
-                    ldb       TRACK_VELOC,y       Get velocity for this channel
+                    ldb       #NOTE_VELOCITY      One natural velocity - loudness is expression (CC11), not velocity
                     stb       >MIDI_DataReg
                     rts
 
@@ -727,9 +750,57 @@ a@                  orb       TRACK_MIDICHAN,y    Get the target channel
                     lda       TRACK_MIDIPITCH,y
                     sta       >MIDI_DataReg       The note value to turn on
                     ldb       #$00 
-*                    ldb       TRACK_VELOC,y       Get velocity for this channel
+*                    ldb       #NOTE_VELOCITY      One natural velocity - loudness is expression (CC11), not velocity
                     stb       >MIDI_DataReg
                     rts
+
+* Set CC7 (channel volume) to maximum on all 16 MIDI channels.
+* Must run AFTER MidiMuteAll: the GM reset sysex it sends returns
+* every channel volume to the power-on default (~100), which leaves
+* .lyr playback noticeably quiet on the SAM2695.
+MidiVolAll          clr       ,-s                 First MIDI channel #
+a@                  lda       #MIDICMD_CC         Control Change $Bx
+                    ora       ,s                  Mix in the channel (x)
+                    sta       >MIDI_DataReg
+                    ldb       #7                  CC7 = channel volume
+                    stb       >MIDI_DataReg
+                    ldb       #127                maximum
+                    stb       >MIDI_DataReg
+                    inc       ,s
+                    lda       ,s
+                    cmpa      #16
+                    blo       a@
+                    puls      a,pc
+
+* Set CC11 (expression) on all 16 channels to the default Lyra level's value, so
+* tracks that never send a volume event (and .ume files) start at the same loudness
+* as a Lyra track at LYRA_DEFAULT_LEVEL. Run after MidiVolAll (the GM reset sysex
+* in MidiMuteAll leaves expression at 127).
+MidiExprAll         clr       ,-s                 First MIDI channel #
+e@                  lda       #MIDICMD_CC         Control Change $Bx
+                    ora       ,s                  Mix in the channel (x)
+                    sta       >MIDI_DataReg
+                    ldb       #11                 CC11 = expression
+                    stb       >MIDI_DataReg
+                    ldb       #LYRA_DEFAULT_EXPR
+                    stb       >MIDI_DataReg
+                    inc       ,s
+                    lda       ,s
+                    cmpa      #16
+                    blo       e@
+                    puls      a,pc
+
+* Send CC11 (expression) on one track's MIDI channel.
+* Entry: A = expression value 0..127, Y = track.  Preserves D, X, Y.
+MidiExpression      pshs      d
+                    lda       #MIDICMD_CC         Control Change $Bx
+                    ora       TRACK_MIDICHAN,y    on this track's channel
+                    sta       >MIDI_DataReg
+                    lda       #11                 CC11 = expression
+                    sta       >MIDI_DataReg
+                    lda       ,s                  the value
+                    sta       >MIDI_DataReg
+                    puls      d,pc
 
 MidiMuteAll         clr       ,-s                 First MIDI channel #
 a@                  lda       #MIDICMD_CC         Control Change $Bx
@@ -1007,7 +1078,7 @@ UmeMusicN           pshs      a
                     cmpb      #32
                     beq       next@                 Is it a rest?
                     sta       TRACK_MIDIPITCH,y   Set the new pitch
-                    lda       #MIDIVEL_DEFAULT
+                    lda       #LYRA_DEFAULT_EXPR  non-zero = sounding (DebugNotes); the velocity itself is NOTE_VELOCITY
                     sta       TRACK_VELOC,y
                     lbsr      MidiNoteOn
 next@               leax      8,x
@@ -1719,9 +1790,9 @@ LOUD_ALL
                     bra       PSG_LOUD
                 endc
 
-PSG_LOUD            ldd       #$B090
+PSG_LOUD            ldd       #$B334
                     lbsr      WritePSG
-                    ldd       #$D0FF
+                    ldd       #$D3FF
                     lbra      WritePSG
 
 QUIET_ALL
@@ -1916,8 +1987,22 @@ TrioLengths         fcb       $00
                     fcb       $02               [2,4,2]
                     fcb       $01               [0,4,0]
 
-* Conversion table for Lyra volume (0-7) into MIDI velocity (0-127)
-LyraVelocConv       fcb       1,70,75,80,85,90,95,105
+* Lyra track volume (0-7) -> MIDI CC11 expression (0-127), 2026-09-05.
+* Lyra's soft levels are still meant to be heard, so levels 1..7 run from
+* 80 to 127 in even 1.33dB steps on the GM volume curve (dB = 40*log10(v/127)):
+*   level 0 = silent, levels 1..7 = -8,-6.7,-5.3,-4,-2.7,-1.3,0 dB.
+*   (A first cut spread 1..7 over -24..0 dB; the low levels vanished.)
+*   Level 6 (118) is assumed for tracks that never send a volume event
+*   (LYRA_DEFAULT_EXPR - keep the equate in step with this table).
+* History: as a VELOCITY table it was 1,70,75,80,85,90,95,105, then
+* 1,90,96,102,108,114,120,127 (2026-08-28) - a 3.5dB spread, so Lyra
+* dynamics barely registered.
+LyraExprConv        fcb       0,80,87,93,101,109,118,127
+
+* .rsd volume-nibble rescale: maps a raw dump's 0-15 SID master
+* volume onto the calibrated range (entry n = n*SID_MAX_VOL/15,
+* nearest). Regenerate this table if SID_MAX_VOL changes from 6.
+RsdVolScale         fcb       0,0,1,1,2,2,2,3,3,4,4,4,5,5,6,6
 
 * Program the MIDI instruments per the Lyra header
 * Lyra has 8 virtual channels, and each one can link to any physical MIDI channel.

--- a/level1/wildbits/cmds/wmset.asm
+++ b/level1/wildbits/cmds/wmset.asm
@@ -1,0 +1,187 @@
+********************************************************************
+* wmset - write a WM8776 codec register live, for balancing by ear
+*
+* Usage:  wmset <reg> <value>        both hex, e.g.  wmset 03 E4
+*         wmset                      with no args, prints usage
+*
+* The codec control port is at CODEC.Base ($FE70) in FIXED I/O, so it
+* needs no MMU mapping and works from any task.  A write is 16 bits:
+*   [6:0] register  [8] UPDATE  [7:0] value
+* i.e. D = (reg<<9) | $100 | value.  The UPDATE bit is always set here,
+* which is what makes an attenuation change take effect immediately.
+*
+* The two knobs worth turning (see the kit README):
+*   R03/R04  DAC attenuation      $FF = 0dB, 0.5dB per step down
+*   R00/R01  headphone attenuation $79 = 0dB, 1dB per step down
+* Change left and right together or the image shifts.
+*
+* Headphone master — everything, including the synth (wmset 00 xx / 01 xx, 1 dB per step, higher = louder)
+* value	cut	how it sounds
+* 79	0 dB	loudest possible		K2 (headphone jack)
+* 73	−6 dB	a bit quieter		
+* 6C	−13 dB	half as loud		Jr2
+* 66	−19 dB	quiet		
+* 60	−25 dB	very quiet
+*
+* DAC attenuation — SID, PSG, .mus (wmset 03 xx / 04 xx, 0.5 dB per step, higher = louder)
+* value	cut	how it sounds
+* FF	0 dB	loudest possible		
+* FD	−1 dB	nearly full		Jr2
+* F5	−5 dB	a little quieter		
+* EB	−10 dB	about half as loud		
+* E5	−13 dB	noticeably quieter
+* DF	−16 dB	quieter
+* D7	−20 dB	quieter still		K2 (headphone jack)
+* DB	−18 dB	quiet		
+* CB	−26 dB	very quiet
+*
+* Jr2 balanced on 9/5/2026 with $00/$01 = $6C  03/04 = $FD  
+* K2 balanced on 9/5/2026 at the HEADPHONE jack with $00/$01 = $79  03/04 = $D7
+*    ($DF first; -20dB after play moved Lyra volume onto CC11 expression, which
+*    left .mus a little ahead of .lyr on the K2 headphones)
+*    (.mus level with .lyr; synth reaches the K2 mix ~15dB below the Jr2's).
+*    K2 RCA (stereo out) NOT tuned - parked. Values live in vtio InitCODEC (K2 block).
+*
+* What reaches the WM8776's DAC on the K2 (SoundChips2DAC_Interface → audio_out → I2S → CODEC_DAC_BCLK/LRCK/DAT):
+* source	core	channels	how it enters the sum
+* SID	two 6581 cores (left, right; a "mono" chip-select writes both)	stereo	first term, 16-bit signed
+* PSG	SN76489	mono → both	left and right PSG outputs are added together and the same sum fed to both channels
+* OPL3	YMF262 core	stereo	third term
+*
+
+* Edt/Rev  YYYY/MM/DD  Modified by
+* ------------------------------------------------------------------
+*   1      2026/09/05  assembled for the wm8776-balance kit
+
+                    ifp1
+                    use       defsfile
+                    endc
+
+tylg                set       Prgrm+Objct
+atrv                set       ReEnt+rev
+rev                 set       $00
+edition             set       1
+
+                    mod       eom,name,tylg,atrv,start,size
+
+                    org       0
+regnum              rmb       1                   register number  0..127
+regval              rmb       1                   value to write
+size                equ       .
+
+name                fcs       /wmset/
+                    fcb       edition
+
+usemsg              fcc       /Usage: wmset <reg> <value>   (hex, e.g. wmset 03 E4)/
+                    fcb       C$CR
+usemsgl             equ       *-usemsg
+
+* X points at the command line on entry
+start               clr       regnum,u
+                    clr       regval,u
+                    lbsr      SkipSpc
+                    cmpa      #C$CR               nothing typed?
+                    lbeq      Usage
+                    lbsr      GetHex              first argument -> register
+                    lbcs      Usage
+                    stb       regnum,u
+                    lbsr      SkipSpc
+                    cmpa      #C$CR               second argument missing?
+                    lbeq      Usage
+                    lbsr      GetHex              second argument -> value
+                    lbcs      Usage
+                    stb       regval,u
+
+* Build the 16-bit codec word:
+*   bits 15..9 = register, bit 8 = UPDATE, bits 7..0 = value
+* so the high byte is (reg<<1)|1 and the low byte is the value.
+                    lda       regnum,u
+                    anda      #$7F                registers are 7 bits
+                    lsla                          reg << 1, leaving bit 0 for UPDATE
+                    ora       #$01                set UPDATE so the change takes effect
+                    ldb       regval,u
+                    ldx       #CODEC.Base
+                    lbsr      SendToCODEC
+                    clrb
+                    os9       F$Exit
+
+* NOTE: global on purpose - the branches cross an os9 call, and the os9
+* macro breaks @-local label scope in lwasm (same trap as keydrv_k2).
+Usage               leax      usemsg,pcr
+                    ldy       #usemsgl
+                    lda       #$02                stderr
+                    os9       I$WritLn
+                    ldb       #$01
+                    os9       F$Exit
+
+********************************************************************
+* SendToCODEC - same handshake vtio uses: wait for the busy bit to
+* clear, load the two halves, then strobe the control register.
+SendToCODEC         pshs      d
+w@                  lda       CODECCtrl,x
+                    lsra
+                    bcs       w@
+                    puls      d
+                    sta       CODECCmdHi,x
+                    stb       CODECCmdLo,x
+                    lda       #$01
+                    sta       CODECCtrl,x
+                    rts
+
+********************************************************************
+* SkipSpc - advance X past spaces, return the character in A
+SkipSpc             lda       ,x
+                    cmpa      #C$SPAC
+                    bne       ex@
+                    leax      1,x
+                    bra       SkipSpc
+ex@                 rts
+
+********************************************************************
+* GetHex - parse up to two hex digits at X into B.  Carry set = bad.
+GetHex              clrb
+                    lbsr      HexDig
+                    bcs       bad@
+                    stb       ,-s                 first nybble
+                    lbsr      HexDig
+                    bcs       one@                only one digit - that is fine
+                    lda       ,s+
+                    lsla
+                    lsla
+                    lsla
+                    lsla
+                    pshs      b
+                    ora       ,s+
+                    tfr       a,b
+                    andcc     #^Carry
+                    rts
+one@                puls      b
+                    andcc     #^Carry
+                    rts
+bad@                orcc      #Carry
+                    rts
+
+* HexDig - one hex digit at X into B, X advanced.  Carry set = not hex.
+HexDig              lda       ,x
+                    cmpa      #'0
+                    blo       no@
+                    cmpa      #'9
+                    bhi       af@
+                    suba      #'0
+                    bra       ok@
+af@                 anda      #$DF                fold to upper case
+                    cmpa      #'A
+                    blo       no@
+                    cmpa      #'F
+                    bhi       no@
+                    suba      #'A-10
+ok@                 tfr       a,b
+                    leax      1,x
+                    andcc     #^Carry
+                    rts
+no@                 orcc      #Carry
+                    rts
+
+                    emod
+eom                 equ       *
+                    end

--- a/level1/wildbits/modules/vtio.asm
+++ b/level1/wildbits/modules/vtio.asm
@@ -264,6 +264,27 @@ InitPSG             pshs      cc                save the condition code register
 InitCODEC
                     ldx       #CODEC.Base
 
+* Each machine wires the codec chip differently - keep a fully
+* independent register sequence per platform (no shared writes), so
+* either machine's audio setup can be tuned without touching the
+* other's.
+                    ifne      jr2
+* ------------------- Jr2 InitCODEC -------------------
+* Attenuations tuned by ear 2026-08-29/30 (balanced play command,
+* SID_MAX_VOL=6, Lyra velocities to 127, CC7=127):
+*   - The SAM2695 (.lyr) enters the output mux as ANALOG with no gain
+*     control of its own, so the HEADPHONE master (R00/R01, 1dB/step
+*     below $79=0dB) is the .lyr level knob; the DAC att (R03/R04,
+*     0.5dB/step below $FF=0dB) is the .mus/SID level knob. Move them
+*     in opposite directions to shift one without the other.
+*   - Final: DAC $FD (-1.0dB) + headphones $60 (-25dB). The Jr2's
+*     .lyr runs ~12dB hotter into the mix than the K2's, hence the
+*     deep headphone cut with the DAC nearly open (only 1dB of "make
+*     .mus louder" headroom remains - past that, raise SID_MAX_VOL).
+*   - The Jr2's LINE-OUT tracks the headphone stage (board wiring),
+*     so this one setting balances BOTH jacks - unlike the K2, whose
+*     line-out taps the DAC directly. Tune each machine's block
+*     separately; do not copy values across.
                     ldd       #%0010111000000000                    R23 - Reset chip
                     lbsr      SendToCODEC
                     ldd       #%0001010000000010                    R10 - DAC Interface Control 16-bit i2s
@@ -276,14 +297,50 @@ InitCODEC
                     lbsr      SendToCODEC
                     ldd       #%0001101000000000                    R13 - PWR Down Control, Everything on
                     lbsr      SendToCODEC
-                    ldd       #%0000011111110000                    R03 - Left DAC Attenuation
+                    ldd       #%0000011111111101                    R03 - Left DAC Attenuation ($FD = -1.0dB)
                     lbsr      SendToCODEC
-                    ldd       #%0000100111110000                    R04 - Right DAC Attenuation
+                    ldd       #%0000100111111101                    R04 - Right DAC Attenuation ($FD = -1.0dB)
                     lbsr      SendToCODEC
-                    ldd       #%0000000101101100                    R00 - Left Headphone Attenuation Control
+                    ldd       #%0000000101100000                    R00 - Left Headphone Attenuation ($60 = -25dB)
                     lbsr      SendToCODEC
-                    ldd       #%0000001101101100                    R01 - Right Headphone Attenuation Control
+                    ldd       #%0000001101100000                    R01 - Right Headphone Attenuation ($60 = -25dB)
                     lbsr      SendToCODEC
+
+                    else
+* -------------- K2: independently tunable InitCODEC --------------
+* K2 tuned by ear on the HEADPHONE jack, 2026-09-05 (wmset, .mus vs .lyr):
+*   DAC $D7 (-20dB) + headphones $79 (0dB); was $DF until the play command
+*   moved Lyra volume onto CC11 expression (2026-09-05 pm). The K2's synth reaches the
+*   mix ~15dB lower than the Jr2's, so the DAC is cut to meet it and the
+*   headphone master opened fully. RCA (stereo out) NOT tuned - parked.
+* Background (2026-08-29): the SAM2695 MIDI synth (.lyr) enters
+* the output mux through the Aux/Bypass ANALOG inputs, which have no
+* gain control in the WM8776 - it cannot be boosted directly, so the
+* DAC (SID/PSG) path is cut toward it instead, and the headphone
+* master raised to compensate that output. (DAC att R03/R04:
+* 0.5dB/step below $FF=0dB; headphone att R00/R01: 1dB/step below
+* $79=0dB.)
+                    ldd       #%0010111000000000                    R23 - Reset chip
+                    lbsr      SendToCODEC
+                    ldd       #%0001010000000010                    R10 - DAC Interface Control 16-bit i2s
+                    lbsr      SendToCODEC
+                    ldd       #%0010001100000001                    R17 - ALC Control 2 
+                    lbsr      SendToCODEC
+                    ldd       #%0010101000000011                    R21 - ADC Mux Control   AIN
+                    lbsr      SendToCODEC
+                    ldd       #%0010110000000111                    R22 - Output Mux MX[2:0] = "111" 
+                    lbsr      SendToCODEC
+                    ldd       #%0001101000000000                    R13 - PWR Down Control, Everything on
+                    lbsr      SendToCODEC
+                    ldd       #%0000011111010111                    R03 - Left DAC Attenuation ($D7 = -20dB)
+                    lbsr      SendToCODEC
+                    ldd       #%0000100111010111                    R04 - Right DAC Attenuation ($D7 = -20dB)
+                    lbsr      SendToCODEC
+                    ldd       #%0000000101111001                    R00 - Left Headphone Attenuation ($79 = 0dB)
+                    lbsr      SendToCODEC
+                    ldd       #%0000001101111001                    R01 - Right Headphone Attenuation ($79 = 0dB)
+                    lbsr      SendToCODEC
+                    endc
 *                   ldd       #%0001011000000010                    R11 - ADC Interface Control 
 *                   lbsr      SendToCODEC
 *                   ldd       #%0001100111010101                    R12 - Master Mode Control

--- a/recipes/wildbits/wildbits.mak
+++ b/recipes/wildbits/wildbits.mak
@@ -83,7 +83,7 @@ endif
 CMDS += $(STDCMDS) shell \
 	bootos9 scfg wbinfo wbreset modem \
 inetd telnet dw httpd $(BASIC09) $(BF) \
-	$(CMDS_EXTRA) wildspeed w6100eth lcdload
+	$(CMDS_EXTRA) wildspeed w6100eth lcdload wmset
 
 ifeq ($(LEVEL),2)
 UTILPAK1_MODS = attr copy date del deiniz dir display list makdir mdir \


### PR DESCRIPTION
Update play.asm to reflect new MIDI address names in wildbits.d

Balance the volumes out between different music formats and sound chips on both the Jr2 and K2.

Set (Jr2/K2) conditional assembly of CODEC configuration

Add wmset - live WM8776 codec register writer for balancing by ear

wmset <reg> <value> (hex) writes one 16-bit control word to the codec at CODEC.Base using the same busy-wait sequence as vtio's SendToCODEC, with UPDATE set so attenuation changes take effect immediately.  Lets the DAC (R03/R04) and headphone (R00/R01) attenuations be tuned on a running machine instead of one disk build per guess.  Added to the wildbits CMDS list so it ships on the disk.

play: Lyra track volume drives CC11 expression; constant note velocity

Lyra's $E0 event is a track volume (0-7), not a per-note articulation, so it now sends CC11 (expression) on the track's channel through LyraExprConv (0,32,40,50,64,80,101,127: silent, then -24..0 dB in even 4 dB steps on the GM volume curve) instead of scaling note velocity through a 90..127 table that spanned only 3.5 dB.  Every note-on/off goes out at NOTE_VELOCITY (100). LYRA_DEFAULT_LEVEL 5 (CC11 80) is applied to all channels after MidiVolAll and to tracks that never send a volume event.  Per-track CC11 is sent only on change.  CC7 stays at 127.  Machine-independent: absolute loudness is the codec's job.

vtio: K2 DAC attenuation $D7 (-20dB); wmset notes updated

K2 headphone-jack balance re-trimmed by ear after play moved Lyra volume onto CC11 expression, which left .mus a little ahead of .lyr: R03/R04 $DF -> $D7, headphones stay $79.  Jr2 block unchanged ($FD/$60).

play: Lyra levels 1..7 -> CC11 80..127; level 0 stays silent

The -24..0 dB spread made Lyra's soft levels vanish on the SAM2695.  Lyra's lower volumes are still meant to be heard, so LyraExprConv now runs 0,80,87,93,101,109,118,127 (levels 1..7 = -8..0 dB in even 1.33 dB steps on the GM curve).  LYRA_DEFAULT_EXPR follows level 6 -> 118.