### PR TITLE
Package Masterpiece Infocom stories and update interpreter in mega recipes

### DIFF
--- a/recipes/coco3/README.md
+++ b/recipes/coco3/README.md
@@ -125,8 +125,8 @@ software and story files fetched from pinned upstream revisions:
   `forth09` command, with its test program in `/FORTH09/forthtest.4th`
 - [`rlucente-retro/infocom-os9-port`](https://github.com/rlucente-retro/infocom-os9-port),
   installed as the `infocom` command
-- the Version 3 Zork I-III story files under `/GAMES/INFOCOM`, installed as
-  `zork1.dat`, `zork2.dat`, and `zork3.dat`
+- the Version 3 Zork I-III story files from the Masterpiece Collection under
+  `/GAMES/INFOCOM`, installed as `zork1.z3`, `zork2.z3`, and `zork3.z3`
 - the Version 3 [`drpitre/raakatu`](https://github.com/drpitre/raakatu) story,
   installed as `/GAMES/INFOCOM/raakatu.z3`
 - the OS-9 Level 2 BBS from `nitros9-apps/os9l2bbs`, with its commands merged
@@ -146,7 +146,7 @@ interpreter:
 ```text
 forth09
 forth09 </dd/FORTH09/forthtest.4th
-infocom /dd/GAMES/INFOCOM/zork1.dat
+infocom /dd/GAMES/INFOCOM/zork1.z3
 infocom /dd/GAMES/INFOCOM/raakatu.z3
 chd /dd/BBS
 runbbs
@@ -157,12 +157,19 @@ raw TCP terminal, such as Serial on macOS, on port 6909. A Telnet client is not
 suitable because its protocol negotiation interferes with the BBS input. Set
 `BBS_PORT` on the `make` command line to select another port.
 
-`INFOCOM_STORY_DIR` and `INFOCOM_STORIES` may be overridden to package another
+By default, only the open-source Zork trilogy is included. To package all 21
+games from the Masterpiece Collection, pass `ALL_GAMES=1`:
+
+```sh
+make ALL_GAMES=1
+```
+
+`INFOCOM_STORY_DIR` and `INFOCOM_STORIES` may also be overridden to package another
 legally obtained Version 3 story-file collection:
 
 ```sh
 make INFOCOM_STORY_DIR=/path/to/stories \
-  INFOCOM_STORIES="ZORK1.DAT PLANETFALL.DAT WITNESS.DAT"
+  INFOCOM_STORIES="zork1.z3 planetfall.z3 witness.z3"
 ```
 
 ## Notes

--- a/recipes/coco3/dw_mega/recipe.mak
+++ b/recipes/coco3/dw_mega/recipe.mak
@@ -20,7 +20,7 @@ EXTERNAL_DIR ?= .external
 COCO_SHELF ?= $(abspath $(NITROS9DIR)/..)
 
 INFOCOM_REPO ?= https://github.com/rlucente-retro/infocom-os9-port.git
-INFOCOM_REF ?= 23c88a7d40f0591c451ca53fbe7887a30f559718
+INFOCOM_REF ?= 8f3bc2b6f67a7897eb426783c52a6cf8cc6c729f
 INFOCOM_SRC = $(EXTERNAL_DIR)/infocom-os9-port
 INFOCOM_CHECKOUT = $(INFOCOM_SRC)/.checkout-$(INFOCOM_REF)
 INFOCOM_CMD = $(INFOCOM_SRC)/infocom
@@ -51,10 +51,20 @@ CCOMPILER_INPUTS = $(CCOMPILER_DIR)/Makefile $(CCOMPILER_DIR)/defsfile \
 	$(wildcard $(CCOMPILER_DIR)/lib/*) \
 	$(wildcard $(CCOMPILER_DIR)/sources/*)
 
-# The interpreter supports Version 3 story files. Override INFOCOM_STORY_DIR
-# and INFOCOM_STORIES to package another legally obtained collection.
-INFOCOM_STORY_DIR ?= $(NITROS9_APPS_DIR)/cpm/software/zork
-INFOCOM_STORIES ?= ZORK1.DAT ZORK2.DAT ZORK3.DAT
+ALL_GAMES ?= 0
+
+# The interpreter supports Version 3 story files from the Masterpiece Collection.
+# Override INFOCOM_STORY_DIR and INFOCOM_STORIES to package custom story files.
+INFOCOM_STORY_DIR ?= $(INFOCOM_SRC)/games
+ifeq ($(ALL_GAMES),1)
+INFOCOM_STORIES ?= ballyhoo.z3 cutthroats.z3 deadline.z3 enchanter.z3 \
+	hollywoodhijinx.z3 infidel.z3 leathergoddesses.z3 moonmist.z3 \
+	planetfall.z3 plunderedhearts.z3 seastalker.z3 sorcerer.z3 \
+	spellbreaker.z3 starcross.z3 stationfall.z3 suspect.z3 \
+	wishbringer.z3 witness.z3 zork1.z3 zork2.z3 zork3.z3
+else
+INFOCOM_STORIES ?= zork1.z3 zork2.z3 zork3.z3
+endif
 INFOCOM_STORY_FILES = $(addprefix $(INFOCOM_STORY_DIR)/,$(INFOCOM_STORIES))
 
 $(MODDIR)/midi_scdwv.dd: scdwvdesc.asm | $(MODDIR)
@@ -122,6 +132,9 @@ $(FORTH09_CHECKOUT):
 
 $(INFOCOM_CMD): $(INFOCOM_CHECKOUT)
 	$(MAKE) -C $(INFOCOM_SRC) --no-print-directory NITROS9DIR=$(NITROS9DIR) infocom
+
+$(INFOCOM_SRC)/games/%: $(INFOCOM_CHECKOUT)
+	$(MAKE) -C $(INFOCOM_SRC) --no-print-directory games/$*
 
 $(RAAKATU_STORY): $(RAAKATU_CHECKOUT)
 	@test -f $@

--- a/recipes/wildbits/README.md
+++ b/recipes/wildbits/README.md
@@ -137,7 +137,8 @@ Primary outputs:
 
 Both mega images add the same expanded software collection as
 [`coco3/dw_mega`](../coco3/dw_mega/): the native C compiler, Forth09, the
-Infocom interpreter with Zork I-III and Raaka-Tu, and the OS-9 Level 2 BBS.
+Infocom interpreter with Zork I-III from the Masterpiece Collection (or all 21
+titles with `ALL_GAMES=1`) and Raaka-Tu, and the OS-9 Level 2 BBS.
 They require `git`, CMOC, the CMOC OS-9 runtime, `nitros9-apps`, and
 `nitros9-languages`; see the CoCo 3 mega recipe documentation for configuration
 and command-line overrides.

--- a/recipes/wildbits/mega.mak
+++ b/recipes/wildbits/mega.mak
@@ -15,7 +15,7 @@ COCO_SHELF ?= $(abspath $(NITROS9DIR)/..)
 WILDBITS_MEGA_DIR = $(NITROS9DIR)/recipes/wildbits
 
 INFOCOM_REPO ?= https://github.com/rlucente-retro/infocom-os9-port.git
-INFOCOM_REF ?= 998cd4c6c813f327f4e400d374a404d1bc1fd9b9
+INFOCOM_REF ?= 8f3bc2b6f67a7897eb426783c52a6cf8cc6c729f
 INFOCOM_SRC = $(EXTERNAL_DIR)/infocom-os9-port
 INFOCOM_CHECKOUT = $(INFOCOM_SRC)/.checkout-$(INFOCOM_REF)
 INFOCOM_CMD = $(INFOCOM_SRC)/infocom
@@ -46,10 +46,20 @@ CCOMPILER_INPUTS = $(CCOMPILER_DIR)/Makefile $(CCOMPILER_DIR)/defsfile \
 	$(wildcard $(CCOMPILER_DIR)/lib/*) \
 	$(wildcard $(CCOMPILER_DIR)/sources/*)
 
-# The interpreter supports Version 3 story files. Override INFOCOM_STORY_DIR
-# and INFOCOM_STORIES to package another legally obtained collection.
-INFOCOM_STORY_DIR ?= $(NITROS9_APPS_DIR)/cpm/software/zork
-INFOCOM_STORIES ?= ZORK1.DAT ZORK2.DAT ZORK3.DAT
+ALL_GAMES ?= 0
+
+# The interpreter supports Version 3 story files from the Masterpiece Collection.
+# Override INFOCOM_STORY_DIR and INFOCOM_STORIES to package custom story files.
+INFOCOM_STORY_DIR ?= $(INFOCOM_SRC)/games
+ifeq ($(ALL_GAMES),1)
+INFOCOM_STORIES ?= ballyhoo.z3 cutthroats.z3 deadline.z3 enchanter.z3 \
+	hollywoodhijinx.z3 infidel.z3 leathergoddesses.z3 moonmist.z3 \
+	planetfall.z3 plunderedhearts.z3 seastalker.z3 sorcerer.z3 \
+	spellbreaker.z3 starcross.z3 stationfall.z3 suspect.z3 \
+	wishbringer.z3 witness.z3 zork1.z3 zork2.z3 zork3.z3
+else
+INFOCOM_STORIES ?= zork1.z3 zork2.z3 zork3.z3
+endif
 INFOCOM_STORY_FILES = $(addprefix $(INFOCOM_STORY_DIR)/,$(INFOCOM_STORIES))
 
 CMDS_EXTRA += forth09 infocom
@@ -93,6 +103,9 @@ $(FORTH09_CHECKOUT):
 
 $(INFOCOM_CMD): $(INFOCOM_CHECKOUT)
 	$(MAKE) -C $(INFOCOM_SRC) --no-print-directory NITROS9DIR=$(NITROS9DIR) infocom
+
+$(INFOCOM_SRC)/games/%: $(INFOCOM_CHECKOUT)
+	$(MAKE) -C $(INFOCOM_SRC) --no-print-directory games/$*
 
 $(RAAKATU_STORY): $(RAAKATU_CHECKOUT)
 	@test -f $@


### PR DESCRIPTION
Switches Infocom story files in the mega recipes (`recipes/wildbits/mega.mak` and `recipes/coco3/dw_mega/recipe.mak`) from legacy CP/M-padded `.DAT` binaries to canonical Version 3 `.z3` story files from the Masterpiece Collection, fetched on demand via `infocom-os9-port`.

## Changes

* **Bump `INFOCOM_REF`**: Updated interpreter to `8f3bc2b6f67a7897eb426783c52a6cf8cc6c729f`.
* **Masterpiece Collection integration**: Sourced story files directly from `$(INFOCOM_SRC)/games` instead of `nitros9-apps/cpm/software/zork`.
* **`ALL_GAMES` toggle**: Added `ALL_GAMES ?= 0` build option:
  * `ALL_GAMES=0` (default): packages only the open-source *Zork* trilogy (`zork1.z3`, `zork2.z3`, `zork3.z3`).
  * `ALL_GAMES=1`: packages all 21 Masterpiece titles.
* **On-demand fetch rule**: Added pattern rule `$(INFOCOM_SRC)/games/%` to download stories via `infocom-os9-port`'s `masterpiece.csv` recipe.
* **Documentation**: Updated `recipes/wildbits/README.md` and `recipes/coco3/README.md` for `.z3` filenames, example commands, and `ALL_GAMES=1` usage.

> **Note on game licensing**: By default (`ALL_GAMES=0`), only the MIT-licensed open-source *Zork* trilogy is distributed. It is left to individual users to decide whether building with `ALL_GAMES=1` is appropriate for their use.

## Verification

* Built and inspected `recipes/wildbits/l2_mega` default image (`l2_wildbits_megajr2.dsk`); verified `infocom` binary and `/GAMES/INFOCOM/{zork1,zork2,zork3,raakatu}.z3`.
* Verified `make ALL_GAMES=1` expansion across all 21 story targets.